### PR TITLE
Collaborators vue improvements

### DIFF
--- a/backend/module/eCampApi/test/Rest/CampCollaborationTest.php
+++ b/backend/module/eCampApi/test/Rest/CampCollaborationTest.php
@@ -18,6 +18,8 @@ class CampCollaborationTest extends AbstractApiControllerTestCase {
     /** @var CampCollaboration */
     protected $campCollaborationInvited;
 
+    protected CampCollaboration $campCollaborationLeft;
+
     /** @var User */
     protected $user;
 
@@ -37,6 +39,7 @@ class CampCollaborationTest extends AbstractApiControllerTestCase {
         $this->user = $userLoader->getReference(UserTestData::$USER1);
         $this->campCollaboration1 = $campCollaborationLoader->getReference(CampCollaborationTestData::$COLLAB1);
         $this->campCollaborationInvited = $campCollaborationLoader->getReference(CampCollaborationTestData::$COLLAB_INVITED);
+        $this->campCollaborationLeft = $campCollaborationLoader->getReference(CampCollaborationTestData::$COLLAB_LEFT);
 
         $this->authenticateUser($this->user);
     }
@@ -206,6 +209,18 @@ JSON;
 
         // TODO: this should not be posible (implement ACL & write tests for it)
         $this->assertEquals('manager', $this->getResponseContent()->role);
+    }
+
+    public function testInviteAgain() {
+        $this->setRequestContent([
+            'status' => CampCollaboration::STATUS_INVITED,
+        ]);
+
+        $this->dispatch("{$this->apiEndpoint}/{$this->campCollaborationLeft->getId()}", 'PATCH');
+
+        $this->assertResponseStatusCode(200);
+
+        $this->assertEquals(CampCollaboration::STATUS_INVITED, $this->getResponseContent()->status);
     }
 
     public function testDelete() {

--- a/backend/module/eCampCore/src/Entity/CampCollaboration.php
+++ b/backend/module/eCampCore/src/Entity/CampCollaboration.php
@@ -153,6 +153,10 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
         return self::STATUS_INVITED === $this->status;
     }
 
+    public function isLeft(): bool {
+        return self::STATUS_LEFT === $this->status;
+    }
+
     public function getRole(): string {
         return $this->role;
     }

--- a/backend/module/eCampCore/src/EntityService/CampCollaborationService.php
+++ b/backend/module/eCampCore/src/EntityService/CampCollaborationService.php
@@ -125,14 +125,7 @@ class CampCollaborationService extends AbstractEntityService {
         }
 
         if (CampCollaboration::STATUS_INVITED == $campCollaboration->getStatus() && $campCollaboration->getInviteEmail()) {
-            $uniqid = uniqid('', true);
-            $campCollaboration->setInviteKey($uniqid);
-            $this->sendmailService->sendInviteToCampMail(
-                $authUser,
-                $camp,
-                $uniqid,
-                $campCollaboration->getInviteEmail()
-            );
+            $this->sendInviteEmail($campCollaboration, $authUser, $camp);
         }
 
         return $campCollaboration;
@@ -166,6 +159,8 @@ class CampCollaborationService extends AbstractEntityService {
             $campCollaboration = $this->updateInvitation($campCollaboration, $data);
         } elseif ($campCollaboration->isRequest()) {
             $campCollaboration = $this->updateRequest($campCollaboration, $data);
+        } elseif ($campCollaboration->isLeft()) {
+            $campCollaboration = $this->updateLeft($campCollaboration, $data);
         }
 
         return $campCollaboration;
@@ -227,6 +222,17 @@ class CampCollaborationService extends AbstractEntityService {
         }
 
         return $q;
