### PR TITLE
Tell renovate about the cypress/included docker image version used in CI

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,12 @@
       "updateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^.github/workflows/continuous-integration.yml$"],
+      "matchStrings": ["(?<depName>cypress/included):(?<currentValue>[0-9.]+)\n"],
+      "datasourceTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
Follow-up for #826

Documentation for regex managers in renovate: https://docs.renovatebot.com/modules/manager/regex/