### PR TITLE
Reduce network requests for picasso

### DIFF
--- a/backend/module/eCampApi/config/Rest/activity.config.php
+++ b/backend/module/eCampApi/config/Rest/activity.config.php
@@ -6,7 +6,8 @@ $config = ConfigFactory::createConfig('Activity', 'Activities');
 
 array_push(
     $config['api-tools-rest']['eCampApi\\V1\\Rest\\Activity\\Controller']['collection_query_whitelist'],
-    'campId'
+    'campId',
+    'periodId'
 );
 
 $config['api-tools-content-validation'] = [

--- a/backend/module/eCampApi/test/Rest/ActivityTest.php
+++ b/backend/module/eCampApi/test/Rest/ActivityTest.php
@@ -8,6 +8,8 @@ use eCamp\Core\Entity\ActivityCategory;
 use eCamp\Core\Entity\User;
 use eCamp\CoreTest\Data\ActivityCategoryTestData;
 use eCamp\CoreTest\Data\ActivityTestData;
+use eCamp\CoreTest\Data\PeriodTestData;
+use eCamp\CoreTest\Data\ScheduleEntryTestData;
 use eCamp\CoreTest\Data\UserTestData;
 use eCamp\LibTest\PHPUnit\AbstractApiControllerTestCase;
 
@@ -31,10 +33,14 @@ class ActivityTest extends AbstractApiControllerTestCase {
 
         $userLoader = new UserTestData();
         $activityLoader = new ActivityTestData();
+        $periodLoader = new PeriodTestData();
+        $scheduleEntryLoader = new ScheduleEntryTestData();
 
         $loader = new Loader();
         $loader->addFixture($userLoader);
         $loader->addFixture($activityLoader);
+        $loader->addFixture($periodLoader);
+        $loader->addFixture($scheduleEntryLoader);
         $this->loadFixtures($loader);
 
         $this->user = $userLoader->getReference(UserTestData::$USER1);
@@ -78,6 +84,18 @@ JSON;
         $this->assertEquals(1, $this->getResponseContent()->total_items);
         $this->assertEquals(10, $this->getResponseContent()->page_size);
         $this->assertEquals("http://{$this->host}{$this->apiEndpoint}?page_size=10&campId={$campId}&page=1", $this->getResponseContent()->_links->self->href);
+        $this->assertEquals($this->activity->getId(), $this->getResponseContent()->_embedded->items[0]->id);
+    }
+
+    public function testFetchAllByPeriod() {
+        $periodId = $this->activity->getCamp()->getPeriods()->get(0)->getId();
+        $this->dispatch("{$this->apiEndpoint}?page_size=10&periodId={$periodId}", 'GET');
+
+        $this->assertResponseStatusCode(200);
+
+        $this->assertEquals(1, $this->getResponseContent()->total_items);
+        $this->assertEquals(10, $this->getResponseContent()->page_size);
+        $this->assertEquals("http://{$this->host}{$this->apiEndpoint}?page_size=10&periodId={$periodId}&page=1", $this->getResponseContent()->_links->self->href);
         $this->assertEquals($this->activity->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 

--- a/backend/module/eCampApi/test/Rpc/RootTest.php
+++ b/backend/module/eCampApi/test/Rpc/RootTest.php
@@ -81,7 +81,7 @@ JSON;
                     "templated": true
                 },
                 "activities": {
-                    "href": "http://{$host}/api/activities{/activityId}{?page_size,campId}",
+                    "href": "http://{$host}/api/activities{/activityId}{?page_size,campId,periodId}",
                     "templated": true
                 }
             }

--- a/backend/module/eCampCore/src/EntityService/ActivityService.php
+++ b/backend/module/eCampCore/src/EntityService/ActivityService.php
@@ -98,6 +98,12 @@ class ActivityService extends AbstractEntityService {
             $q->setParameter('campId', $params['campId']);
         }
 
+        if (isset($params['periodId'])) {
+            $q->innerJoin('row.scheduleEntries', 'scheduleEntry');
+            $q->andWhere('scheduleEntry.period = :periodId');
+            $q->setParameter('periodId', $params['periodId']);
+        }
+
         return $q;
     }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9212,9 +9212,9 @@
       }
     },
     "hal-json-vuex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hal-json-vuex/-/hal-json-vuex-1.1.0.tgz",
