### PR TITLE
Bugfix: api docu swagger

### DIFF
--- a/backend/module/eCampApi/config/documentation.config.php
+++ b/backend/module/eCampApi/config/documentation.config.php
@@ -1,5 +1,7 @@
 <?php
 
+error_reporting(E_ALL & ~E_DEPRECATED);
+
 return [
     'eCampApi\\V1\\Rpc\\Index\\Controller' => [
         'description' => 'Entrypoint',


### PR DESCRIPTION
closes #545

Swagger-Doku erstellen wirft eine Deprecated-Warnung.
Swagger-Doku kann daher nicht dargestellt werden.

Alternativ könnten auch Deprecated-Warnungen generell ausgeschalten werden (/backend/public/index.php)