### PR TITLE
backend/Dockerfile: add iproute2

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,5 +15,7 @@ RUN docker-php-ext-enable xdebug
 RUN touch /var/log/xdebug.log && chmod a+rw /var/log/xdebug.log
 ENV XDEBUG_CONFIG="remote_enable=1 remote_autostart=1 remote_connect_back=0 remote_host=host.docker.internal remote_port=9000 remote_log=/var/log/xdebug.log"
 
+RUN apt update
+RUN apt install -y iproute2
 
 ENTRYPOINT bash docker-run.sh

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,9 @@ FROM php:7.4-apache
 
 WORKDIR /app
 
+RUN apt update
+RUN apt install -y iproute2
+
 # Apache site config
 RUN a2enmod rewrite
 COPY apache-vhost.conf /etc/apache2/sites-enabled/000-default.conf
@@ -14,8 +17,5 @@ RUN pecl install xdebug-2.9.6
 RUN docker-php-ext-enable xdebug
 RUN touch /var/log/xdebug.log && chmod a+rw /var/log/xdebug.log
 ENV XDEBUG_CONFIG="remote_enable=1 remote_autostart=1 remote_connect_back=0 remote_host=host.docker.internal remote_port=9000 remote_log=/var/log/xdebug.log"
-
-RUN apt update
-RUN apt install -y iproute2
 
 ENTRYPOINT bash docker-run.sh


### PR DESCRIPTION
That the /etc/hosts entry for host.docker.internal can be generated.
Then, xdebug works out of the box.