### PR TITLE
Really tell renovate to use NPM v6 for updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
   ],
   "force": {
     "constraints": {
-      "node": "< 15.0.0"
+      "node": "< 15.0.0",
+      "npm": ">=6.0.0 <7"
     }
   },
   "packageRules": [


### PR DESCRIPTION
Follow-up to #928, which didn't work as expected... The job log still contained `DEBUG: No npm compatibility range found - installing npm latest`, and npm latest is v7 since a few days. v6 is still LTS though.

https://docs.renovatebot.com/configuration-options/#constraints details the correct way to set these constraints.

The recently merged https://github.com/renovatebot/renovate/pull/8506/files contains tests that served as a guide as for how to formulate the constraint.