### PR TITLE
Fix coveralls (frontend/backend mix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: generic
+
 notifications:
   webhooks: https://coveralls.io/webhook
   
@@ -44,9 +46,7 @@ jobs:
           - cd ..
 
       after_script:
-          - cd backend
-          - vendor/bin/php-coveralls -v --root_dir ..
-          - cd ..
+          - backend/vendor/bin/php-coveralls -v --root_dir ./backend
     
     - stage: test
       name: "Frontend tests"
@@ -67,6 +67,6 @@ jobs:
         - npm run test:e2e:ci
 
       after_script:
-        - cat ./data/coverage/lcov.info | coveralls -v ..
+        - cat ./data/coverage/lcov.info | coveralls ..
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+notifications:
+  webhooks: https://coveralls.io/webhook
+  
 jobs:
   include:
     - stage: test
@@ -13,6 +16,7 @@ jobs:
       # optionally specify a list of environments, for example to test different RDBMS
       env:
         - DB=sqlite env=test
+        - COVERALLS_PARALLEL=true
 
       cache:
         directories:
@@ -41,7 +45,7 @@ jobs:
 
       after_script:
           - cd backend
-          - vendor/bin/php-coveralls
+          - vendor/bin/php-coveralls -v --root_dir ..
           - cd ..
     
     - stage: test
@@ -50,6 +54,7 @@ jobs:
       node_js: '10'
       env:
         - NODE_ENV=development
+        - COVERALLS_PARALLEL=true
       cache: npm
       before_install:
         - cd frontend/
@@ -62,6 +67,6 @@ jobs:
         - npm run test:e2e:ci
 
       after_script:
-        - cat ./data/coverage/lcov.info | coveralls
+        - cat ./data/coverage/lcov.info | coveralls -v ..
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
           - cd ..
 
       after_script:
-          - backend/vendor/bin/php-coveralls -v --root_dir ./backend
+          - backend/vendor/bin/php-coveralls -v
     
     - stage: test
       name: "Frontend tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
           - cd ..
 
       after_script:
-          - backend/vendor/bin/php-coveralls -v
+          - backend/vendor/bin/php-coveralls -v --coverage_clover ./backend/build/logs/clover.xml --json_path ./backend/build/logs/coveralls-upload.json
     
     - stage: test
       name: "Frontend tests"


### PR DESCRIPTION
Fixing the coveralls issue with mixed folders. Now frontend and backend are reported in their proper subfolder.

Detected another issue in the process:
The overall code coverage percentage is reported on the backend code only instead of merging both backend & frontend results. Root cause is because `php-coveralls` doesn't support any parallel option.

See
https://github.com/php-coveralls/php-coveralls/pull/279
and
https://github.com/php-coveralls/php-coveralls/pull/284