+    }
+
+    protected function sendInviteEmail(CampCollaboration $campCollaboration, User $authUser, Camp $camp): void {
+        $uniqid = uniqid('', true);
+        $campCollaboration->setInviteKey($uniqid);
+        $this->sendmailService->sendInviteToCampMail(
+            $authUser,
+            $camp,
+            $uniqid,
+            $campCollaboration->getInviteEmail()
+        );
     }
 
     /**
@@ -347,6 +353,30 @@ class CampCollaborationService extends AbstractEntityService {
         }
 
         return $campCollaboration;
+    }
+
+    private function updateLeft(CampCollaboration $campCollaboration, object $data): CampCollaboration {
+        $authUser = $this->getAuthUser();
+        $campCollaborationUser = $campCollaboration->getUser();
+        if ($authUser === $campCollaborationUser) {
+            throw new \Exception('The authenticated user cannot edit his own left CampCollaboration');
+        }
+
+        switch ($data->status) {
+                case CampCollaboration::STATUS_INVITED:
+                    $campCollaboration->setStatus(CampCollaboration::STATUS_INVITED);
+                    $inviteEmail = $campCollaboration->getInviteEmail();
+                    if (null != $campCollaborationUser) {
+                        $inviteEmail = $campCollaborationUser->getTrustedMailAddress();
+                    }
+                    $campCollaboration->setInviteEmail($inviteEmail);
+                    $this->sendInviteEmail($campCollaboration, $authUser, $campCollaboration->getCamp());
+
+                    return $campCollaboration;
+
+                default:
+                    throw (new EntityValidationException())->setMessages(['status' => ['invalidStatus' => "A CampCollaboration with status 'left' can only be updated to status 'invited', was : {$data->status}"]]);
+            }
     }
 
     private function createMaterialList(CampCollaboration $campCollaboration) {

--- a/backend/module/eCampCore/test/Data/CampCollaborationTestData.php
+++ b/backend/module/eCampCore/test/Data/CampCollaborationTestData.php
@@ -12,6 +12,7 @@ use eCamp\Core\Entity\User;
 class CampCollaborationTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $COLLAB1 = CampCollaboration::class.':COLLAB1';
     public static $COLLAB_INVITED = CampCollaboration::class.':COLLAB_INVITED';
+    public static $COLLAB_LEFT = CampCollaboration::class.':COLLAB_LEFT';
 
     public function load(ObjectManager $manager) {
         /** @var Camp $camp */
@@ -42,6 +43,17 @@ class CampCollaborationTestData extends AbstractFixture implements DependentFixt
         $manager->flush();
 
         $this->addReference(self::$COLLAB_INVITED, $campCollaborationInvited);
