### PR TITLE
Tests for RPC endpoints

### DIFF
--- a/backend/.vscode/launch.json
+++ b/backend/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "XDebug: eCamp Backend (php running in Docker)",
+            "type": "php",
+            "request": "launch",
+            "hostname": "localhost",
+            "port": 9000,
+            "pathMappings": {
+                "/app": "${workspaceRoot}"
+            }
+        },
+        {
+            "name": "XDebug: UnitTest (php running locally)",
+            "type": "php",
+            "request": "launch",
+            "hostname": "localhost",
+            "port": 9000
+        }
+    ]
+}

--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "php-cs-fixer.config": "./.php_cs",
+    "phpunit.files": "./{module,content-type}/**/test/**/*Test.php",
+    "phpunit.args": [
+        "-cphpunit.xml"
+    ],
+}

--- a/backend/module/eCampApi/test/Rpc/AuthTest.php
+++ b/backend/module/eCampApi/test/Rpc/AuthTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace eCamp\ApiTest\Rest;
+
+use Doctrine\Common\DataFixtures\Loader;
+use eCamp\Core\Entity\User;
+use eCamp\CoreTest\Data\UserTestData;
+use eCamp\LibTest\PHPUnit\AbstractApiControllerTestCase;
+
+/**
+ * @internal
+ */
+class AuthTest extends AbstractApiControllerTestCase {
+    /** @var User */
+    protected $user;
+
+    private $apiEndpoint = '/api/auth';
+
+    public function setUp() {
+        parent::setUp();
+
+        $userLoader = new UserTestData();
+        $loader = new Loader();
+        $loader->addFixture($userLoader);
+
+        $this->loadFixtures($loader);
+        $this->user = $userLoader->getReference(UserTestData::$USER1);
+    }
+
+    public function testFetchAsGuest() {
+        $this->dispatch("{$this->apiEndpoint}", 'GET');
+
+        $this->assertResponseStatusCode(200);
+
+        $expectedBody = <<<'JSON'
+            {
+                "user": "guest",
+                "username": "guest",
+                "role": "guest"
+            }
+JSON;
+
+        $expectedLinks = <<<JSON
+            {
+                "api": {
+                    "href": "http://{$this->host}/api"
+                },
+                "self": {
+                    "href": "http://{$this->host}/api/auth"
+                },
+                "register": {
+                    "href": "http://{$this->host}/api/register"
+                },
+                "login": {
+                    "href": "http://{$this->host}/api/auth/login"
+                },
+                "google": {
+                    "href": "http://{$this->host}/api/auth/google{?callback}",
+                    "templated": true
+                },
+                "pbsmidata": {
+                    "href": "http://{$this->host}/api/auth/pbsmidata{?callback}",
+                    "templated": true
+                },
+                "logout": {
+                    "href": "http://{$this->host}/api/auth/logout"
+                }
+            }
+JSON;
+        $expectedEmbeddedObjects = [];
+
+        $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
+    }
+
+    public function testFetchAsUser() {
+        $this->authenticateUser($this->user);
+        $this->dispatch("{$this->apiEndpoint}", 'GET');
+
+        $this->assertResponseStatusCode(200);
+
+        $this->assertEquals('test-user', $this->getResponseContent()->username);
+    }
+
+    public function testLogin() {
+        $this->assertNull($this->getAuthenticatedUserId());
+
+        $this->setRequestContent([
+            'username' => 'test-user',
+            'password' => 'test',
+        ]);
+        $this->dispatch("{$this->apiEndpoint}/login", 'GET');
+
+        $this->assertResponseStatusCode(302);
+        $this->assertEquals('/api/auth', $this->getResponseHeader('location')->getFieldValue());
+        $this->assertEquals($this->user->getId(), $this->getAuthenticatedUserId());
+    }
+
+    public function testLogout() {
+        $this->authenticateUser($this->user);
+        $this->assertEquals($this->user->getId(), $this->getAuthenticatedUserId());
+
+        $this->dispatch("{$this->apiEndpoint}/logout", 'GET');
+
+        $this->assertResponseStatusCode(302);
+        $this->assertEquals('/api/auth', $this->getResponseHeader('location')->getFieldValue());
+        $this->assertNull($this->getAuthenticatedUserId());
+    }
+}

