### PR TITLE
ApiControl Non-Autosave + ActivityContent InstanceName

### DIFF
--- a/frontend/src/components/activity/ActivityContent.vue
+++ b/frontend/src/components/activity/ActivityContent.vue
@@ -1,6 +1,6 @@
 <template>
   <v-expansion-panel>
-    <v-expansion-panel-header class="pa-0 pr-sm-2" expand-icon="">
+    <v-expansion-panel-header hide-actions class="pa-0 pr-sm-2">
       <v-toolbar dense flat>
         <v-menu bottom
                 right
@@ -35,12 +35,14 @@
           <api-text-field
             dense
             autofocus
+            :auto-save="false"
             :uri="activityContent._meta.self"
-            fieldname="instanceName" />
+            fieldname="instanceName"
+            @finished="editInstanceName = false" />
         </div>
         <div v-else style="flex: 1;">
           <v-toolbar-title>
-            {{ instanceName }}
+            {{ instanceOrContentTypeName }}
           </v-toolbar-title>
         </div>
 
@@ -153,7 +155,7 @@ export default {
     }
   },
   computed: {
-    instanceName () {
+    instanceOrContentTypeName () {
       if (this.activityContent.instanceName) {
         return this.activityContent.instanceName
       }

--- a/frontend/src/components/form/api/ApiCheckbox.vue
+++ b/frontend/src/components/form/api/ApiCheckbox.vue
@@ -8,7 +8,8 @@ Displays a field as a e-checkbox + write access via API wrapper
   <api-wrapper
     v-slot="wrapper"
     v-bind="$props"
-    separate-buttons>
+    separate-buttons
+    v-on="$listeners">
     <e-checkbox
       :input-value="wrapper.localValue"
       v-bind="$attrs"

--- a/frontend/src/components/form/api/ApiColorPicker.vue
+++ b/frontend/src/components/form/api/ApiColorPicker.vue
@@ -5,7 +5,8 @@ Displays a field as a color picker + write access via API wrapper
 <template>
   <api-wrapper
     v-slot="wrapper"
-    v-bind="$props">
+    v-bind="$props"
+    v-on="$listeners">
     <e-color-picker
       :value="wrapper.localValue"
       v-bind="$attrs"

--- a/frontend/src/components/form/api/ApiDatePicker.vue
+++ b/frontend/src/components/form/api/ApiDatePicker.vue
@@ -5,7 +5,8 @@ Displays a field as a date picker + write access via API wrapper
 <template>
   <api-wrapper
     v-slot="wrapper"
-    v-bind="$props">
+    v-bind="$props"
+    v-on="$listeners">
     <e-date-picker
       :value="wrapper.localValue || ''"
       v-bind="$attrs"

--- a/frontend/src/components/form/api/ApiRichtext.vue
+++ b/frontend/src/components/form/api/ApiRichtext.vue
@@ -6,7 +6,8 @@ Displays a field as a e-textarea + write access via API wrapper
   <api-wrapper
     v-slot="wrapper"
     v-bind="$props"
-    separate-buttons>
+    separate-buttons
+    v-on="$listeners">
     <e-richtext
       :value="wrapper.localValue"
       v-bind="$attrs"

--- a/frontend/src/components/form/api/ApiSelect.vue
+++ b/frontend/src/components/form/api/ApiSelect.vue
@@ -5,7 +5,8 @@ Displays a field as a e-select + write access via API wrapper
 <template>
   <api-wrapper
     v-slot="wrapper"
-    v-bind="$props">
+    v-bind="$props"
+    v-on="$listeners">
     <e-select
       :value="wrapper.localValue"
       v-bind="$attrs"

--- a/frontend/src/components/form/api/ApiTextField.vue
+++ b/frontend/src/components/form/api/ApiTextField.vue
@@ -5,7 +5,8 @@ Displays a field as a e-text-field + write access via API wrapper
 <template>
   <api-wrapper
     v-slot="wrapper"
-    v-bind="$props">
+    v-bind="$props"
+    v-on="$listeners">
     <e-text-field
       :value="wrapper.localValue"
       v-bind="$attrs"

--- a/frontend/src/components/form/api/ApiTextarea.vue
+++ b/frontend/src/components/form/api/ApiTextarea.vue
@@ -6,7 +6,8 @@ Displays a field as a e-textarea + write access via API wrapper
   <api-wrapper
     v-slot="wrapper"
     v-bind="$props"
-    separate-buttons>
+    separate-buttons
+    v-on="$listeners">
     <e-textarea
       :value="wrapper.localValue"
       v-bind="$attrs"

--- a/frontend/src/components/form/api/ApiTimePicker.vue
+++ b/frontend/src/components/form/api/ApiTimePicker.vue
@@ -5,7 +5,8 @@ Displays a field as a time picker + write access via API wrapper
 <template>
   <api-wrapper
     v-slot="wrapper"
-    v-bind="$props">
+    v-bind="$props"
+    v-on="$listeners">
     <e-time-picker
       :value="wrapper.localValue || ''"
       v-bind="$attrs"

--- a/frontend/src/components/form/api/ApiWrapper.vue
+++ b/frontend/src/components/form/api/ApiWrapper.vue
@@ -19,35 +19,8 @@ Wrapper component for form components to save data back to API
         :autoSave="autoSave"
         :readonly="readonly || !hasFinishedLoading"
         :status="status"
+        :dirty="dirty"
         :on="eventHandlers" />
-
-      <div
-        v-if="!autoSave && !readonly"
-        :class="['d-flex', {'my-1': separateButtons}]">
-        <v-btn
-          :disabled="disabled || !hasFinishedLoading"
-          small
-          elevation="0"
-          :class="{'ml-auto mr-1': separateButtons}"
-          :tile="!separateButtons"
-          :height="separateButtons ? '' : 'auto'"
-          @click="reset">
-          Reset
-        </v-btn>
-
-        <v-btn
-          type="submit"
-          :color="hasServerError ? 'error' : 'primary'"
-          small
-          elevation="0"
-          :disabled="disabled || !hasFinishedLoading || validationObserver.invalid"
-          class="v-btn--last-instance"
-          :height="separateButtons ? '' : 'auto'"
-          :loading="isSaving"
-          @click="save">
-          {{ hasServerError ? 'Retry' : 'Save' }}
-        </v-btn>
-      </div>
     </v-form>
   </ValidationObserver>
 </template>

--- a/frontend/src/components/form/api/ApiWrapper.vue
+++ b/frontend/src/components/form/api/ApiWrapper.vue
@@ -151,6 +151,8 @@ export default {
     reset () {
       this.localValue = this.apiValue
       this.resetErrors()
+      this.$emit('reseted')
+      this.$emit('finished')
     },
     resetErrors () {
       this.dirty = false
@@ -184,6 +186,8 @@ export default {
       this.api.patch(this.uri, { [this.fieldname]: this.localValue }).then(() => {
         this.isSaving = false
         this.showIconSuccess = true
+        this.$emit('saved')
+        this.$emit('finished')
         setTimeout(() => { this.showIconSuccess = false }, 2000)
       }, (error) => {
         this.isSaving = false

--- a/frontend/src/components/form/api/ApiWrapperAppend.vue
+++ b/frontend/src/components/form/api/ApiWrapperAppend.vue
@@ -1,13 +1,88 @@
 <template>
-  <div class="d-flex">
-    <!-- Retry/Cancel button if saving failed -->
-    <template v-if="wrapper.autoSave && wrapper.hasServerError">
-      <button-retry type="submit" @click="wrapper.on.save" />
+  <div class="d-flex" style="margin-top: -5px">
+    <!-- Success icon after saving -->
+    <div class="checkIconContainer">
+      <v-icon
+        color="green"
+        class="checkIcon"
+        :class="checkIconAddon">
+        mdi-content-save
+      </v-icon>
+      <!--
+      <v-btn
+        fab
+        dark
+        depressed
+        x-small
+        color="success"
+        class="checkIcon"
+        :class="checkIconAddon">
+        <v-icon>mdi-content-save</v-icon>
+      </v-btn>
+      -->
+    </div>
 
+    <!-- Retry/Cancel button if saving failed -->
+    <template v-if="wrapper.hasServerError">
       <v-tooltip bottom class="ml-auto">
         <template v-slot:activator="{ on }">
           <v-btn
-            icon
+            fab
+            dark
+            depressed
+            x-small
+            color="error"
+            type="submit"
+            class="mr-1"
+            v-on="on"
+            @click="wrapper.on.save">
+            <v-icon>mdi-refresh</v-icon>
+          </v-btn>
+        </template>
+        <span>Retry</span>
+      </v-tooltip>
+      <v-tooltip bottom class="ml-auto">
+        <template v-slot:activator="{ on }">
+          <v-btn
+            fab
+            dark
+            depressed
+            x-small
+            color="grey"
+            v-on="on"
+            @click="wrapper.on.reset">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </template>
+        <span>Cancel</span>
+      </v-tooltip>
+    </template>
+
+    <template v-else-if="!wrapper.autoSave && wrapper.dirty">
+      <v-tooltip bottom class="ml-auto">
+        <template v-slot:activator="{ on }">
+          <v-btn
+            fab
+            dark
+            depressed
+            x-small
+            color="success"
+            type="submit"
+            class="mr-1"
+            v-on="on"
+            @click="wrapper.on.save">
+            <v-icon>mdi-check</v-icon>
+          </v-btn>
+        </template>
+        <span>Save</span>
+      </v-tooltip>
+      <v-tooltip bottom class="ml-auto">
+        <template v-slot:activator="{ on }">
+          <v-btn
+            fab
+            dark
+            depressed
+            x-small
             color="grey"
             v-on="on"
             @click="wrapper.on.reset">
@@ -20,23 +95,30 @@
 
     <!-- Retry button if loading failed -->
     <button-retry v-if="wrapper.hasLoadingError" type="submit" @click="wrapper.on.reload" />
-
-    <!-- Success icon after saving -->
-    <icon-success :visible="wrapper.status === 'success'" />
   </div>
 </template>
 
 <script>
-import IconSuccess from './IconSuccess'
 import ButtonRetry from './ButtonRetry'
 
 export default {
   name: 'ApiWrapperAppend',
-  components: { IconSuccess, ButtonRetry },
+  components: { ButtonRetry },
   props: {
     wrapper: {
       required: true,
       type: Object
+    }
+  },
+  computed: {
+    checkIconAddon () {
+      if (this.wrapper.hasServerError || this.wrapper.dirty) {
+        return 'hidden'
+      } else if (this.wrapper.status === 'success') {
+        return 'visible'
+      } else {
+        return ''
+      }
     }
   }
 }
@@ -44,8 +126,25 @@ export default {
 </script>
 
 <style scoped>
-.v-btn {
-    position:relative;
-    top:-5px;
+.checkIconContainer {
+  position: absolute;
 }
+.v-icon.checkIcon {
+  position: relative;
+  top: -11px;
+  right: 13px;
+  transition: opacity .2s ease-out;
+  opacity: 0;
+}
+div.v-input--checkbox .v-icon.checkIcon {
+  top: 5px;
+  right: 40px;
+}
+.v-icon.checkIcon.visible {
+  opacity: 1;
+}
+.v-icon.checkIcon.hidden {
+  transition: none;
+}
+
 </style>

--- a/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
@@ -378,9 +378,6 @@ describe('Testing ApiWrapper [autoSave=false]', () => {
     expect(vm.isSaving).toBe(false)
     expect(vm.status).toBe('init')
     expect(vm.autoSave).toBe(false)
-
-    // expecting both a reset button & a save button in manual mode
-    expect(wrapper.findAllComponents({ name: 'VBtn' })).toHaveLength(2)
   })
 
   test('clears dirty flag when local value matches external value', async () => {

--- a/frontend/src/components/form/api/__tests__/__snapshots__/ApiSelect.spec.js.snap
+++ b/frontend/src/components/form/api/__tests__/__snapshots__/ApiSelect.spec.js.snap
@@ -67,16 +67,20 @@ exports[`ApiTextField.vue renders correctly 1`] = `
                
               <div
                 class="d-flex"
+                style="margin-top: -5px;"
               >
-                <!---->
-                 
-                <!---->
-                 
-                <transition-stub
-                  name="fade"
+                <div
+                  class="checkIconContainer"
                 >
-                  <!---->
-                </transition-stub>
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate checkIcon mdi mdi-content-save theme--light green--text"
+                  />
+                </div>
+                 
+                <!---->
+                 
+                <!---->
               </div>
             </div>
             <input
@@ -93,7 +97,5 @@ exports[`ApiTextField.vue renders correctly 1`] = `
       </div>
     </div>
   </div>
-   
-  <!---->
 </form>
 `;

--- a/frontend/src/components/form/api/__tests__/__snapshots__/ApiTextField.spec.js.snap
+++ b/frontend/src/components/form/api/__tests__/__snapshots__/ApiTextField.spec.js.snap
@@ -13,7 +13,5 @@ exports[`ApiTextField.vue renders correctly 1`] = `
     value="Test Value"
     veerules=""
   />
-   
-  <!---->
 </v-form-stub>
 `;

--- a/frontend/src/components/form/base/ERichtext.vue
+++ b/frontend/src/components/form/base/ERichtext.vue
@@ -8,6 +8,7 @@
     class="e-form-container">
     <v-tiptap-editor
       v-bind="$attrs"
+      :with-extensions="true"
       :filled="filled"
       :hide-details="hideDetails"
       :error-messages="veeErrors.concat(errorMessages)"

--- a/frontend/src/components/form/base/ETextarea.vue
+++ b/frontend/src/components/form/base/ETextarea.vue
@@ -6,8 +6,9 @@
     :vid="veeId"
     :rules="veeRules"
     class="e-form-container">
-    <v-textarea
+    <v-tiptap-editor
       v-bind="$attrs"
+      :with-extensions="false"
       :filled="filled"
       :hide-details="hideDetails"
       :error-messages="veeErrors.concat(errorMessages)"
@@ -19,17 +20,18 @@
       <template v-for="(_, name) in $scopedSlots" :slot="name" slot-scope="slotData">
         <slot :name="name" v-bind="slotData" />
       </template>
-    </v-textarea>
+    </v-tiptap-editor>
   </ValidationProvider>
 </template>
 
 <script>
 import { ValidationProvider } from 'vee-validate'
 import { formComponentPropsMixin } from '@/mixins/formComponentPropsMixin'
+import VTiptapEditor from '@/components/form/tiptap/VTiptapEditor'
 
 export default {
   name: 'ETextarea',
-  components: { ValidationProvider },
+  components: { VTiptapEditor, ValidationProvider },
   mixins: [formComponentPropsMixin]
 }
 </script>

--- a/frontend/src/components/form/tiptap/TiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/TiptapEditor.vue
@@ -35,31 +35,41 @@ export default {
     placeholder: {
       type: String,
       default: ''
+    },
+    withExtensions: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
+    const extensions = [
+      new Placeholder({
+        emptyEditorClass: 'is-editor-empty',
+        emptyNodeClass: 'is-empty',
+        emptyNodeText: '',
+        showOnlyWhenEditable: true,
+        showOnlyCurrent: true
+      })
+    ]
+    if (this.withExtensions) {
+      extensions.push(...[
+        new History(),
+        new Bold(),
+        new Italic(),
+        new Underline(),
+        new Strike(),
+        new ListItem(),
+        new BulletList(),
+        new OrderedList(),
+        new Heading({ levels: [1, 2, 3] }),
+        new HardBreak()
+      ])
+    }
+
     return {
       emitAfterOnUpdate: false,
       editor: new Editor({
-        extensions: [
-          new History(),
-          new Bold(),
-          new Italic(),
-          new Underline(),
-          new Strike(),
-          new ListItem(),
-          new BulletList(),
-          new OrderedList(),
-          new Heading({ levels: [1, 2, 3] }),
-          new HardBreak(),
-          new Placeholder({
-            emptyEditorClass: 'is-editor-empty',
-            emptyNodeClass: 'is-empty',
-            emptyNodeText: this.placeholder,
-            showOnlyWhenEditable: true,
-            showOnlyCurrent: true
-          })
-        ],
+        extensions: extensions,
         content: this.value,
         onUpdate: this.onUpdate,
         onFocus: this.onFocus,
@@ -82,8 +92,11 @@ export default {
       this.lastSelection = null
       this.editor.setContent(val)
     },
-    placeholder (val) {
-      this.editor.extensions.options.placeholder.emptyNodeText = val
+    placeholder: {
+      immediate: true,
+      handler (val) {
+        this.editor.extensions.options.placeholder.emptyNodeText = val
+      }
     }
   },
   methods: {
@@ -132,10 +145,16 @@ export default {
       }
     },
     getContent () {
-      return [
-        this.genToolbar(),
-        this.genEditorContent()
-      ]
+      if (this.withExtensions) {
+        return [
+          this.genToolbar(),
+          this.genEditorContent()
+        ]
+      } else {
+        return [
+          this.genEditorContent()
+        ]
+      }
     },
     genToolbar () {
       return this.$createElement(EditorMenuBubble, {

--- a/frontend/src/components/form/tiptap/VTiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/VTiptapEditor.vue
@@ -8,6 +8,12 @@ export default {
     TiptapEditor
   },
   extends: VTextField,
+  props: {
+    withExtensions: {
+      type: Boolean,
+      default: false
+    }
+  },
   methods: {
     genInput () {
       const listeners = Object.assign({}, this.listeners$)
@@ -18,7 +24,8 @@ export default {
         },
         props: {
           value: this.value,
-          placeholder: this.placeholder
+          placeholder: this.placeholder,
+          withExtensions: this.withExtensions
         },
         on: Object.assign(listeners, {
           blur: this.onBlur,

--- a/frontend/src/views/dev/Controls.vue
+++ b/frontend/src/views/dev/Controls.vue
@@ -43,6 +43,9 @@
               E-Text-Field
             </v-col>
             <v-col>
+              Api-Text-Field autosave
+            </v-col>
+            <v-col>
               Api-Text-Field
             </v-col>
           </v-row>
@@ -67,6 +70,15 @@
                 :placeholder="placeholder"
                 v-bind="config" />
             </v-col>
+            <v-col>
+              <api-text-field
+                v-if="profileUri !== null"
+                :uri="profileUri"
+                fieldname="nickname"
+                :placeholder="placeholder"
+                :auto-save="false"
+                v-bind="config" />
+            </v-col>
           </v-row>
           <v-row dense no-glutters justify="space-around">
             <v-col>
@@ -74,6 +86,9 @@
             </v-col>
             <v-col>
               E-Textarea
+            </v-col>
+            <v-col>
+              Api-Textarea, autosave
             </v-col>
             <v-col>
               Api-Textarea
@@ -106,6 +121,17 @@
                 auto-grow
                 v-bind="config" />
             </v-col>
+            <v-col>
+              <api-textarea
+                v-if="profileUri !== null"
+                :uri="profileUri"
+                fieldname="nickname"
+                :placeholder="placeholder"
+                :auto-save="false"
+                :rows="3"
+                auto-grow
+                v-bind="config" />
+            </v-col>
           </v-row>
           <v-row dense no-glutters justify="space-around">
             <v-col>
@@ -113,6 +139,9 @@
             </v-col>
             <v-col>
               E-Richtext
+            </v-col>
+            <v-col>
+              Api-Richtext, autosave
             </v-col>
             <v-col>
               Api-Richtext
@@ -139,6 +168,15 @@
                 :placeholder="placeholder"
                 v-bind="config" />
             </v-col>
+            <v-col>
+              <api-richtext
+                v-if="profileUri !== null"
+                :uri="profileUri"
+                fieldname="nickname"
+                :placeholder="placeholder"
+                :auto-save="false"
+                v-bind="config" />
+            </v-col>
           </v-row>
           <v-row dense no-glutters justify="space-around">
             <v-col>
@@ -146,6 +184,9 @@
             </v-col>
             <v-col>
               E-Checkbox
+            </v-col>
+            <v-col>
+              Api-Checkbox, autosave
             </v-col>
             <v-col>
               Api-Checkbox
@@ -166,6 +207,13 @@
                 :uri="profileUri"
                 fieldname="nickname" />
             </v-col>
+            <v-col>
+              <api-checkbox
+                v-if="profileUri !== null"
+                :uri="profileUri"
+                fieldname="nickname"
+                :auto-save="false" />
+            </v-col>
           </v-row>
           <v-row dense no-glutters justify="space-around">
             <v-col>
@@ -173,6 +221,9 @@
             </v-col>
             <v-col>
               E-Select
+            </v-col>
+            <v-col>
+              Api-Select, autosave
             </v-col>
             <v-col>
               Api-Select
@@ -199,6 +250,15 @@
                 :items="availableLocales"
                 v-bind="config" />
             </v-col>
+            <v-col>
+              <api-select
+                v-if="profileUri !== null"
+                :uri="profileUri"
+                fieldname="language"
+                :auto-save="false"
+                :items="availableLocales"
+                v-bind="config" />
+            </v-col>
           </v-row>
           <v-row dense no-glutters justify="space-around">
             <v-col>
@@ -206,6 +266,9 @@
             </v-col>
             <v-col>
               E-Date-Picker
+            </v-col>
+            <v-col>
+              Api-Date-Picker, autosave
             </v-col>
             <v-col>
               Api-Date-Picker
@@ -227,6 +290,14 @@
                 fieldname="birthday"
                 v-bind="config" />
             </v-col>
+            <v-col>
+              <api-date-picker
+                v-if="profileUri !== null"
+                :uri="profileUri"
+                fieldname="birthday"
+                :auto-save="false"
+                v-bind="config" />
+            </v-col>
           </v-row>
           <v-row dense no-glutters justify="space-around">
             <v-col>
@@ -234,6 +305,9 @@
             </v-col>
             <v-col>
               E-Time-Picker
+            </v-col>
+            <v-col>
+              Api-Time-Picker, autosave
             </v-col>
             <v-col>
               Api-Time-Picker
@@ -253,6 +327,14 @@
                 v-if="profileUri !== null"
                 :uri="profileUri"
                 fieldname="nickname"
+                v-bind="config" />
+            </v-col>
+            <v-col>
+              <api-time-picker
+                v-if="profileUri !== null"
+                :uri="profileUri"
+                fieldname="nickname"
+                :auto-save="false"
                 v-bind="config" />
             </v-col>
           </v-row>
@@ -327,7 +409,7 @@ export default {
     availableLocales () {
       return VueI18n.availableLocales.map(l => ({
         value: l,
-        text: this.$tc('global.language', l)
+        text: this.$tc('global.language', 1, l)
       }))
     },
     config () {


### PR DESCRIPTION
Replaces #499 
resolves #496, #497

Non-Autosave für Text, Textarea, Richtext, Checkbox, Select, Date, Time
inkl. Events 'saved', 'reseted' und 'finished'

Angewendet bei ActivityContent Instance-Name