### PR TITLE
Fix PHP version to 7.4 in GitHub Actions runner

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backend-cs-check:
-    name: "Backend php-cs-fixer"
+    name: "Lint: Backend (php-cs-fixer)"
     runs-on: ubuntu-latest
     steps:
 
@@ -18,7 +18,7 @@ jobs:
           args: --dry-run --diff --config=backend/.php_cs
 
   frontend-eslint:
-    name: "Frontend ESLint"
+    name: "Lint: Frontend (ESLint)"
     runs-on: ubuntu-latest
     steps:
 
@@ -38,7 +38,7 @@ jobs:
         working-directory: frontend
 
   print-eslint:
-    name: "Print ESLint"
+    name: "Lint: Print (ESLint)"
     runs-on: ubuntu-latest
     steps:
 
@@ -58,7 +58,7 @@ jobs:
         working-directory: print
 
   backend-tests:
-    name: "Backend tests"
+    name: "Tests: Backend"
     runs-on: ubuntu-latest
     steps:
 
@@ -93,7 +93,7 @@ jobs:
           COVERALLS_FLAG_NAME: backend
 
   frontend-tests:
-    name: "Frontend tests"
+    name: "Tests: Frontend"
     runs-on: ubuntu-latest
     steps:
 
@@ -122,7 +122,7 @@ jobs:
           COVERALLS_FLAG_NAME: frontend
 
   e2e-tests:
-    name: "End-to-end tests"
+    name: "Tests: End-to-end"
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -64,6 +64,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
       - name: Get Composer Cache Directory
         id: composer-cache
         run: 'echo "::set-output name=dir::$(composer config cache-files-dir)"'


### PR DESCRIPTION
GitHub has set the default version of PHP in the GitHub Actions runner to 8.0 (https://github.com/actions/virtual-environments/issues/2157#issuecomment-735779081) in the meantime. Therefore, we need to explicitly set up our preferred PHP version before running the unit tests.

php-cs-fixer does not have this problem, because it does not run our code.
E2E-tests also don't have the problem, because they run inside our containers, which only have the correct PHP version installed.