--- a/backend/module/eCampApi/test/Rpc/ProfileTest.php
+++ b/backend/module/eCampApi/test/Rpc/ProfileTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace eCamp\ApiTest\Rest;
+
+use Doctrine\Common\DataFixtures\Loader;
+use eCamp\Core\Entity\User;
+use eCamp\CoreTest\Data\UserTestData;
+use eCamp\LibTest\PHPUnit\AbstractApiControllerTestCase;
+
+/**
+ * @internal
+ */
+class ProfileTest extends AbstractApiControllerTestCase {
+    /** @var User */
+    protected $user;
+
+    private $apiEndpoint = '/api/profile';
+
+    public function setUp() {
+        parent::setUp();
+
+        $userLoader = new UserTestData();
+        $loader = new Loader();
+        $loader->addFixture($userLoader);
+
+        $this->loadFixtures($loader);
+        $this->user = $userLoader->getReference(UserTestData::$USER1);
+
+        $this->authenticateUser($this->user);
+    }
+
+    public function testFetch() {
+        $this->dispatch("{$this->apiEndpoint}", 'GET');
+
+        $this->assertResponseStatusCode(200);
+
+        $expectedBody = <<<'JSON'
+            {
+                "username": "test-user",
+                "firstname": null,
+                "surname": null,
+                "nickname": null,
+                "displayName": "test-user",
+                "mail": "test@ecamp3.dev",
+                "role": "user",
+                "language": null,
+                "birthday": null
+            }
+JSON;
+
+        $expectedLinks = <<<JSON
+            {
+                "self": {
+                    "href": "http://{$this->host}{$this->apiEndpoint}"
+                }
+            }
+JSON;
+        $expectedEmbeddedObjects = [];
+
+        $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
+    }
+
+    public function testCreateSuccess() {
+        $this->dispatch("{$this->apiEndpoint}", 'POST');
+
+        $this->assertResponseStatusCode(405);
+    }
+
+    public function testUpdateSuccess() {
+        $this->setRequestContent([
+            'username' => 'test-user5',
+            'firstname' => 'firstname',
+            'surname' => 'surname',
+            'nickname' => 'nickname',
+            'language' => 'EN',
+            'birthday' => '01.07.1990',
+        ]);
+
+        $this->dispatch("{$this->apiEndpoint}", 'PATCH');
+
+        $this->assertResponseStatusCode(200);
+
+        $this->assertEquals('test-user', $this->getResponseContent()->username); // username cannot be modified
+
+        $this->assertEquals('firstname', $this->getResponseContent()->firstname);
+        $this->assertEquals('surname', $this->getResponseContent()->surname);
+        $this->assertEquals('nickname', $this->getResponseContent()->nickname);
+        $this->assertEquals('EN', $this->getResponseContent()->language);
+        $this->assertEquals('1990-07-01', $this->getResponseContent()->birthday);
+    }
+
+    public function testDelete() {
+        $this->dispatch("{$this->apiEndpoint}", 'DELETE');
+
+        $this->assertResponseStatusCode(405);
+    }
+}

--- a/backend/module/eCampApi/test/Rpc/RootTest.php
+++ b/backend/module/eCampApi/test/Rpc/RootTest.php
@@ -9,6 +9,33 @@ use eCamp\LibTest\PHPUnit\AbstractApiControllerTestCase;
  */
 class RootTest extends AbstractApiControllerTestCase {
     public function testRootResponse() {
+        $this->dispatch('/', 'GET');
+
+        $host = '';
+        $expectedResponse = <<<JSON
+        {
+            "title": "eCamp V3",
+            "_links": {
+                "self": {
+                    "href": "http://{$host}/"
+                },
+                "api": {
+                    "href": "http://{$host}/api"
+                },
+                "setup": {
+                    "href": "http://{$host}/setup.php"
+                },
+                "php-info": {
+                    "href": "http://{$host}/info.php"
+                }
+            }
+        }
+JSON;
+
+        $this->assertEquals(json_decode($expectedResponse), $this->getResponseContent());
+    }
+
+    public function testApiResponse() {
         $this->dispatch('/api', 'GET');
 
         $host = '';

--- a/backend/module/eCampLib/test/PHPUnit/AbstractApiControllerTestCase.php
+++ b/backend/module/eCampLib/test/PHPUnit/AbstractApiControllerTestCase.php
@@ -106,6 +106,16 @@ abstract class AbstractApiControllerTestCase extends ZendAbstractHttpControllerT
     }
 
     /**
+     * Returns id of authenticated user.
+     */
+    protected function getAuthenticatedUserId() {
+        /** @var AuthenticationService $auth */
+        $auth = $this->getApplicationServiceLocator()->get(AuthenticationService::class);
+
+        return $auth->getStorage()->read();
+    }
+
+    /**
      * Verifies HAL response.
      */
     protected function verifyHalResourceResponse(string $rootAsJson, string $linksAsJson, array $embeddedObjectList) {


### PR DESCRIPTION
Test für alle RPC endpoint ausser für `/api/printer`. Der Endpoint wird sowieso noch einige Mal ändern.

Fixes #578 
Fixes #577 

Phpunit extension habe ich nicht zum Laufen gebracht, wenn ich direkt den root Folder öffne. Vom "backend" folder aus geht es.
@pmattmann Vielleicht hast du ja noch eine Idee...

Plus man muss dafür natürlich php, composer, php extensions, etc. auf dem lokalen system installiert haben. Das müssten wir dann irgendwo noch dokumentieren, am Besten wohl im "getting-started" oder einem ähnlichen Guide.