### PR TITLE
Bugfix: CreateEntity AssertAuthenticated

### DIFF
--- a/backend/module/eCampCore/src/EntityService/AbstractEntityService.php
+++ b/backend/module/eCampCore/src/EntityService/AbstractEntityService.php
@@ -14,6 +14,7 @@ use eCamp\Core\Entity\User;
 use eCamp\Lib\Acl\Acl;
 use eCamp\Lib\Acl\Guest;
 use eCamp\Lib\Acl\NoAccessException;
+use eCamp\Lib\Acl\NotAuthenticatedException;
 use eCamp\Lib\Entity\BaseEntity;
 use eCamp\Lib\Service\EntityNotFoundException;
 use eCamp\Lib\Service\EntityValidationException;
@@ -63,6 +64,8 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     public function dispatch(ResourceEvent $event) {
         try {
             return parent::dispatch($event);
+        } catch (NotAuthenticatedException $e) {
+            return new ApiProblem(401, $e->getMessage());
         } catch (NoAccessException $e) {
             return new ApiProblem(403, $e->getMessage());
         } catch (EntityNotFoundException $e) {
@@ -309,11 +312,11 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     }
 
     /**
-     * @throws NoAccessException if no user is authenticated
+     * @throws NotAuthenticatedException if no user is authenticated
      */
     protected function assertAuthenticated() {
         if (!$this->isAuthenticated()) {
-            throw new NoAccessException();
+            throw new NotAuthenticatedException();
         }
     }
 

--- a/backend/module/eCampCore/src/EntityService/AbstractEntityService.php
+++ b/backend/module/eCampCore/src/EntityService/AbstractEntityService.php
@@ -302,13 +302,29 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     }
 
     /**
+     * @return true if User is authenticated
+     */
+    protected function isAuthenticated() {
+        return $this->authenticationService->hasIdentity();
+    }
+
+    /**
+     * @throws NoAccessException if no user is authenticated
+     */
+    protected function assertAuthenticated() {
+        if (!$this->isAuthenticated()) {
+            throw new NoAccessException();
+        }
+    }
+
+    /**
      * @return Guest|User
      */
     protected function getAuthUser() {
         /** @var User $user */
         $user = new Guest();
 
-        if ($this->authenticationService->hasIdentity()) {
+        if ($this->isAuthenticated()) {
             $userRepository = $this->serviceUtils->emGetRepository(User::class);
             $userId = $this->authenticationService->getIdentity();
             $user = $userRepository->find($userId);

--- a/backend/module/eCampCore/src/EntityService/CampCollaborationService.php
+++ b/backend/module/eCampCore/src/EntityService/CampCollaborationService.php
@@ -32,6 +32,8 @@ class CampCollaborationService extends AbstractEntityService {
      * @return ApiProblem|CampCollaboration
      */
     protected function createEntity($data) {
+        $this->assertAuthenticated();
+
         $authUser = $this->getAuthUser();
         if (!isset($data->userId)) {
             $data->userId = $authUser->getId();

--- a/backend/module/eCampCore/src/EntityService/CampService.php
+++ b/backend/module/eCampCore/src/EntityService/CampService.php
@@ -60,6 +60,8 @@ class CampService extends AbstractEntityService {
      * @return Camp
      */
     protected function createEntity($data) {
+        $this->assertAuthenticated();
+
         /** @var CampType $campType */
         $campType = $this->findEntity(CampType::class, $data->campTypeId);
 

--- a/backend/module/eCampLib/src/Acl/NotAuthenticatedException.php
+++ b/backend/module/eCampLib/src/Acl/NotAuthenticatedException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace eCamp\Lib\Acl;
+
+class NotAuthenticatedException extends \Exception {
+}


### PR DESCRIPTION
Beim Testen am Swagger-GUI ist mir folgendes aufgefallen:
Wenn man als Gast (nicht angemeldet) ein Lager erstellen will (POST auf /camps) erscheint nicht die Fehlermeldung 'Forbidden', sondern ein Server-Error 500. Grund dafür ist, dass der ACL-Check erst nach dem erstellen des Lagers läuft. Vorher wird versucht der User "Guest" als Camp-Creator zu setzen.

Lösung:
AssertAuthentication prüft, ob der User angemeldet ist.
Kann nach bedarf eingesetzt werden. Besonders da hilfreich, wo getAuthUser() verwendet wird.
z.B. auch im CampCollaborationService