### PR TITLE
JS Based Browser URL manipulation

### DIFF
--- a/application/Module/WebApp/Controller/LoginController.php
+++ b/application/Module/WebApp/Controller/LoginController.php
@@ -19,8 +19,7 @@
  */
 
 
-class WebApp_LoginController
-	extends WebApp\Controller\BaseController
+class WebApp_LoginController extends WebApp\Controller\BaseController
 {
 
 	/**
@@ -28,19 +27,20 @@ class WebApp_LoginController
 	 * @Inject \Core\Repository\UserRepository
 	 */
 	private $userRepo;
-	
+
 	/**
 	 * @var \CoreApi\Service\Login
 	 * @Inject \CoreApi\Service\Login
 	 */
 	private $loginService;
-	
+
 
 	public function indexAction()
 	{
-		if(!is_null($this->me))
+		if (!is_null($this->me))
 		{
 			$this->_forward('index', 'dashboard');
+			$this->view->browserUrl();
 		}
 
 		$loginForm = new \WebApp\Form\Login();
@@ -51,7 +51,7 @@ class WebApp_LoginController
 
 		//TODO: Remove this in Release
 		$this->view->userlist = $this->userRepo->findAll();
-		
+
 	}
 
 
@@ -59,53 +59,57 @@ class WebApp_LoginController
 	{
 		$loginForm = new \WebApp\Form\Login();
 
-		if(!$loginForm->isValid($this->getRequest()->getParams()))
-		{	$this->_forward('index');	}
+		if (!$loginForm->isValid($this->getRequest()->getParams()))
+		{
+			$this->_forward('index');
+			$this->view->browserUrl();
+		}
 
 
-        if($this->checkLogin($loginForm->getValues()))
-        {
-            $this->_forward('index', 'dashboard');
-			$this->view->getHelper('BrowserUrl')->browserUrl("/");
-        }
-        else
-        {
-            $this->_forward('index');
-        }
+		if ($this->checkLogin($loginForm->getValues()))
+		{
+			$this->_forward('index', 'dashboard');
+			$this->view->browserUrl();
+		}
+		else
+		{
+			$this->_forward('index');
+			$this->view->browserUrl();
+		}
 
 	}
 
 
 	public function logoutAction()
 	{
-        $this->loginService->logout();
-        
+		$this->loginService->logout();
+
 		$this->_redirect("login");
 	}
 
 
-    protected function checkLogin($values)
-    {
-    	$result = $this->loginService->login($values['login'], $values['password']);
+	protected function checkLogin($values)
+	{
+		$result = $this->loginService->login($values['login'], $values['password']);
 
-        $this->view->message = $result->getMessages();
+		$this->view->message = $result->getMessages();
 
-        if(Zend_Auth::getInstance()->hasIdentity())
-        {   return true;    }
+		if (Zend_Auth::getInstance()->hasIdentity())
+		{
+			return true;
+		}
 
-        return false;
-    }
-	
+		return false;
+	}
+
 	public function bypassAction()
 	{
 		$user = $this->userRepo->find($this->getRequest()->getParam('user'));
 		$authAdapter = new \CoreApi\Service\Auth\Bypass($user);
-        $result = Zend_Auth::getInstance()->authenticate($authAdapter);
-	
-		$this->_forward('index', 'dashboard');
-		$this->view->getHelper('BrowserUrl')->browserUrl("/");
-	}
+		$result = Zend_Auth::getInstance()->authenticate($authAdapter);
 
-    
+		$this->_forward('index', 'dashboard');
+		$this->view->browserUrl();
+	}
 
 }

--- a/application/Module/WebApp/Controller/LoginController.php
+++ b/application/Module/WebApp/Controller/LoginController.php
@@ -51,6 +51,7 @@ class WebApp_LoginController
 
 		//TODO: Remove this in Release
 		$this->view->userlist = $this->userRepo->findAll();
+		
 	}
 
 
@@ -65,6 +66,7 @@ class WebApp_LoginController
         if($this->checkLogin($loginForm->getValues()))
         {
             $this->_forward('index', 'dashboard');
+			$this->view->getHelper('BrowserUrl')->browserUrl("/");
         }
         else
         {
@@ -101,6 +103,7 @@ class WebApp_LoginController
         $result = Zend_Auth::getInstance()->authenticate($authAdapter);
 	
 		$this->_forward('index', 'dashboard');
+		$this->view->getHelper('BrowserUrl')->browserUrl("/");
 	}
 
     

--- a/application/Module/WebApp/layouts/scripts/layout.phtml
+++ b/application/Module/WebApp/layouts/scripts/layout.phtml
@@ -5,6 +5,8 @@
 		<script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 		<![endif]-->
 
+		<tal:block condition="exists: BrowserUrlScript" content="structure BrowserUrlScript" />
+
 		<tal:block content="structure headTitle" />
 		<tal:block content="structure headMeta"  />
 		<tal:block content="structure headLink"  />

--- a/application/Module/WebApp/views/helpers/BrowserUrl.php
+++ b/application/Module/WebApp/views/helpers/BrowserUrl.php
@@ -4,11 +4,24 @@ namespace WebApp\View\Helper;
 
 class BrowserUrl extends \Zend_View_Helper_Abstract
 {
-	
-	public function browserUrl($url = '/')
+
+	public function browserUrl($param = array(), $route = null)
 	{
+		$r = \Zend_Controller_Front::getInstance()->getRequest();
+		
+		$urlArray = 
+			array(
+				$r->getActionKey() 		=> $r->getActionName(), 
+				$r->getControllerKey() 	=> $r->getControllerName(), 
+				$r->getModuleKey() 		=> $r->getModuleName()
+			);
+		
+		$urlArray = array_merge($urlArray, $param);
+		
+		$url = $this->view->url($urlArray, $route, true);
+		
 		$this->view->BrowserUrlScript = 
-		"<script type='text/javascript'> window.history.replaceState({}, '', '$url'); </script>";
+			"<script type='text/javascript'> window.history.replaceState({}, '', '$url'); </script>";
 	}
 	
 }

--- a/application/Module/WebApp/views/helpers/BrowserUrl.php
+++ b/application/Module/WebApp/views/helpers/BrowserUrl.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace WebApp\View\Helper;
+
+class BrowserUrl extends \Zend_View_Helper_Abstract
+{
+	
+	public function browserUrl($url = '/')
+	{
+		$this->view->BrowserUrlScript = 
+		"<script type='text/javascript'> window.history.replaceState({}, '', '$url'); </script>";
+	}
+	
+}


### PR DESCRIPTION
Browser URL manipulation prevents from forwarding the browser to a new URL… This prevents from additional HTML Requests.

I.E:
After Login (calls the url ecamp3.ch/login/login) the MVC is forwarded to the Dashboard URL (ecamp3.ch/), but the browser still shows the former URL. This can lead to unexpected behaviour on refreshing a Site (by F5).

There are two way's to prevent this.
1) Send a Redirection-Header to the browser (instead of the internal forwarding)
2) Add a small JS-Tag, which changes the URL in the Browser to the forwarded URL.

This PullRequest implements the second approach. It have to be done manually. Example in the LoginController.
Let's check out, whether on can catch the ->_forward() statements and adjust the URL magically.
