### PR TITLE
Avoid deprication warning

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "eCamp/eCamp3",
+  "name": "ecamp/ecamp3",
   "description": "eCamp3",
   "type": "library",
   "homepage": "http://eCamp3.ch/",


### PR DESCRIPTION
In composer 2.0 uppercase letters will no longer be accepted in package-names.
Rename to lowercase to avoid issues...