### PR TITLE
Don't try to send a ci-passed event in forks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -150,7 +150,7 @@ jobs:
 
   ci-passed-event:
     name: "Send out CI success event"
-    if: ${{ github.event_name == 'push' }}
+    if: github.event_name == 'push' && github.repository_owner == 'ecamp'
     needs:
       - backend-cs-check
       - frontend-eslint


### PR DESCRIPTION
Forks don't have access to the main repo's secrets. When a branch on a fork is pushed to, CI still runs, but the last step of sending out the CI success event shouldn't happen there (unless the fork owner defines his own REPO_ACCESS_TOKEN in the fork's secrets).

I previously didn't notice this problem because I had defined such a secret in my fork, in order to test the later workflows.