### PR TITLE
Prevent the weasy print worker from spamming Sentry

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -9,7 +9,6 @@ inputs:
   ssh-username:
     description: 'The SSH username that will be used to log in to the server'
     required: false
-    default: root
 
   ssh-host:
     description: 'The SSH server where to deploy'
@@ -18,32 +17,26 @@ inputs:
   ssh-directory:
     description: 'The directory on the SSH server where to deploy'
     required: false
-    default: ecamp3
 
   db-host:
     description: 'The URL of the database server'
     required: false
-    default: db
 
   db-port:
     description: 'The port on which the database server listens'
     required: false
-    default: '3306'
 
   db-user:
     description: 'The username that will be used to log in to the database'
     required: false
-    default: ecamp3
 
   db-pass:
     description: 'The password that will be used to log in to the database'
     required: false
-    default: ecamp3
 
   db-name:
     description: 'The database name in the database server'
     required: false
-    default: ecamp3dev
 
   session-cookie-domain:
     description: 'The domain that will be used for the session cookie. All services should be on subdomains of this domain.'
@@ -56,7 +49,6 @@ inputs:
   internal-backend-url:
     description: 'The internal address via which the API server can be reached'
     required: false
-    default: 'http://backend/api'
 
   frontend-url:
     description: 'The location of the application'
@@ -73,57 +65,46 @@ inputs:
   sentry-backend-dsn:
     description: 'DSN for reporting backend errors to sentry'
     required: false
-    default: ''
 
   sentry-frontend-dsn:
     description: 'DSN for reporting frontend errors to sentry'
     required: false
-    default: ''
 
   sentry-print-dsn:
     description: 'DSN for reporting errors in the print service to sentry'
     required: false
-    default: ''
 
   sentry-worker-print-puppeteer-dsn:
     description: 'DSN for reporting errors in the puppeteer print worker to sentry'
     required: false
-    default: ''
 
   sentry-worker-print-weasy-dsn:
     description: 'DSN for reporting errors in the weasy print worker to sentry'
     required: false
-    default: ''
 
   rabbitmq-host:
     description: 'The URL of the RabbitMQ server'
     required: false
-    default: rabbitmq
 
   rabbitmq-port:
     description: 'The port on which the RabbitMQ server listens'
     required: false
-    default: '5672'
 
   rabbitmq-vhost:
     description: 'The vhost used on the RabbitMQ server for this application'
     required: false
-    default: '/'
 
   rabbitmq-user:
     description: 'The username that will be used to log in to the RabbitMQ server'
     required: false
-    default: guest
 
   rabbitmq-pass:
     description: 'The password that will be used to log in to the RabbitMQ server'
     required: false
-    default: guest
 
   version-link-template:
     description: 'An URL template that is used to render the version link in the application'
     required: false
-    default: 'https://github.com/ecamp/ecamp3/commits/{version}'
 
 runs:
   using: "composite"
@@ -134,17 +115,17 @@ runs:
       env:
         COMMIT_SHA: ${{ inputs.commit-sha }}
         SSH_PRIVATE_KEY: ${{ inputs.ssh-private-key }}
-        SSH_USERNAME: ${{ inputs.ssh-username }}
+        SSH_USERNAME: ${{ inputs.ssh-username || 'root' }}
         SSH_HOST: ${{ inputs.ssh-host }}
-        SSH_DIRECTORY: ${{ inputs.ssh-directory }}
-        DB_HOST: ${{ inputs.db-host }}
-        DB_PORT: ${{ inputs.db-port }}
-        DB_USER: ${{ inputs.db-user }}
-        DB_PASS: ${{ inputs.db-pass }}
-        DB_NAME: ${{ inputs.db-name }}
+        SSH_DIRECTORY: ${{ inputs.ssh-directory || 'ecamp3' }}
+        DB_HOST: ${{ inputs.db-host || 'db' }}
+        DB_PORT: ${{ inputs.db-port || '3306' }}
+        DB_USER: ${{ inputs.db-user || 'ecamp3' }}
+        DB_PASS: ${{ inputs.db-pass || 'ecamp3' }}
+        DB_NAME: ${{ inputs.db-name || 'ecamp3dev' }}
         SESSION_COOKIE_DOMAIN: ${{ inputs.session-cookie-domain }}
         BACKEND_URL: ${{ inputs.backend-url }}
-        INTERNAL_BACKEND_URL: ${{ inputs.internal-backend-url }}
+        INTERNAL_BACKEND_URL: ${{ inputs.internal-backend-url || 'http://backend/api' }}
         FRONTEND_URL: ${{ inputs.frontend-url }}
         PRINT_SERVER_URL: ${{ inputs.print-server-url }}
         PRINT_FILE_SERVER_URL: ${{ inputs.print-file-server-url }}
@@ -153,9 +134,9 @@ runs:
         SENTRY_PRINT_DSN: ${{ inputs.sentry-print-dsn }}
         SENTRY_WORKER_PRINT_PUPPETEER_DSN: ${{ inputs.sentry-worker-print-puppeteer-dsn }}
         SENTRY_WORKER_PRINT_WEASY_DSN: ${{ inputs.sentry-worker-print-weasy-dsn }}
-        RABBITMQ_HOST: ${{ inputs.rabbitmq-host }}
-        RABBITMQ_PORT: ${{ inputs.rabbitmq-port }}
-        RABBITMQ_VHOST: ${{ inputs.rabbitmq-vhost }}
-        RABBITMQ_USER: ${{ inputs.rabbitmq-user }}
-        RABBITMQ_PASS: ${{ inputs.rabbitmq-pass }}
-        VERSION_LINK_TEMPLATE: ${{ inputs.version-link-template }}
+        RABBITMQ_HOST: ${{ inputs.rabbitmq-host || 'rabbitmq' }}
+        RABBITMQ_PORT: ${{ inputs.rabbitmq-port || '5672' }}
+        RABBITMQ_VHOST: ${{ inputs.rabbitmq-vhost || '/' }}
+        RABBITMQ_USER: ${{ inputs.rabbitmq-user || 'guest' }}
+        RABBITMQ_PASS: ${{ inputs.rabbitmq-pass || 'guest' }}
+        VERSION_LINK_TEMPLATE: ${{ inputs.version-link-template || 'https://github.com/ecamp/ecamp3/commits/{version}' }}

--- a/workers/print-weasy/print.py
+++ b/workers/print-weasy/print.py
@@ -6,6 +6,7 @@ import pika
 import json
 import requests
 import sys
+import time
 
 from urllib.parse import urlencode
 
@@ -70,7 +71,9 @@ parameters = pika.ConnectionParameters(AMQP_HOST,
 while True:
     try:
         connection = pika.BlockingConnection(parameters)
-    except:
+    except Exception as e:
+        print('[AMQP] Connection error', e)
+        time.sleep(1)
         continue
     break
 


### PR DESCRIPTION
We didn't set a VHOST secret so far since we wanted to use the default value of '/'. But as it turns out, because we still pass the nonexistent secret to the deploy action, the action argument is not filled with the default value. So we need to explicitly use the default values as fallback.

As a consequence of the empty rabbitmq VHOST, the weasy print worker went ahead and produced exceptions in a while: True loop. This busted our sentry event limit overnight. So additionally, I set a timeout of 1 second after a failed connection attempt. In the puppeteer worker it was already done this way.