### PR TITLE
Invitation.vue improvements

### DIFF
--- a/backend/module/eCampApi/src/eCampApi/V1/Rpc/Invitation/InvitationController.php
+++ b/backend/module/eCampApi/src/eCampApi/V1/Rpc/Invitation/InvitationController.php
@@ -9,6 +9,7 @@ use eCamp\Core\Service\InvitationService;
 use eCamp\Lib\Acl\NoAccessException;
 use eCamp\Lib\Hydrator\Resolver\BaseResolver;
 use eCamp\Lib\Service\EntityNotFoundException;
+use eCamp\Lib\Service\EntityValidationException;
 use eCamp\Lib\Service\ServiceUtils;
 use Laminas\ApiTools\Hal\Entity;
 use Laminas\ApiTools\Hal\Link\Link;
@@ -97,8 +98,9 @@ class InvitationController extends RpcController {
     /**
      * @param $inviteKey
      *
-     * @throws EntityNotFoundException
      * @throws NoAccessException
+     * @throws EntityValidationException
+     * @throws EntityNotFoundException
      */
     public function accept($inviteKey): HalJsonModel {
         /** @var Request $request */
@@ -120,6 +122,11 @@ class InvitationController extends RpcController {
             throw new NoAccessException('You cannot fetch your own User', 401);
         } catch (EntityNotFoundException $e) {
             throw new EntityNotFoundException('Not Found', 404);
+        } catch (EntityValidationException $e) {
+            $entityValidationException = new EntityValidationException('Failed to update CampCollaboration', 422);
+            $entityValidationException->setMessages($e->getMessages());
+
+            throw $entityValidationException;
         }
     }
 

--- a/backend/module/eCampApi/test/Rest/UserTest.php
+++ b/backend/module/eCampApi/test/Rest/UserTest.php
@@ -62,7 +62,7 @@ JSON;
 
         $this->assertResponseStatusCode(200);
 
-        $this->assertEquals(1, $this->getResponseContent()->total_items);
+        $this->assertEquals(2, $this->getResponseContent()->total_items);
         $this->assertEquals(10, $this->getResponseContent()->page_size);
         $this->assertEquals("http://{$this->host}{$this->apiEndpoint}?page_size=10&page=1", $this->getResponseContent()->_links->self->href);
         $this->assertEquals($this->user->getId(), $this->getResponseContent()->_embedded->items[0]->id);

--- a/backend/module/eCampCore/src/Hydrator/InvitationHydrator.php
+++ b/backend/module/eCampCore/src/Hydrator/InvitationHydrator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace eCamp\Core\Hydrator;
+
+use eCamp\Core\Service\Invitation;
+use Laminas\Hydrator\HydratorInterface;
+
+class InvitationHydrator implements HydratorInterface {
+    /**
+     * @param object $object
+     */
+    public function extract($object): array {
+        /** @var Invitation $invitation */
+        $invitation = $object;
+
+        return [
+            'campId' => $invitation->getCampId(),
+            'campTitle' => $invitation->getCampTitle(),
+            'userDisplayName' => $invitation->getUserDisplayName(),
+            'userAlreadyInCamp' => $invitation->isUserAlreadyInCamp(),
+        ];
+    }
+
+    /**
+     * @param object $object
+     */
+    public function hydrate(array $data, $object): Invitation {
+        throw new \BadMethodCallException('This method is not implemented, because Invitations are read only');
+    }
+}

--- a/backend/module/eCampCore/src/Repository/CampCollaborationRepository.php
+++ b/backend/module/eCampCore/src/Repository/CampCollaborationRepository.php
@@ -4,13 +4,33 @@ namespace eCamp\Core\Repository;
 
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
+use eCamp\Core\Entity\Camp;
 use eCamp\Core\Entity\CampCollaboration;
+use eCamp\Core\Entity\User;
 
 class CampCollaborationRepository extends EntityRepository {
     public function findByInviteKey(string $inviteKey): ?CampCollaboration {
         $q = $this->createQueryBuilder('c');
         $q->where('c.inviteKey = :inviteKey');
         $q->setParameter('inviteKey', $inviteKey);
+
+        try {
+            $q->setMaxResults(1);
+
+            return $q->getQuery()->getOneOrNullResult();
+        } catch (NonUniqueResultException $e) {
+            // This shouldn't ever happen
+            return null;
+        }
+    }
+
+    public function findByUserAndCamp(User $user, Camp $camp): ?CampCollaboration {
+        $q = $this->createQueryBuilder('c');
+        $q->where('c.user = :user')
+            ->andWhere('c.camp = :camp')
+        ;
+        $q->setParameter('user', $user);
+        $q->setParameter('camp', $camp);
 
         try {
             $q->setMaxResults(1);

--- a/backend/module/eCampCore/src/Service/Invitation.php
+++ b/backend/module/eCampCore/src/Service/Invitation.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace eCamp\Core\Service;
+
+class Invitation {
+    private string $campId;
+    private string $campTitle;
+    private ?string $userDisplayName;
+    private ?bool $userAlreadyInCamp;
+
+    public function __construct(string $campId, string $campTitle, ?string $userDisplayName, ?bool $userAlreadyInCamp) {
+        $this->campId = $campId;
+        $this->campTitle = $campTitle;
+        $this->userDisplayName = $userDisplayName;
+        $this->userAlreadyInCamp = $userAlreadyInCamp;
+    }
+
+    public function getCampId(): string {
+        return $this->campId;
+    }
+
+    public function getCampTitle(): string {
+        return $this->campTitle;
+    }
+
+    public function getUserDisplayName(): ?string {
+        return $this->userDisplayName;
+    }
+
+    public function isUserAlreadyInCamp(): ?bool {
+        return $this->userAlreadyInCamp;
+    }
+}

--- a/backend/module/eCampCore/src/Service/InvitationService.php
+++ b/backend/module/eCampCore/src/Service/InvitationService.php
@@ -20,12 +20,35 @@ class InvitationService {
 
     public function __construct(ServiceUtils $serviceUtils, AuthenticationService $authenticationService, UserService $userService) {
         $this->authenticationService = $authenticationService;
-        $this->campCollaborationRepository = $serviceUtils->emGetRepository(CampCollaboration::class);
+        /** @var CampCollaborationRepository $entityRepository */
+        $entityRepository = $serviceUtils->emGetRepository(CampCollaboration::class);
+        $this->campCollaborationRepository = $entityRepository;
         $this->userService = $userService;
     }
 
-    public function findInvitation(string $inviteKey): ?CampCollaboration {
-        return $this->campCollaborationRepository->findByInviteKey($inviteKey);
+    /**
+     * @throws EntityNotFoundException
+     * @throws NoAccessException
+     * @throws NonUniqueResultException
+     */
+    public function findInvitation(string $inviteKey): ?Invitation {
+        $campCollaboration = $this->campCollaborationRepository->findByInviteKey($inviteKey);
+        if (null == $campCollaboration) {
+            return null;
+        }
+        $camp = $campCollaboration->getCamp();
+        $userDisplayName = null;
+        $userAlreadyInCamp = null;
+        $userId = $this->authenticationService->getIdentity();
+        if (null != $userId) {
+            /** @var User $user */
+            $user = $this->userService->fetch($userId);
+            $userDisplayName = $user->getDisplayName();
+            $existingCampCollaboration = $this->campCollaborationRepository->findByUserAndCamp($user, $camp);
+            $userAlreadyInCamp = null != $existingCampCollaboration;
+        }
+
+        return new Invitation($camp->getId(), $camp->getTitle(), $userDisplayName, $userAlreadyInCamp);
     }
 
     /**
@@ -34,8 +57,9 @@ class InvitationService {
      * @throws NoAccessException
      * @throws EntityValidationException
      */
-    public function acceptInvitation(string $inviteKey, string $userId): CampCollaboration {
-        $campCollaboration = $this->findInvitation($inviteKey);
+    public function acceptInvitation(string $inviteKey, string $userId): Invitation {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = $this->campCollaborationRepository->findByInviteKey($inviteKey);
         if (null == $campCollaboration) {
             throw new EntityNotFoundException();
         }
@@ -47,7 +71,13 @@ class InvitationService {
         $camp = $campCollaboration->getCamp();
         $existingCampCollaboration = $this->campCollaborationRepository->findByUserAndCamp($user, $camp);
         if (null != $existingCampCollaboration) {
-            throw (new EntityValidationException())->setMessages(['user' => ['alreadyInCamp' => "This user is already associated with the camp {$camp->getId()}"]]);
+            throw (new EntityValidationException())->setMessages(
+                [
+                    'user' => [
+                        'alreadyInCamp' => "The user {$user->getDisplayName()} is already associated with the camp {$camp->getTitle()}",
+                    ],
+                ]
+            );
         }
         $campCollaboration->setUser($user);
         $campCollaboration->setStatus(CampCollaboration::STATUS_ESTABLISHED);
@@ -55,14 +85,15 @@ class InvitationService {
         $campCollaboration->setInviteEmail(null);
         $this->campCollaborationRepository->saveWithoutAcl($campCollaboration);
 
-        return $campCollaboration;
+        return new Invitation($camp->getId(), $camp->getTitle(), $user->getDisplayName(), true);
     }
 
     /**
      * @throws EntityNotFoundException
      */
-    public function rejectInvitation(string $inviteKey): CampCollaboration {
-        $campCollaboration = $this->findInvitation($inviteKey);
+    public function rejectInvitation(string $inviteKey): Invitation {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = $this->campCollaborationRepository->findByInviteKey($inviteKey);
         if (null == $campCollaboration) {
             throw new EntityNotFoundException();
         }
@@ -70,6 +101,8 @@ class InvitationService {
         $campCollaboration->setInviteKey(null);
         $this->campCollaborationRepository->saveWithoutAcl($campCollaboration);
 
-        return $campCollaboration;
+        $camp = $campCollaboration->getCamp();
+
+        return new Invitation($camp->getId(), $camp->getTitle(), null, null);
     }
 }

--- a/backend/module/eCampCore/src/Service/InvitationService.php
+++ b/backend/module/eCampCore/src/Service/InvitationService.php
@@ -70,7 +70,7 @@ class InvitationService {
         }
         $camp = $campCollaboration->getCamp();
         $existingCampCollaboration = $this->campCollaborationRepository->findByUserAndCamp($user, $camp);
-        if (null != $existingCampCollaboration) {
+        if (null != $existingCampCollaboration && $existingCampCollaboration->isEstablished()) {
             throw (new EntityValidationException())->setMessages(
                 [
                     'user' => [

--- a/backend/module/eCampCore/src/Service/InvitationService.php
+++ b/backend/module/eCampCore/src/Service/InvitationService.php
@@ -45,7 +45,7 @@ class InvitationService {
             $user = $this->userService->fetch($userId);
             $userDisplayName = $user->getDisplayName();
             $existingCampCollaboration = $this->campCollaborationRepository->findByUserAndCamp($user, $camp);
-            $userAlreadyInCamp = null != $existingCampCollaboration;
+            $userAlreadyInCamp = null != $existingCampCollaboration && $existingCampCollaboration->isEstablished();
         }
 
         return new Invitation($camp->getId(), $camp->getTitle(), $userDisplayName, $userAlreadyInCamp);

--- a/backend/module/eCampCore/test/Data/UserTestData.php
+++ b/backend/module/eCampCore/test/Data/UserTestData.php
@@ -9,6 +9,7 @@ use eCamp\Core\Entity\User;
 
 class UserTestData extends AbstractFixture {
     public static $USER1 = User::class.':USER1';
+    public static $USER2 = User::class.':USER2';
 
     public function load(ObjectManager $manager) {
         $user = new User();
@@ -25,5 +26,20 @@ class UserTestData extends AbstractFixture {
         $manager->flush();
 
         $this->addReference(self::$USER1, $user);
+
+        $user = new User();
+        $user->setUsername('NameWhichYouDontGuessInUnitTests');
+        $user->setRole(User::ROLE_USER);
+        $user->setTrustedMailAddress('NameWhichYouDontGuessInUnitTests@ecamp3.dev');
+        $user->setState(User::STATE_ACTIVATED);
+
+        $login = new Login($user, 'test2');
+
+        $manager->persist($user);
+        $manager->persist($login);
+
+        $manager->flush();
+
+        $this->addReference(self::$USER2, $user);
     }
 }

--- a/backend/module/eCampLib/test/V1/Rpc/Invitation/InvitationControllerTest.php
+++ b/backend/module/eCampLib/test/V1/Rpc/Invitation/InvitationControllerTest.php
@@ -15,7 +15,10 @@ use eCamp\LibTest\PHPUnit\AbstractApiControllerTestCase;
  */
 class InvitationControllerTest extends AbstractApiControllerTestCase {
     /** @var User */
-    protected $user;
+    protected $userAlreadyInCamp;
+
+    /** @var User */
+    private $newUser;
 
     private $apiEndpoint = '/api/invitation';
     private $camp;
@@ -37,7 +40,8 @@ class InvitationControllerTest extends AbstractApiControllerTestCase {
         $loader->addFixture($campCollaborationTestData);
         $this->loadFixtures($loader);
 
-        $this->user = $userLoader->getReference(UserTestData::$USER1);
+        $this->userAlreadyInCamp = $userLoader->getReference(UserTestData::$USER1);
+        $this->newUser = $userLoader->getReference(UserTestData::$USER2);
         $this->camp = $campLoader->getReference(CampTestData::$CAMP1);
         $this->campCollaborationInvited = $campCollaborationTestData->getReference(CampCollaborationTestData::$COLLAB_INVITED);
     }
@@ -96,8 +100,15 @@ JSON;
         $this->assertResponseStatusCode(401);
     }
 
+    public function testAcceptInvitationWithUserAlreadyInCamp() {
+        $this->authenticateUser($this->userAlreadyInCamp);
+        $this->dispatch("{$this->apiEndpoint}/accept/{$this->campCollaborationInvited->getInviteKey()}", 'POST');
+
+        $this->assertResponseStatusCode(422);
+    }
+
     public function testAcceptInvitation() {
-        $this->authenticateUser($this->user);
+        $this->authenticateUser($this->newUser);
         $this->dispatch("{$this->apiEndpoint}/accept/{$this->campCollaborationInvited->getInviteKey()}", 'POST');
 
         $this->assertResponseStatusCode(200);

--- a/backend/module/eCampLib/test/V1/Rpc/Invitation/InvitationControllerTest.php
+++ b/backend/module/eCampLib/test/V1/Rpc/Invitation/InvitationControllerTest.php
@@ -57,27 +57,78 @@ class InvitationControllerTest extends AbstractApiControllerTestCase {
 
         $this->assertResponseStatusCode(200);
 
+        $camp = $this->campCollaborationInvited->getCamp();
         $expectedBody = <<<JSON
             {
-                "id": "{$this->campCollaborationInvited->getId()}",
-                "role": "{$this->campCollaborationInvited->getRole()}",
-                "status": "{$this->campCollaborationInvited->getStatus()}",
-                "inviteEmail": "{$this->campCollaborationInvited->getInviteEmail()}",
-                "user": null
+                "campId": "{$camp->getId()}",
+                "campTitle": "{$camp->getTitle()}",
+                "userDisplayName": null,
+                "userAlreadyInCamp": null
             }
 JSON;
 
-        $expectedLinks = <<<JSON
+        $expectedLinks = <<<'JSON'
         {
            "self":{
-              "href":"http:///api/camp-collaborations/{$this->campCollaborationInvited->getId()}"
+              "href":"http:///api/invitation/find"
            }
         }
 JSON;
-        $expectedEmbeddedObjects = ['camp'];
+        $expectedEmbeddedObjects = [];
 
-        $responseContent = $this->getResponseContent();
-        self::assertThat($responseContent->_embedded->camp->title, self::logicalNot(self::isEmpty()));
+        $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
+    }
+
+    public function testFindsInvitationWhenLoggedIn() {
+        $this->authenticateUser($this->newUser);
+        $this->dispatch("{$this->apiEndpoint}/find/{$this->campCollaborationInvited->getInviteKey()}", 'GET');
+
+        $this->assertResponseStatusCode(200);
+
+        $expectedBody = <<<JSON
+            {
+                "campId": "{$this->campCollaborationInvited->getCamp()->getId()}",
+                "campTitle": "{$this->campCollaborationInvited->getCamp()->getTitle()}",
+                "userDisplayName": "{$this->newUser->getDisplayName()}",
+                "userAlreadyInCamp": false
+            }
+JSON;
+
+        $expectedLinks = <<<'JSON'
+        {
+           "self":{
+              "href":"http:///api/invitation/find"
+           }
+        }
+JSON;
+        $expectedEmbeddedObjects = [];
+
+        $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
+    }
+
+    public function testFindsInvitationWhenAlreadyInCamp() {
+        $this->authenticateUser($this->userAlreadyInCamp);
+        $this->dispatch("{$this->apiEndpoint}/find/{$this->campCollaborationInvited->getInviteKey()}", 'GET');
+
+        $this->assertResponseStatusCode(200);
+
+        $expectedBody = <<<JSON
+            {
+                "campId": "{$this->campCollaborationInvited->getCamp()->getId()}",
+                "campTitle": "{$this->campCollaborationInvited->getCamp()->getTitle()}",
+                "userDisplayName": "{$this->userAlreadyInCamp->getDisplayName()}",
+                "userAlreadyInCamp": true
+            }
+JSON;
+
+        $expectedLinks = <<<'JSON'
+        {
+           "self":{
+              "href":"http:///api/invitation/find"
+           }
+        }
+JSON;
+        $expectedEmbeddedObjects = [];
 
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -137,7 +137,7 @@
     },
     "invitation" : {
       "acceptCurrentAuth" : "Accept invitation with current account",
-      "backToLogin" : "Back to Login",
+      "backToHome" : "Back to Home",
       "error" : "An unexpected error occurred",
       "login": "Login",
       "notFound" : "This invitation is already accepted or was deleted",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -137,6 +137,7 @@
     },
     "invitation" : {
       "acceptCurrentAuth" : "Accept invitation with current account",
+      "error" : "An unexpected error occurred",
       "login": "Login",
       "notFound" : "This invitation is already accepted or was deleted",
       "register" : "Register",
@@ -145,7 +146,8 @@
       "useOtherAuth" : "Use another account",
       "userAlreadyInCamp" : "You are already part of this camp",
       "userWelcome" : "Welcome",
-      "openCamp" : "Open camp"
+      "openCamp" : "Open camp",
+      "successfullyRejected" : "The invitation was successfully rejected"
     },
     "layout": {
       "authContainer": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -137,6 +137,7 @@
     },
     "invitation" : {
       "acceptCurrentAuth" : "Accept invitation with current account",
+      "backToLogin" : "Back to Login",
       "error" : "An unexpected error occurred",
       "login": "Login",
       "notFound" : "This invitation is already accepted or was deleted",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -142,7 +142,8 @@
       "register" : "Register",
       "reject" : "Deny invitation",
       "title" : "Invitation to Camp",
-      "useOtherAuth" : "Use another account"
+      "useOtherAuth" : "Use another account",
+      "userWelcome" : "Welcome"
     },
     "layout": {
       "authContainer": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -143,7 +143,9 @@
       "reject" : "Deny invitation",
       "title" : "Invitation to Camp",
       "useOtherAuth" : "Use another account",
-      "userWelcome" : "Welcome"
+      "userAlreadyInCamp" : "You are already part of this camp",
+      "userWelcome" : "Welcome",
+      "openCamp" : "Open camp"
     },
     "layout": {
       "authContainer": {

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -103,9 +103,25 @@ export default new Router({
       props: {
         default: route => {
           return {
-            campCollaboration: campCollaborationsFromInviteKey(route.params.inviteKey)
+            invitation: invitationFromInviteKey(route.params.inviteKey)
           }
         }
+      }
+    },
+    {
+      path: '/camps/invitation/rejected',
+      name: 'invitationRejected',
+      components: {
+        navigation: NavigationAuth,
+        default: () => import(/* webpackChunkName: "login" */ './views/camp/InvitationRejected')
+      }
+    },
+    {
+      path: '/camps/invitation/updateError',
+      name: 'invitationUpdateError',
+      components: {
+        navigation: NavigationAuth,
+        default: () => import(/* webpackChunkName: "login" */ './views/camp/InvitationUpdateError')
       }
     },
     {
@@ -241,7 +257,7 @@ export function campFromRoute (route) {
   }
 }
 
-export function campCollaborationsFromInviteKey (inviteKey) {
+export function invitationFromInviteKey (inviteKey) {
   return function () {
     return this.api.get().invitation({ action: 'find', inviteKey: inviteKey })
   }

--- a/frontend/src/views/camp/Invitation.vue
+++ b/frontend/src/views/camp/Invitation.vue
@@ -61,6 +61,12 @@
     <v-alert v-else type="error">
       {{ this.$tc('components.invitation.error') }}
     </v-alert>
+    <v-btn color="primary"
+           x-large
+           class="my-4" block
+           :to="backToLogin">
+      {{ this.$tc('components.invitation.backToLogin') }}
+    </v-btn>
   </auth-container>
 </template>
 
@@ -99,6 +105,9 @@ export default {
         return undefined
       }
       return this.campCollaboration().status === 'invited'
+    },
+    backToLogin () {
+      return loginRoute()
     },
     isLoggedIn () {
       return this.$auth.isLoggedIn()

--- a/frontend/src/views/camp/Invitation.vue
+++ b/frontend/src/views/camp/Invitation.vue
@@ -1,6 +1,7 @@
 <template>
   <auth-container>
     <div v-if="invitationFound !== false && campCollaborationOpen !== false">
+      <h1 v-if="isLoggedIn" class="display-1">{{ this.$tc('components.invitation.userWelcome') }} {{ userDisplayName }}</h1>
       <h1 class="display-1">{{ this.$tc('components.invitation.title') }} {{ camp ? camp.title : '' }}</h1>
 
       <v-spacer />
@@ -73,12 +74,18 @@ export default {
     },
     loginLink () {
       return loginRoute(this.$route.fullPath)
+    },
+    userDisplayName () {
+      return this.api.get().profile().displayName
     }
   },
   mounted: function () {
     this.campCollaboration()._meta.load.then(
       () => { this.invitationFound = true },
       () => { this.invitationFound = false })
+    if (this.$auth.isLoggedIn() === true) {
+      this.api.get().profile()
+    }
   },
   methods: {
     useAnotherAccount () {

--- a/frontend/src/views/camp/InvitationRejected.vue
+++ b/frontend/src/views/camp/InvitationRejected.vue
@@ -1,0 +1,25 @@
+<template>
+  <auth-container>
+    <v-alert type="info">
+      {{ this.$tc('components.invitation.successfullyRejected') }}
+    </v-alert>
+    <v-btn color="primary"
+           x-large
+           class="my-4" block
+           :to="{ name: 'home' }">
+      {{ this.$tc('components.invitation.backToHome') }}
+    </v-btn>
+  </auth-container>
+</template>
+
+<script>
+import AuthContainer from '@/components/layout/AuthContainer'
+export default {
+  name: 'InvitationRejected',
+  components: { AuthContainer }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/views/camp/InvitationUpdateError.vue
+++ b/frontend/src/views/camp/InvitationUpdateError.vue
@@ -1,0 +1,25 @@
+<template>
+  <auth-container>
+    <v-alert type="error">
+      {{ this.$tc('components.invitation.error') }}
+    </v-alert>
+    <v-btn color="primary"
+           x-large
+           class="my-4" block
+           :to="{ name: 'home' }">
+      {{ this.$tc('components.invitation.backToHome') }}
+    </v-btn>
+  </auth-container>
+</template>
+
+<script>
+import AuthContainer from '@/components/layout/AuthContainer'
+export default {
+  name: 'InvitationUpdateError',
+  components: { AuthContainer }
+}
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
This PR fixes the following points in #631
- [ ] Wenn man auf den Einladungslink in der E-Mail klickt, dann kommt man auf einer Seite mit folgenden Möglichkeiten:
    - [ ] Der InviteKey wurde gefunden, man ist nicht eingeloggt:
        - [x] Login -> funktioniert
        - [x] Reject , der Status wechselt auf LEFT
    - Der InviteKey wurde gefunden, man ist eingeloggt:
        - [x] displayName des momentan verwendeten Accounts
        - [x] Deny, der Status wechselt auf LEFT
- [x] ~~If logged in~~, display some kind of "Cancel" link on the invitation accept page that brings the user back to the Home page
- [x] Nicht erlauben, dass ein User zwei mal eine Invitation akzeptieren kann