### PR TITLE
Update docker e2e cypress version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -161,7 +161,7 @@ jobs:
 
       - run: bash wait-for-container-startup.sh
 
-      - run: docker run -v $PWD:/e2e -w /e2e --network host -e CYPRESS_BASE_URL=http://localhost:3000 cypress/included:3.4.0
+      - run: docker run -v $PWD:/e2e -w /e2e --network host -e CYPRESS_BASE_URL=http://localhost:3000 cypress/included:6.2.1
         working-directory: frontend
 
   coveralls-finished:


### PR DESCRIPTION
I noticed that the continuous integration uses cypress 3.4.0. The current version is 6.2.1