### PR TITLE
AbstractDatabaseTestCase: use in memory sqlite database for tests

### DIFF
--- a/backend/config/autoload/.gitignore
+++ b/backend/config/autoload/.gitignore
@@ -1,3 +1,4 @@
 local.php
 *.local.php
 *.local.*.php
+!doctrine.local.test.php

--- a/backend/config/autoload/doctrine.local.test.php
+++ b/backend/config/autoload/doctrine.local.test.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'doctrine' => [
+        'connection' => [
+            'orm_default' => [
+                'driverClass' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
+                'params' => [
+                    'user' => 'ecamp3',
+                    'memory' => true,
+                ],
+            ],
+        ],
+    ],
+];

--- a/backend/module/eCampLib/test/PHPUnit/AbstractDatabaseTestCase.php
+++ b/backend/module/eCampLib/test/PHPUnit/AbstractDatabaseTestCase.php
@@ -13,7 +13,7 @@ abstract class AbstractDatabaseTestCase extends TestCase {
      */
     public function setUp() {
         parent::setUp();
-
+        putenv('env=test');
         $em = $this->getEntityManager();
         $this->createDatabaseSchema($em);
     }


### PR DESCRIPTION
Allows to run the unittests against inmemory sqlite db.
Fixes #514 