### PR TITLE
Puppeteer: replace waitFor with waitForTimeout

### DIFF
--- a/workers/print-puppeteer/index.js
+++ b/workers/print-puppeteer/index.js
@@ -41,7 +41,7 @@ async function html2pdf(url, filename, sessionId) {
     // page.setCacheEnabled(false)
     await page.goto(url);
 
-    await page.waitFor(15000);
+    await page.waitForTimeout(15000);
     //await page.waitForSelector(".pagedjs_pages", {timeout:15000}); // TODO: easy to fail, if response takes longer than expected
 
     await page.pdf({path: `data/${filename}-puppeteer.pdf`});


### PR DESCRIPTION
Papppeter startup sais:
waitFor is deprecated and will be removed in a future release. See puppeteer/puppeteer#6214 for details and how to migrate your code.