### PR TITLE
Check that the Meeting Discuss label is not present on PRs

### DIFF
--- a/.github/workflows/no-meeting-discuss-label.yml
+++ b/.github/workflows/no-meeting-discuss-label.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, labeled, unlabeled, synchronize]
 
 jobs:
-  label:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/github-action-required-labels@v1

--- a/.github/workflows/no-meeting-discuss-label.yml
+++ b/.github/workflows/no-meeting-discuss-label.yml
@@ -1,0 +1,15 @@
+name: Label "Meeting Discuss" should not be present
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 0
+          labels: "Meeting Discuss"


### PR DESCRIPTION
Uses the following action: https://github.com/mheap/github-action-required-labels
This action will run on every PR, and run again when the labels on a PR change.
It is a GitHub Actions build step, and should appear similarly to the Travis and Coveralls checks on PRs.
Once this action runs, we can adjust the repository settings such that passing this check is required before merging.