-      "integrity": "sha512-Z/jJDYmKf6GZZN94AJOpuFJxWz36mV6yTvmYgqfAvKLvkEbdZhSr7sldwTf2G53YSenFGIogsOI3BTV9uqQyvg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hal-json-vuex/-/hal-json-vuex-1.2.0.tgz",
+      "integrity": "sha512-tVi7H2jIbt32BJFS44tboiFbTi4qXzlHr35I0qx9/u3ubkDzOBlf4vFCsNtym/FlkTJ6wJJ354XkOU0u4i14MQ==",
       "requires": {
         "hal-json-normalizer": "^3.0.2",
         "url-template": "^2.0.8"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9212,9 +9212,9 @@
       }
     },
     "hal-json-vuex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hal-json-vuex/-/hal-json-vuex-1.2.0.tgz",
-      "integrity": "sha512-tVi7H2jIbt32BJFS44tboiFbTi4qXzlHr35I0qx9/u3ubkDzOBlf4vFCsNtym/FlkTJ6wJJ354XkOU0u4i14MQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/hal-json-vuex/-/hal-json-vuex-1.2.1.tgz",
+      "integrity": "sha512-fubXjDvOT8SO9dbggSzvs9mpZn367SbuAviMjKzQaPCACiDI2EinPVLLn+e4mfN9wxwGCWpdtG1AdE/POa/4rA==",
       "requires": {
         "hal-json-normalizer": "^3.0.2",
         "url-template": "^2.0.8"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "@mdi/font": "^4.9.95",
     "axios": "^0.19.2",
     "deepmerge": "^4.2.2",
-    "hal-json-vuex": "^1.1.0",
+    "hal-json-vuex": "^1.2.0",
     "inter-ui": "^3.13.1",
     "lodash": "^4.17.19",
     "moment-locales-webpack-plugin": "^1.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "@mdi/font": "^4.9.95",
     "axios": "^0.19.2",
     "deepmerge": "^4.2.2",
-    "hal-json-vuex": "^1.2.0",
+    "hal-json-vuex": "^1.2.1",
     "inter-ui": "^3.13.1",
     "lodash": "^4.17.19",
     "moment-locales-webpack-plugin": "^1.2.0",

--- a/frontend/src/components/camp/ActivityList.vue
+++ b/frontend/src/components/camp/ActivityList.vue
@@ -6,7 +6,7 @@ Lists all activity instances in a list view.
   <v-list dense>
     <template v-for="scheduleEntry in scheduleEntries">
       <v-skeleton-loader
-        v-if="scheduleEntry.activity()._meta.loading"
+        v-if="activitiesLoading || scheduleEntry.activity()._meta.loading"
         :key="scheduleEntry._meta.self"
         type="list-item-avatar-two-line" height="60" />
       <v-list-item
@@ -42,10 +42,18 @@ export default {
       required: true
     }
   },
