### PR TITLE
Use templated links for OAuth login

### DIFF
--- a/backend/module/eCampApi/config/module.config.php
+++ b/backend/module/eCampApi/config/module.config.php
@@ -23,6 +23,26 @@ return [
                     ],
                 ],
             ],
+            'e-camp-api.rpc.auth.google' => [
+                'type' => 'Segment',
+                'options' => [
+                    'route' => '/api/auth/google',
+                    'defaults' => [
+                        'controller' => 'eCampApi\\V1\\Rpc\\Auth\\AuthController',
+                        'action' => 'google',
+                    ],
+                ],
+            ],
+            'e-camp-api.rpc.auth.pbsmidata' => [
+                'type' => 'Segment',
+                'options' => [
+                    'route' => '/api/auth/pbsmidata',
+                    'defaults' => [
+                        'controller' => 'eCampApi\\V1\\Rpc\\Auth\\AuthController',
+                        'action' => 'pbsmidata',
+                    ],
+                ],
+            ],
             'e-camp-api.rpc.register' => [
                 'type' => 'Segment',
                 'options' => [
@@ -1588,6 +1608,9 @@ return [
                 1 => 'POST',
             ],
             'route_name' => 'e-camp-api.rpc.auth',
+            'collection_query_whitelist' => [
+                'callback'
+            ]
         ],
         'eCampApi\\V1\\Rpc\\Index\\IndexController' => [
             'service_name' => 'Index',

--- a/backend/module/eCampApi/config/module.config.php
+++ b/backend/module/eCampApi/config/module.config.php
@@ -1609,8 +1609,8 @@ return [
             ],
             'route_name' => 'e-camp-api.rpc.auth',
             'collection_query_whitelist' => [
-                'callback'
-            ]
+                'callback',
+            ],
         ],
         'eCampApi\\V1\\Rpc\\Index\\IndexController' => [
             'service_name' => 'Index',

--- a/backend/module/eCampApi/src/eCampApi/V1/Rpc/Auth/AuthController.php
+++ b/backend/module/eCampApi/src/eCampApi/V1/Rpc/Auth/AuthController.php
@@ -5,6 +5,7 @@ namespace eCampApi\V1\Rpc\Auth;
 use eCamp\Core\Auth\Adapter\LoginPassword;
 use eCamp\Core\Entity\User;
 use eCamp\Core\EntityService\UserService;
+use eCamp\Lib\Hal\TemplatedLink;
 use Laminas\ApiTools\Hal\Entity;
 use Laminas\ApiTools\Hal\Link\Link;
 use Laminas\ApiTools\Hal\View\HalJsonModel;
@@ -91,19 +92,17 @@ class AuthController extends AbstractActionController {
             ],
         ]);
 
