### PR TITLE
BelongsToActivityContentInterface

### DIFF
--- a/backend/content-type/eCampSingleText/src/Module.php
+++ b/backend/content-type/eCampSingleText/src/Module.php
@@ -3,7 +3,9 @@
 namespace eCamp\ContentType\SingleText;
 
 use eCamp\ContentType\SingleText\Entity\SingleText;
+use eCamp\Core\Acl\UserIsCollaborator;
 use eCamp\Core\ContentType\ConfigFactory;
+use eCamp\Core\Entity\CampCollaboration;
 use eCamp\Core\Entity\User;
 use eCamp\Lib\Acl\Acl;
 use eCamp\Lib\InputFilter\HtmlPurify;
@@ -44,16 +46,19 @@ class Module {
         $acl->allow(
             User::ROLE_USER,
             SingleText::class,
+            [Acl::REST_PRIVILEGE_FETCH_ALL]
+        );
+        $acl->allow(
+            User::ROLE_USER,
+            SingleText::class,
             [
+                Acl::REST_PRIVILEGE_CREATE,
                 Acl::REST_PRIVILEGE_FETCH,
-                Acl::REST_PRIVILEGE_FETCH_ALL,
-                // Acl::REST_PRIVILEGE_CREATE,
-                // disallow posting directly. Single entities should always be created via ActivityContent.
                 Acl::REST_PRIVILEGE_PATCH,
                 Acl::REST_PRIVILEGE_UPDATE,
-                // Acl::REST_PRIVILEGE_DELETE,
-                // disallow deleting directly. Single entities should always be deleted via ActivityContent.
-            ]
+                Acl::REST_PRIVILEGE_DELETE,
+            ],
+            new UserIsCollaborator([CampCollaboration::ROLE_MEMBER, CampCollaboration::ROLE_MANAGER])
         );
     }
 }

--- a/backend/content-type/eCampStoryboard/src/Module.php
+++ b/backend/content-type/eCampStoryboard/src/Module.php
@@ -3,9 +3,11 @@
 namespace eCamp\ContentType\Storyboard;
 
 use eCamp\ContentType\Storyboard\Entity\Section;
+use eCamp\Core\Acl\UserIsCollaborator;
 use eCamp\Core\ContentType\ConfigFactory;
+use eCamp\Core\Entity\CampCollaboration;
+use eCamp\Core\Entity\User;
 use eCamp\Lib\Acl\Acl;
-use eCamp\Lib\Acl\Guest;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Permissions\Acl\AclInterface;
 
@@ -21,16 +23,21 @@ class Module {
         $acl->addResource(Section::class);
 
         $acl->allow(
-            Guest::class,
+            User::ROLE_USER,
+            Section::class,
+            [Acl::REST_PRIVILEGE_FETCH_ALL]
+        );
+        $acl->allow(
+            User::ROLE_USER,
             Section::class,
             [
-                Acl::REST_PRIVILEGE_FETCH,
-                Acl::REST_PRIVILEGE_FETCH_ALL,
                 Acl::REST_PRIVILEGE_CREATE,
+                Acl::REST_PRIVILEGE_FETCH,
                 Acl::REST_PRIVILEGE_PATCH,
                 Acl::REST_PRIVILEGE_UPDATE,
                 Acl::REST_PRIVILEGE_DELETE,
-            ]
+            ],
+            new UserIsCollaborator([CampCollaboration::ROLE_MEMBER, CampCollaboration::ROLE_MANAGER])
         );
     }
 }

--- a/backend/module/eCampCore/src/Acl/UserIsCollaborator.php
+++ b/backend/module/eCampCore/src/Acl/UserIsCollaborator.php
@@ -2,6 +2,7 @@
 
 namespace eCamp\Core\Acl;
 
+use eCamp\Core\Entity\BelongsToActivityContentInterface;
 use eCamp\Core\Entity\BelongsToCampInterface;
 use eCamp\Core\Entity\CampCollaboration;
 use eCamp\Core\Entity\User;
@@ -20,6 +21,10 @@ class UserIsCollaborator implements AssertionInterface {
     public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null) {
         /** @var User $user */
         $user = $role;
+
+        if ($resource instanceof BelongsToActivityContentInterface) {
+            $resource = $resource->getActivityContent();
+        }
 
         if ($resource instanceof BelongsToCampInterface) {
             $camp = $resource->getCamp();

--- a/backend/module/eCampCore/src/ContentType/BaseContentTypeEntity.php
+++ b/backend/module/eCampCore/src/ContentType/BaseContentTypeEntity.php
@@ -4,12 +4,13 @@ namespace eCamp\Core\ContentType;
 
 use Doctrine\ORM\Mapping as ORM;
 use eCamp\Core\Entity\ActivityContent;
+use eCamp\Core\Entity\BelongsToActivityContentInterface;
 use eCamp\Lib\Entity\BaseEntity;
 
 /**
  * @ORM\MappedSuperclass
  */
-abstract class BaseContentTypeEntity extends BaseEntity {
+abstract class BaseContentTypeEntity extends BaseEntity implements BelongsToActivityContentInterface {
     /**
      * @var ActivityContent
      * @ORM\ManyToOne(targetEntity="eCamp\Core\Entity\ActivityContent")

--- a/backend/module/eCampCore/src/Entity/BelongsToActivityContentInterface.php
+++ b/backend/module/eCampCore/src/Entity/BelongsToActivityContentInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace eCamp\Core\Entity;
+
+interface BelongsToActivityContentInterface {
+    /**
+     * @return ActivityContent
+     */
+    public function getActivityContent();
+}


### PR DESCRIPTION
closes #443 

Neues Interface: BelongsToActivityContentInterface
Wird von BaseContentTypeEntity implementiert.
Kann bei Bedarf auch von weiteren Sub-Entitäten von einem ContentType implementiert werden.

Kann für ACL verwendet werden.
Aktuelles Beispiel in UserIsCollaborator-AclAssertion