+  data () {
+    return {
+      activitiesLoading: true
+    }
+  },
   computed: {
     camp () {
       return this.period().camp()
     }
+  },
+  mounted () {
+    this.api.get().activities({ periodId: this.period().id })._meta.load.then(() => { this.activitiesLoading = false })
   },
   methods: {
     scheduleEntryLink (scheduleEntry) {

--- a/frontend/src/components/camp/Picasso.vue
+++ b/frontend/src/components/camp/Picasso.vue
@@ -10,8 +10,8 @@ Listing all given activity schedule entries in a calendar view.
       v-resize="resize"
       class="ec-picasso"
       :events="scheduleEntriesWithTemporary"
-      :event-name="getActivityName | loading('Lädt…', ({ input }) => isActivityLoading(input))"
-      :event-color="getActivityColor | loading('grey lighten-2', (entry) => isActivityLoading(entry))"
+      :event-name="getActivityName"
+      :event-color="getActivityColor"
       event-start="startTime"
       event-end="endTime"
       :interval-height="intervalHeight"
@@ -137,7 +137,8 @@ export default {
       currentStartTime: null,
       extendOriginal: null,
       nativeTarget: null,
-      openedInNewTab: false
+      openedInNewTab: false,
+      activitiesLoading: true
     }
   },
   computed: {
@@ -173,25 +174,27 @@ export default {
       return this.period().camp()
     }
   },
+  mounted () {
+    this.api.get().activities({ periodId: this.period().id })._meta.load.then(() => { this.activitiesLoading = false })
+  },
   methods: {
     resize () {
       const widthIntervals = 46
       this.entryWidth = Math.max((this.$refs.calendar.$el.offsetWidth - widthIntervals) / this.$refs.calendar.days.length, 80)
     },
-    getActivityCategory (scheduleEntry, _) {
-      return scheduleEntry.activity().activityCategory()
-    },
     getActivityName (scheduleEntry, _) {
+      if (this.isActivityLoading(scheduleEntry)) return this.$tc('global.loading')
       return (scheduleEntry.number ? '(' + scheduleEntry.number + ') ' : '') +
         (scheduleEntry.activity().activityCategory().short ? scheduleEntry.activity().activityCategory().short + ': ' : '') +
         scheduleEntry.activity().title
     },
     getActivityColor (scheduleEntry, _) {
+      if (this.isActivityLoading(scheduleEntry)) return 'grey lighten-2'
       const color = scheduleEntry.activity().activityCategory().color
       return isCssColor(color) ? color : color + ' elevation-4 v-event--temporary'
     },
     isActivityLoading (scheduleEntry) {
-      return scheduleEntry.activity()._meta ? scheduleEntry.activity()._meta.loading : false
+      return this.activitiesLoading || (scheduleEntry.activity()._meta ? scheduleEntry.activity()._meta.loading : false)
     },
     intervalFormat (time) {
       return this.$moment.utc(time.date + ' ' + time.time).format(this.$tc('global.moment.hourLong'))

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -231,6 +231,7 @@
     },
     "changeLanguage": "Change language",
     "language": "English",
+    "loading": "Loading …",
     "lokaliseMessage": "Language switching powered by lokalise.com",
     "moment": {
       "dateLong": "dd L",

--- a/frontend/src/plugins/filterLoading.js
+++ b/frontend/src/plugins/filterLoading.js
@@ -2,7 +2,7 @@ class FilterLoadingPlugin {
   install (Vue, options) {
     Vue.filter('loading', function (value, loadingState, isLoading = v => typeof v === 'function' && v.loading) {
       if (typeof value === 'function' && !value.loading) {
-      // Wrap the function that is passed into the | loading filter
+        // Wrap the function that is passed into the | loading filter
         return (v, ...args) => isLoading(v) ? loadingState : value(v, ...args)
       }
       return isLoading(value) ? loadingState : value

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -27,7 +27,7 @@ Show all activity schedule entries of a single period.
           </template>
           <template v-else>
             <picasso
-              v-show="!listFormat"
+              v-if="!listFormat"
               class="mx-2 ma-sm-0 pa-sm-2"
               :schedule-entries="slotProps.scheduleEntries"
               :period="period"
@@ -36,7 +36,7 @@ Show all activity schedule entries of a single period.
               :dialog-activity-create="slotProps.showActivityCreateDialog"
               :dialog-activity-edit="slotProps.showActivityEditDialog" />
             <activity-list
-              v-show="listFormat"
+              v-else
               :schedule-entries="slotProps.scheduleEntries"
               :period="period" />
           </template>


### PR DESCRIPTION
I'm testing with a camp with a moderate 17 schedule entries, I expect many camps to have more than that in the future.

The new version of hal-json-vuex helps to reduce the number of unnecessary network requests across the whole application. In our case, it is additionally needed to pre-load the activities (or adjust the 

## Before this PR
23 requests, most of them for single schedule entries. Separate network request for each schedule entry.
![Screenshot from 2020-11-23 14-59-12](https://user-images.githubusercontent.com/7566995/99971060-fb591700-2d9c-11eb-81ef-68baa57cbad7.png)

## After this PR
9 requests, all schedule entries are loaded at once in a single request to the period, and all activities (which are only references in the period response) are loaded in another single request.
![Screenshot from 2020-11-23 15-00-13](https://user-images.githubusercontent.com/7566995/99971071-fe540780-2d9c-11eb-9f90-0a88dae46e20.png)