+
+        $campCollaborationLeft = new CampCollaboration();
+        $campCollaborationLeft->setCamp($camp);
+        $campCollaborationLeft->setInviteEmail('e.mail.left@test.com');
+        $campCollaborationLeft->setRole(CampCollaboration::ROLE_GUEST);
+        $campCollaborationLeft->setStatus(CampCollaboration::STATUS_LEFT);
+
+        $manager->persist($campCollaborationLeft);
+        $manager->flush();
+
+        $this->addReference(self::$COLLAB_LEFT, $campCollaborationLeft);
     }
 
     public function getDependencies() {

--- a/frontend/src/components/buttons/IconButton.vue
+++ b/frontend/src/components/buttons/IconButton.vue
@@ -1,0 +1,27 @@
+<template>
+  <v-btn
+    class="px-3 px-sm-4"
+    min-width="0"
+    :color="color"
+    v-bind="$attrs"
+    v-on="$listeners">
+    <span :class="{'d-sr-only': hideLabel}">
+      <slot />
+    </span>
+    <v-icon :right="!hideLabel" size="150%">{{ icon }}</v-icon>
+  </v-btn>
+</template>
+
+<script>
+export default {
+  name: 'IconButton',
+  props: {
+    icon: { type: String, required: true },
+    hideLabel: { type: Boolean, default: false },
+    color: { type: String, default: 'normal' }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/components/camp/LeftCollaboratorListItem.vue
+++ b/frontend/src/components/camp/LeftCollaboratorListItem.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-list-item class="px-0" two-line>
+    <v-list-item-avatar>
+      <v-img src="https://i.pravatar.cc/300" />
+    </v-list-item-avatar>
+    <v-list-item-content>
+      <v-list-item-title v-if="collaborator.user">
+        {{ collaborator.user().displayName }}
+      </v-list-item-title>
+      <v-list-item-subtitle v-else>
+        {{ collaborator.inviteEmail }}
+      </v-list-item-subtitle>
+    </v-list-item-content>
+  </v-list-item>
+</template>
+
+<script>
+
+export default {
+  name: 'LeftCollaboratorListItem',
+  components: { },
+  props: {
+    collaborator: { type: Object, required: true }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/components/camp/LeftCollaboratorListItem.vue
+++ b/frontend/src/components/camp/LeftCollaboratorListItem.vue
@@ -11,14 +11,24 @@
         {{ collaborator.inviteEmail }}
       </v-list-item-subtitle>
     </v-list-item-content>
+    <v-list-item-action class="ml-5">
+      <icon-button color="normal"
+                   icon="mdi-refresh"
+                   text="inviteAgainText"
+                   @click="api.patch(collaborator, {status: 'invited'})">
+        {{ $tc("components.camp.leftCampCollaboratorListItem.inviteAgain") }}
+      </icon-button>
+    </v-list-item-action>
   </v-list-item>
 </template>
 
 <script>
 
+import IconButton from '@/components/buttons/IconButton'
+
 export default {
   name: 'LeftCollaboratorListItem',
-  components: { },
+  components: { IconButton },
   props: {
     collaborator: { type: Object, required: true }
   }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -105,6 +105,9 @@
       "collaboratorListItem": {
         "remove": "Remove"
       },
+      "leftCampCollaboratorListItem": {
+        "inviteAgain": "Invite again"
+      },
       "periodMaterialLists": {
         "addNewItem": "Add new item"
       },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -348,6 +348,7 @@
       "collaborators": {
         "email": "Email address",
         "invite": "Invite",
+        "leftCollaborators": "Rejected invitations and collaborators which left",
         "members": "Members",
         "openInvitations": "Open invitations",
         "openRequests": "Open requests",

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -86,6 +86,8 @@ import ETextField from '@/components/form/base/ETextField'
 import ESelect from '@/components/form/base/ESelect'
 import LeftCollaboratorListItem from '@/components/camp/LeftCollaboratorListItem'
 
+const DEFAULT_INVITE_ROLE = 'member'
+
 export default {
   name: 'Collaborators',
   components: {
@@ -105,7 +107,7 @@ export default {
       editing: false,
       messages: [],
       inviteEmail: '',
-      inviteRole: 'member'
+      inviteRole: DEFAULT_INVITE_ROLE
     }
   },
   computed: {
@@ -151,6 +153,8 @@ export default {
       }
     },
     refreshCamp () {
+      this.inviteEmail = null
+      this.inviteRole = DEFAULT_INVITE_ROLE
       this.messages = []
       this.api.reload(this.camp()._meta.self)
     }

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -29,6 +29,14 @@ Displays collaborators of a single camp.
         </v-list>
       </content-group>
 
+      <content-group v-if="leftCollaborators.length > 0" :title="$tc('views.camp.collaborators.leftCollaborators')">
+        <v-list>
+          <left-collaborator-list-item
+            v-for="collaborator in leftCollaborators"
+            :key="collaborator._meta.self" :collaborator="collaborator" />
+        </v-list>
+      </content-group>
+
       <content-group :title="$tc('views.camp.collaborators.invite')">
         <v-form @submit.prevent="invite">
           <v-container>
@@ -76,6 +84,7 @@ import CollaboratorListItem from '@/components/camp/CollaboratorListItem'
 import ButtonAdd from '@/components/buttons/ButtonAdd'
 import ETextField from '@/components/form/base/ETextField'
 import ESelect from '@/components/form/base/ESelect'
+import LeftCollaboratorListItem from '@/components/camp/LeftCollaboratorListItem'
 
 export default {
   name: 'Collaborators',
@@ -85,7 +94,8 @@ export default {
     ContentGroup,
     ContentCard,
     ETextField,
-    ESelect
+    ESelect,
+    LeftCollaboratorListItem
   },
   props: {
     camp: { type: Function, required: true }
@@ -110,6 +120,9 @@ export default {
     },
     invitedCollaborators () {
       return this.collaborators.filter(c => c.status === 'invited')
+    },
+    leftCollaborators () {
+      return this.collaborators.filter(c => c.status === 'left')
     },
     inviteEmailMessages () {
       return this.messages.inviteEmail ? Object.values({ ...this.messages.inviteEmail }) : []


### PR DESCRIPTION
#631 
This fixes
- [x]  Man sieht auf der Collaborators Seite auch die CampCollaborations mit Status Left (Dann weiss man, welche E-Mails man nicht mehr senden kann. Es hat einen Knopf daneben: E-Mail erneut senden.
- [x]   Reset Invitation-Form after submit