### PR TITLE
Während dem Löschvorgang keine Entities neu laden die als deleting markiert sind

### DIFF
--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -50,7 +50,7 @@ export const mutations = {
    * @param uri   URI of the entity that is currently being deleted
    */
   deleting (state, uri) {
-    Vue.set(state.api[uri]._meta, 'deleting', true)
+    if (state.api[uri]) Vue.set(state.api[uri]._meta, 'deleting', true)
   },
   /**
    * Marks a single entity in the Vuex store as normal again, after it has been marked as deleting before.
@@ -58,7 +58,7 @@ export const mutations = {
    * @param uri   URI of the entity that failed to be deleted
    */
   deletingFailed (state, uri) {
-    Vue.set(state.api[uri]._meta, 'deleting', false)
+    if (state.api[uri]) Vue.set(state.api[uri]._meta, 'deleting', false)
   }
 }
 
@@ -205,6 +205,7 @@ function loadFromApi (uri) {
       },
       ({ response }) => {
         if (response.status === 404) {
+          store.commit('deleting', uri)
           return deleted(uri)
         }
         reject(response)
@@ -252,6 +253,7 @@ const patch = function (uriOrEntity, data) {
     return get(uri)
   }, ({ response }) => {
     if (response.status === 404) {
+      store.commit('deleting', uri)
       return deleted(uri)
     }
   }))

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -323,8 +323,11 @@ function findEntitiesReferencing (uri) {
  * @returns Promise resolves when the cleanup has completed and the Vuex store is up to date again
  */
 function deleted (uri) {
-  return Promise.all(findEntitiesReferencing(uri).map(outdatedEntity => reload(outdatedEntity)._meta.load))
-    .then(() => purge(uri))
+  return Promise.all(findEntitiesReferencing(uri)
+    // don't reload entities that are already being deleted, to break circular dependencies
+    .filter(outdatedEntity => !outdatedEntity._meta.deleting)
+    .map(outdatedEntity => reload(outdatedEntity)._meta.load)
+  ).then(() => purge(uri))
 }
 
 /**

--- a/frontend/tests/unit/api-store.spec.js
+++ b/frontend/tests/unit/api-store.spec.js
@@ -12,6 +12,7 @@ import linkedSingleEntity from './resources/linked-single-entity'
 import linkedCollection from './resources/linked-collection'
 import collectionFirstPage from './resources/collection-firstPage'
 import collectionPage1 from './resources/collection-page1'
+import circularReference from './resources/circular-reference'
 import multipleReferencesToUser from './resources/multiple-references-to-user'
 
 async function letNetworkRequestFinish () {
@@ -664,6 +665,26 @@ describe('API store', () => {
     await letNetworkRequestFinish()
     expect(axiosMock.history.delete.length).toEqual(1)
     expect(axiosMock.history.get.length).toEqual(3)
+    done()
+  })
+
+  it('breaks circular dependencies when reloading entities referencing a deleted entity', async done => {
+    // given
+    axiosMock.onDelete('http://localhost/periods/1').replyOnce(204)
+    axiosMock.onGet('http://localhost/periods/1').replyOnce(200, circularReference.serverResponse)
+    axiosMock.onGet('http://localhost/periods/1').networkError()
+    axiosMock.onGet('http://localhost/days/2').reply(404)
+    const load = vm.api.get('/periods/1')._meta.load
+    await letNetworkRequestFinish()
+    const period = await load
+    expect(vm.$store.state.api).toMatchObject(circularReference.storeState)
+
+    // when
+    vm.api.del(period)
+
+    // then
+    await letNetworkRequestFinish()
+    expect(axiosMock.history.get.length).toBe(2)
     done()
   })
 

--- a/frontend/tests/unit/resources/circular-reference.json
+++ b/frontend/tests/unit/resources/circular-reference.json
@@ -1,4 +1,11 @@
 {
+  "campServerResponse": {
+    "_links": {
+      "self": {
+        "href": "http://localhost/camps/3"
+      }
+    }
+  },
   "serverResponse": {
     "_embedded": {
       "lastUsedDay": {
@@ -15,11 +22,17 @@
     "_links": {
       "self": {
         "href": "http://localhost/periods/1"
+      },
+      "camp": {
+        "href": "http://localhost/camps/3"
       }
     }
   },
   "storeState": {
     "/periods/1": {
+      "camp": {
+        "href": "/camps/3"
+      },
       "lastUsedDay": {
         "href": "/days/2"
       },

--- a/frontend/tests/unit/resources/circular-reference.json
+++ b/frontend/tests/unit/resources/circular-reference.json
@@ -1,0 +1,39 @@
+{
+  "serverResponse": {
+    "_embedded": {
+      "lastUsedDay": {
+        "_links": {
+          "self": {
+            "href": "http://localhost/days/2"
+          },
+          "owner": {
+            "href": "http://localhost/periods/1"
+          }
+        }
+      }
+    },
+    "_links": {
+      "self": {
+        "href": "http://localhost/periods/1"
+      }
+    }
+  },
+  "storeState": {
+    "/periods/1": {
+      "lastUsedDay": {
+        "href": "/days/2"
+      },
+      "_meta": {
+        "self": "/periods/1"
+      }
+    },
+    "/days/2": {
+      "owner": {
+        "href": "/periods/1"
+      },
+      "_meta": {
+        "self": "/days/2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
@usu hat folgendes in https://github.com/ecamp/ecamp3/pull/367#pullrequestreview-366804392 bemerkt:
> Beim Löschen von Entitäten geht die Seite bei mir in eine Endlosschlaufe von Netzwerk-Requests. Konnte aber noch nicht herausfinden wieso. Könnt ihr das reproduzieren?

Ein Beispiel trat beim Löschen einer Periode auf. Das frontend setzte einen DELETE request in die API ab. Nach der Bestätigung (Status 204) sucht das frontend noch alle weiteren Entities, die noch eine Referenz auf die gelöschte Periode haben. Diese werden alle neu aus der API geladen, darunter auch ein Day der gelöschten Periode. Dieser reload-request endet beim Day in Status 404, das Frontend nimmt also an dass dieser auch gelöscht ist. Somit muss es alle Entities neu laden die den Day kannten. Darunter findet sich die (gelöschte aber im API store immer noch vorhandene) Periode. Diese wird neu geladen, 404, alle entities die die Periode kannten neu laden, usw.

Lösung ist, bei der Suche nach Entities die das gelöschte Objekt kennen diejenigen Entities auszuschliessen die bereits mit `deleting=true` im API Store markiert sind.