### PR TITLE
CampCollaboration Status 'left'

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "XDebug: eCamp Backend",
+            "type": "php",
+            "request": "launch",
+            "hostname": "localhost",
+            "port": 9000,
+            "pathMappings": {
+                "/app": "${workspaceRoot}/backend"
+            }
+        },
+        {
+            "name": "XDebug: UnitTest",
+            "type": "php",
+            "request": "launch",
+            "hostname": "localhost",
+            "port": 9000
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "php-cs-fixer.config": "./backend/.php_cs",
     "javascript.format.enable": false,
-    "eslint.format.enable": true
+    "eslint.format.enable": true,
+    "phpunit.files": "backend/{module,content-type}/**/test/**/*Test.php",
+    "phpunit.args": [ "-cbackend/phpunit.xml" ],
 }

--- a/backend/module/eCampCore/src/Entity/CampCollaboration.php
+++ b/backend/module/eCampCore/src/Entity/CampCollaboration.php
@@ -22,6 +22,14 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
     const STATUS_REQUESTED = 'requested';
     const STATUS_INVITED = 'invited';
     const STATUS_ESTABLISHED = 'established';
+    const STATUS_LEFT = 'leaved';
+
+    const VALID_STATUS = [
+        self::STATUS_INVITED,
+        self::STATUS_REQUESTED,
+        self::STATUS_ESTABLISHED,
+        self::STATUS_LEFT,
+    ];
 
     /**
      * @var ArrayCollection
@@ -96,7 +104,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
      * @throws \Exception
      */
     public function setStatus(string $status): void {
-        if (!in_array($status, [self::STATUS_UNRELATED, self::STATUS_INVITED, self::STATUS_REQUESTED, self::STATUS_ESTABLISHED])) {
+        if (!in_array($status, self::VALID_STATUS)) {
             throw new \Exception('Invalid status: '.$status);
         }
         $this->status = $status;

--- a/backend/module/eCampCore/src/Entity/CampCollaboration.php
+++ b/backend/module/eCampCore/src/Entity/CampCollaboration.php
@@ -22,7 +22,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
     const STATUS_REQUESTED = 'requested';
     const STATUS_INVITED = 'invited';
     const STATUS_ESTABLISHED = 'established';
-    const STATUS_LEFT = 'leaved';
+    const STATUS_LEFT = 'left';
 
     const VALID_STATUS = [
         self::STATUS_INVITED,

--- a/backend/module/eCampCore/src/EntityService/AbstractEntityService.php
+++ b/backend/module/eCampCore/src/EntityService/AbstractEntityService.php
@@ -204,8 +204,9 @@ abstract class AbstractEntityService extends AbstractResourceListener {
             $entity = $this->fetch($id);
             $this->assertAllowed($entity, __FUNCTION__);
 
-            $this->deleteEntity($entity);
-            $this->serviceUtils->emRemove($entity);
+            if ($this->deleteEntity($entity)) {
+                $this->serviceUtils->emRemove($entity);
+            }
             $this->serviceUtils->emFlush();
 
             return true;
@@ -268,10 +269,10 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     /**
      * @param $entity
      *
-     * @return BaseEntity
+     * @return bool true: delete $entity, false: keep $entity
      */
     protected function deleteEntity(BaseEntity $entity) {
-        return $entity;
+        return true;
     }
 
     /**

--- a/backend/module/eCampCore/src/EntityService/AbstractEntityService.php
+++ b/backend/module/eCampCore/src/EntityService/AbstractEntityService.php
@@ -204,9 +204,8 @@ abstract class AbstractEntityService extends AbstractResourceListener {
             $entity = $this->fetch($id);
             $this->assertAllowed($entity, __FUNCTION__);
 
-            if ($this->deleteEntity($entity)) {
-                $this->serviceUtils->emRemove($entity);
-            }
+            $this->deleteEntity($entity);
+
             $this->serviceUtils->emFlush();
 
             return true;
@@ -268,11 +267,9 @@ abstract class AbstractEntityService extends AbstractResourceListener {
 
     /**
      * @param $entity
-     *
-     * @return bool true: delete $entity, false: keep $entity
      */
     protected function deleteEntity(BaseEntity $entity) {
-        return true;
+        $this->serviceUtils->emRemove($entity);
     }
 
     /**

--- a/backend/module/eCampCore/src/EntityService/CampCollaborationService.php
+++ b/backend/module/eCampCore/src/EntityService/CampCollaborationService.php
@@ -141,8 +141,6 @@ class CampCollaborationService extends AbstractEntityService {
         } elseif ($campCollaboration->isRequest()) {
             $campCollaboration = $this->updateRequest($campCollaboration, $data);
         }
-
-        return false;
     }
 
     protected function fetchAllQueryBuilder($params = []) {

--- a/backend/module/eCampCore/src/EntityService/DayService.php
+++ b/backend/module/eCampCore/src/EntityService/DayService.php
@@ -48,10 +48,10 @@ class DayService extends AbstractEntityService {
      */
     protected function deleteEntity(BaseEntity $entity) {
         /** @var Day $day */
-        $day = parent::deleteEntity($entity);
+        $day = $entity;
         $day->getPeriod()->removeDay($day);
 
-        return $day;
+        return true;
     }
 
     protected function fetchAllQueryBuilder($params = []) {

--- a/backend/module/eCampCore/src/EntityService/DayService.php
+++ b/backend/module/eCampCore/src/EntityService/DayService.php
@@ -43,15 +43,12 @@ class DayService extends AbstractEntityService {
         return $day;
     }
 
-    /**
-     * @return Day
-     */
     protected function deleteEntity(BaseEntity $entity) {
+        parent::deleteEntity($entity);
+
         /** @var Day $day */
         $day = $entity;
         $day->getPeriod()->removeDay($day);
-
-        return true;
     }
 
     protected function fetchAllQueryBuilder($params = []) {

--- a/backend/module/eCampCore/src/EntityService/PeriodService.php
+++ b/backend/module/eCampCore/src/EntityService/PeriodService.php
@@ -120,11 +120,11 @@ class PeriodService extends AbstractEntityService {
      * @return Period
      */
     protected function deleteEntity(BaseEntity $entity) {
+        parent::deleteEntity($entity);
+
         /** @var Period $period */
         $period = $entity;
         $period->getCamp()->removePeriod($period);
-
-        return true;
     }
 
     /**

--- a/backend/module/eCampCore/src/EntityService/PeriodService.php
+++ b/backend/module/eCampCore/src/EntityService/PeriodService.php
@@ -121,10 +121,10 @@ class PeriodService extends AbstractEntityService {
      */
     protected function deleteEntity(BaseEntity $entity) {
         /** @var Period $period */
-        $period = parent::deleteEntity($entity);
+        $period = $entity;
         $period->getCamp()->removePeriod($period);
 
-        return $period;
+        return true;
     }
 
     /**

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="phpunit.xsd" verbose="true">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="phpunit.xsd"
+    bootstrap="autoload.php"
+    verbose="true"
+>
     <php>
         <env name="env" value="test"/>
         <const name="PHPUNIT_TESTSUITE" value="true"/>
     </php>
-
 
     <testsuites>
         <testsuite name="eCamp.Lib">
@@ -25,7 +29,6 @@
         </testsuite>
     </testsuites>
 
-
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">module/eCampLib/src</directory>
@@ -35,7 +38,6 @@
             <directory suffix=".php">content-type/eCampTextarea/src</directory>
         </whitelist>
     </filter>
-
 
     <logging>
         <log type="coverage-html" target="./data/codeCoverage" charset="UTF-8" yui="true" highlight="true" lowUpperBound="50" highLowerBound="80" showUncoveredFiles="false" />

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -116,6 +116,9 @@
       },
       "name": "Lager"
     },
+    "campCollaboration": {
+      "campLeft": "Lager verlassen"
+    },
     "period": {
       "defaultDescription": "Hauptlager",
       "fields": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -110,6 +110,9 @@
       },
       "name": "Camp"
     },
+    "campCollaboration": {
+      "campLeft": "left camp"
+    },
     "period": {
       "defaultDescription": "Main",
       "fields": {

--- a/frontend/src/views/activity/Activity.vue
+++ b/frontend/src/views/activity/Activity.vue
@@ -144,8 +144,8 @@ export default {
       return this.campCollaborations.filter(cc => {
         return (cc.status === 'established') || (currentCampCollaborationIds.includes(cc.id))
       }).map(value => {
-        const leaved = value.status !== 'established'
-        const text = value.user().username + (leaved ? ' (Lager verlassen)' : '')
+        const left = value.status === 'left'
+        const text = value.user().username + (left ? (' (' + this.$tc('entity.campCollaboration.campLeft')) + ')' : '')
         return {
           value,
           text

--- a/frontend/src/views/activity/Activity.vue
+++ b/frontend/src/views/activity/Activity.vue
@@ -140,10 +140,15 @@ export default {
   },
   computed: {
     availableCampCollaborations () {
-      return this.campCollaborations.map(cc => {
+      const currentCampCollaborationIds = this.activity.campCollaborations().items.map(cc => cc.id)
+      return this.campCollaborations.filter(cc => {
+        return (cc.status === 'established') || (currentCampCollaborationIds.includes(cc.id))
+      }).map(value => {
+        const leaved = value.status !== 'established'
+        const text = value.user().username + (leaved ? ' (Lager verlassen)' : '')
         return {
-          value: cc,
-          text: cc.user().username
+          value,
+          text
         }
       })
     },

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -106,13 +106,13 @@ export default {
     },
     searchResults () {
       if (this.search.length >= 3) {
-        const filterUsers = this.collaborators.filter(
-          c => c.user !== undefined
-        ).map(
-          c => c.user().id
-        )
+        const filterUserIds = [
+          ...this.establishedCollaborators,
+          ...this.requestedCollaborators,
+          ...this.invitedCollaborators
+        ].map(c => c.user().id)
         return this.api.get().users({ search: this.search }).items.filter(
-          u => !filterUsers.includes(u.id)
+          u => !filterUserIds.includes(u.id)
         )
       }
       return []


### PR DESCRIPTION
based on #560 
closes #521 

Wenn Lager verlassen wird, bleibt CampCollaboration mit Status 'left' stehen.
Falls bereits ActivityResponsible vorhanden ist, wird der Status 'left' angezeigt:

![image](https://user-images.githubusercontent.com/470237/97369723-bfba5280-18ad-11eb-8aeb-0807ae02d3d4.png)