-        $data['google'] = Link::factory([
+        $data['google'] = TemplatedLink::factory([
             'rel' => 'google',
             'route' => [
-                'name' => 'e-camp-api.rpc.auth',
-                'params' => ['action' => 'google'],
+                'name' => 'e-camp-api.rpc.auth.google',
             ],
         ]);
 
-        $data['pbsmidata'] = Link::factory([
+        $data['pbsmidata'] = TemplatedLink::factory([
             'rel' => 'pbsmidata',
             'route' => [
-                'name' => 'e-camp-api.rpc.auth',
-                'params' => ['action' => 'pbsmidata'],
+                'name' => 'e-camp-api.rpc.auth.pbsmidata',
             ],
         ]);
 

--- a/backend/module/eCampLib/src/Hal/Extractor/LinkExtractor.php
+++ b/backend/module/eCampLib/src/Hal/Extractor/LinkExtractor.php
@@ -32,6 +32,9 @@ class LinkExtractor extends HalLinkExtractor {
     /** @var array */
     protected $zfRestConfig;
 
+    /** @var array */
+    protected $rpcConfig;
+
     /** @return SimpleRouteStack */
     public function getRouter() {
         return $this->router;
@@ -102,6 +105,22 @@ class LinkExtractor extends HalLinkExtractor {
      */
     public function setZfRestConfig($zfRestConfig) {
         $this->zfRestConfig = $zfRestConfig;
+
+        return $this;
+    }
+
+    /** @return array */
+    public function getRpcConfig() {
+        return $this->rpcConfig;
+    }
+
+    /**
+     * @param array $rpcConfig
+     *
+     * @return $this
+     */
+    public function setRpcConfig($rpcConfig) {
+        $this->rpcConfig = $rpcConfig;
 
         return $this;
     }
@@ -364,12 +383,20 @@ class LinkExtractor extends HalLinkExtractor {
         }
 
         $zfRestConfig = $this->getZfRestConfig();
+        $rpcConfig = $this->getRpcConfig();
         $controller = $defaults['controller'];
 
-        if (!isset($zfRestConfig[$controller]['collection_query_whitelist'])) {
+        $config = [];
+        if (isset($zfRestConfig[$controller])) {
+            $config = $zfRestConfig[$controller];
+        }
+        if (isset($rpcConfig[$controller])) {
+            $config = $rpcConfig[$controller];
+        }
+        if (!isset($config['collection_query_whitelist'])) {
             return '';
         }
-        $queryWhiteList = $zfRestConfig[$controller]['collection_query_whitelist'];
+        $queryWhiteList = $config['collection_query_whitelist'];
 
         return sprintf('{?%s}', implode(',', $queryWhiteList));
     }

--- a/backend/module/eCampLib/src/Hal/Factory/LinkExtractorFactory.php
+++ b/backend/module/eCampLib/src/Hal/Factory/LinkExtractorFactory.php
@@ -36,6 +36,9 @@ class LinkExtractorFactory {
         if (isset($container->get('Config')['api-tools-rest'])) {
             $linkExtractor->setZfRestConfig($container->get('Config')['api-tools-rest']);
         }
+        if (isset($container->get('Config')['api-tools-rpc'])) {
+            $linkExtractor->setRpcConfig($container->get('Config')['api-tools-rpc']);
+        }
 
         return $linkExtractor;
     }

--- a/frontend/src/plugins/__tests__/auth.spec.js
+++ b/frontend/src/plugins/__tests__/auth.spec.js
@@ -189,7 +189,7 @@ describe('authentication logic', () => {
       // then
       expect(result).toBeTruthy()
       expect(window.open).toHaveBeenCalledTimes(1)
-      expect(window.open).toHaveBeenCalledWith('http://localhost/auth/google?callback=http://localhost/loginCallback', expect.anything(), expect.anything())
+      expect(window.open).toHaveBeenCalledWith('http://localhost/auth/google?callback=http%3A%2F%2Flocalhost%2FloginCallback', expect.anything(), expect.anything())
       done()
     })
   })
@@ -213,7 +213,7 @@ describe('authentication logic', () => {
       // then
       expect(result).toBeTruthy()
       expect(window.open).toHaveBeenCalledTimes(1)
-      expect(window.open).toHaveBeenCalledWith('http://localhost/auth/pbsmidata?callback=http://localhost/loginCallback', expect.anything(), expect.anything())
+      expect(window.open).toHaveBeenCalledWith('http://localhost/auth/pbsmidata?callback=http%3A%2F%2Flocalhost%2FloginCallback', expect.anything(), expect.anything())
       done()
     })
   })
@@ -262,10 +262,12 @@ function createState (authState) {
           href: '/auth/register'
         },
         google: {
-          href: '/auth/google'
+          href: 'http://localhost/auth/google{?callback}',
+          templated: true
         },
         pbsmidata: {
-          href: '/auth/pbsmidata'
+          href: 'http://localhost/auth/pbsmidata{?callback}',
+          templated: true
         },
         _meta: {
           self: '/auth'

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -34,10 +34,9 @@ async function oAuthLoginInSeparateWindow (provider) {
     // Make the promise resolve function available on global level, so the separate window can call it
     window.afterLogin = resolve
 
-    href(get().auth(), provider).then(url => {
-      const returnUrl = window.location.origin + router.resolve({ name: 'loginCallback' }).href
-      // TODO use templated relations once #369 is implemented
-      window.open(url + '?callback=' + encodeURI(returnUrl), '', 'width=500px,height=600px')
+    const returnUrl = window.location.origin + router.resolve({ name: 'loginCallback' }).href
+    href(get().auth(), provider, { callback: encodeURI(returnUrl) }).then(url => {
+      window.open(url, '', 'width=500px,height=600px')
     })
   })
 }

--- a/frontend/src/plugins/store/__tests__/resources/templated-link.json
+++ b/frontend/src/plugins/store/__tests__/resources/templated-link.json
@@ -6,7 +6,7 @@
         "href": "/camps/1"
       },
       "users": {
-        "href": "/camps/1/users{/id}",
+        "href": "http://localhost/camps/1/users{/id}",
         "templated": true
       }
     }
@@ -24,7 +24,7 @@
     "/camps/1": {
       "id": 1,
       "users": {
-        "href": "/camps/1/users{/id}",
+        "href": "http://localhost/camps/1/users{/id}",
         "templated": true
       },
       "_meta": {
@@ -36,7 +36,7 @@
     "/camps/1": {
       "id": 1,
       "users": {
-        "href": "/camps/1/users{/id}",
+        "href": "http://localhost/camps/1/users{/id}",
         "templated": true
       },
       "_meta": {

--- a/frontend/src/plugins/store/apiPlugin.js
+++ b/frontend/src/plugins/store/apiPlugin.js
@@ -220,7 +220,7 @@ export const href = async function (uriOrEntity, relation, templateParams = {}) 
   const rel = store.state.api[self][relation]
   if (!rel || !rel.href) return undefined
   if (rel.templated) {
-    return API_ROOT + urltemplate.parse(rel.href).expand(templateParams)
+    return urltemplate.parse(rel.href).expand(templateParams)
   }
   return API_ROOT + rel.href
 }


### PR DESCRIPTION
Fixes #463 
Adds explicit routes (including the Controller action) for Google and PbsMiData OAuth login.
Adds support for templated Rpc Controller Links.
Fixes a bug in `href` and a few tests, Templated links should never be normalized or de-normalized (API_ROOT stripped away or prepended)