### PR TITLE
docker-hub: use npm ci instead of npm install to build docker images

### DIFF
--- a/.docker-hub/frontend/Dockerfile
+++ b/.docker-hub/frontend/Dockerfile
@@ -5,7 +5,7 @@ COPY common /common
 
 WORKDIR /app
 COPY frontend/package*.json ./
-RUN npm install
+RUN npm ci
 COPY frontend .
 RUN npm run build
 

--- a/.docker-hub/print/Dockerfile
+++ b/.docker-hub/print/Dockerfile
@@ -6,7 +6,7 @@ COPY common /common
 WORKDIR /app
 COPY print .
 
-RUN npm install
+RUN npm ci
 RUN npm run build
 
 # production stage

--- a/.docker-hub/worker-print-puppeteer/Dockerfile
+++ b/.docker-hub/worker-print-puppeteer/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildkite/puppeteer
 WORKDIR /app
 COPY workers/print-puppeteer/package*.json ./
-RUN npm install
+RUN npm ci
 COPY workers/print-puppeteer .
 CMD npm run print

--- a/workers/print-puppeteer/Dockerfile
+++ b/workers/print-puppeteer/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildkite/puppeteer
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 COPY . .
 CMD npm run print


### PR DESCRIPTION
Because npm ci fails if package.json and package-lock.json are
out of sync.
npm install just updates the package-lock.json, and we will never notice,
 because the updated package-lock.json is in the image.

 Issue: #775