### PR TITLE
Disable serif variant of capital i in all-caps texts

### DIFF
--- a/frontend/src/scss/global.scss
+++ b/frontend/src/scss/global.scss
@@ -6,6 +6,7 @@
 @include inter-ui.weight-500;
 @include inter-ui.weight-600;
 body {font-feature-settings: "ss03", "calt", "rlig", "kern", "cv05", "cv07", "cv08"}
+.text-uppercase {font-feature-settings: "ss03", "calt", "rlig", "kern", "cv05", "cv07"}
 .v-toolbar__title {font-weight: 500;}
 .theme--light.v-application {
 	background: #546E7A!important;


### PR DESCRIPTION
Before:
![Screenshot from 2020-11-11 15-25-33](https://user-images.githubusercontent.com/7566995/98823522-80097400-2432-11eb-8991-159dbf84b240.png)

After:
![Screenshot from 2020-11-11 15-25-21](https://user-images.githubusercontent.com/7566995/98823536-85ff5500-2432-11eb-94f2-c0756b655e4f.png)

