### PR TITLE
Fix php function return types

### DIFF
--- a/backend/.php_cs
+++ b/backend/.php_cs
@@ -14,7 +14,8 @@ return PhpCsFixer\Config::create()
         '@DoctrineAnnotation' => true,
         '@PhpCsFixer' => true,
         'braces' => ['position_after_functions_and_oop_constructs' => 'same'],
-        'php_unit_test_class_requires_covers' => false
+        'php_unit_test_class_requires_covers' => false,
+        'no_superfluous_phpdoc_tags' => true,
     ])
     ->setFinder($finder)
 ;

--- a/backend/content-type/eCampMultiSelect/src/Entity/Option.php
+++ b/backend/content-type/eCampMultiSelect/src/Entity/Option.php
@@ -25,10 +25,7 @@ class Option extends BaseContentTypeEntity {
      */
     private bool $checked = false;
 
-    /**
-     * @return int
-     */
-    public function getPos() {
+    public function getPos(): int {
         return $this->pos;
     }
 
@@ -39,10 +36,7 @@ class Option extends BaseContentTypeEntity {
         $this->pos = $pos;
     }
 
-    /**
-     * @return string
-     */
-    public function getTranslateKey() {
+    public function getTranslateKey(): string {
         return $this->translateKey;
     }
 
@@ -53,10 +47,7 @@ class Option extends BaseContentTypeEntity {
         $this->translateKey = $translateKey;
     }
 
-    /**
-     * @return bool
-     */
-    public function getChecked() {
+    public function getChecked(): bool {
         return $this->checked;
     }
 

--- a/backend/content-type/eCampMultiSelect/src/Hydrator/OptionHydrator.php
+++ b/backend/content-type/eCampMultiSelect/src/Hydrator/OptionHydrator.php
@@ -9,10 +9,8 @@ use Laminas\Hydrator\HydratorInterface;
 class OptionHydrator implements HydratorInterface {
     /**
      * @param object $object
-     *
-     * @return array
      */
-    public function extract($object) {
+    public function extract($object): array {
         /** @var Option $option */
         $option = $object;
 
@@ -34,10 +32,8 @@ class OptionHydrator implements HydratorInterface {
 
     /**
      * @param object $object
-     *
-     * @return object
      */
-    public function hydrate(array $data, $object) {
+    public function hydrate(array $data, $object): object {
         /** @var Option $option */
         $option = $object;
 

--- a/backend/content-type/eCampMultiSelect/src/Module.php
+++ b/backend/content-type/eCampMultiSelect/src/Module.php
@@ -23,7 +23,7 @@ class Module {
         return $config;
     }
 
-    public function onBootstrap(MvcEvent $e) {
+    public function onBootstrap(MvcEvent $e): void {
         /** @var Acl $acl */
         $acl = $e->getApplication()->getServiceManager()->get(AclInterface::class);
 

--- a/backend/content-type/eCampSingleText/src/Entity/SingleText.php
+++ b/backend/content-type/eCampSingleText/src/Entity/SingleText.php
@@ -19,7 +19,7 @@ class SingleText extends BaseContentTypeEntity {
         return $this->text;
     }
 
-    public function setText(?string $text) {
+    public function setText(?string $text): void {
         $this->text = $text;
     }
 }

--- a/backend/content-type/eCampSingleText/src/Module.php
+++ b/backend/content-type/eCampSingleText/src/Module.php
@@ -37,7 +37,7 @@ class Module {
         return $config;
     }
 
-    public function onBootstrap(MvcEvent $e) {
+    public function onBootstrap(MvcEvent $e): void {
         /** @var Acl $acl */
         $acl = $e->getApplication()->getServiceManager()->get(AclInterface::class);
 

--- a/backend/content-type/eCampStoryboard/src/Controller/SectionActionController.php
+++ b/backend/content-type/eCampStoryboard/src/Controller/SectionActionController.php
@@ -4,6 +4,7 @@ namespace eCamp\ContentType\Storyboard\Controller;
 
 use eCamp\ContentType\Storyboard\Service\SectionService;
 use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\View\Model\ViewModel;
 
 class SectionActionController extends AbstractActionController {
     private SectionService $sectionService;
@@ -12,7 +13,7 @@ class SectionActionController extends AbstractActionController {
         $this->sectionService = $sectionService;
     }
 
-    public function moveUpAction() {
+    public function moveUpAction(): ViewModel {
         $sectionId = $this->params()->fromRoute('sectionId');
 
         $this->sectionService->moveUp($sectionId);
@@ -23,7 +24,7 @@ class SectionActionController extends AbstractActionController {
         );
     }
 
-    public function moveDownAction() {
+    public function moveDownAction(): ViewModel {
         $sectionId = $this->params()->fromRoute('sectionId');
 
         $this->sectionService->moveDown($sectionId);

--- a/backend/content-type/eCampStoryboard/src/Entity/Section.php
+++ b/backend/content-type/eCampStoryboard/src/Entity/Section.php
@@ -42,7 +42,7 @@ class Section extends BaseContentTypeEntity {
         return $this->column1;
     }
 
-    public function setColumn1(?string $text) {
+    public function setColumn1(?string $text): void {
         $this->column1 = $text;
     }
 
@@ -50,7 +50,7 @@ class Section extends BaseContentTypeEntity {
         return $this->column2;
     }
 
-    public function setColumn2(?string $text) {
+    public function setColumn2(?string $text): void {
         $this->column2 = $text;
     }
 
@@ -58,7 +58,7 @@ class Section extends BaseContentTypeEntity {
         return $this->column3;
     }
 
-    public function setColumn3(?string $text) {
+    public function setColumn3(?string $text): void {
         $this->column3 = $text;
     }
 }

--- a/backend/content-type/eCampStoryboard/src/Module.php
+++ b/backend/content-type/eCampStoryboard/src/Module.php
@@ -16,7 +16,7 @@ class Module {
         return ConfigFactory::createConfig('Storyboard', true, 'Section');
     }
 
-    public function onBootstrap(MvcEvent $e) {
+    public function onBootstrap(MvcEvent $e): void {
         /** @var Acl $acl */
         $acl = $e->getApplication()->getServiceManager()->get(AclInterface::class);
 

--- a/backend/content-type/eCampStoryboard/src/Service/SectionService.php
+++ b/backend/content-type/eCampStoryboard/src/Service/SectionService.php
@@ -20,7 +20,7 @@ class SectionService extends BaseContentTypeService {
         );
     }
 
-    public function moveUp($id) {
+    public function moveUp($id): void {
         /** @var Section $section2 */
         $section2 = $this->findEntity(Section::class, $id);
 
@@ -47,7 +47,7 @@ class SectionService extends BaseContentTypeService {
         }
     }
 
-    public function moveDown($id) {
+    public function moveDown($id): void {
         /** @var Section $section1 */
         $section1 = $this->findEntity(Section::class, $id);
 

--- a/backend/content-type/eCampStoryboard/test/SectionTest.php
+++ b/backend/content-type/eCampStoryboard/test/SectionTest.php
@@ -8,7 +8,7 @@ use eCamp\LibTest\PHPUnit\AbstractApiControllerTestCase;
  * @internal
  */
 class SectionTest extends AbstractApiControllerTestCase {
-    public function testSectionMoveUp() {
+    public function testSectionMoveUp(): void {
         $this->dispatch('/api/activity-content/b6612b43/section/b6612b41/move_up', 'GET');
 
         $req = $this->getRequest();

--- a/backend/module/eCampAoT/src/FactoryBuilder.php
+++ b/backend/module/eCampAoT/src/FactoryBuilder.php
@@ -23,11 +23,11 @@ class FactoryBuilder {
         $this->services = \eCampApp::CreateServiceManagerWithoutDi();
     }
 
-    public function setVerbose(bool $verbose = true) {
+    public function setVerbose(bool $verbose = true): void {
         $this->verbose = $verbose;
     }
 
-    public function setOutputDirectory($directory) {
+    public function setOutputDirectory($directory): void {
         $cnf = $this->app->getConfig();
         $cnf['dependencies']['auto']['aot']['directory'] = $directory;
 
@@ -37,7 +37,7 @@ class FactoryBuilder {
         $this->app->getServiceManager()->setAllowOverride($allowOverride);
     }
 
-    public function build() {
+    public function build(): void {
         /** @var ContainerInterface $container */
         $container = $this->app->getServiceManager();
         $generator = $container->get(InjectorGenerator::class);

--- a/backend/module/eCampAoT/test/eCamp/AoT/DiGenerateAotTest.php
+++ b/backend/module/eCampAoT/test/eCamp/AoT/DiGenerateAotTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class DiGenerateAotTest extends AbstractTestCase {
     const GEN_DIRECTORY = __DIR__.'/../../../gen_tmp';
 
-    public function testRunsThroughWithoutErrors() {
+    public function testRunsThroughWithoutErrors(): void {
         // delete temporary output folder if it exists
         // should not be the case
         if (file_exists(self::GEN_DIRECTORY)) {

--- a/backend/module/eCampApi/src/eCampApi/ConfigFactory.php
+++ b/backend/module/eCampApi/src/eCampApi/ConfigFactory.php
@@ -103,8 +103,6 @@ class ConfigFactory {
 
     /**
      * Returns Pascal in kebab-case.
-     *
-     * @param mixed $pascal
      */
     private static function pascalToKebabCase($pascal) {
         return ltrim(strtolower(preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '-$0', $pascal)), '-');

--- a/backend/module/eCampApi/src/eCampApi/HalResourceFactory.php
+++ b/backend/module/eCampApi/src/eCampApi/HalResourceFactory.php
@@ -29,10 +29,8 @@ class HalResourceFactory extends ResourceFactory {
 
     /**
      * @param array|Paginator|Traversable $object
-     *
-     * @return Collection
      */
-    public function createCollectionFromMetadata($object, Metadata $metadata) {
+    public function createCollectionFromMetadata($object, Metadata $metadata): Collection {
         $halCollection = parent::createCollectionFromMetadata($object, $metadata);
 
         $collection = $halCollection->getCollection();

--- a/backend/module/eCampApi/src/eCampApi/Module.php
+++ b/backend/module/eCampApi/src/eCampApi/Module.php
@@ -28,7 +28,7 @@ class Module implements ApiToolsProviderInterface {
         ];
     }
 
-    public function onBootstrap(MvcEvent $e) {
+    public function onBootstrap(MvcEvent $e): void {
         Paginator::setDefaultItemCountPerPage(PHP_INT_MAX);
 
         /** @var Application $app */

--- a/backend/module/eCampApi/src/eCampApi/V1/Rpc/ApiController.php
+++ b/backend/module/eCampApi/src/eCampApi/V1/Rpc/ApiController.php
@@ -9,11 +9,14 @@ use Laminas\ApiTools\Hal\Plugin\Hal;
 use Laminas\ApiTools\Hal\View\HalJsonModel;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\MvcEvent;
+use Laminas\Validator\Exception\InvalidArgumentException;
 
 class ApiController extends AbstractActionController {
     public function onDispatch(MvcEvent $e) {
         try {
             $return = parent::onDispatch($e);
+        } catch (InvalidArgumentException $ex) {
+            $return = new ApiProblem(400, $ex->getMessage());
         } catch (\Exception $ex) {
             $return = new ApiProblem(500, $ex->getMessage());
         }
@@ -26,16 +29,14 @@ class ApiController extends AbstractActionController {
             return $problem;
         }
 
-        if ($return instanceof Entity) {
-            $json = new HalJsonModel();
-            $json->setPayload($return);
-
-            $e->setResult($json);
-
-            return $json;
-        }
-
         return $return;
+    }
+
+    protected function entityToHalJsonModel(Entity $entity): HalJsonModel {
+        $json = new HalJsonModel();
+        $json->setPayload($entity);
+
+        return $json;
     }
 
     protected function createHalEntity($entity, $route, $routeIdentifierName) {

--- a/backend/module/eCampApi/src/eCampApi/V1/Rpc/Index/IndexController.php
+++ b/backend/module/eCampApi/src/eCampApi/V1/Rpc/Index/IndexController.php
@@ -8,6 +8,7 @@ use Laminas\ApiTools\Hal\Entity;
 use Laminas\ApiTools\Hal\Link\Link;
 use Laminas\ApiTools\Hal\View\HalJsonModel;
 use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\View\Model\ViewModel;
 
 class IndexController extends AbstractActionController {
     private UserService $userService;
@@ -16,7 +17,7 @@ class IndexController extends AbstractActionController {
         $this->userService = $userService;
     }
 
-    public function indexAction(): HalJsonModel {
+    public function indexAction(): ViewModel {
         $data = [];
         $data['title'] = 'eCamp V3';
 
@@ -61,7 +62,7 @@ class IndexController extends AbstractActionController {
         return $json;
     }
 
-    public function apiAction(): HalJsonModel {
+    public function apiAction(): ViewModel {
         $data = [];
         $data['title'] = 'eCamp V3 - API';
 

--- a/backend/module/eCampApi/src/eCampApi/V1/Rpc/Profile/ProfileController.php
+++ b/backend/module/eCampApi/src/eCampApi/V1/Rpc/Profile/ProfileController.php
@@ -43,16 +43,14 @@ class ProfileController extends AbstractActionController {
             /** @var User $user */
             $user = $this->userService->fetch($userId);
 
-            $data = call_user_func([$this, $method], $user);
-
-            return new HalJsonModel(['payload' => new Entity($data)]);
+            return call_user_func([$this, $method], $user);
         }
 
         return new ApiProblemModel(new ApiProblem(401, null));
     }
 
-    private function getAction(User $user): array {
-        return [
+    private function getAction(User $user): ViewModel {
+        return new HalJsonModel(['payload' => new Entity([
             'self' => Link::factory([
                 'rel' => 'self',
                 'route' => 'e-camp-api.rpc.profile',
@@ -67,13 +65,13 @@ class ProfileController extends AbstractActionController {
             'language' => $user->getLanguage(),
             'birthday' => $user->getBirthday(),
             'isAdmin' => (User::ROLE_ADMIN == $user->getRole()),
-        ];
+        ])]);
     }
 
     /**
      * @throws \Exception
      */
-    private function patchAction(User $user): array {
+    private function patchAction(User $user): ViewModel {
         /** @var Request $request */
         $request = $this->getRequest();
         $content = $request->getContent();

--- a/backend/module/eCampApi/src/eCampApi/V1/Rpc/Register/RegisterController.php
+++ b/backend/module/eCampApi/src/eCampApi/V1/Rpc/Register/RegisterController.php
@@ -4,10 +4,8 @@ namespace eCampApi\V1\Rpc\Register;
 
 use eCamp\Core\Service\RegisterService;
 use eCampApi\V1\Rpc\ApiController;
-use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Laminas\Http\Request;
 use Laminas\Json\Json;
-use Laminas\Mvc\Exception\RuntimeException;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\View\Model\ViewModel;
 
@@ -36,10 +34,6 @@ class RegisterController extends ApiController {
         }
         $data->mailAddress = $data->email;
         $user = $this->registerService->register($data);
-
-        if ($user instanceof ApiProblem) {
-            throw new RuntimeException($user->toArray()['detail']);
-        }
 
         return $this->entityToHalJsonModel($this->createHalEntity($user, 'e-camp-api.rest.doctrine.user', 'userId'));
     }

--- a/backend/module/eCampApi/test/Rest/ActivityResponsibleTest.php
+++ b/backend/module/eCampApi/test/Rest/ActivityResponsibleTest.php
@@ -39,7 +39,7 @@ class ActivityResponsibleTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->activityResponsible->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -62,7 +62,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $activityId = $this->activityResponsible->getActivity()->getId();
         $campCollaborationId = $this->activityResponsible->getCampCollaboration()->getId();
 
@@ -76,7 +76,7 @@ JSON;
         $this->assertEquals($this->activityResponsible->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateDuplicateEntry() {
+    public function testCreateDuplicateEntry(): void {
         $this->setRequestContent([
             'activityId' => $this->activityResponsible->getActivity()->getId(),
             'campCollaborationId' => $this->activityResponsible->getCampCollaboration()->getId(), ]);
@@ -86,7 +86,7 @@ JSON;
         $this->assertResponseStatusCode(500);
     }
 
-    public function testCreateSuccess() {
+    public function testCreateSuccess(): void {
         $activity = new Activity();
         $activity->setCamp($this->activityResponsible->getCamp());
         $activity->setTitle('Activity1');
@@ -104,14 +104,14 @@ JSON;
         $this->assertResponseStatusCode(201);
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->activityResponsible->getId()}", 'PATCH');
 
         // nothing worth updating on this entity
         $this->assertResponseStatusCode(405);
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->activityResponsible->getId()}", 'DELETE');
 
         $this->assertResponseStatusCode(204);

--- a/backend/module/eCampApi/test/Rest/ActivityTest.php
+++ b/backend/module/eCampApi/test/Rest/ActivityTest.php
@@ -51,7 +51,7 @@ class ActivityTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->activity->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -76,7 +76,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $campId = $this->activity->getCamp()->getId();
         $this->dispatch("{$this->apiEndpoint}?page_size=10&campId={$campId}", 'GET');
 
@@ -88,7 +88,7 @@ JSON;
         $this->assertEquals($this->activity->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testFetchAllByPeriod() {
+    public function testFetchAllByPeriod(): void {
         $periodId = $this->activity->getCamp()->getPeriods()->get(0)->getId();
         $this->dispatch("{$this->apiEndpoint}?page_size=10&periodId={$periodId}", 'GET');
 
@@ -114,7 +114,7 @@ JSON;
     }
     */
 
-    public function testCreateWithoutCategory() {
+    public function testCreateWithoutCategory(): void {
         $this->setRequestContent([
             'title' => 'Activity2',
             'categoryId' => 'xxx', ]);
@@ -125,7 +125,7 @@ JSON;
         $this->assertObjectHasAttribute('notFound', $this->getResponseContent()->validation_messages->categoryId);
     }
 
-    public function testCreateSuccess() {
+    public function testCreateSuccess(): void {
         $this->setRequestContent([
             'title' => 'Activity2',
             'categoryId' => $this->activity->getCategory()->getId(), ]);
@@ -136,7 +136,7 @@ JSON;
         $this->assertEquals('Activity2', $this->getResponseContent()->title);
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'title' => 'Activity3',
             'categoryId' => $this->category->getId(), ]);
@@ -149,7 +149,7 @@ JSON;
         $this->assertEquals($this->category->getId(), $this->getResponseContent()->_embedded->category->id);
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->activity->getId()}", 'DELETE');
 
         $this->assertResponseStatusCode(204);

--- a/backend/module/eCampApi/test/Rest/CampCollaborationTest.php
+++ b/backend/module/eCampApi/test/Rest/CampCollaborationTest.php
@@ -44,7 +44,7 @@ class CampCollaborationTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->campCollaboration1->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -73,7 +73,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchOnlyEmail() {
+    public function testFetchOnlyEmail(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->campCollaborationInvited->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -100,7 +100,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $campId = $this->campCollaboration1->getCamp()->getId();
         $userId = $this->user->getId();
         $this->dispatch("{$this->apiEndpoint}?page_size=10&userId={$userId}&campId={$campId}", 'GET');
@@ -113,7 +113,7 @@ JSON;
         $this->assertEquals($this->campCollaboration1->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateWithoutRole() {
+    public function testCreateWithoutRole(): void {
         $this->setRequestContent([
             'role' => '', ]); // TODO: Validierung wär nicht zwingend notwendig. Der Service nimmt einfach 'member' als Default
 
@@ -123,7 +123,7 @@ JSON;
         $this->assertObjectHasAttribute('isEmpty', $this->getResponseContent()->validation_messages->role);
     }
 
-    public function testCreateWithoutCamp() {
+    public function testCreateWithoutCamp(): void {
         $this->setRequestContent([
             'role' => 'member',
             'campId' => 'xxx', ]);
@@ -134,7 +134,7 @@ JSON;
         $this->assertObjectHasAttribute('notFound', $this->getResponseContent()->validation_messages->campId);
     }
 
-    public function testCreateDuplicateEntry() {
+    public function testCreateDuplicateEntry(): void {
         $this->setRequestContent([
             'role' => 'member',
             'campId' => $this->campCollaboration1->getCamp()->getId(),
@@ -146,7 +146,7 @@ JSON;
         $this->assertResponseStatusCode(422);
     }
 
-    public function testCreateDuplicateEntryOnlyWithEmail() {
+    public function testCreateDuplicateEntryOnlyWithEmail(): void {
         $this->setRequestContent([
             'role' => 'member',
             'campId' => $this->campCollaborationInvited->getCamp()->getId(),
@@ -160,7 +160,7 @@ JSON;
         $this->assertResponseStatusCode(422);
     }
 
-    public function testCreateSuccess() {
+    public function testCreateSuccess(): void {
         $user2 = new User();
         $user2->setUsername('test-user2');
         $user2->setRole(User::ROLE_USER);
@@ -181,7 +181,7 @@ JSON;
         $this->assertEquals(CampCollaboration::STATUS_INVITED, $this->getResponseContent()->status);
     }
 
-    public function testCreateOnlyWithEmail() {
+    public function testCreateOnlyWithEmail(): void {
         $inviteEmail = 'my.mail@fantasy.com';
         $this->setRequestContent([
             'role' => CampCollaboration::ROLE_MEMBER,
@@ -199,7 +199,7 @@ JSON;
         $this->assertThat($this->getResponseContent()->user, self::isNull());
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'role' => 'manager', ]);
 
@@ -211,7 +211,7 @@ JSON;
         $this->assertEquals('manager', $this->getResponseContent()->role);
     }
 
-    public function testInviteAgain() {
+    public function testInviteAgain(): void {
         $this->setRequestContent([
             'status' => CampCollaboration::STATUS_INVITED,
         ]);
@@ -223,7 +223,7 @@ JSON;
         $this->assertEquals(CampCollaboration::STATUS_INVITED, $this->getResponseContent()->status);
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $collaborationToDelete = $this->campCollaborationInvited->getId();
         $this->dispatch("{$this->apiEndpoint}/{$collaborationToDelete}", 'DELETE');
 
@@ -234,7 +234,7 @@ JSON;
         self::assertThat($cc, self::isNull());
     }
 
-    public function testUpdateToLeftWhenDeleteAndStatusIsEstablished() {
+    public function testUpdateToLeftWhenDeleteAndStatusIsEstablished(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->campCollaboration1->getId()}", 'DELETE');
 
         $this->assertResponseStatusCode(204);

--- a/backend/module/eCampApi/test/Rest/CampTemplateTest.php
+++ b/backend/module/eCampApi/test/Rest/CampTemplateTest.php
@@ -37,7 +37,7 @@ class CampTemplateTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->campTemplate->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -61,7 +61,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $this->dispatch("{$this->apiEndpoint}?page_size=10", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -72,22 +72,22 @@ JSON;
         $this->assertEquals($this->campTemplate->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateForbidden() {
+    public function testCreateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}", 'POST');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testPatchForbidden() {
+    public function testPatchForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->campTemplate->getId()}", 'PATCH');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testUpdateForbidden() {
+    public function testUpdateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->campTemplate->getId()}", 'PUT');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testDeleteForbidden() {
+    public function testDeleteForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->campTemplate->getId()}", 'DELETE');
         $this->assertResponseStatusCode(405);
     }

--- a/backend/module/eCampApi/test/Rest/CampTest.php
+++ b/backend/module/eCampApi/test/Rest/CampTest.php
@@ -37,7 +37,7 @@ class CampTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("/api/camps/{$this->camp->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -70,7 +70,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $this->dispatch('/api/camps?page_size=10', 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -81,7 +81,7 @@ JSON;
         $this->assertEquals($this->camp->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateWithoutName() {
+    public function testCreateWithoutName(): void {
         $this->setRequestContent([
             'name' => '', ]);
 
@@ -93,7 +93,7 @@ JSON;
         $this->assertObjectHasAttribute('isEmpty', $this->getResponseContent()->validation_messages->motto);
     }
 
-    public function testCreateSuccess() {
+    public function testCreateSuccess(): void {
         $this->setRequestContent([
             'name' => 'CampName2',
             'title' => 'CampTitle',
@@ -107,7 +107,7 @@ JSON;
         $this->assertEquals(CampCollaboration::ROLE_MANAGER, $this->getResponseContent()->role);
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'name' => 'CampName3',
             'title' => 'CampTitle3',
@@ -124,7 +124,7 @@ JSON;
         $this->assertEquals('CampTitle3', $this->camp->getTitle());
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $this->dispatch("/api/camps/{$this->camp->getId()}", 'DELETE');
 
         $this->assertResponseStatusCode(204);

--- a/backend/module/eCampApi/test/Rest/CategoryContentTypeTemplateTest.php
+++ b/backend/module/eCampApi/test/Rest/CategoryContentTypeTemplateTest.php
@@ -45,7 +45,7 @@ class CategoryContentTypeTemplateTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->categoryContentTypeTemplate->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -68,7 +68,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $categoryTemplateId = $this->categoryTemplate->getId();
         $this->dispatch("{$this->apiEndpoint}?page_size=10&categoryTemplateId={$categoryTemplateId}", 'GET');
 
@@ -80,22 +80,22 @@ JSON;
         $this->assertEquals($this->categoryContentTypeTemplate->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateForbidden() {
+    public function testCreateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}", 'POST');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testPatchForbidden() {
+    public function testPatchForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->categoryContentTypeTemplate->getId()}", 'PATCH');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testUpdateForbidden() {
+    public function testUpdateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->categoryContentTypeTemplate->getId()}", 'PUT');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testDeleteForbidden() {
+    public function testDeleteForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->categoryContentTypeTemplate->getId()}", 'DELETE');
         $this->assertResponseStatusCode(405);
     }

--- a/backend/module/eCampApi/test/Rest/CategoryTemplateTest.php
+++ b/backend/module/eCampApi/test/Rest/CategoryTemplateTest.php
@@ -46,7 +46,7 @@ class CategoryTemplateTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->categoryTemplate->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -73,7 +73,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $campTemplateId = $this->campTemplate->getId();
         $this->dispatch("{$this->apiEndpoint}?page_size=10&campTemplateId={$campTemplateId}", 'GET');
 
@@ -85,22 +85,22 @@ JSON;
         $this->assertEquals($this->categoryTemplate->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateForbidden() {
+    public function testCreateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}", 'POST');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testPatchForbidden() {
+    public function testPatchForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->categoryTemplate->getId()}", 'PATCH');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testUpdateForbidden() {
+    public function testUpdateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->categoryTemplate->getId()}", 'PUT');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testDeleteForbidden() {
+    public function testDeleteForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->categoryTemplate->getId()}", 'DELETE');
         $this->assertResponseStatusCode(405);
     }

--- a/backend/module/eCampApi/test/Rest/CategoryTest.php
+++ b/backend/module/eCampApi/test/Rest/CategoryTest.php
@@ -38,7 +38,7 @@ class CategoryTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->category->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -65,7 +65,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $campId = $this->category->getCamp()->getId();
         $this->dispatch("{$this->apiEndpoint}?page_size=10&campId={$campId}", 'GET');
 
@@ -77,7 +77,7 @@ JSON;
         $this->assertEquals($this->category->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateWithoutParams() {
+    public function testCreateWithoutParams(): void {
         $this->setRequestContent(['name' => '']);
 
         $this->dispatch("{$this->apiEndpoint}", 'POST');
@@ -89,7 +89,7 @@ JSON;
         $this->assertObjectHasAttribute('isEmpty', $this->getResponseContent()->validation_messages->numberingStyle);
     }
 
-    public function testCreateWithoutCamp() {
+    public function testCreateWithoutCamp(): void {
         $this->setRequestContent([
             'name' => 'ActivityCategory2',
             'short' => 'AC2',
@@ -104,7 +104,7 @@ JSON;
         $this->assertObjectHasAttribute('notFound', $this->getResponseContent()->validation_messages->campId);
     }
 
-    public function testCreateSuccess() {
+    public function testCreateSuccess(): void {
         $this->setRequestContent([
             'name' => 'ActivityCategory2',
             'short' => 'AC2',
@@ -118,7 +118,7 @@ JSON;
         $this->assertEquals('ActivityCategory2', $this->getResponseContent()->name);
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'name' => 'ActivityCategory3', ]);
 
@@ -129,7 +129,7 @@ JSON;
         $this->assertEquals('ActivityCategory3', $this->getResponseContent()->name);
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->category->getId()}", 'DELETE');
 
         $this->assertResponseStatusCode(204);

--- a/backend/module/eCampApi/test/Rest/ContentTypeTest.php
+++ b/backend/module/eCampApi/test/Rest/ContentTypeTest.php
@@ -38,7 +38,7 @@ class ContentTypeTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->contentType->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -62,7 +62,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, []);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $this->dispatch("{$this->apiEndpoint}?page_size=10", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -73,22 +73,22 @@ JSON;
         $this->assertEquals($this->contentType->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateForbidden() {
+    public function testCreateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}", 'POST');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testPatchForbidden() {
+    public function testPatchForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->contentType->getId()}", 'PATCH');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testUpdateForbidden() {
+    public function testUpdateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->contentType->getId()}", 'PUT');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testDeleteForbidden() {
+    public function testDeleteForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->contentType->getId()}", 'DELETE');
         $this->assertResponseStatusCode(405);
     }

--- a/backend/module/eCampApi/test/Rest/DayTest.php
+++ b/backend/module/eCampApi/test/Rest/DayTest.php
@@ -38,7 +38,7 @@ class DayTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->day->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -63,7 +63,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $periodId = $this->day->getPeriod()->getId();
         $campId = $this->day->getCamp()->getId();
         $this->dispatch("{$this->apiEndpoint}?periodId={$periodId}&campId={$campId}", 'GET');
@@ -77,7 +77,7 @@ JSON;
         $this->assertEquals($this->day->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testFetchAllPaged() {
+    public function testFetchAllPaged(): void {
         $periodId = $this->day->getPeriod()->getId();
         $campId = $this->day->getCamp()->getId();
         $this->dispatch("{$this->apiEndpoint}?page_size=10&periodId={$periodId}&campId={$campId}", 'GET');
@@ -91,7 +91,7 @@ JSON;
         $this->assertEquals($this->day->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreate() {
+    public function testCreate(): void {
         $this->setRequestContent([]);
 
         $this->dispatch("{$this->apiEndpoint}", 'POST');
@@ -100,7 +100,7 @@ JSON;
         $this->assertResponseStatusCode(405); //405 = Method not allowed
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'dayOffset' => 15, ]);
 
@@ -111,7 +111,7 @@ JSON;
         $this->assertResponseStatusCode(400);
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->day->getId()}", 'DELETE');
 
         // Single days should not be deleted via API directly (only by changing the parent Period)

--- a/backend/module/eCampApi/test/Rest/MaterialItemTest.php
+++ b/backend/module/eCampApi/test/Rest/MaterialItemTest.php
@@ -55,7 +55,7 @@ class MaterialItemTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->materialItem->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -82,7 +82,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testCreatePeriodItemSuccess() {
+    public function testCreatePeriodItemSuccess(): void {
         $this->setRequestContent([
             'quantity' => 2,
             'unit' => 'kg',
@@ -99,7 +99,7 @@ JSON;
         $this->assertEquals('water', $this->getResponseContent()->article);
     }
 
-    public function testCreateActivityItemSuccess() {
+    public function testCreateActivityItemSuccess(): void {
         $this->setRequestContent([
             'quantity' => 2,
             'unit' => 'kg',
@@ -116,7 +116,7 @@ JSON;
         $this->assertEquals('water', $this->getResponseContent()->article);
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'quantity' => 10,
             'unit' => 'kg',
@@ -131,7 +131,7 @@ JSON;
         $this->assertEquals('water', $this->getResponseContent()->article);
     }
 
-    public function testDeleteSuccess() {
+    public function testDeleteSuccess(): void {
         $this->dispatch($this->apiEndpoint.'/'.$this->materialItem->getId(), 'DELETE');
 
         $this->assertResponseStatusCode(204);

--- a/backend/module/eCampApi/test/Rest/MaterialListTemplateTest.php
+++ b/backend/module/eCampApi/test/Rest/MaterialListTemplateTest.php
@@ -44,7 +44,7 @@ class MaterialListTemplateTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->materialListTemplate->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -68,7 +68,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $campTemplateId = $this->campTemplate->getId();
         $this->dispatch("{$this->apiEndpoint}?page_size=10&campTemplateId={$campTemplateId}", 'GET');
 
@@ -80,22 +80,22 @@ JSON;
         $this->assertEquals($this->materialListTemplate->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateForbidden() {
+    public function testCreateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}", 'POST');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testPatchForbidden() {
+    public function testPatchForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->materialListTemplate->getId()}", 'PATCH');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testUpdateForbidden() {
+    public function testUpdateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->materialListTemplate->getId()}", 'PUT');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testDeleteForbidden() {
+    public function testDeleteForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->materialListTemplate->getId()}", 'DELETE');
         $this->assertResponseStatusCode(405);
     }

--- a/backend/module/eCampApi/test/Rest/MaterialListTest.php
+++ b/backend/module/eCampApi/test/Rest/MaterialListTest.php
@@ -37,7 +37,7 @@ class MaterialListTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->materialList->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -64,7 +64,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testCreateSuccess() {
+    public function testCreateSuccess(): void {
         $this->setRequestContent([
             'name' => 'NewMaterialList',
             'campId' => $this->materialList->getCamp()->getId(),
@@ -76,7 +76,7 @@ JSON;
         $this->assertEquals('NewMaterialList', $this->getResponseContent()->name);
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'name' => 'NewMaterialListName',
         ]);
@@ -87,7 +87,7 @@ JSON;
         $this->assertEquals('NewMaterialListName', $this->getResponseContent()->name);
     }
 
-    public function testDeleteSuccess() {
+    public function testDeleteSuccess(): void {
         $this->dispatch($this->apiEndpoint.'/'.$this->materialList->getId(), 'DELETE');
 
         $this->assertResponseStatusCode(204);

--- a/backend/module/eCampApi/test/Rest/OrganizationTest.php
+++ b/backend/module/eCampApi/test/Rest/OrganizationTest.php
@@ -38,7 +38,7 @@ class OrganizationTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->organization->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -62,7 +62,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $this->dispatch("{$this->apiEndpoint}?page_size=10", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -73,22 +73,22 @@ JSON;
         $this->assertEquals($this->organization->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateForbidden() {
+    public function testCreateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}", 'POST');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testPatchForbidden() {
+    public function testPatchForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->organization->getId()}", 'PATCH');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testUpdateForbidden() {
+    public function testUpdateForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->organization->getId()}", 'PUT');
         $this->assertResponseStatusCode(405);
     }
 
-    public function testDeleteForbidden() {
+    public function testDeleteForbidden(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->organization->getId()}", 'DELETE');
         $this->assertResponseStatusCode(405);
     }

--- a/backend/module/eCampApi/test/Rest/PeriodTest.php
+++ b/backend/module/eCampApi/test/Rest/PeriodTest.php
@@ -36,7 +36,7 @@ class PeriodTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("/api/periods/{$this->period->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -64,7 +64,7 @@ JSON;
         $this->assertCount(13, $this->getResponseContent()->_embedded->days);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $campId = $this->period->getCamp()->getId();
         $this->dispatch("/api/periods?page_size=10&campId={$campId}", 'GET');
 
@@ -76,7 +76,7 @@ JSON;
         $this->assertEquals($this->period->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateWithoutStartAndEnd() {
+    public function testCreateWithoutStartAndEnd(): void {
         $this->setRequestContent([
             'description' => '', ]);
 
@@ -87,7 +87,7 @@ JSON;
         $this->assertObjectHasAttribute('isEmpty', $this->getResponseContent()->validation_messages->end);
     }
 
-    public function testCreateWithoutCamp() {
+    public function testCreateWithoutCamp(): void {
         $this->setRequestContent([
             'description' => '',
             'start' => '2000-07-05',
@@ -100,7 +100,7 @@ JSON;
         $this->assertObjectHasAttribute('notFound', $this->getResponseContent()->validation_messages->campId);
     }
 
-    public function testCreateSuccess() {
+    public function testCreateSuccess(): void {
         $this->setRequestContent([
             'description' => '',
             'start' => '2000-07-05',
@@ -113,7 +113,7 @@ JSON;
         $this->assertEquals('2000-07-05', $this->getResponseContent()->start);
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'start' => '1999-12-15', ]);
 
@@ -125,7 +125,7 @@ JSON;
         $this->assertEquals('2000-01-13', $this->getResponseContent()->end);
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $this->dispatch("/api/periods/{$this->period->getId()}", 'DELETE');
 
         $this->assertResponseStatusCode(204);

--- a/backend/module/eCampApi/test/Rest/ScheduleEntryTest.php
+++ b/backend/module/eCampApi/test/Rest/ScheduleEntryTest.php
@@ -38,7 +38,7 @@ class ScheduleEntryTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->scheduleEntry->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -68,7 +68,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $activityId = $this->scheduleEntry->getActivity()->getId();
         $this->dispatch("{$this->apiEndpoint}?page_size=10&activityId={$activityId}", 'GET');
 
@@ -80,7 +80,7 @@ JSON;
         $this->assertEquals($this->scheduleEntry->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateWithoutStartAndLength() {
+    public function testCreateWithoutStartAndLength(): void {
         $this->setRequestContent([
             'periodOffset' => '', ]);
 
@@ -91,7 +91,7 @@ JSON;
         $this->assertObjectHasAttribute('isEmpty', $this->getResponseContent()->validation_messages->length);
     }
 
-    public function testCreateWithoutActivity() {
+    public function testCreateWithoutActivity(): void {
         $this->setRequestContent([
             'periodOffset' => 900,
             'length' => 180,
@@ -103,7 +103,7 @@ JSON;
         $this->assertObjectHasAttribute('notFound', $this->getResponseContent()->validation_messages->periodId);
     }
 
-    public function testCreateSuccess() {
+    public function testCreateSuccess(): void {
         $this->setRequestContent([
             'periodOffset' => 900,
             'length' => 180,
@@ -116,7 +116,7 @@ JSON;
         $this->assertEquals(900, $this->getResponseContent()->periodOffset);
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'periodOffset' => 780, ]);
 
@@ -127,7 +127,7 @@ JSON;
         $this->assertEquals(780, $this->getResponseContent()->periodOffset);
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->scheduleEntry->getId()}", 'DELETE');
 
         $this->assertResponseStatusCode(204);

--- a/backend/module/eCampApi/test/Rest/UserTest.php
+++ b/backend/module/eCampApi/test/Rest/UserTest.php
@@ -29,7 +29,7 @@ class UserTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->user->getId()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -57,7 +57,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAll() {
+    public function testFetchAll(): void {
         $this->dispatch("{$this->apiEndpoint}?page_size=10", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -69,7 +69,7 @@ JSON;
     }
 
     // TODO: more tests for user creation + registration necessary to cover all variations
-    public function testCreateSuccess() {
+    public function testCreateSuccess(): void {
         $this->setRequestContent([
             'state' => 'registered',
             'mailAddress' => 'test@test.com',
@@ -83,7 +83,7 @@ JSON;
         $this->assertEquals('unrelated', $this->getResponseContent()->relation);
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'username' => 'test-user5', ]);
 
@@ -94,7 +94,7 @@ JSON;
         $this->assertEquals('test-user5', $this->getResponseContent()->username);
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $this->dispatch("{$this->apiEndpoint}/{$this->user->getId()}", 'DELETE');
 
         $this->assertResponseStatusCode(204);

--- a/backend/module/eCampApi/test/Rpc/AuthTest.php
+++ b/backend/module/eCampApi/test/Rpc/AuthTest.php
@@ -27,7 +27,7 @@ class AuthTest extends AbstractApiControllerTestCase {
         $this->user = $userLoader->getReference(UserTestData::$USER1);
     }
 
-    public function testFetchAsGuest() {
+    public function testFetchAsGuest(): void {
         $this->dispatch("{$this->apiEndpoint}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -72,7 +72,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFetchAsUser() {
+    public function testFetchAsUser(): void {
         $this->authenticateUser($this->user);
         $this->dispatch("{$this->apiEndpoint}", 'GET');
 
@@ -81,7 +81,7 @@ JSON;
         $this->assertEquals('test-user', $this->getResponseContent()->username);
     }
 
-    public function testLogin() {
+    public function testLogin(): void {
         $this->assertNull($this->getAuthenticatedUserId());
 
         $this->setRequestContent([
@@ -95,7 +95,7 @@ JSON;
         $this->assertEquals($this->user->getId(), $this->getAuthenticatedUserId());
     }
 
-    public function testLogout() {
+    public function testLogout(): void {
         $this->authenticateUser($this->user);
         $this->assertEquals($this->user->getId(), $this->getAuthenticatedUserId());
 

--- a/backend/module/eCampApi/test/Rpc/ProfileTest.php
+++ b/backend/module/eCampApi/test/Rpc/ProfileTest.php
@@ -29,7 +29,7 @@ class ProfileTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testFetch() {
+    public function testFetch(): void {
         $this->dispatch("{$this->apiEndpoint}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -61,13 +61,13 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testCreateSuccess() {
+    public function testCreateSuccess(): void {
         $this->dispatch("{$this->apiEndpoint}", 'POST');
 
         $this->assertResponseStatusCode(405);
     }
 
-    public function testUpdateSuccess() {
+    public function testUpdateSuccess(): void {
         $this->setRequestContent([
             'username' => 'test-user5',
             'firstname' => 'firstname',
@@ -90,7 +90,7 @@ JSON;
         $this->assertEquals('1990-07-01', $this->getResponseContent()->birthday);
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $this->dispatch("{$this->apiEndpoint}", 'DELETE');
 
         $this->assertResponseStatusCode(405);

--- a/backend/module/eCampApi/test/Rpc/RegisterTest.php
+++ b/backend/module/eCampApi/test/Rpc/RegisterTest.php
@@ -24,7 +24,7 @@ class RegisterTest extends AbstractApiControllerTestCase {
         $this->dispatch('/api/register', 'POST');
 
         $this->assertResponseStatusCode(400);
-        $this->assertStringContainsString('No eMail', $this->getResponseContent()->detail);
+        $this->assertStringContainsString('No email', $this->getResponseContent()->detail);
     }
 
     public function testRegisterWithoutPassword(): void {

--- a/backend/module/eCampApi/test/Rpc/RegisterTest.php
+++ b/backend/module/eCampApi/test/Rpc/RegisterTest.php
@@ -8,7 +8,7 @@ use eCamp\LibTest\PHPUnit\AbstractApiControllerTestCase;
  * @internal
  */
 class RegisterTest extends AbstractApiControllerTestCase {
-    public function testRegisterWithoutUsername() {
+    public function testRegisterWithoutUsername(): void {
         $this->setRequestContent(['username' => '']);
         $this->dispatch('/api/register', 'POST');
 
@@ -16,7 +16,7 @@ class RegisterTest extends AbstractApiControllerTestCase {
         $this->assertStringContainsString('No username', $this->getResponseContent()->detail);
     }
 
-    public function testRegisterWithoutEmail() {
+    public function testRegisterWithoutEmail(): void {
         $this->setRequestContent([
             'username' => 'test',
             'email' => '',
@@ -27,7 +27,7 @@ class RegisterTest extends AbstractApiControllerTestCase {
         $this->assertStringContainsString('No eMail', $this->getResponseContent()->detail);
     }
 
-    public function testRegisterWithoutPassword() {
+    public function testRegisterWithoutPassword(): void {
         $this->setRequestContent([
             'username' => 'test',
             'email' => 'test@test.com',
@@ -38,7 +38,7 @@ class RegisterTest extends AbstractApiControllerTestCase {
         $this->assertStringContainsString('No password', $this->getResponseContent()->detail);
     }
 
-    public function testRegisterSuccess() {
+    public function testRegisterSuccess(): void {
         $this->setRequestContent([
             'username' => 'test',
             'email' => 'test@test.com',

--- a/backend/module/eCampApi/test/Rpc/RootTest.php
+++ b/backend/module/eCampApi/test/Rpc/RootTest.php
@@ -8,7 +8,7 @@ use eCamp\LibTest\PHPUnit\AbstractApiControllerTestCase;
  * @internal
  */
 class RootTest extends AbstractApiControllerTestCase {
-    public function testRootResponse() {
+    public function testRootResponse(): void {
         $this->dispatch('/', 'GET');
 
         $host = '';
@@ -35,7 +35,7 @@ JSON;
         $this->assertEquals(json_decode($expectedResponse), $this->getResponseContent());
     }
 
-    public function testApiResponse() {
+    public function testApiResponse(): void {
         $this->dispatch('/api', 'GET');
 
         $host = '';

--- a/backend/module/eCampApp.php
+++ b/backend/module/eCampApp.php
@@ -10,15 +10,13 @@ class eCampApp {
     /** @var Application */
     private static $instance;
 
-    /** @return Application */
-    public static function CreateApp() {
+    public static function CreateApp(): Application {
         $config = self::GetAppConfig();
 
         return Application::init($config);
     }
 
-    /** @return ServiceManager */
-    public static function CreateServiceManagerWithoutDi() {
+    public static function CreateServiceManagerWithoutDi(): ServiceManager {
         // remove 'Laminas\Di' config
         $configuration = self::GetAppConfig();
         unset($configuration['modules'][array_search('Laminas\Di', $configuration['modules'])]);
@@ -41,8 +39,7 @@ class eCampApp {
         return $serviceManager;
     }
 
-    /** @return Application */
-    public static function App() {
+    public static function App(): Application {
         if (null == self::$instance) {
             self::$instance = self::CreateApp();
         }
@@ -50,11 +47,11 @@ class eCampApp {
         return self::$instance;
     }
 
-    public static function Reset() {
+    public static function Reset(): void {
         self::$instance = null;
     }
 
-    public static function Run() {
+    public static function Run(): void {
         self::App()->run();
     }
 
@@ -66,23 +63,17 @@ class eCampApp {
         return self::ServiceManager()->get($name);
     }
 
-    /**
-     * @param string $name
-     *
-     * @return \Doctrine\ORM\EntityManager
-     */
-    public static function GetEntityManager($name = 'orm_default') {
+    public static function GetEntityManager(string $name = 'orm_default'): Doctrine\ORM\EntityManager {
         return self::GetService('doctrine.entitymanager.'.$name);
     }
 
-    /** @return Application */
-    public static function CreateSetup() {
+    public static function CreateSetup(): Application {
         $config = self::GetSetupConfig();
 
         return Application::init($config);
     }
 
-    public static function RegisterErrorHandler() {
+    public static function RegisterErrorHandler(): void {
         // if sentry-configuration available, use sentry
         $sentryConfig = __DIR__.'/../config/sentry.config.php';
 
@@ -93,7 +84,7 @@ class eCampApp {
         }
     }
 
-    public static function RegisterWhoops($handler = PrettyPageHandler::class) {
+    public static function RegisterWhoops($handler = PrettyPageHandler::class): void {
         $whoops = new Run();
         $whoops->pushHandler(new $handler());
         $whoops->register();

--- a/backend/module/eCampCore/data/dev/ActivityData.php
+++ b/backend/module/eCampCore/data/dev/ActivityData.php
@@ -19,7 +19,7 @@ class ActivityData extends AbstractFixture implements DependentFixtureInterface,
     public static $EVENT_2_LS = Activity::class.':EVENT_2_LS';
     public static $EVENT_2_LA = Activity::class.':EVENT_2_LA';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(Activity::class);
 
         /** @var Camp $camp */

--- a/backend/module/eCampCore/data/dev/CampCollaborationData.php
+++ b/backend/module/eCampCore/data/dev/CampCollaborationData.php
@@ -10,7 +10,7 @@ use eCamp\Core\Entity\CampCollaboration;
 use eCamp\Core\Entity\User;
 
 class CampCollaborationData extends AbstractFixture implements DependentFixtureInterface {
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(CampCollaboration::class);
         $campRepository = $manager->getRepository(Camp::class);
         $userRepository = $manager->getRepository(User::class);

--- a/backend/module/eCampCore/data/dev/CampData.php
+++ b/backend/module/eCampCore/data/dev/CampData.php
@@ -12,7 +12,7 @@ class CampData extends AbstractFixture implements DependentFixtureInterface {
     public static $CAMP_1 = Camp::class.':CAMP_1';
     public static $CAMP_2 = Camp::class.':CAMP_2';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(Camp::class);
 
         /** @var User $user */

--- a/backend/module/eCampCore/data/dev/CategoryData.php
+++ b/backend/module/eCampCore/data/dev/CategoryData.php
@@ -16,7 +16,7 @@ class CategoryData extends AbstractFixture implements DependentFixtureInterface 
     public static $EVENTCATEGORY_2_LS = Category::class.':EVENTCATEGORY_2_LS';
     public static $EVENTCATEGORY_2_LA = Category::class.':EVENTCATEGORY_2_LA';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(Category::class);
 
         /** @var Camp $camp */

--- a/backend/module/eCampCore/data/dev/GroupMembershipData.php
+++ b/backend/module/eCampCore/data/dev/GroupMembershipData.php
@@ -10,7 +10,7 @@ use eCamp\Core\Entity\GroupMembership;
 use eCamp\Core\Entity\User;
 
 class GroupMembershipData extends AbstractFixture implements DependentFixtureInterface {
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         // disable group code
         return;
         $repository = $manager->getRepository(GroupMembership::class);

--- a/backend/module/eCampCore/data/dev/PeriodData.php
+++ b/backend/module/eCampCore/data/dev/PeriodData.php
@@ -14,7 +14,7 @@ class PeriodData extends AbstractFixture implements DependentFixtureInterface {
     public static $PERIOD_1 = Period::class.':PERIOD_1';
     public static $PERIOD_2 = Period::class.':PERIOD_2';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(Period::class);
 
         /** @var Camp $camp */

--- a/backend/module/eCampCore/data/dev/ScheduleEntryData.php
+++ b/backend/module/eCampCore/data/dev/ScheduleEntryData.php
@@ -17,7 +17,7 @@ class ScheduleEntryData extends AbstractFixture implements DependentFixtureInter
     public static $SCHEDULE_ENTRY_2_LS = Activity::class.':SCHEDULE_ENTRY_2_LS';
     public static $SCHEDULE_ENTRY_2_LA = Activity::class.':SCHEDULE_ENTRY_2_LA';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(ScheduleEntry::class);
 
         /** @var Period $period */

--- a/backend/module/eCampCore/data/dev/UserData.php
+++ b/backend/module/eCampCore/data/dev/UserData.php
@@ -10,7 +10,7 @@ use eCamp\Core\Entity\User;
 class UserData extends AbstractFixture {
     public static $USER = User::class.':USER';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(User::class);
 
         $user = $repository->findOneBy(['username' => 'test-user']);

--- a/backend/module/eCampCore/data/prod/CampTemplateData.php
+++ b/backend/module/eCampCore/data/prod/CampTemplateData.php
@@ -10,7 +10,7 @@ class CampTemplateData extends AbstractFixture {
     public static $PBS_JS_KIDS = CampTemplate::class.':PBS_JS_KIDS';
     public static $PBS_JS_TEEN = CampTemplate::class.':PBS_JS_TEEN';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(CampTemplate::class);
 
         /** @var CampTemplate $campTemplate */

--- a/backend/module/eCampCore/data/prod/CategoryTemplateData.php
+++ b/backend/module/eCampCore/data/prod/CategoryTemplateData.php
@@ -16,7 +16,7 @@ class CategoryTemplateData extends AbstractFixture implements DependentFixtureIn
     public static $PBS_JS_TEEN_LAGERSPORT = 'PBS_JS_TEEN_LAGERSPORT';
     public static $PBS_JS_TEEN_LAGERAKTIVITAET = 'PBS_JS_TEEN_LAGERAKTIVITAET';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(CategoryTemplate::class);
 
         /** @var CampTemplate $pbsJsKids */

--- a/backend/module/eCampCore/data/prod/ContentTypeData.php
+++ b/backend/module/eCampCore/data/prod/ContentTypeData.php
@@ -18,7 +18,7 @@ class ContentTypeData extends AbstractFixture {
     public static $MATERIAL = ContentType::class.':MATERIAL';
     public static $LATHEMATICAREA = ContentType::class.':LATHEMATICAREA';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(ContentType::class);
 
         // Story board (Programmablauf)

--- a/backend/module/eCampCore/data/prod/GroupData.php
+++ b/backend/module/eCampCore/data/prod/GroupData.php
@@ -12,7 +12,7 @@ class GroupData extends AbstractFixture implements DependentFixtureInterface {
     public static $PFADI_LUZERN = Group::class.':PBS:PfadiLuzern';
     public static $PFADI_BASEL = Group::class.':PBS:PfadiBasel';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         // disable group code
         return;
         $repository = $manager->getRepository(Group::class);

--- a/backend/module/eCampCore/data/prod/MaterialListTemplateData.php
+++ b/backend/module/eCampCore/data/prod/MaterialListTemplateData.php
@@ -14,7 +14,7 @@ class MaterialListTemplateData extends AbstractFixture implements DependentFixtu
 
     private ObjectManager $manager;
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $this->manager = $manager;
 
         $repository = $manager->getRepository(MaterialListTemplate::class);

--- a/backend/module/eCampCore/data/prod/OrganizationData.php
+++ b/backend/module/eCampCore/data/prod/OrganizationData.php
@@ -9,7 +9,7 @@ use eCamp\Core\Entity\Organization;
 class OrganizationData extends AbstractFixture {
     public static $PBS = Organization::class.':PBS';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(Organization::class);
 
         $organization = $repository->findOneBy(['name' => 'PBS']);

--- a/backend/module/eCampCore/src/Auth/Adapter/LoginPassword.php
+++ b/backend/module/eCampCore/src/Auth/Adapter/LoginPassword.php
@@ -75,8 +75,6 @@ class LoginPassword implements AdapterInterface {
      *
      * @param int    The Result code, see Zend_Auth_Result
      * @param mixed      The Message, can be a string or array
-     * @param mixed $code
-     * @param mixed $messages
      */
     private function authResult($code, $messages = []): Result {
         if (!is_array($messages)) {

--- a/backend/module/eCampCore/src/Auth/Provider/Hitobito.php
+++ b/backend/module/eCampCore/src/Auth/Provider/Hitobito.php
@@ -31,7 +31,7 @@ abstract class Hitobito extends OAuth2 {
         return $userProfile;
     }
 
-    protected function configure() {
+    protected function configure(): void {
         parent::configure();
         $this->apiBaseUrl = preg_replace('/\/(profile)?$/', '', $this->config->filter('endpoints')->get('profile'));
         $this->authorizeUrl = $this->config->filter('endpoints')->get('authorize');

--- a/backend/module/eCampCore/src/ContentType/BaseContentTypeEntity.php
+++ b/backend/module/eCampCore/src/ContentType/BaseContentTypeEntity.php
@@ -21,7 +21,7 @@ abstract class BaseContentTypeEntity extends BaseEntity implements BelongsToActi
         return $this->activityContent;
     }
 
-    public function setActivityContent(ActivityContent $activityContent) {
+    public function setActivityContent(ActivityContent $activityContent): void {
         $this->activityContent = $activityContent;
     }
 }

--- a/backend/module/eCampCore/src/ContentType/BaseContentTypeService.php
+++ b/backend/module/eCampCore/src/ContentType/BaseContentTypeService.php
@@ -26,8 +26,6 @@ abstract class BaseContentTypeService extends AbstractEntityService {
 
     /**
      * Returns a single contentType entity attached to $activityContentId (1:1 connection).
-     *
-     * @param mixed $activityContentId
      */
     public function findOneByActivityContent($activityContentId): BaseEntity {
         return $this->getRepository()->findOneBy(['activityContent' => $activityContentId]);
@@ -45,8 +43,6 @@ abstract class BaseContentTypeService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws NoAccessException
      * @throws EntityNotFoundException
      * @throws ORMException

--- a/backend/module/eCampCore/src/ContentType/ConfigFactory.php
+++ b/backend/module/eCampCore/src/ContentType/ConfigFactory.php
@@ -8,10 +8,8 @@ class ConfigFactory {
      * @param bool        $multiple   false=single entitity per activityContent; true=multiple entities per activityContent
      * @param null|string $entityName Specify entity name if it deviates from main name
      * @param null|string $namePlural specify non-standard plural names
-     *
-     * @return array
      */
-    public static function createConfig(string $name, bool $multiple = false, ?string $entityName = null, ?string $namePlural = null) {
+    public static function createConfig(string $name, bool $multiple = false, ?string $entityName = null, ?string $namePlural = null): array {
         // used in class namespace (PascalCase)
         $namespace = $name;
 

--- a/backend/module/eCampCore/src/ContentType/ContentTypeStrategyProviderInjector.php
+++ b/backend/module/eCampCore/src/ContentType/ContentTypeStrategyProviderInjector.php
@@ -11,15 +11,15 @@ class ContentTypeStrategyProviderInjector {
         $this->contentTypeStrategyProvider = $contentTypeStrategyProvider;
     }
 
-    public function postLoad(LifecycleEventArgs $eventArgs) {
+    public function postLoad(LifecycleEventArgs $eventArgs): void {
         $this->inject($eventArgs);
     }
 
-    public function prePersist(LifecycleEventArgs $eventArgs) {
+    public function prePersist(LifecycleEventArgs $eventArgs): void {
         $this->inject($eventArgs);
     }
 
-    private function inject(LifecycleEventArgs $eventArgs) {
+    private function inject(LifecycleEventArgs $eventArgs): void {
         $entity = $eventArgs->getEntity();
         if ($entity instanceof ContentTypeStrategyProviderAware) {
             $entity->setContentTypeStrategyProvider($this->contentTypeStrategyProvider);

--- a/backend/module/eCampCore/src/ContentType/ContentTypeStrategyProviderTrait.php
+++ b/backend/module/eCampCore/src/ContentType/ContentTypeStrategyProviderTrait.php
@@ -5,7 +5,7 @@ namespace eCamp\Core\ContentType;
 trait ContentTypeStrategyProviderTrait {
     private ContentTypeStrategyProvider $contentTypeStrategyProvider;
 
-    public function setContentTypeStrategyProvider(ContentTypeStrategyProvider $contentTypeStrategyProvider) {
+    public function setContentTypeStrategyProvider(ContentTypeStrategyProvider $contentTypeStrategyProvider): void {
         $this->contentTypeStrategyProvider = $contentTypeStrategyProvider;
     }
 

--- a/backend/module/eCampCore/src/Controller/Auth/BaseController.php
+++ b/backend/module/eCampCore/src/Controller/Auth/BaseController.php
@@ -109,7 +109,7 @@ abstract class BaseController extends AbstractActionController {
      * @throws InvalidArgumentException
      * @throws UnexpectedValueException
      */
-    public function logoutAction() {
+    public function logoutAction(): void {
         $this->laminasAuthenticationService->clearIdentity();
         $this->getHybridAuthAdapter()->disconnect();
 
@@ -126,7 +126,7 @@ abstract class BaseController extends AbstractActionController {
         return $this->sessionContainer->redirect;
     }
 
-    protected function setRedirect(?string $redirect) {
+    protected function setRedirect(?string $redirect): void {
         if (null == $this->sessionContainer) {
             $this->sessionContainer = new Container(self::SESSION_NAMESPACE);
         }

--- a/backend/module/eCampCore/src/Entity/Activity.php
+++ b/backend/module/eCampCore/src/Entity/Activity.php
@@ -66,7 +66,7 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
      *
      * @param $camp
      */
-    public function setCamp(?Camp $camp) {
+    public function setCamp(?Camp $camp): void {
         $this->camp = $camp;
     }
 
@@ -98,12 +98,12 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
         return $this->activityContents;
     }
 
-    public function addActivityContent(ActivityContent $activityContent) {
+    public function addActivityContent(ActivityContent $activityContent): void {
         $activityContent->setActivity($this);
         $this->activityContents->add($activityContent);
     }
 
-    public function removeActivityContent(ActivityContent $activityContent) {
+    public function removeActivityContent(ActivityContent $activityContent): void {
         $activityContent->setActivity(null);
         $this->activityContents->removeElement($activityContent);
     }
@@ -112,12 +112,12 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
         return $this->scheduleEntries;
     }
 
-    public function addScheduleEntry(ScheduleEntry $scheduleEntry) {
+    public function addScheduleEntry(ScheduleEntry $scheduleEntry): void {
         $scheduleEntry->setActivity($this);
         $this->scheduleEntries->add($scheduleEntry);
     }
 
-    public function removeScheduleEntry(ScheduleEntry $scheduleEntry) {
+    public function removeScheduleEntry(ScheduleEntry $scheduleEntry): void {
         $scheduleEntry->setActivity(null);
         $this->scheduleEntries->removeElement($scheduleEntry);
     }
@@ -126,12 +126,12 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
         return $this->activityResponsibles;
     }
 
-    public function addActivityResponsible(ActivityResponsible $activityResponsible) {
+    public function addActivityResponsible(ActivityResponsible $activityResponsible): void {
         $activityResponsible->setActivity($this);
         $this->activityResponsibles->add($activityResponsible);
     }
 
-    public function removeActivityResponsible(ActivityResponsible $activityResponsible) {
+    public function removeActivityResponsible(ActivityResponsible $activityResponsible): void {
         $activityResponsible->setActivity(null);
         $this->activityResponsibles->removeElement($activityResponsible);
     }

--- a/backend/module/eCampCore/src/Entity/ActivityContent.php
+++ b/backend/module/eCampCore/src/Entity/ActivityContent.php
@@ -126,7 +126,7 @@ class ActivityContent extends BaseEntity implements ContentTypeStrategyProviderA
     }
 
     /** @ORM\PrePersist */
-    public function PrePersist() {
+    public function PrePersist(): void {
         $this->getContentTypeStrategy()->activityContentCreated($this);
     }
 }

--- a/backend/module/eCampCore/src/Entity/ActivityResponsible.php
+++ b/backend/module/eCampCore/src/Entity/ActivityResponsible.php
@@ -29,7 +29,7 @@ class ActivityResponsible extends BaseEntity implements BelongsToCampInterface {
         return $this->activity;
     }
 
-    public function setActivity(?Activity $activity) {
+    public function setActivity(?Activity $activity): void {
         $this->activity = $activity;
     }
 
@@ -41,7 +41,7 @@ class ActivityResponsible extends BaseEntity implements BelongsToCampInterface {
         return $this->campCollaboration;
     }
 
-    public function setCampCollaboration(?CampCollaboration $collaboration) {
+    public function setCampCollaboration(?CampCollaboration $collaboration): void {
         $this->campCollaboration = $collaboration;
     }
 }

--- a/backend/module/eCampCore/src/Entity/Camp.php
+++ b/backend/module/eCampCore/src/Entity/Camp.php
@@ -95,7 +95,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
         return $this->campTemplateId;
     }
 
-    public function setCampTemplateId(?string $campTemplateId) {
+    public function setCampTemplateId(?string $campTemplateId): void {
         $this->campTemplateId = $campTemplateId;
     }
 
@@ -103,7 +103,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
         return $this->name;
     }
 
-    public function setName(?string $name) {
+    public function setName(?string $name): void {
         $this->name = $name;
     }
 
@@ -111,7 +111,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
         return $this->title;
     }
 
-    public function setTitle(?string $title) {
+    public function setTitle(?string $title): void {
         $this->title = $title;
     }
 
@@ -119,7 +119,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
         return $this->motto;
     }
 
-    public function setMotto(?string $motto) {
+    public function setMotto(?string $motto): void {
         $this->motto = $motto;
     }
 
@@ -127,7 +127,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
         return $this->creator;
     }
 
-    public function setCreator(?User $creator) {
+    public function setCreator(?User $creator): void {
         $this->creator = $creator;
     }
 
@@ -135,7 +135,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
         return $this->owner;
     }
 
-    public function setOwner(?AbstractCampOwner $owner) {
+    public function setOwner(?AbstractCampOwner $owner): void {
         if (!$owner instanceof User) {
             throw new \Exception('Owner must be a user. Groups are not (yet) supported.');
         }
@@ -155,12 +155,12 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
         return $this->collaborations;
     }
 
-    public function addCampCollaboration(CampCollaboration $collaboration) {
+    public function addCampCollaboration(CampCollaboration $collaboration): void {
         $collaboration->setCamp($this);
         $this->collaborations->add($collaboration);
     }
 
-    public function removeCampCollaboration(CampCollaboration $collaboration) {
+    public function removeCampCollaboration(CampCollaboration $collaboration): void {
         $collaboration->setCamp(null);
         $this->collaborations->removeElement($collaboration);
     }
@@ -205,12 +205,12 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
         return $this->jobs;
     }
 
-    public function addJob(Job $job) {
+    public function addJob(Job $job): void {
         $job->setCamp($this);
         $this->jobs->add($job);
     }
 
-    public function removeJob(Job $job) {
+    public function removeJob(Job $job): void {
         $job->setCamp(null);
         $this->jobs->removeElement($job);
     }
@@ -261,12 +261,12 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
         return $this->materialLists;
     }
 
-    public function addMaterialList(MaterialList $materialList) {
+    public function addMaterialList(MaterialList $materialList): void {
         $materialList->setCamp($this);
         $this->materialLists->add($materialList);
     }
 
-    public function removeMaterialList(MaterialList $materialList) {
+    public function removeMaterialList(MaterialList $materialList): void {
         $materialList->setCamp(null);
         $this->materialLists->removeElement($materialList);
     }

--- a/backend/module/eCampCore/src/Entity/CampCollaboration.php
+++ b/backend/module/eCampCore/src/Entity/CampCollaboration.php
@@ -94,7 +94,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
         return $this->camp;
     }
 
-    public function setCamp(?Camp $camp) {
+    public function setCamp(?Camp $camp): void {
         $this->camp = $camp;
     }
 
@@ -174,7 +174,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
         return $this->collaborationAcceptedBy;
     }
 
-    public function setCollaborationAcceptedBy(?string $collaborationAcceptedBy) {
+    public function setCollaborationAcceptedBy(?string $collaborationAcceptedBy): void {
         $this->collaborationAcceptedBy = $collaborationAcceptedBy;
     }
 
@@ -182,12 +182,12 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
         return $this->activityResponsibles;
     }
 
-    public function addActivityResponsible(ActivityResponsible $activityResponsible) {
+    public function addActivityResponsible(ActivityResponsible $activityResponsible): void {
         $activityResponsible->setCampCollaboration($this);
         $this->activityResponsibles->add($activityResponsible);
     }
 
-    public function removeActivityResponsible(ActivityResponsible $activityResponsible) {
+    public function removeActivityResponsible(ActivityResponsible $activityResponsible): void {
         $activityResponsible->setCampCollaboration(null);
         $this->activityResponsibles->removeElement($activityResponsible);
     }
@@ -195,7 +195,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
     /**
      * @ORM\PrePersist
      */
-    public function PrePersist() {
+    public function PrePersist(): void {
         parent::PrePersist();
 
         if (in_array($this->status, [self::STATUS_REQUESTED, self::STATUS_UNRELATED])) {

--- a/backend/module/eCampCore/src/Entity/CampTemplate.php
+++ b/backend/module/eCampCore/src/Entity/CampTemplate.php
@@ -39,7 +39,7 @@ class CampTemplate extends BaseEntity {
         return $this->name;
     }
 
-    public function setName(?string $name) {
+    public function setName(?string $name): void {
         $this->name = $name;
     }
 
@@ -47,12 +47,12 @@ class CampTemplate extends BaseEntity {
         return $this->categoryTemplates;
     }
 
-    public function addCategoryTemplate(CategoryTemplate $categoryTemplate) {
+    public function addCategoryTemplate(CategoryTemplate $categoryTemplate): void {
         $categoryTemplate->setCampTemplate($this);
         $this->categoryTemplates->add($categoryTemplate);
     }
 
-    public function removeCategoryTemplate(CategoryTemplate $categoryTemplate) {
+    public function removeCategoryTemplate(CategoryTemplate $categoryTemplate): void {
         $categoryTemplate->setCampTemplate(null);
         $this->categoryTemplates->removeElement($categoryTemplate);
     }
@@ -61,12 +61,12 @@ class CampTemplate extends BaseEntity {
         return $this->materialListTemplates;
     }
 
-    public function addMaterialListTemplate(MaterialListTemplate $materialListTemplate) {
+    public function addMaterialListTemplate(MaterialListTemplate $materialListTemplate): void {
         $materialListTemplate->setCampTemplate($this);
         $this->materialListTemplates->add($materialListTemplate);
     }
 
-    public function removeMaterialListTemplate(MaterialListTemplate $materialListTemplate) {
+    public function removeMaterialListTemplate(MaterialListTemplate $materialListTemplate): void {
         $materialListTemplate->setCampTemplate(null);
         $this->materialListTemplates->removeElement($materialListTemplate);
     }

--- a/backend/module/eCampCore/src/Entity/Category.php
+++ b/backend/module/eCampCore/src/Entity/Category.php
@@ -68,7 +68,7 @@ class Category extends BaseEntity implements BelongsToCampInterface {
     /**
      * @internal Do not set the {@link Camp} directly on the Category. Instead use {@see Camp::addCategory()}
      */
-    public function setCamp(?Camp $camp) {
+    public function setCamp(?Camp $camp): void {
         $this->camp = $camp;
     }
 
@@ -76,12 +76,12 @@ class Category extends BaseEntity implements BelongsToCampInterface {
         return $this->categoryContentTypes;
     }
 
-    public function addCategoryContentType(CategoryContentType $categoryContentType) {
+    public function addCategoryContentType(CategoryContentType $categoryContentType): void {
         $categoryContentType->setCategory($this);
         $this->categoryContentTypes->add($categoryContentType);
     }
 
-    public function removeCategoryContentType(CategoryContentType $categoryContentType) {
+    public function removeCategoryContentType(CategoryContentType $categoryContentType): void {
         $categoryContentType->setCategory(null);
         $this->categoryContentTypes->removeElement($categoryContentType);
     }
@@ -94,12 +94,12 @@ class Category extends BaseEntity implements BelongsToCampInterface {
         return $this->categoryContents->filter(fn (CategoryContent $cc) => $cc->isRoot());
     }
 
-    public function addCategoryContent(CategoryContent $categoryContent) {
+    public function addCategoryContent(CategoryContent $categoryContent): void {
         $categoryContent->setCategory($this);
         $this->categoryContents->add($categoryContent);
     }
 
-    public function removeCategoryContent(CategoryContent $categoryContent) {
+    public function removeCategoryContent(CategoryContent $categoryContent): void {
         $categoryContent->setCategory(null);
         $this->categoryContents->removeElement($categoryContent);
     }
@@ -108,7 +108,7 @@ class Category extends BaseEntity implements BelongsToCampInterface {
         return $this->categoryTemplateId;
     }
 
-    public function setCategoryTemplateId(?string $categoryTemplateId) {
+    public function setCategoryTemplateId(?string $categoryTemplateId): void {
         $this->categoryTemplateId = $categoryTemplateId;
     }
 
@@ -116,7 +116,7 @@ class Category extends BaseEntity implements BelongsToCampInterface {
         return $this->short;
     }
 
-    public function setShort(?string $short) {
+    public function setShort(?string $short): void {
         $this->short = $short;
     }
 
@@ -124,7 +124,7 @@ class Category extends BaseEntity implements BelongsToCampInterface {
         return $this->name;
     }
 
-    public function setName(?string $name) {
+    public function setName(?string $name): void {
         $this->name = $name;
     }
 
@@ -132,7 +132,7 @@ class Category extends BaseEntity implements BelongsToCampInterface {
         return $this->color;
     }
 
-    public function setColor(?string $color) {
+    public function setColor(?string $color): void {
         $this->color = $color;
     }
 
@@ -140,7 +140,7 @@ class Category extends BaseEntity implements BelongsToCampInterface {
         return $this->numberingStyle;
     }
 
-    public function setNumberingStyle(?string $numberingStyle) {
+    public function setNumberingStyle(?string $numberingStyle): void {
         $this->numberingStyle = $numberingStyle;
     }
 

--- a/backend/module/eCampCore/src/Entity/CategoryContentTypeTemplate.php
+++ b/backend/module/eCampCore/src/Entity/CategoryContentTypeTemplate.php
@@ -28,7 +28,7 @@ class CategoryContentTypeTemplate extends BaseEntity {
         return $this->categoryTemplate;
     }
 
-    public function setCategoryTemplate(?CategoryTemplate $categoryTemplate) {
+    public function setCategoryTemplate(?CategoryTemplate $categoryTemplate): void {
         $this->categoryTemplate = $categoryTemplate;
     }
 
@@ -36,7 +36,7 @@ class CategoryContentTypeTemplate extends BaseEntity {
         return $this->contentType;
     }
 
-    public function setContentType(?ContentType $contentType) {
+    public function setContentType(?ContentType $contentType): void {
         $this->contentType = $contentType;
     }
 }

--- a/backend/module/eCampCore/src/Entity/CategoryTemplate.php
+++ b/backend/module/eCampCore/src/Entity/CategoryTemplate.php
@@ -60,7 +60,7 @@ class CategoryTemplate extends BaseEntity {
         return $this->campTemplate;
     }
 
-    public function setCampTemplate(?CampTemplate $campTemplate) {
+    public function setCampTemplate(?CampTemplate $campTemplate): void {
         $this->campTemplate = $campTemplate;
     }
 
@@ -68,7 +68,7 @@ class CategoryTemplate extends BaseEntity {
         return $this->short;
     }
 
-    public function setShort(?string $short) {
+    public function setShort(?string $short): void {
         $this->short = $short;
     }
 
@@ -76,7 +76,7 @@ class CategoryTemplate extends BaseEntity {
         return $this->name;
     }
 
-    public function setName(?string $name) {
+    public function setName(?string $name): void {
         $this->name = $name;
     }
 
@@ -84,7 +84,7 @@ class CategoryTemplate extends BaseEntity {
         return $this->color;
     }
 
-    public function setColor(?string $color) {
+    public function setColor(?string $color): void {
         $this->color = $color;
     }
 
@@ -92,7 +92,7 @@ class CategoryTemplate extends BaseEntity {
         return $this->numberingStyle;
     }
 
-    public function setNumberingStyle(?string $numberingStyle) {
+    public function setNumberingStyle(?string $numberingStyle): void {
         $this->numberingStyle = $numberingStyle;
     }
 
@@ -100,12 +100,12 @@ class CategoryTemplate extends BaseEntity {
         return $this->categoryContentTypeTemplates;
     }
 
-    public function addCategoryContentTypeTemplate(CategoryContentTypeTemplate $categoryContentTypeTemplate) {
+    public function addCategoryContentTypeTemplate(CategoryContentTypeTemplate $categoryContentTypeTemplate): void {
         $categoryContentTypeTemplate->setCategoryTemplate($this);
         $this->categoryContentTypeTemplates->add($categoryContentTypeTemplate);
     }
 
-    public function removeCategoryContentTypeTemplate(CategoryContentTypeTemplate $categoryContentTypeTemplate) {
+    public function removeCategoryContentTypeTemplate(CategoryContentTypeTemplate $categoryContentTypeTemplate): void {
         $categoryContentTypeTemplate->setCategoryTemplate(null);
         $this->categoryContentTypeTemplates->removeElement($categoryContentTypeTemplate);
     }
@@ -118,12 +118,12 @@ class CategoryTemplate extends BaseEntity {
         return $this->categoryContentTemplates->filter(fn (CategoryContentTemplate $cct) => $cct->isRoot());
     }
 
-    public function addCategoryContentTemplate(CategoryContentTemplate $categoryContentTemplate) {
+    public function addCategoryContentTemplate(CategoryContentTemplate $categoryContentTemplate): void {
         $categoryContentTemplate->setCategoryTemplate($this);
         $this->categoryContentTemplates->add($categoryContentTemplate);
     }
 
-    public function removeCategoryContentTemplate(CategoryContentTemplate $categoryContentTemplate) {
+    public function removeCategoryContentTemplate(CategoryContentTemplate $categoryContentTemplate): void {
         $categoryContentTemplate->setCategoryTemplate(null);
         $this->categoryContentTemplates->removeElement($categoryContentTemplate);
     }

--- a/backend/module/eCampCore/src/Entity/ContentType.php
+++ b/backend/module/eCampCore/src/Entity/ContentType.php
@@ -62,9 +62,6 @@ class ContentType extends BaseEntity {
         $this->jsonConfig = $jsonConfig;
     }
 
-    /**
-     * @return mixed
-     */
     public function getConfig(?string $key = null) {
         if (null != $this->jsonConfig) {
             if (null != $key) {

--- a/backend/module/eCampCore/src/Entity/Day.php
+++ b/backend/module/eCampCore/src/Entity/Day.php
@@ -29,7 +29,7 @@ class Day extends BaseEntity implements BelongsToCampInterface {
         return $this->period;
     }
 
-    public function setPeriod(?Period $period) {
+    public function setPeriod(?Period $period): void {
         $this->period = $period;
     }
 
@@ -41,7 +41,7 @@ class Day extends BaseEntity implements BelongsToCampInterface {
         return $this->dayOffset;
     }
 
-    public function setDayOffset(int $dayOffset) {
+    public function setDayOffset(int $dayOffset): void {
         $this->dayOffset = $dayOffset;
     }
 

--- a/backend/module/eCampCore/src/Entity/Group.php
+++ b/backend/module/eCampCore/src/Entity/Group.php
@@ -106,12 +106,12 @@ class Group extends AbstractCampOwner {
         return $this->children;
     }
 
-    public function addChild(Group $child) {
+    public function addChild(Group $child): void {
         $child->setParent($this);
         $this->children->add($child);
     }
 
-    public function removeChild(Group $child) {
+    public function removeChild(Group $child): void {
         $child->setParent(null);
         $this->children->removeElement($child);
     }
@@ -120,12 +120,12 @@ class Group extends AbstractCampOwner {
         return $this->memberships;
     }
 
-    public function addGroupMembership(GroupMembership $membership) {
+    public function addGroupMembership(GroupMembership $membership): void {
         $membership->setGroup($this);
         $this->memberships->add($membership);
     }
 
-    public function removeGroupMembership(GroupMembership $membership) {
+    public function removeGroupMembership(GroupMembership $membership): void {
         $membership->setGroup(null);
         $this->memberships->removeElement($membership);
     }

--- a/backend/module/eCampCore/src/Entity/GroupMembership.php
+++ b/backend/module/eCampCore/src/Entity/GroupMembership.php
@@ -68,7 +68,7 @@ class GroupMembership extends BaseEntity {
         return $this->group;
     }
 
-    public function setGroup(?Group $group) {
+    public function setGroup(?Group $group): void {
         $this->group = $group;
     }
 
@@ -128,7 +128,7 @@ class GroupMembership extends BaseEntity {
         return $this->membershipAcceptedBy;
     }
 
-    public function setMembershipAcceptedBy(?string $membershipAcceptedBy) {
+    public function setMembershipAcceptedBy(?string $membershipAcceptedBy): void {
         $this->membershipAcceptedBy = $membershipAcceptedBy;
     }
 
@@ -137,7 +137,7 @@ class GroupMembership extends BaseEntity {
      *
      * @throws \Exception
      */
-    public function PrePersist() {
+    public function PrePersist(): void {
         parent::PrePersist();
 
         if (in_array($this->status, [self::STATUS_REQUESTED, self::STATUS_UNRELATED])) {

--- a/backend/module/eCampCore/src/Entity/Job.php
+++ b/backend/module/eCampCore/src/Entity/Job.php
@@ -55,7 +55,7 @@ class Job extends BaseEntity implements BelongsToCampInterface {
         return $this->camp;
     }
 
-    public function setCamp(?Camp $camp) {
+    public function setCamp(?Camp $camp): void {
         $this->camp = $camp;
     }
 
@@ -63,7 +63,7 @@ class Job extends BaseEntity implements BelongsToCampInterface {
         return $this->name;
     }
 
-    public function setName(?string $name) {
+    public function setName(?string $name): void {
         $this->name = $name;
     }
 
@@ -91,12 +91,12 @@ class Job extends BaseEntity implements BelongsToCampInterface {
         return $this->jobResps;
     }
 
-    public function addJobResp(JobResp $jobResp) {
+    public function addJobResp(JobResp $jobResp): void {
         $jobResp->setJob($this);
         $this->jobResps->add($jobResp);
     }
 
-    public function removeJobResp(JobResp $jobResp) {
+    public function removeJobResp(JobResp $jobResp): void {
         $jobResp->setJob(null);
         $this->jobResps->removeElement($jobResp);
     }

--- a/backend/module/eCampCore/src/Entity/JobResp.php
+++ b/backend/module/eCampCore/src/Entity/JobResp.php
@@ -49,7 +49,7 @@ class JobResp extends BaseEntity implements BelongsToCampInterface {
         return $this->day;
     }
 
-    public function setDay(?Day $day) {
+    public function setDay(?Day $day): void {
         $this->day = $day;
     }
 
@@ -65,7 +65,7 @@ class JobResp extends BaseEntity implements BelongsToCampInterface {
         return $this->job;
     }
 
-    public function setJob(?Job $job) {
+    public function setJob(?Job $job): void {
         $this->job = $job;
     }
 
@@ -73,7 +73,7 @@ class JobResp extends BaseEntity implements BelongsToCampInterface {
         return $this->campCollaboration;
     }
 
-    public function setCampCollaboration(?CampCollaboration $collaboration) {
+    public function setCampCollaboration(?CampCollaboration $collaboration): void {
         $this->campCollaboration = $collaboration;
     }
 

--- a/backend/module/eCampCore/src/Entity/Login.php
+++ b/backend/module/eCampCore/src/Entity/Login.php
@@ -86,7 +86,7 @@ class Login extends BaseEntity {
      *
      * @throws \Exception
      */
-    public function resetPassword(string $pwResetKey, string $password, ?int $hashVersion = null) {
+    public function resetPassword(string $pwResetKey, string $password, ?int $hashVersion = null): void {
         if ($this->checkPwResetKey($pwResetKey)) {
             $this->setNewPassword($password, $hashVersion);
         } else {
@@ -101,7 +101,7 @@ class Login extends BaseEntity {
      *
      * @throws \Exception
      */
-    public function changePassword(string $oldPassword, string $newPassword, ?int $hashVersion = null) {
+    public function changePassword(string $oldPassword, string $newPassword, ?int $hashVersion = null): void {
         if ($this->checkPassword($oldPassword)) {
             $this->setNewPassword($newPassword, $hashVersion);
         } else {
@@ -128,13 +128,13 @@ class Login extends BaseEntity {
     /**
      * Sets a new Password. It creates a new salt and stores the salten password.
      */
-    private function setNewPassword(string $password, ?int $hashVersion = null) {
+    private function setNewPassword(string $password, ?int $hashVersion = null): void {
         $this->createSalt();
         $this->hashVersion = $hashVersion ?? self::CURRENT_HASH_VERSION;
         $this->password = $this->getHash($password);
     }
 
-    private function createSalt() {
+    private function createSalt(): void {
         $this->password = null;
         $this->pwResetKey = null;
         $this->salt = md5(microtime(true));

--- a/backend/module/eCampCore/src/Entity/MaterialItem.php
+++ b/backend/module/eCampCore/src/Entity/MaterialItem.php
@@ -46,7 +46,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface {
         return $this->materialList;
     }
 
-    public function setMaterialList(?MaterialList $materialList) {
+    public function setMaterialList(?MaterialList $materialList): void {
         $this->materialList = $materialList;
     }
 
@@ -58,7 +58,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface {
         return $this->period;
     }
 
-    public function setPeriod(?Period $period) {
+    public function setPeriod(?Period $period): void {
         $this->activityContent = null;
         $this->period = $period;
     }
@@ -67,7 +67,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface {
         return $this->activityContent;
     }
 
-    public function setActivityContent(?ActivityContent $activityContent) {
+    public function setActivityContent(?ActivityContent $activityContent): void {
         $this->period = null;
         $this->activityContent = $activityContent;
     }
@@ -76,7 +76,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface {
         return $this->article;
     }
 
-    public function setArticle(?string $article) {
+    public function setArticle(?string $article): void {
         $this->article = $article;
     }
 
@@ -84,7 +84,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface {
         return $this->quantity;
     }
 
-    public function setQuantity(?float $quantity) {
+    public function setQuantity(?float $quantity): void {
         $this->quantity = $quantity;
     }
 
@@ -92,7 +92,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface {
         return $this->unit;
     }
 
-    public function setUnit(?string $unit) {
+    public function setUnit(?string $unit): void {
         $this->unit = $unit;
     }
 }

--- a/backend/module/eCampCore/src/Entity/MaterialList.php
+++ b/backend/module/eCampCore/src/Entity/MaterialList.php
@@ -45,7 +45,7 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface {
     /**
      * @internal Do not set the {@link Camp} directly on the Activity. Instead use {@see Camp::addMaterialList()}
      */
-    public function setCamp(?Camp $camp) {
+    public function setCamp(?Camp $camp): void {
         $this->camp = $camp;
     }
 
@@ -53,7 +53,7 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface {
         return $this->materialListTemplateId;
     }
 
-    public function setMaterialListTemplateId(?string $materialListTemplateId) {
+    public function setMaterialListTemplateId(?string $materialListTemplateId): void {
         $this->materialListTemplateId = $materialListTemplateId;
     }
 
@@ -61,7 +61,7 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface {
         return $this->name;
     }
 
-    public function setName(?string $name) {
+    public function setName(?string $name): void {
         $this->name = $name;
     }
 
@@ -69,12 +69,12 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface {
         return $this->materialItems;
     }
 
-    public function addMaterialItem(MaterialItem $materialItem) {
+    public function addMaterialItem(MaterialItem $materialItem): void {
         $materialItem->setMaterialList($this);
         $this->materialItems->add($materialItem);
     }
 
-    public function removeMaterialItem(MaterialItem $materialItem) {
+    public function removeMaterialItem(MaterialItem $materialItem): void {
         $materialItem->setMaterialList(null);
         $this->materialItems->removeElement($materialItem);
     }

--- a/backend/module/eCampCore/src/Entity/MaterialListTemplate.php
+++ b/backend/module/eCampCore/src/Entity/MaterialListTemplate.php
@@ -24,7 +24,7 @@ class MaterialListTemplate extends BaseEntity {
         return $this->campTemplate;
     }
 
-    public function setCampTemplate(?CampTemplate $campTemplate) {
+    public function setCampTemplate(?CampTemplate $campTemplate): void {
         $this->campTemplate = $campTemplate;
     }
 
@@ -32,7 +32,7 @@ class MaterialListTemplate extends BaseEntity {
         return $this->name;
     }
 
-    public function setName(?string $name) {
+    public function setName(?string $name): void {
         $this->name = $name;
     }
 }

--- a/backend/module/eCampCore/src/Entity/Organization.php
+++ b/backend/module/eCampCore/src/Entity/Organization.php
@@ -18,7 +18,7 @@ class Organization extends BaseEntity {
         return $this->name;
     }
 
-    public function setName(?string $name) {
+    public function setName(?string $name): void {
         $this->name = $name;
     }
 }

--- a/backend/module/eCampCore/src/Entity/Period.php
+++ b/backend/module/eCampCore/src/Entity/Period.php
@@ -62,7 +62,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
         return $this->camp;
     }
 
-    public function setCamp(?Camp $camp) {
+    public function setCamp(?Camp $camp): void {
         $this->camp = $camp;
     }
 
@@ -127,12 +127,12 @@ class Period extends BaseEntity implements BelongsToCampInterface {
         return $this->scheduleEntries;
     }
 
-    public function addScheduleEntry(ScheduleEntry $scheduleEntry) {
+    public function addScheduleEntry(ScheduleEntry $scheduleEntry): void {
         $scheduleEntry->setPeriod($this);
         $this->scheduleEntries->add($scheduleEntry);
     }
 
-    public function removeScheduleEntry(ScheduleEntry $scheduleEntry) {
+    public function removeScheduleEntry(ScheduleEntry $scheduleEntry): void {
         $scheduleEntry->setPeriod(null);
         $this->scheduleEntries->removeElement($scheduleEntry);
     }
@@ -141,12 +141,12 @@ class Period extends BaseEntity implements BelongsToCampInterface {
         return $this->materialItems;
     }
 
-    public function addMaterialItem(MaterialItem $materialItem) {
+    public function addMaterialItem(MaterialItem $materialItem): void {
         $materialItem->setPeriod($this);
         $this->materialItems->add($materialItem);
     }
 
-    public function removeMaterialItem(MaterialItem $materialItem) {
+    public function removeMaterialItem(MaterialItem $materialItem): void {
         $materialItem->setPeriod(null);
         $this->materialItems->removeElement($materialItem);
     }

--- a/backend/module/eCampCore/src/Entity/ScheduleEntry.php
+++ b/backend/module/eCampCore/src/Entity/ScheduleEntry.php
@@ -54,7 +54,7 @@ class ScheduleEntry extends BaseEntity implements BelongsToCampInterface {
     /**
      * @internal Do not set the {@link Period} directly on the ScheduleEntry. Instead use {@see Period::addScheduleEntry()}
      */
-    public function setPeriod(?Period $period) {
+    public function setPeriod(?Period $period): void {
         $this->period = $period;
     }
 
@@ -69,7 +69,7 @@ class ScheduleEntry extends BaseEntity implements BelongsToCampInterface {
     /**
      * @internal Do not set the {@see Activity} directly on the ScheduleEntry. Instead use {@see Activity::addScheduleEntry()}
      */
-    public function setActivity(?Activity $activity) {
+    public function setActivity(?Activity $activity): void {
         $this->activity = $activity;
     }
 

--- a/backend/module/eCampCore/src/Entity/User.php
+++ b/backend/module/eCampCore/src/Entity/User.php
@@ -132,7 +132,7 @@ class User extends AbstractCampOwner implements RoleInterface {
         return $this->firstname;
     }
 
-    public function setFirstname(?string $firstname) {
+    public function setFirstname(?string $firstname): void {
         $this->firstname = $firstname;
     }
 
@@ -140,7 +140,7 @@ class User extends AbstractCampOwner implements RoleInterface {
         return $this->surname;
     }
 
-    public function setSurname(?string $surname) {
+    public function setSurname(?string $surname): void {
         $this->surname = $surname;
     }
 
@@ -148,7 +148,7 @@ class User extends AbstractCampOwner implements RoleInterface {
         return $this->nickname;
     }
 
-    public function setNickname(?string $nickname) {
+    public function setNickname(?string $nickname): void {
         $this->nickname = $nickname;
     }
 
@@ -207,7 +207,7 @@ class User extends AbstractCampOwner implements RoleInterface {
         return $this->trustedMailAddress->getMail();
     }
 
-    public function setTrustedMailAddress(string $mail) {
+    public function setTrustedMailAddress(string $mail): void {
         if (null == $this->trustedMailAddress) {
             $this->trustedMailAddress = new MailAddress();
         }
@@ -290,7 +290,7 @@ class User extends AbstractCampOwner implements RoleInterface {
         return $this->language;
     }
 
-    public function setLanguage(?string $language) {
+    public function setLanguage(?string $language): void {
         $this->language = $language;
     }
 
@@ -298,7 +298,7 @@ class User extends AbstractCampOwner implements RoleInterface {
         return (null !== $this->birthday) ? (clone $this->birthday) : null;
     }
 
-    public function setBirthday(?DateUtc $birthday) {
+    public function setBirthday(?DateUtc $birthday): void {
         $this->birthday = null !== $birthday ? clone $birthday : $birthday;
     }
 
@@ -306,12 +306,12 @@ class User extends AbstractCampOwner implements RoleInterface {
         return $this->memberships;
     }
 
-    public function addGroupMembership(GroupMembership $membership) {
+    public function addGroupMembership(GroupMembership $membership): void {
         $membership->setUser($this);
         $this->memberships->add($membership);
     }
 
-    public function removeGroupMembership(GroupMembership $membership) {
+    public function removeGroupMembership(GroupMembership $membership): void {
         $membership->setUser(null);
         $this->memberships->removeElement($membership);
     }
@@ -320,12 +320,12 @@ class User extends AbstractCampOwner implements RoleInterface {
         return $this->collaborations;
     }
 
-    public function addCampCollaboration(CampCollaboration $collaboration) {
+    public function addCampCollaboration(CampCollaboration $collaboration): void {
         $collaboration->setUser($this);
         $this->collaborations->add($collaboration);
     }
 
-    public function removeCampCollaboration(CampCollaboration $collaboration) {
+    public function removeCampCollaboration(CampCollaboration $collaboration): void {
         $collaboration->setUser(null);
         $this->collaborations->removeElement($collaboration);
     }
@@ -334,12 +334,12 @@ class User extends AbstractCampOwner implements RoleInterface {
         return $this->userIdentities;
     }
 
-    public function addUserIdentity(UserIdentity $userIdentity) {
+    public function addUserIdentity(UserIdentity $userIdentity): void {
         $userIdentity->setUser($this);
         $this->userIdentities->add($userIdentity);
     }
 
-    public function removeUserIdentity(UserIdentity $userIdentity) {
+    public function removeUserIdentity(UserIdentity $userIdentity): void {
         $userIdentity->setUser(null);
         $this->userIdentities->removeElement($userIdentity);
     }

--- a/backend/module/eCampCore/src/Entity/UserIdentity.php
+++ b/backend/module/eCampCore/src/Entity/UserIdentity.php
@@ -35,7 +35,7 @@ class UserIdentity extends BaseEntity {
     /**
      * Set user.
      */
-    public function setUser(?User $user) {
+    public function setUser(?User $user): void {
         $this->user = $user;
     }
 
@@ -49,7 +49,7 @@ class UserIdentity extends BaseEntity {
     /**
      * Set provider.
      */
-    public function setProvider(?string $provider) {
+    public function setProvider(?string $provider): void {
         $this->provider = $provider;
     }
 
@@ -65,7 +65,7 @@ class UserIdentity extends BaseEntity {
      *
      * @param string $providerId
      */
-    public function setProviderId(?string $providerId) {
+    public function setProviderId(?string $providerId): void {
         $this->providerId = $providerId;
     }
 

--- a/backend/module/eCampCore/src/EntityFilter/BaseFilter.php
+++ b/backend/module/eCampCore/src/EntityFilter/BaseFilter.php
@@ -37,10 +37,8 @@ abstract class BaseFilter implements EntityFilterInterface {
      * @param $className
      * @param $alias
      * @param $id
-     *
-     * @return QueryBuilder
      */
-    protected function findEntityQueryBuilder($className, $alias, $id) {
+    protected function findEntityQueryBuilder($className, $alias, $id): QueryBuilder {
         $q = $this->createQueryBuilder($className, $alias);
         $q->where($alias.'.id = :entityId');
         $q->setParameter('entityId', $id);
@@ -51,10 +49,8 @@ abstract class BaseFilter implements EntityFilterInterface {
     /**
      * @param $className
      * @param string $alias
-     *
-     * @return QueryBuilder
      */
-    protected function findCollectionQueryBuilder($className, $alias) {
+    protected function findCollectionQueryBuilder($className, $alias): QueryBuilder {
         return $this->createQueryBuilder($className, $alias);
     }
 }

--- a/backend/module/eCampCore/src/EntityService/AbstractEntityService.php
+++ b/backend/module/eCampCore/src/EntityService/AbstractEntityService.php
@@ -54,8 +54,6 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     /**
      * Dispatch an incoming event to the appropriate method
      * Catches exceptions and returns ApiProblem.
-     *
-     * @return mixed
      */
     public function dispatch(ResourceEvent $event) {
         try {
@@ -92,8 +90,6 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     }
 
     /**
-     * @param mixed $id
-     *
      * @throws EntityNotFoundException
      * @throws NonUniqueResultException
      * @throws NoAccessException
@@ -123,8 +119,6 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     /**
      * Calls createEntity + is responsible for permission check and persistance.
      *
-     * @param mixed $data
-     *
      * @throws NoAccessException
      * @throws ORMException
      */
@@ -141,7 +135,6 @@ abstract class AbstractEntityService extends AbstractResourceListener {
 
     /**
      * @param string $id
-     * @param mixed  $data
      *
      * @throws ORMException
      * @throws OptimisticLockException
@@ -160,9 +153,6 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     }
 
     /**
-     * @param mixed $id
-     * @param mixed $data
-     *
      * @throws ORMException
      * @throws OptimisticLockException
      * @throws EntityNotFoundException
@@ -180,8 +170,6 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     }
 
     /**
-     * @param mixed $id
-     *
      * @throws ORMException
      * @throws NoAccessException
      */
@@ -205,8 +193,6 @@ abstract class AbstractEntityService extends AbstractResourceListener {
      * Responsible for creation of entity + hydration of data.
      * Should be overriden by subclass for specific additional business logic during create process.
      *
-     * @param mixed $data
-     *
      * @return BaseEntity Instantiated but non-persisted entity
      */
     protected function createEntity($data): BaseEntity {
@@ -216,9 +202,6 @@ abstract class AbstractEntityService extends AbstractResourceListener {
         return $entity;
     }
 
-    /**
-     * @param mixed $data
-     */
     protected function createEntityPost(BaseEntity $entity, $data): BaseEntity {
         return $entity;
     }
@@ -243,11 +226,11 @@ abstract class AbstractEntityService extends AbstractResourceListener {
         return $entity;
     }
 
-    protected function deleteEntity(BaseEntity $entity) {
+    protected function deleteEntity(BaseEntity $entity): void {
         $this->serviceUtils->emRemove($entity);
     }
 
-    protected function validateEntity(BaseEntity $entity) {
+    protected function validateEntity(BaseEntity $entity): void {
     }
 
     protected function getServiceUtils(): ServiceUtils {
@@ -272,7 +255,7 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     /**
      * @throws NotAuthenticatedException if no user is authenticated
      */
-    protected function assertAuthenticated() {
+    protected function assertAuthenticated(): void {
         if (!$this->isAuthenticated()) {
             throw new NotAuthenticatedException();
         }
@@ -312,7 +295,7 @@ abstract class AbstractEntityService extends AbstractResourceListener {
      *
      * @throws NoAccessException
      */
-    protected function assertAllowed($resource, $privilege = null) {
+    protected function assertAllowed($resource, $privilege = null): void {
         $user = $this->getAuthUser();
         $this->serviceUtils->aclAssertAllowed($user, $resource, $privilege);
     }
@@ -421,8 +404,6 @@ abstract class AbstractEntityService extends AbstractResourceListener {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws EntityValidationException
      *
      * @return mixed

--- a/backend/module/eCampCore/src/EntityService/ActivityContentService.php
+++ b/backend/module/eCampCore/src/EntityService/ActivityContentService.php
@@ -54,8 +54,6 @@ class ActivityContentService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      * @throws ORMException

--- a/backend/module/eCampCore/src/EntityService/ActivityService.php
+++ b/backend/module/eCampCore/src/EntityService/ActivityService.php
@@ -40,8 +40,6 @@ class ActivityService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws EntityNotFoundException
      * @throws ORMException
      * @throws NoAccessException
@@ -62,8 +60,6 @@ class ActivityService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws EntityNotFoundException
      * @throws NoAccessException
      * @throws ORMException
@@ -138,7 +134,7 @@ class ActivityService extends AbstractEntityService {
         return $q;
     }
 
-    private function updateActivityResponsibles(Activity $activity, $data) {
+    private function updateActivityResponsibles(Activity $activity, $data): void {
         if (isset($data->campCollaborations)) {
             $ccIds = array_map(function ($cc) {
                 return $cc['id'];
@@ -165,7 +161,7 @@ class ActivityService extends AbstractEntityService {
         }
     }
 
-    private function updateScheduleEntries(Activity $activity, $data) {
+    private function updateScheduleEntries(Activity $activity, $data): void {
         if (isset($data->scheduleEntries) && is_array($data->scheduleEntries)) {
             $scheduleEntryIds = array_reduce($data->scheduleEntries, function ($result, $entry) {
                 if (isset($entry['id'])) {
@@ -195,7 +191,7 @@ class ActivityService extends AbstractEntityService {
         }
     }
 
-    private function createInitialActivityContents(Activity $activity) {
+    private function createInitialActivityContents(Activity $activity): void {
         $categoryContents = $activity->getCategory()->getRootCategoryContents();
 
         /** @var CategoryContent $categoryContent */

--- a/backend/module/eCampCore/src/EntityService/CampCollaborationService.php
+++ b/backend/module/eCampCore/src/EntityService/CampCollaborationService.php
@@ -38,8 +38,6 @@ class CampCollaborationService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws ORMException
      * @throws \Exception
      */
@@ -162,8 +160,6 @@ class CampCollaborationService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws ORMException
      */
     protected function updateEntity(BaseEntity $entity, $data): CampCollaboration {
@@ -184,7 +180,7 @@ class CampCollaborationService extends AbstractEntityService {
     /**
      * @throws ORMException
      */
-    protected function deleteEntity(BaseEntity $entity) {
+    protected function deleteEntity(BaseEntity $entity): void {
         /** @var CampCollaboration $campCollaboration */
         $campCollaboration = $entity;
         if (in_array(
@@ -230,10 +226,8 @@ class CampCollaborationService extends AbstractEntityService {
      * @param $data
      *
      * @throws \Exception
-     *
-     * @return CampCollaboration
      */
-    private function updateCollaboration(CampCollaboration $campCollaboration, $data) {
+    private function updateCollaboration(CampCollaboration $campCollaboration, $data): CampCollaboration {
         // TODO: ACL-Check can update Collaboration
 
         if (isset($data->role)) {
@@ -253,10 +247,8 @@ class CampCollaborationService extends AbstractEntityService {
      * @param $data
      *
      * @throws \Exception
-     *
-     * @return CampCollaboration
      */
-    private function updateInvitation(CampCollaboration $campCollaboration, $data) {
+    private function updateInvitation(CampCollaboration $campCollaboration, $data): CampCollaboration {
         $authUser = $this->getAuthUser();
 
         // TODO: ACL-Check can update Invitation
@@ -300,10 +292,8 @@ class CampCollaborationService extends AbstractEntityService {
      *
      * @throws ORMException
      * @throws \Exception
-     *
-     * @return CampCollaboration
      */
-    private function updateRequest(CampCollaboration $campCollaboration, $data) {
+    private function updateRequest(CampCollaboration $campCollaboration, $data): CampCollaboration {
         $authUser = $this->getAuthUser();
 
         // TODO: ACL-Check can update Request
@@ -370,7 +360,7 @@ class CampCollaborationService extends AbstractEntityService {
             }
     }
 
-    private function createMaterialList(CampCollaboration $campCollaboration) {
+    private function createMaterialList(CampCollaboration $campCollaboration): void {
         $this->materialListService->create((object) [
             'campId' => $campCollaboration->getCamp()->getId(),
             'name' => $campCollaboration->getUser()->getDisplayName(),

--- a/backend/module/eCampCore/src/EntityService/CampService.php
+++ b/backend/module/eCampCore/src/EntityService/CampService.php
@@ -54,8 +54,6 @@ class CampService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws NoAccessException
      * @throws EntityNotFoundException
      * @throws ORMException

--- a/backend/module/eCampCore/src/EntityService/CategoryService.php
+++ b/backend/module/eCampCore/src/EntityService/CategoryService.php
@@ -61,8 +61,6 @@ class CategoryService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws EntityNotFoundException
      * @throws ORMException
      * @throws NoAccessException

--- a/backend/module/eCampCore/src/EntityService/DayService.php
+++ b/backend/module/eCampCore/src/EntityService/DayService.php
@@ -25,8 +25,6 @@ class DayService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws NoAccessException
      * @throws EntityNotFoundException
      * @throws ORMException
@@ -42,7 +40,7 @@ class DayService extends AbstractEntityService {
         return $day;
     }
 
-    protected function deleteEntity(BaseEntity $entity) {
+    protected function deleteEntity(BaseEntity $entity): void {
         parent::deleteEntity($entity);
 
         /** @var Day $day */

--- a/backend/module/eCampCore/src/EntityService/GroupMembershipService.php
+++ b/backend/module/eCampCore/src/EntityService/GroupMembershipService.php
@@ -24,8 +24,6 @@ class GroupMembershipService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws \Doctrine\ORM\ORMException
      * @throws \Exception
      */
@@ -65,8 +63,6 @@ class GroupMembershipService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws ORMException
      * @throws \Exception
      */
@@ -105,7 +101,7 @@ class GroupMembershipService extends AbstractEntityService {
      *
      * @throws \Exception
      */
-    private function updateMembership(GroupMembership $groupMembership, $data) {
+    private function updateMembership(GroupMembership $groupMembership, $data): void {
         // TODO: ACL-Check can update Membership
 
         if (isset($data->role)) {
@@ -123,7 +119,7 @@ class GroupMembershipService extends AbstractEntityService {
      * @throws \Doctrine\ORM\ORMException
      * @throws \Exception
      */
-    private function updateInvitation(GroupMembership $groupMembership, $data) {
+    private function updateInvitation(GroupMembership $groupMembership, $data): void {
         $authUser = $this->getAuthUser();
 
         // TODO: ACL-Check can update Invitation
@@ -151,7 +147,7 @@ class GroupMembershipService extends AbstractEntityService {
      * @throws \Doctrine\ORM\ORMException
      * @throws \Exception
      */
-    private function updateRequest(GroupMembership $groupMembership, $data) {
+    private function updateRequest(GroupMembership $groupMembership, $data): void {
         $authUser = $this->getAuthUser();
 
         // TODO: ACL-Check can update Request

--- a/backend/module/eCampCore/src/EntityService/MaterialItemService.php
+++ b/backend/module/eCampCore/src/EntityService/MaterialItemService.php
@@ -138,7 +138,7 @@ class MaterialItemService extends AbstractEntityService {
         return $q;
     }
 
-    protected function validateEntity(BaseEntity $entity) {
+    protected function validateEntity(BaseEntity $entity): void {
         /** @var MaterialItem $materialItem */
         $materialItem = $entity;
 

--- a/backend/module/eCampCore/src/EntityService/PeriodService.php
+++ b/backend/module/eCampCore/src/EntityService/PeriodService.php
@@ -103,7 +103,7 @@ class PeriodService extends AbstractEntityService {
         return $period;
     }
 
-    protected function deleteEntity(BaseEntity $entity): Period {
+    protected function deleteEntity(BaseEntity $entity): void {
         /** @var Period $period */
         $period = $entity;
         $period->getCamp()->removePeriod($period);

--- a/backend/module/eCampCore/src/EntityService/PeriodService.php
+++ b/backend/module/eCampCore/src/EntityService/PeriodService.php
@@ -36,8 +36,6 @@ class PeriodService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws ORMException
      * @throws EntityNotFoundException
      * @throws NoAccessException
@@ -76,8 +74,6 @@ class PeriodService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws NoAccessException
      * @throws ORMException
      */
@@ -93,9 +89,6 @@ class PeriodService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $id
-     * @param mixed $data
-     *
      * @throws ORMException
      * @throws NoAccessException
      */
@@ -110,10 +103,7 @@ class PeriodService extends AbstractEntityService {
         return $period;
     }
 
-    /**
-     * @return Period
-     */
-    protected function deleteEntity(BaseEntity $entity) {
+    protected function deleteEntity(BaseEntity $entity): Period {
         /** @var Period $period */
         $period = $entity;
         $period->getCamp()->removePeriod($period);
@@ -124,7 +114,7 @@ class PeriodService extends AbstractEntityService {
     /**
      * @param $entity
      */
-    protected function validateEntity(BaseEntity $entity) {
+    protected function validateEntity(BaseEntity $entity): void {
         /** @var Period $period */
         $period = $entity;
 
@@ -172,7 +162,7 @@ class PeriodService extends AbstractEntityService {
      * @throws NoAccessException
      * @throws ORMException
      */
-    private function updatePeriodDays(Period $period) {
+    private function updatePeriodDays(Period $period): void {
         $days = $period->getDays();
         $daysCountNew = $period->getDurationInDays();
 
@@ -204,7 +194,7 @@ class PeriodService extends AbstractEntityService {
      *
      * @throws NoAccessException
      */
-    private function updateScheduleEntries(Period $period, $moveActivities = null) {
+    private function updateScheduleEntries(Period $period, $moveActivities = null): void {
         if (is_null($moveActivities)) {
             $moveActivities = true;
         }

--- a/backend/module/eCampCore/src/EntityService/ScheduleEntryService.php
+++ b/backend/module/eCampCore/src/EntityService/ScheduleEntryService.php
@@ -23,8 +23,6 @@ class ScheduleEntryService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws EntityValidationException
      */
     protected function createEntity($data): ScheduleEntry {

--- a/backend/module/eCampCore/src/EntityService/UserIdentityService.php
+++ b/backend/module/eCampCore/src/EntityService/UserIdentityService.php
@@ -89,7 +89,6 @@ class UserIdentityService extends AbstractEntityService {
 
     /**
      * @param array $data
-     * @param User  $user
      */
     protected function createEntity($data): UserIdentity {
         /** @var UserIdentity $identity */

--- a/backend/module/eCampCore/src/EntityService/UserService.php
+++ b/backend/module/eCampCore/src/EntityService/UserService.php
@@ -65,8 +65,6 @@ class UserService extends AbstractEntityService {
     }
 
     /**
-     * @param mixed $data
-     *
      * @throws ORMException
      * @throws \Exception
      */

--- a/backend/module/eCampCore/src/Module.php
+++ b/backend/module/eCampCore/src/Module.php
@@ -14,7 +14,7 @@ class Module {
         return include __DIR__.'/../config/module.config.php';
     }
 
-    public function onBootstrap(MvcEvent $e) {
+    public function onBootstrap(MvcEvent $e): void {
         /** @var Application $app */
         $app = $e->getApplication();
         $events = $app->getEventManager();
@@ -30,11 +30,11 @@ class Module {
         // Enable next line for Doctrine debug output
         // $em->getConfiguration()->setSQLLogger(new EchoSQLLogger());
 
-        $events->attach(MvcEvent::EVENT_DISPATCH, function (MvcEvent $e) use ($em) {
+        $events->attach(MvcEvent::EVENT_DISPATCH, function (MvcEvent $e) use ($em): void {
             $em->beginTransaction();
         }, 10);
 
-        $events->attach(MvcEvent::EVENT_FINISH, function (MvcEvent $e) use ($em) {
+        $events->attach(MvcEvent::EVENT_FINISH, function (MvcEvent $e) use ($em): void {
             if ($e->getError() || $e->getResponse() instanceof ApiProblemResponse) {
                 if ($em->getConnection()->isTransactionActive()) {
                     $em->getConnection()->rollback();

--- a/backend/module/eCampCore/src/Repository/CampCollaborationRepository.php
+++ b/backend/module/eCampCore/src/Repository/CampCollaborationRepository.php
@@ -42,7 +42,7 @@ class CampCollaborationRepository extends EntityRepository {
         }
     }
 
-    public function saveWithoutAcl(CampCollaboration $campCollaboration) {
+    public function saveWithoutAcl(CampCollaboration $campCollaboration): void {
         $this->getEntityManager()->persist($campCollaboration);
         $this->getEntityManager()->flush();
     }

--- a/backend/module/eCampCore/src/Service/AbstractService.php
+++ b/backend/module/eCampCore/src/Service/AbstractService.php
@@ -56,7 +56,7 @@ abstract class AbstractService {
      *
      * @throws \eCamp\Lib\Acl\NoAccessException
      */
-    protected function assertAllowed($resource, $privilege = null) {
+    protected function assertAllowed($resource, $privilege = null): void {
         $user = $this->getAuthUser();
         $this->serviceUtils->aclAssertAllowed($user, $resource, $privilege);
     }

--- a/backend/module/eCampCore/src/Service/SendmailService.php
+++ b/backend/module/eCampCore/src/Service/SendmailService.php
@@ -28,7 +28,7 @@ class SendmailService extends AbstractService {
         $this->frontendUrl = $frontendUrl;
     }
 
-    public function sendRegisterMail(User $user, $key) {
+    public function sendRegisterMail(User $user, $key): void {
         $data = new MessageData();
         $data->from = $this->from;
         $data->to = $user->getUntrustedMailAddress();
@@ -42,7 +42,7 @@ class SendmailService extends AbstractService {
         $this->mailProvider->sendMail($data);
     }
 
-    public function sendInviteToCampMail(User $byUser, Camp $camp, string $key, string $emailToInvite) {
+    public function sendInviteToCampMail(User $byUser, Camp $camp, string $key, string $emailToInvite): void {
         $data = new MessageData();
         $data->from = $this->from;
         $data->to = $emailToInvite;

--- a/backend/module/eCampCore/test/Auth/AuthUserProviderTest.php
+++ b/backend/module/eCampCore/test/Auth/AuthUserProviderTest.php
@@ -11,7 +11,7 @@ use Laminas\Authentication\AuthenticationService;
  * @internal
  */
 class AuthUserProviderTest extends AbstractDatabaseTestCase {
-    public function testAuthUser() {
+    public function testAuthUser(): void {
         /** @var UserService $userService */
         $userService = \eCampApp::GetService(UserService::class);
 
@@ -31,7 +31,7 @@ class AuthUserProviderTest extends AbstractDatabaseTestCase {
         $this->assertEquals($user->getId(), $authUser->getId());
     }
 
-    public function testNoAuthUser() {
+    public function testNoAuthUser(): void {
         $authenticationService = new AuthenticationService();
         $authenticationService->clearIdentity();
 

--- a/backend/module/eCampCore/test/Data/ActivityResponsibleTestData.php
+++ b/backend/module/eCampCore/test/Data/ActivityResponsibleTestData.php
@@ -11,7 +11,7 @@ use eCamp\Core\Entity\CampCollaboration;
 class ActivityResponsibleTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $RESPONSIBLE1 = ActivityResponsible::class.':RESPONSIBLE1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var Activity $activity */
         $activity = $this->getReference(ActivityTestData::$ACTIVITY1);
 

--- a/backend/module/eCampCore/test/Data/ActivityTestData.php
+++ b/backend/module/eCampCore/test/Data/ActivityTestData.php
@@ -12,7 +12,7 @@ use eCamp\Core\Entity\Category;
 class ActivityTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $ACTIVITY1 = Activity::class.':ACTIVITY1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var Camp $ccamp */
         $camp = $this->getReference(CampTestData::$CAMP1);
 

--- a/backend/module/eCampCore/test/Data/CampCollaborationTestData.php
+++ b/backend/module/eCampCore/test/Data/CampCollaborationTestData.php
@@ -14,7 +14,7 @@ class CampCollaborationTestData extends AbstractFixture implements DependentFixt
     public static $COLLAB_INVITED = CampCollaboration::class.':COLLAB_INVITED';
     public static $COLLAB_LEFT = CampCollaboration::class.':COLLAB_LEFT';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var Camp $camp */
         $camp = $this->getReference(CampTestData::$CAMP1);
 

--- a/backend/module/eCampCore/test/Data/CampTemplateTestData.php
+++ b/backend/module/eCampCore/test/Data/CampTemplateTestData.php
@@ -9,7 +9,7 @@ use eCamp\Core\Entity\CampTemplate;
 class CampTemplateTestData extends AbstractFixture {
     public static $TEMPLATE1 = CampTemplate::class.':Template1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $campTemplate = new CampTemplate();
         $campTemplate->setName('CampTemplate1');
 

--- a/backend/module/eCampCore/test/Data/CampTestData.php
+++ b/backend/module/eCampCore/test/Data/CampTestData.php
@@ -11,7 +11,7 @@ use eCamp\Core\Entity\User;
 class CampTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $CAMP1 = Camp::class.':CAMP1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var User $user */
         $user1 = $this->getReference(UserTestData::$USER1);
 

--- a/backend/module/eCampCore/test/Data/CategoryContentTemplateTestData.php
+++ b/backend/module/eCampCore/test/Data/CategoryContentTemplateTestData.php
@@ -11,7 +11,7 @@ use eCamp\Core\Entity\CategoryTemplate;
 class CategoryContentTemplateTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $TEMPLATE1 = CategoryContentTemplateTestData::class.':Template1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var CategoryTemplate $categoryTemplate */
         $categoryTemplate = $this->getReference(CategoryTemplateTestData::$TEMPLATE1);
         $contentType = $this->getReference(ContentTypeTestData::$TYPE1);

--- a/backend/module/eCampCore/test/Data/CategoryContentTestData.php
+++ b/backend/module/eCampCore/test/Data/CategoryContentTestData.php
@@ -11,7 +11,7 @@ use eCamp\Core\Entity\CategoryContent;
 class CategoryContentTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $CATEGORY_CONTENT1 = CategoryContentTestData::class.':CategoryContent1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var Category $category */
         $category = $this->getReference(CategoryTestData::$CATEGORY1);
         $contentType = $this->getReference(ContentTypeTestData::$TYPE1);

--- a/backend/module/eCampCore/test/Data/CategoryContentTypeTemplateTestData.php
+++ b/backend/module/eCampCore/test/Data/CategoryContentTypeTemplateTestData.php
@@ -11,7 +11,7 @@ use eCamp\Core\Entity\CategoryTemplate;
 class CategoryContentTypeTemplateTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $TEMPLATE1 = CategoryContentTypeTemplateTestData::class.':Template1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var CategoryTemplate $categoryTemplate */
         $categoryTemplate = $this->getReference(CategoryTemplateTestData::$TEMPLATE1);
         $contentType = $this->getReference(ContentTypeTestData::$TYPE1);

--- a/backend/module/eCampCore/test/Data/CategoryContentTypeTestData.php
+++ b/backend/module/eCampCore/test/Data/CategoryContentTypeTestData.php
@@ -11,7 +11,7 @@ use eCamp\Core\Entity\CategoryContentType;
 class CategoryContentTypeTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $CATEGORY_CONTENT_TYPE1 = CategoryContentTypeTestData::class.':CategoryContentType1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var Category $category */
         $category = $this->getReference(CategoryTestData::$CATEGORY1);
         $contentType = $this->getReference(ContentTypeTestData::$TYPE1);

--- a/backend/module/eCampCore/test/Data/CategoryTemplateTestData.php
+++ b/backend/module/eCampCore/test/Data/CategoryTemplateTestData.php
@@ -10,7 +10,7 @@ use eCamp\Core\Entity\CategoryTemplate;
 class CategoryTemplateTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $TEMPLATE1 = CategoryTemplate::class.':Template1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $campTemplate = $this->getReference(CampTemplateTestData::$TEMPLATE1);
 
         $categoryTemplate = new CategoryTemplate();

--- a/backend/module/eCampCore/test/Data/CategoryTestData.php
+++ b/backend/module/eCampCore/test/Data/CategoryTestData.php
@@ -12,7 +12,7 @@ class CategoryTestData extends AbstractFixture implements DependentFixtureInterf
     public static $CATEGORY1 = Category::class.':CATEGORY1';
     public static $CATEGORY2 = Category::class.':CATEGORY2';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var Camp $camp */
         $camp = $this->getReference(CampTestData::$CAMP1);
 

--- a/backend/module/eCampCore/test/Data/ContentTypeTestData.php
+++ b/backend/module/eCampCore/test/Data/ContentTypeTestData.php
@@ -12,7 +12,7 @@ class ContentTypeTestData extends AbstractFixture {
     public static $TYPE1 = ContentType::class.':TYPE1';
     public static $TYPE_MATERIAL = ContentType::class.':TYPE_MATERIAL';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $contentType = new ContentType();
         $contentType->setName('Storyboard');
         $contentType->setStrategyClass(StoryboardStrategy::class);

--- a/backend/module/eCampCore/test/Data/MaterialItemTestData.php
+++ b/backend/module/eCampCore/test/Data/MaterialItemTestData.php
@@ -23,7 +23,7 @@ class MaterialItemTestData extends AbstractFixture implements DependentFixtureIn
         $this->container = $container;
     }
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $contentTypeStrategyProvider = new ContentTypeStrategyProvider($this->container);
 
         /** @var Activity $activity */

--- a/backend/module/eCampCore/test/Data/MaterialListTemplateTestData.php
+++ b/backend/module/eCampCore/test/Data/MaterialListTemplateTestData.php
@@ -11,7 +11,7 @@ use eCamp\Core\Entity\MaterialListTemplate;
 class MaterialListTemplateTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $MATERIALLISTTEMPLATE1 = MaterialListTemplate::class.':MATERIALLISTTEMPLATE1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var CampTemplate $campTemplate */
         $campTemplate = $this->getReference(CampTemplateTestData::$TEMPLATE1);
 

--- a/backend/module/eCampCore/test/Data/MaterialListTestData.php
+++ b/backend/module/eCampCore/test/Data/MaterialListTestData.php
@@ -11,7 +11,7 @@ use eCamp\Core\Entity\MaterialList;
 class MaterialListTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $MATERIALLIST1 = MaterialList::class.':MATERIALLIST1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var Camp $ccamp */
         $camp = $this->getReference(CampTestData::$CAMP1);
 

--- a/backend/module/eCampCore/test/Data/OrganizationTestData.php
+++ b/backend/module/eCampCore/test/Data/OrganizationTestData.php
@@ -9,7 +9,7 @@ use eCamp\Core\Entity\Organization;
 class OrganizationTestData extends AbstractFixture {
     public static $ORG1 = Organization::class.':Org1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $repository = $manager->getRepository(Organization::class);
 
         $organization = new Organization();

--- a/backend/module/eCampCore/test/Data/PeriodTestData.php
+++ b/backend/module/eCampCore/test/Data/PeriodTestData.php
@@ -14,7 +14,7 @@ class PeriodTestData extends AbstractFixture implements DependentFixtureInterfac
     public static $PERIOD1 = Period::class.':PERIOD1';
     public static $DAY1 = Day::class.':DAY1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var Camp $ccamp */
         $camp = $this->getReference(CampTestData::$CAMP1);
 

--- a/backend/module/eCampCore/test/Data/ScheduleEntryTestData.php
+++ b/backend/module/eCampCore/test/Data/ScheduleEntryTestData.php
@@ -12,7 +12,7 @@ use eCamp\Core\Entity\ScheduleEntry;
 class ScheduleEntryTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $ENTRY1 = ScheduleEntry::class.':ENTRY1';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         /** @var Category $category */
         $activity = $this->getReference(ActivityTestData::$ACTIVITY1);
 

--- a/backend/module/eCampCore/test/Data/UserTestData.php
+++ b/backend/module/eCampCore/test/Data/UserTestData.php
@@ -11,7 +11,7 @@ class UserTestData extends AbstractFixture {
     public static $USER1 = User::class.':USER1';
     public static $USER2 = User::class.':USER2';
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $user = new User();
         $user->setUsername('test-user');
         $user->setRole(User::ROLE_USER);

--- a/backend/module/eCampCore/test/Entity/ActivityContentTest.php
+++ b/backend/module/eCampCore/test/Entity/ActivityContentTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class ActivityContentTest extends AbstractTestCase {
-    public function testActivityContent() {
+    public function testActivityContent(): void {
         $camp = new Camp();
 
         $contentType = new ContentType();
@@ -34,7 +34,7 @@ class ActivityContentTest extends AbstractTestCase {
         $this->assertEquals($camp, $activityContent->getCamp());
     }
 
-    public function testActivityContentHierarchy() {
+    public function testActivityContentHierarchy(): void {
         $activityContent = new ActivityContent();
         $childActivityContent = new ActivityContent();
 

--- a/backend/module/eCampCore/test/Entity/ActivityTest.php
+++ b/backend/module/eCampCore/test/Entity/ActivityTest.php
@@ -13,7 +13,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class ActivityTest extends AbstractTestCase {
-    public function testCategory() {
+    public function testCategory(): void {
         $camp = new Camp();
         $category = new Category();
 
@@ -27,7 +27,7 @@ class ActivityTest extends AbstractTestCase {
         $this->assertEquals($category, $activity->getCategory());
     }
 
-    public function testActivityContent() {
+    public function testActivityContent(): void {
         $activity = new Activity();
         $activityContent = new ActivityContent();
 
@@ -38,7 +38,7 @@ class ActivityTest extends AbstractTestCase {
         $this->assertEquals(0, $activity->getActivityContents()->count());
     }
 
-    public function testScheduleEntry() {
+    public function testScheduleEntry(): void {
         $activity = new Activity();
         $scheduleEntry = new ScheduleEntry();
 

--- a/backend/module/eCampCore/test/Entity/CampCollaborationTest.php
+++ b/backend/module/eCampCore/test/Entity/CampCollaborationTest.php
@@ -11,7 +11,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CampCollaborationTest extends AbstractTestCase {
-    public function testCampCollaboration() {
+    public function testCampCollaboration(): void {
         $camp = new Camp();
         $user = new User();
 
@@ -29,7 +29,7 @@ class CampCollaborationTest extends AbstractTestCase {
         $this->assertEquals('install', $collaboration->getCollaborationAcceptedBy());
     }
 
-    public function testStatus() {
+    public function testStatus(): void {
         $collaboration = new CampCollaboration();
         $collaboration->setStatus(CampCollaboration::STATUS_REQUESTED);
         $this->assertTrue($collaboration->isRequest());
@@ -44,7 +44,7 @@ class CampCollaborationTest extends AbstractTestCase {
         $collaboration->setStatus('test');
     }
 
-    public function testRole() {
+    public function testRole(): void {
         $collaboration = new CampCollaboration();
         $collaboration->setRole(CampCollaboration::ROLE_GUEST);
         $this->assertTrue($collaboration->isGuest());
@@ -59,7 +59,7 @@ class CampCollaborationTest extends AbstractTestCase {
         $collaboration->setRole('test');
     }
 
-    public function testLifecycle() {
+    public function testLifecycle(): void {
         $collaboration = new CampCollaboration();
         $collaboration->setStatus(CampCollaboration::STATUS_REQUESTED);
         $collaboration->setCollaborationAcceptedBy('install');

--- a/backend/module/eCampCore/test/Entity/CampTemplateTest.php
+++ b/backend/module/eCampCore/test/Entity/CampTemplateTest.php
@@ -10,14 +10,14 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CampTemplateTest extends AbstractTestCase {
-    public function testCampTemplate() {
+    public function testCampTemplate(): void {
         $campTemplate = new CampTemplate();
         $campTemplate->setName('CampTemplate.Name');
 
         $this->assertEquals('CampTemplate.Name', $campTemplate->getName());
     }
 
-    public function testCategoryTemplate() {
+    public function testCategoryTemplate(): void {
         $campTemplate = new CampTemplate();
         $categoryTemplate = new CategoryTemplate();
 

--- a/backend/module/eCampCore/test/Entity/CampTest.php
+++ b/backend/module/eCampCore/test/Entity/CampTest.php
@@ -15,7 +15,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CampTest extends AbstractTestCase {
-    public function testCamp() {
+    public function testCamp(): void {
         $user = new User();
         $user->setUsername('username');
 
@@ -36,7 +36,7 @@ class CampTest extends AbstractTestCase {
         $this->assertTrue($camp->belongsToUser());
     }
 
-    public function testPeriod() {
+    public function testPeriod(): void {
         $camp = new Camp();
         $period = new Period();
 
@@ -47,7 +47,7 @@ class CampTest extends AbstractTestCase {
         $this->assertEquals(0, $camp->getPeriods()->count());
     }
 
-    public function testCampCollaboration() {
+    public function testCampCollaboration(): void {
         $camp = new Camp();
         $collaboration = new CampCollaboration();
 
@@ -58,7 +58,7 @@ class CampTest extends AbstractTestCase {
         $this->assertEquals(0, $camp->getCampCollaborations()->count());
     }
 
-    public function testJob() {
+    public function testJob(): void {
         $camp = new Camp();
         $job = new Job();
 
@@ -69,7 +69,7 @@ class CampTest extends AbstractTestCase {
         $this->assertEquals(0, $camp->getJobs()->count());
     }
 
-    public function testCategory() {
+    public function testCategory(): void {
         $camp = new Camp();
         $category = new Category();
 
@@ -80,7 +80,7 @@ class CampTest extends AbstractTestCase {
         $this->assertEquals(0, $camp->getCategories()->count());
     }
 
-    public function testActivity() {
+    public function testActivity(): void {
         $camp = new Camp();
         $activity = new Activity();
 

--- a/backend/module/eCampCore/test/Entity/CategoryContentTemplateTest.php
+++ b/backend/module/eCampCore/test/Entity/CategoryContentTemplateTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CategoryContentTemplateTest extends AbstractTestCase {
-    public function testCategoryContentTemplate() {
+    public function testCategoryContentTemplate(): void {
         $campTemplate = new CampTemplate();
 
         $contentType = new ContentType();
@@ -33,7 +33,7 @@ class CategoryContentTemplateTest extends AbstractTestCase {
         $this->assertEquals('position', $categoryContentTemplate->getPosition());
     }
 
-    public function testCategoryContentTemplateHierarchy() {
+    public function testCategoryContentTemplateHierarchy(): void {
         $categoryContentTemplate = new CategoryContentTemplate();
         $childCategoryContentTemplate = new CategoryContentTemplate();
 

--- a/backend/module/eCampCore/test/Entity/CategoryContentTest.php
+++ b/backend/module/eCampCore/test/Entity/CategoryContentTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CategoryContentTest extends AbstractTestCase {
-    public function testCategoryContent() {
+    public function testCategoryContent(): void {
         $camp = new Camp();
 
         $contentType = new ContentType();
@@ -34,7 +34,7 @@ class CategoryContentTest extends AbstractTestCase {
         $this->assertEquals($camp, $categoryContent->getCamp());
     }
 
-    public function testCategoryContentHierarchy() {
+    public function testCategoryContentHierarchy(): void {
         $categoryContent = new CategoryContent();
         $childCategoryContent = new CategoryContent();
 

--- a/backend/module/eCampCore/test/Entity/CategoryContentTypeTemplateTest.php
+++ b/backend/module/eCampCore/test/Entity/CategoryContentTypeTemplateTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CategoryContentTypeTemplateTest extends AbstractTestCase {
-    public function testCategoryContentTypeTemplate() {
+    public function testCategoryContentTypeTemplate(): void {
         $campTemplate = new CampTemplate();
 
         $contentType = new ContentType();

--- a/backend/module/eCampCore/test/Entity/CategoryContentTypeTest.php
+++ b/backend/module/eCampCore/test/Entity/CategoryContentTypeTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CategoryContentTypeTest extends AbstractTestCase {
-    public function testCategoryContentType() {
+    public function testCategoryContentType(): void {
         $camp = new Camp();
 
         $contentType = new ContentType();

--- a/backend/module/eCampCore/test/Entity/CategoryTemplateTest.php
+++ b/backend/module/eCampCore/test/Entity/CategoryTemplateTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CategoryTemplateTest extends AbstractTestCase {
-    public function testCategoryTemplate() {
+    public function testCategoryTemplate(): void {
         $campTemplate = new CampTemplate();
         $categoryTemplate = new CategoryTemplate();
         $categoryTemplate->setName('ActivityType Name');
@@ -28,7 +28,7 @@ class CategoryTemplateTest extends AbstractTestCase {
         $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $categoryTemplate->getCategoryContentTypeTemplates());
     }
 
-    public function testCategoryContentTypeTemplate() {
+    public function testCategoryContentTypeTemplate(): void {
         $categoryTemplate = new CategoryTemplate();
         $categoryContentTypeTemplate = new CategoryContentTypeTemplate();
 
@@ -39,7 +39,7 @@ class CategoryTemplateTest extends AbstractTestCase {
         $this->assertCount(0, $categoryTemplate->getCategoryContentTypeTemplates());
     }
 
-    public function testCategoryContentTemplate() {
+    public function testCategoryContentTemplate(): void {
         $categoryTemplate = new CategoryTemplate();
         $categoryContentTemplate = new CategoryContentTemplate();
 

--- a/backend/module/eCampCore/test/Entity/CategoryTest.php
+++ b/backend/module/eCampCore/test/Entity/CategoryTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CategoryTest extends AbstractTestCase {
-    public function testCategory() {
+    public function testCategory(): void {
         $camp = new Camp();
 
         $category = new Category();
@@ -31,7 +31,7 @@ class CategoryTest extends AbstractTestCase {
         $this->assertEquals('i', $category->getNumberingStyle());
     }
 
-    public function testCategoryContentType() {
+    public function testCategoryContentType(): void {
         $category = new Category();
         $categoryContentType = new CategoryContentType();
 
@@ -42,7 +42,7 @@ class CategoryTest extends AbstractTestCase {
         $this->assertCount(0, $category->getCategoryContentTypes());
     }
 
-    public function testCategoryContent() {
+    public function testCategoryContent(): void {
         $category = new Category();
         $categoryContent = new CategoryContent();
 
@@ -53,7 +53,7 @@ class CategoryTest extends AbstractTestCase {
         $this->assertCount(0, $category->getCategoryContents());
     }
 
-    public function testNumberingStyle() {
+    public function testNumberingStyle(): void {
         $category = new Category();
 
         $this->assertEquals('31', $category->getStyledNumber(31));

--- a/backend/module/eCampCore/test/Entity/ContentTypeTest.php
+++ b/backend/module/eCampCore/test/Entity/ContentTypeTest.php
@@ -9,7 +9,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class ContentTypeTest extends AbstractTestCase {
-    public function testContentType() {
+    public function testContentType(): void {
         $contentType = new ContentType();
         $config_key = 'test';
         $config_value = 4;

--- a/backend/module/eCampCore/test/Entity/DayTest.php
+++ b/backend/module/eCampCore/test/Entity/DayTest.php
@@ -11,7 +11,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class DayTest extends AbstractTestCase {
-    public function testDay() {
+    public function testDay(): void {
         $camp = new Camp();
 
         $period = new Period();

--- a/backend/module/eCampCore/test/Entity/GroupMembershipTest.php
+++ b/backend/module/eCampCore/test/Entity/GroupMembershipTest.php
@@ -11,7 +11,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class GroupMembershipTest extends AbstractTestCase {
-    public function testGroupMembership() {
+    public function testGroupMembership(): void {
         $group = new Group();
         $user = new User();
 
@@ -29,7 +29,7 @@ class GroupMembershipTest extends AbstractTestCase {
         $this->assertEquals('install', $membership->getMembershipAcceptedBy());
     }
 
-    public function testStatus() {
+    public function testStatus(): void {
         $membership = new GroupMembership();
         $membership->setStatus(GroupMembership::STATUS_REQUESTED);
         $this->assertTrue($membership->isRequest());
@@ -44,7 +44,7 @@ class GroupMembershipTest extends AbstractTestCase {
         $membership->setStatus('test');
     }
 
-    public function testRole() {
+    public function testRole(): void {
         $membership = new GroupMembership();
         $membership->setRole(GroupMembership::ROLE_GUEST);
         $this->assertTrue($membership->isGuest());
@@ -59,7 +59,7 @@ class GroupMembershipTest extends AbstractTestCase {
         $membership->setRole('test');
     }
 
-    public function testLifecycle() {
+    public function testLifecycle(): void {
         $membership = new GroupMembership();
         $membership->setStatus(GroupMembership::STATUS_REQUESTED);
         $membership->setMembershipAcceptedBy('install');

--- a/backend/module/eCampCore/test/Entity/GroupTest.php
+++ b/backend/module/eCampCore/test/Entity/GroupTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class GroupTest extends AbstractTestCase {
-    public function testGroup() {
+    public function testGroup(): void {
         $organization = new Organization();
 
         $group = new Group();
@@ -28,7 +28,7 @@ class GroupTest extends AbstractTestCase {
         $this->assertNull($group->getParent());
     }
 
-    public function testParentGroup() {
+    public function testParentGroup(): void {
         $organization = new Organization();
 
         $group1 = new Group();
@@ -51,7 +51,7 @@ class GroupTest extends AbstractTestCase {
         $this->assertEquals(0, $group2->getChildren()->count());
     }
 
-    public function testCamp() {
+    public function testCamp(): void {
         $camp = new Camp();
         $group = new Group();
 
@@ -67,7 +67,7 @@ class GroupTest extends AbstractTestCase {
         $this->assertEquals(0, $group->getOwnedCamps()->count()); */
     }
 
-    public function testMembership() {
+    public function testMembership(): void {
         $membership = new GroupMembership();
         $group = new Group();
 

--- a/backend/module/eCampCore/test/Entity/LoginTest.php
+++ b/backend/module/eCampCore/test/Entity/LoginTest.php
@@ -11,7 +11,7 @@ use ReflectionClass;
  * @internal
  */
 class LoginTest extends AbstractTestCase {
-    public function testCreateLogin() {
+    public function testCreateLogin(): void {
         $user = new User();
         $login = new Login($user, 'test-password');
 
@@ -19,7 +19,7 @@ class LoginTest extends AbstractTestCase {
         $this->assertFalse($login->checkPassword('wrong-password'));
     }
 
-    public function testPwResetKey() {
+    public function testPwResetKey(): void {
         $user = new User();
         $login = new Login($user, 'test-password');
 
@@ -41,7 +41,7 @@ class LoginTest extends AbstractTestCase {
         $login->resetPassword('wrong-key', 'newer-password');
     }
 
-    public function testChangePassword() {
+    public function testChangePassword(): void {
         $user = new User();
         $login = new Login($user, 'test-password');
         $this->assertTrue($login->checkPassword('test-password'));
@@ -54,7 +54,7 @@ class LoginTest extends AbstractTestCase {
         $login->changePassword('test-password', 'new-password');
     }
 
-    public function testUpdateHashVersion() {
+    public function testUpdateHashVersion(): void {
         $password = (new ReflectionClass(Login::class))->getProperty('password');
         $password->setAccessible(true);
 

--- a/backend/module/eCampCore/test/Entity/MaterialItemTest.php
+++ b/backend/module/eCampCore/test/Entity/MaterialItemTest.php
@@ -13,7 +13,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class MaterialItemTest extends AbstractTestCase {
-    public function testMaterialItem() {
+    public function testMaterialItem(): void {
         $materialItem = new MaterialItem();
         $materialList = new MaterialList();
         $camp = new Camp();
@@ -35,7 +35,7 @@ class MaterialItemTest extends AbstractTestCase {
         $this->assertEquals(null, $materialItem->getUnit());
     }
 
-    public function testMaterialItemTarget() {
+    public function testMaterialItemTarget(): void {
         $materialItem = new MaterialItem();
         $period = new Period();
         $activityContent = new ActivityContent();

--- a/backend/module/eCampCore/test/Entity/MaterialListTemplateTest.php
+++ b/backend/module/eCampCore/test/Entity/MaterialListTemplateTest.php
@@ -10,7 +10,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class MaterialListTemplateTest extends AbstractTestCase {
-    public function testMaterialListTemplate() {
+    public function testMaterialListTemplate(): void {
         $materialListTemplate = new MaterialListTemplate();
         $campTemplate = new CampTemplate();
 

--- a/backend/module/eCampCore/test/Entity/MaterialListTest.php
+++ b/backend/module/eCampCore/test/Entity/MaterialListTest.php
@@ -11,7 +11,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class MaterialListTest extends AbstractTestCase {
-    public function testMaterialList() {
+    public function testMaterialList(): void {
         $materialList = new MaterialList();
         $camp = new Camp();
 
@@ -22,7 +22,7 @@ class MaterialListTest extends AbstractTestCase {
         $this->assertEquals($camp, $materialList->getCamp());
     }
 
-    public function testMaterialListAddRemoveItem() {
+    public function testMaterialListAddRemoveItem(): void {
         $materialList = new MaterialList();
         $materialItem = new MaterialItem();
 

--- a/backend/module/eCampCore/test/Entity/OrganizationTest.php
+++ b/backend/module/eCampCore/test/Entity/OrganizationTest.php
@@ -9,7 +9,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class OrganizationTest extends AbstractTestCase {
-    public function testOrganization() {
+    public function testOrganization(): void {
         $organization = new Organization();
         $organization->setName('OrganizationName');
 

--- a/backend/module/eCampCore/test/Entity/PeriodTest.php
+++ b/backend/module/eCampCore/test/Entity/PeriodTest.php
@@ -13,7 +13,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class PeriodTest extends AbstractTestCase {
-    public function testCamp() {
+    public function testCamp(): void {
         $camp = new Camp();
 
         $start = new DateUtc();
@@ -32,7 +32,7 @@ class PeriodTest extends AbstractTestCase {
         $this->assertEquals($end, $period->getEnd());
     }
 
-    public function testStartEnd() {
+    public function testStartEnd(): void {
         $start = new DateUtc();
         $end = clone $start;
         $end->add(new \DateInterval('P7D'));
@@ -48,7 +48,7 @@ class PeriodTest extends AbstractTestCase {
         $this->assertEquals($end, $period->getEnd());
     }
 
-    public function testDuration() {
+    public function testDuration(): void {
         $start = new DateUtc();
         $end = clone $start;
         $end->add(new \DateInterval('P7D'));
@@ -61,7 +61,7 @@ class PeriodTest extends AbstractTestCase {
         $this->assertEquals(8, $period->getDurationInDays());
     }
 
-    public function testDay() {
+    public function testDay(): void {
         $period = new Period();
         $day = new Day();
 
@@ -72,7 +72,7 @@ class PeriodTest extends AbstractTestCase {
         $this->assertEquals(0, $period->getDays()->count());
     }
 
-    public function testScheduleEntry() {
+    public function testScheduleEntry(): void {
         $period = new Period();
         $scheduleEntry = new ScheduleEntry();
 
@@ -83,7 +83,7 @@ class PeriodTest extends AbstractTestCase {
         $this->assertEquals(0, $period->getScheduleEntries()->count());
     }
 
-    public function testLifecycle() {
+    public function testLifecycle(): void {
         $period = new Period();
         $period->PrePersist();
         $period->PreUpdate();

--- a/backend/module/eCampCore/test/Entity/ScheduleEntryTest.php
+++ b/backend/module/eCampCore/test/Entity/ScheduleEntryTest.php
@@ -14,7 +14,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class ScheduleEntryTest extends AbstractTestCase {
-    public function testScheduleEntry() {
+    public function testScheduleEntry(): void {
         $camp = new Camp();
 
         $start = new DateUtc();

--- a/backend/module/eCampCore/test/Entity/UserTest.php
+++ b/backend/module/eCampCore/test/Entity/UserTest.php
@@ -9,7 +9,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class UserTest extends AbstractTestCase {
-    public function testUserNonRegistered() {
+    public function testUserNonRegistered(): void {
         $user = new User();
         $user->setUsername('username');
         $user->setMailAddress('test@eCamp3.ch');
@@ -20,7 +20,7 @@ class UserTest extends AbstractTestCase {
         $this->assertEquals('test@eCamp3.ch', $user->getUntrustedMailAddress());
     }
 
-    public function testUserActivated() {
+    public function testUserActivated(): void {
         $user = new User();
         $user->setState(User::STATE_REGISTERED);
         $user->setRole(User::ROLE_USER);

--- a/backend/module/eCampCore/test/Hydrator/CampHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/CampHydratorTest.php
@@ -10,7 +10,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CampHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $camp = new Camp();
         $camp->setName('name');
         $camp->setTitle('title');
@@ -24,7 +24,7 @@ class CampHydratorTest extends AbstractTestCase {
         $this->assertEquals('motto', $data['motto']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $camp = new Camp();
         $data = [
             'name' => 'name',

--- a/backend/module/eCampCore/test/Hydrator/CampTemplateHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/CampTemplateHydratorTest.php
@@ -11,7 +11,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CampTemplateHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $campTemplate = new CampTemplate();
         $campTemplate->setName('name');
 
@@ -25,7 +25,7 @@ class CampTemplateHydratorTest extends AbstractTestCase {
         // $this->assertEquals($organization, $data['organization']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $campTemplate = new CampTemplate();
         $data = [
             'name' => 'name',

--- a/backend/module/eCampCore/test/Hydrator/CategoryContentHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/CategoryContentHydratorTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CategoryContentHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $category = new Category();
         $contentType = new ContentType();
         $contentType->setName('ContentTypeName');
@@ -28,7 +28,7 @@ class CategoryContentHydratorTest extends AbstractTestCase {
         $this->assertEquals('ContentTypeName', $data['contentTypeName']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $categoryContent = new CategoryContent();
         $data = [
             'instanceName' => 'CategoryContentName',

--- a/backend/module/eCampCore/test/Hydrator/CategoryContentTemplateHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/CategoryContentTemplateHydratorTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CategoryContentTemplateHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $categoryTemplate = new CategoryTemplate();
         $contentType = new ContentType();
         $contentType->setName('ContentTypeName');
@@ -28,7 +28,7 @@ class CategoryContentTemplateHydratorTest extends AbstractTestCase {
         $this->assertEquals('ContentTypeName', $data['contentTypeName']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $categoryContentTemplate = new CategoryContentTemplate();
         $data = [
             'instanceName' => 'CategoryContentName',

--- a/backend/module/eCampCore/test/Hydrator/CategoryHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/CategoryHydratorTest.php
@@ -11,7 +11,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CategoryHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $camp = new Camp();
         $category = new Category();
         $category->setCamp($camp);
@@ -29,7 +29,7 @@ class CategoryHydratorTest extends AbstractTestCase {
         $this->assertEquals('i', $data['numberingStyle']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $camp = new Camp();
 
         $category = new Category();

--- a/backend/module/eCampCore/test/Hydrator/CategoryTemplateHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/CategoryTemplateHydratorTest.php
@@ -10,7 +10,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class CategoryTemplateHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $categoryTemplate = new CategoryTemplate();
         $categoryTemplate->setShort('n');
         $categoryTemplate->setName('name');
@@ -26,7 +26,7 @@ class CategoryTemplateHydratorTest extends AbstractTestCase {
         $this->assertEquals('i', $data['numberingStyle']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $categoryTemplate = new CategoryTemplate();
         $data = [
             'short' => 'n',

--- a/backend/module/eCampCore/test/Hydrator/ContentTypeHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/ContentTypeHydratorTest.php
@@ -10,7 +10,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class ContentTypeHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $contentType = new ContentType();
         $contentType->setName('name');
         $contentType->setActive(true);
@@ -23,7 +23,7 @@ class ContentTypeHydratorTest extends AbstractTestCase {
         $this->assertTrue($data['active']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $contentType = new ContentType();
         $data = [
             'name' => 'name',

--- a/backend/module/eCampCore/test/Hydrator/DayHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/DayHydratorTest.php
@@ -16,7 +16,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class DayHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $camp = new Camp();
         $camp->setName('name');
         $camp->setTitle('title');
@@ -58,7 +58,7 @@ class DayHydratorTest extends AbstractTestCase {
         $this->assertEquals(1, $scheduleEntries->getTotalItemCount());
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $camp = new Camp();
 
         $period = new Period();

--- a/backend/module/eCampCore/test/Hydrator/GroupHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/GroupHydratorTest.php
@@ -11,7 +11,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class GroupHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         // Disable Test
         $this->assertTrue(true);
 
@@ -36,7 +36,7 @@ class GroupHydratorTest extends AbstractTestCase {
         $this->assertEquals($parent, $data['parent']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         // Disable Test
         $this->assertTrue(true);
 

--- a/backend/module/eCampCore/test/Hydrator/GroupMembershipHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/GroupMembershipHydratorTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class GroupMembershipHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         // Disable Test
         $this->assertTrue(true);
 
@@ -36,7 +36,7 @@ class GroupMembershipHydratorTest extends AbstractTestCase {
         $this->assertEquals(GroupMembership::STATUS_ESTABLISHED, $data['status']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         // Disable Test
         $this->assertTrue(true);
 

--- a/backend/module/eCampCore/test/Hydrator/MaterialListTemplateHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/MaterialListTemplateHydratorTest.php
@@ -10,7 +10,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class MaterialListTemplateHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $materialListTemplate = new MaterialListTemplate();
         $materialListTemplate->setName('name');
 
@@ -20,7 +20,7 @@ class MaterialListTemplateHydratorTest extends AbstractTestCase {
         $this->assertEquals('name', $data['name']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $materialListTemplate = new MaterialListTemplate();
         $data = [
             'name' => 'name',

--- a/backend/module/eCampCore/test/Hydrator/OrganizationHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/OrganizationHydratorTest.php
@@ -10,7 +10,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class OrganizationHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $organization = new Organization();
         $organization->setName('name');
 
@@ -20,7 +20,7 @@ class OrganizationHydratorTest extends AbstractTestCase {
         $this->assertEquals('name', $data['name']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $organization = new Organization();
         $data = [
             'name' => 'name',

--- a/backend/module/eCampCore/test/Hydrator/PeriodHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/PeriodHydratorTest.php
@@ -12,7 +12,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class PeriodHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $camp = new Camp();
         $camp->setName('name');
         $camp->setTitle('title');
@@ -33,7 +33,7 @@ class PeriodHydratorTest extends AbstractTestCase {
         $this->assertEquals('2000-01-03', $data['end']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $camp = new Camp();
 
         $period = new Period();

--- a/backend/module/eCampCore/test/Hydrator/UserHydratorTest.php
+++ b/backend/module/eCampCore/test/Hydrator/UserHydratorTest.php
@@ -10,7 +10,7 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class UserHydratorTest extends AbstractTestCase {
-    public function testExtract() {
+    public function testExtract(): void {
         $user = new User();
         $user->setUsername('test');
 
@@ -20,7 +20,7 @@ class UserHydratorTest extends AbstractTestCase {
         $this->assertEquals('test', $data['username']);
     }
 
-    public function testHydrate() {
+    public function testHydrate(): void {
         $user = new User();
 
         $hydrator = new UserHydrator();

--- a/backend/module/eCampCore/test/Repository/UserRepositoryTest.php
+++ b/backend/module/eCampCore/test/Repository/UserRepositoryTest.php
@@ -13,7 +13,7 @@ use Hybridauth\User\Profile;
  * @internal
  */
 class UserRepositoryTest extends AbstractDatabaseTestCase {
-    public function testFindByUsername() {
+    public function testFindByUsername(): void {
         /** @var UserService $userService */
         $userService = \eCampApp::GetService(UserService::class);
 
@@ -36,7 +36,7 @@ class UserRepositoryTest extends AbstractDatabaseTestCase {
         $this->assertEmpty($user);
     }
 
-    public function testFindByMail() {
+    public function testFindByMail(): void {
         /** @var UserService $userService */
         $userService = \eCampApp::GetService(UserService::class);
 

--- a/backend/module/eCampCore/test/Service/ActivityServiceTest.php
+++ b/backend/module/eCampCore/test/Service/ActivityServiceTest.php
@@ -53,7 +53,7 @@ class ActivityServiceTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testCreateActivity() {
+    public function testCreateActivity(): void {
         /** @var ActivityService $activityService */
         $activityService = $this->getApplicationServiceLocator()->get(ActivityService::class);
 

--- a/backend/module/eCampCore/test/Service/CampServiceTest.php
+++ b/backend/module/eCampCore/test/Service/CampServiceTest.php
@@ -50,7 +50,7 @@ class CampServiceTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testCreateCampFromTemplate() {
+    public function testCreateCampFromTemplate(): void {
         /** @var CampService $campService */
         $campService = $this->getApplicationServiceLocator()->get(CampService::class);
 

--- a/backend/module/eCampCore/test/Service/MaterialItemServiceTest.php
+++ b/backend/module/eCampCore/test/Service/MaterialItemServiceTest.php
@@ -52,7 +52,7 @@ class MaterialItemServiceTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testCreateMaterialItem() {
+    public function testCreateMaterialItem(): void {
         /** @var MaterialItemService $materialItemService */
         $materialItemService = $this->getApplicationServiceLocator()->get(MaterialItemService::class);
 
@@ -85,7 +85,7 @@ class MaterialItemServiceTest extends AbstractApiControllerTestCase {
         $this->assertEquals('kg', $materialItem->getUnit());
     }
 
-    public function testAddInvalidItem() {
+    public function testAddInvalidItem(): void {
         /** @var MaterialItemService $materialItemService */
         $materialItemService = $this->getApplicationServiceLocator()->get(MaterialItemService::class);
 

--- a/backend/module/eCampCore/test/Service/MaterialListServiceTest.php
+++ b/backend/module/eCampCore/test/Service/MaterialListServiceTest.php
@@ -44,7 +44,7 @@ class MaterialListServiceTest extends AbstractApiControllerTestCase {
         $this->authenticateUser($this->user);
     }
 
-    public function testCreateMaterialList() {
+    public function testCreateMaterialList(): void {
         /** @var MaterialListService $materialListService */
         $materialListService = $this->getApplicationServiceLocator()->get(MaterialListService::class);
 
@@ -72,7 +72,7 @@ class MaterialListServiceTest extends AbstractApiControllerTestCase {
         $this->assertEquals('MaterialList', $materialList->getName());
     }
 
-    public function testUpdateMaterialList() {
+    public function testUpdateMaterialList(): void {
         /** @var MaterialListService $materialListService */
         $materialListService = $this->getApplicationServiceLocator()->get(MaterialListService::class);
 
@@ -96,7 +96,7 @@ class MaterialListServiceTest extends AbstractApiControllerTestCase {
         $this->assertEquals('NewName', $materialList->getName());
     }
 
-    public function testDeleteMaterialList() {
+    public function testDeleteMaterialList(): void {
         /** @var MaterialListService $materialListService */
         $materialListService = $this->getApplicationServiceLocator()->get(MaterialListService::class);
 

--- a/backend/module/eCampCore/test/Service/UserServiceTest.php
+++ b/backend/module/eCampCore/test/Service/UserServiceTest.php
@@ -16,7 +16,7 @@ class UserServiceTest extends AbstractDatabaseTestCase {
     const USERNAME = 'username';
     const EMAIL = 'test@eCamp3.ch';
 
-    public function testCreateUser() {
+    public function testCreateUser(): void {
         /** @var UserService $userService */
         $userService = \eCampApp::GetService(UserService::class);
 
@@ -29,7 +29,7 @@ class UserServiceTest extends AbstractDatabaseTestCase {
         $this->assertEquals(User::STATE_NONREGISTERED, $user->getState());
     }
 
-    public function testGetUser() {
+    public function testGetUser(): void {
         /** @var UserService $userService */
         $userService = \eCampApp::GetService(UserService::class);
         /** @var AuthenticationService $auth */
@@ -51,7 +51,7 @@ class UserServiceTest extends AbstractDatabaseTestCase {
         $user3 = $userService->fetch(-1);
     }
 
-    public function testGetUserByEmail() {
+    public function testGetUserByEmail(): void {
         /** @var UserService $userService */
         $userService = \eCampApp::GetService(UserService::class);
 
@@ -64,7 +64,7 @@ class UserServiceTest extends AbstractDatabaseTestCase {
         $this->assertThat($foundUser, self::isSameUserAs($user));
     }
 
-    public function testGetUserByName() {
+    public function testGetUserByName(): void {
         /** @var UserService $userService */
         $userService = \eCampApp::GetService(UserService::class);
 

--- a/backend/module/eCampLib/src/Acl/Acl.php
+++ b/backend/module/eCampLib/src/Acl/Acl.php
@@ -34,7 +34,7 @@ class Acl extends LaminasAcl {
      *
      * @throws NoAccessException
      */
-    public function assertAllowed($role = null, $resource = null, $privilege = null) {
+    public function assertAllowed($role = null, $resource = null, $privilege = null): void {
         if (!$this->isAllowed($role, $resource, $privilege)) {
             throw new NoAccessException();
         }

--- a/backend/module/eCampLib/src/Amqp/AmqpService.php
+++ b/backend/module/eCampLib/src/Amqp/AmqpService.php
@@ -34,7 +34,7 @@ class AmqpService {
         return $queue;
     }
 
-    public function sendAsJson($topicOrQueue, $messageArrayOrObject) {
+    public function sendAsJson($topicOrQueue, $messageArrayOrObject): void {
         $message = $this->context->createMessage(json_encode($messageArrayOrObject));
         $this->context->createProducer()->send($topicOrQueue, $message);
     }

--- a/backend/module/eCampLib/src/Command/LoadDataFixturesCommand.php
+++ b/backend/module/eCampLib/src/Command/LoadDataFixturesCommand.php
@@ -22,7 +22,7 @@ class LoadDataFixturesCommand extends AbstractParamAwareCommand {
         $this->filesystem = $filesystem;
     }
 
-    protected function configure() {
+    protected function configure(): void {
         $this->addParam(new PathParam('path', PathParam::TYPE_DIR));
     }
 

--- a/backend/module/eCampLib/src/Entity/BaseEntity.php
+++ b/backend/module/eCampLib/src/Entity/BaseEntity.php
@@ -53,7 +53,7 @@ abstract class BaseEntity implements ResourceInterface {
     /**
      * @ORM\PrePersist
      */
-    public function PrePersist() {
+    public function PrePersist(): void {
         $this->createTime = new DateTimeUtc();
         $this->updateTime = new DateTimeUtc();
     }
@@ -61,7 +61,7 @@ abstract class BaseEntity implements ResourceInterface {
     /**
      * @ORM\PreUpdate
      */
-    public function PreUpdate() {
+    public function PreUpdate(): void {
         $this->updateTime = new DateTimeUtc();
     }
 

--- a/backend/module/eCampLib/src/Fixture/ContainerAwareTrait.php
+++ b/backend/module/eCampLib/src/Fixture/ContainerAwareTrait.php
@@ -11,7 +11,7 @@ trait ContainerAwareTrait {
         return $this->container;
     }
 
-    public function setContainer(ContainerInterface $container) {
+    public function setContainer(ContainerInterface $container): void {
         $this->container = $container;
     }
 }

--- a/backend/module/eCampLib/src/Fixture/FixtureLoader.php
+++ b/backend/module/eCampLib/src/Fixture/FixtureLoader.php
@@ -16,7 +16,7 @@ class FixtureLoader extends BaseLoader {
         $this->container = $container;
     }
 
-    public function addFixture(FixtureInterface $fixture) {
+    public function addFixture(FixtureInterface $fixture): void {
         if ($fixture instanceof ContainerAwareInterface) {
             $fixture->setContainer($this->container);
         }

--- a/backend/module/eCampLib/src/Hal/CollectionRenderer.php
+++ b/backend/module/eCampLib/src/Hal/CollectionRenderer.php
@@ -19,32 +19,32 @@ class CollectionRenderer extends AbstractListenerAggregate {
      */
     protected $sharedListeners = [];
 
-    public function attach(EventManagerInterface $events, $priority = 1) {
+    public function attach(EventManagerInterface $events, $priority = 1): void {
         $sharedEvents = $events->getSharedManager();
         $this->attachShared($sharedEvents);
     }
 
-    public function detach(EventManagerInterface $events) {
+    public function detach(EventManagerInterface $events): void {
         parent::detach($events);
 
         $sharedEvents = $events->getSharedManager();
         $this->detachShared($sharedEvents);
     }
 
-    public function attachShared(SharedEventManagerInterface $sharedEvents) {
+    public function attachShared(SharedEventManagerInterface $sharedEvents): void {
         $this->sharedListeners[] = $sharedEvents->attach('Laminas\ApiTools\Hal\Plugin\Hal', 'renderEntity', [$this, 'renderEntity'], 100);
         $this->sharedListeners[] = $sharedEvents->attach('Laminas\ApiTools\Hal\Plugin\Hal', 'renderEntity.post', [$this, 'renderEntityPost'], 100);
         $this->sharedListeners[] = $sharedEvents->attach('Laminas\ApiTools\Hal\Plugin\Hal', 'renderCollection', [$this, 'renderCollection'], 100);
     }
 
-    public function detachShared(SharedEventManagerInterface $sharedEvents) {
+    public function detachShared(SharedEventManagerInterface $sharedEvents): void {
         foreach ($this->sharedListeners as $index => $callback) {
             $sharedEvents->detach($callback);
             unset($this->sharedListeners[$index]);
         }
     }
 
-    public function renderEntity(Event $e) {
+    public function renderEntity(Event $e): void {
         /** @var Hal $hal */
         $hal = $e->getTarget();
 
@@ -75,7 +75,7 @@ class CollectionRenderer extends AbstractListenerAggregate {
         }
     }
 
-    public function renderEntityPost(Event $e) {
+    public function renderEntityPost(Event $e): void {
         /** @var Hal $hal */
         $hal = $e->getTarget();
 
@@ -107,7 +107,7 @@ class CollectionRenderer extends AbstractListenerAggregate {
 //        );
     }
 
-    public function renderCollection(Event $e) {
+    public function renderCollection(Event $e): void {
         /** @var Hal $hal */
         $hal = $e->getTarget();
         $halCollection = $e->getParam('collection');

--- a/backend/module/eCampLib/src/Hal/Extractor/LinkExtractor.php
+++ b/backend/module/eCampLib/src/Hal/Extractor/LinkExtractor.php
@@ -238,7 +238,6 @@ class LinkExtractor extends HalLinkExtractor {
 
     /**
      * @param $parts
-     * @param array $mergedParams
      * @param $isOptional
      * @param $hasChild
      */
@@ -303,7 +302,7 @@ class LinkExtractor extends HalLinkExtractor {
      *
      * @throws \ReflectionException
      */
-    protected function addChildRoutes(Part $route) {
+    protected function addChildRoutes(Part $route): void {
         $reflectionProp = new \ReflectionProperty(get_class($route), 'childRoutes');
         $reflectionProp->setAccessible(true);
         $childRoutes = $reflectionProp->getValue($route);

--- a/backend/module/eCampLib/src/Mail/ElasticMail.php
+++ b/backend/module/eCampLib/src/Mail/ElasticMail.php
@@ -13,7 +13,7 @@ class ElasticMail implements ProviderInterface {
         $this->mailTransport = $mailTransport;
     }
 
-    public function sendMail(MessageData $data) {
+    public function sendMail(MessageData $data): void {
         $mail = new ElasticEmail();
         $mail->setFrom($data->from);
         $mail->setTo($data->to);

--- a/backend/module/eCampLib/src/Mail/LaminasMail.php
+++ b/backend/module/eCampLib/src/Mail/LaminasMail.php
@@ -22,7 +22,7 @@ class LaminasMail implements ProviderInterface {
         $this->templateConfig = $templateConfig;
     }
 
-    public function sendMail(MessageData $message) {
+    public function sendMail(MessageData $message): void {
         $body = $this->createBody($message);
 
         $mail = new MailMessage();

--- a/backend/module/eCampLib/src/Module.php
+++ b/backend/module/eCampLib/src/Module.php
@@ -19,11 +19,11 @@ class Module implements InitProviderInterface {
         return include __DIR__.'/../config/module.config.php';
     }
 
-    public function init(ModuleManagerInterface $manager) {
+    public function init(ModuleManagerInterface $manager): void {
         EntityFilterManagerFactory::initModule($manager);
     }
 
-    public function onBootstrap(MvcEvent $e) {
+    public function onBootstrap(MvcEvent $e): void {
         /** @var Application $app */
         $app = $e->getApplication();
         /** @var EventManager $events */
@@ -40,7 +40,7 @@ class Module implements InitProviderInterface {
         (new CollectionRenderer())->attach($events);
     }
 
-    public function registerSentry(Application $app) {
+    public function registerSentry(Application $app): void {
         $container = $app->getServiceManager();
         $eventManager = $app->getEventManager();
 

--- a/backend/module/eCampLib/src/Service/ServiceUtils.php
+++ b/backend/module/eCampLib/src/Service/ServiceUtils.php
@@ -45,10 +45,8 @@ class ServiceUtils {
      * @param RoleInterface|string     $role
      * @param ResourceInterface|string $resource
      * @param string                   $privilege
-     *
-     * @return bool
      */
-    public function aclIsAllowed($role = null, $resource = null, $privilege = null) {
+    public function aclIsAllowed($role = null, $resource = null, $privilege = null): bool {
         return $this->acl->isAllowed($role, $resource, $privilege);
     }
 
@@ -59,7 +57,7 @@ class ServiceUtils {
      *
      * @throws NoAccessException
      */
-    public function aclAssertAllowed($role = null, $resource = null, $privilege = null) {
+    public function aclAssertAllowed($role = null, $resource = null, $privilege = null): void {
         $this->acl->assertAllowed($role, $resource, $privilege);
     }
 
@@ -80,14 +78,14 @@ class ServiceUtils {
     /**
      * @throws ORMException
      */
-    public function emPersist(BaseEntity $entity) {
+    public function emPersist(BaseEntity $entity): void {
         $this->entityManager->persist($entity);
     }
 
     /**
      * @throws ORMException
      */
-    public function emRemove(BaseEntity $entity) {
+    public function emRemove(BaseEntity $entity): void {
         $this->entityManager->remove($entity);
     }
 
@@ -95,7 +93,7 @@ class ServiceUtils {
      * @throws ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
      */
-    public function emFlush() {
+    public function emFlush(): void {
         $this->entityManager->flush();
     }
 

--- a/backend/module/eCampLib/src/ServiceManager/EntityFilterManagerFactory.php
+++ b/backend/module/eCampLib/src/ServiceManager/EntityFilterManagerFactory.php
@@ -11,7 +11,7 @@ class EntityFilterManagerFactory extends AbstractPluginManagerFactory {
     const CONFIG_KEY = 'entity_filter';
     const CONFIG_METHOD = 'getEntityFilterConfig';
 
-    public static function initModule(ModuleManagerInterface $manager) {
+    public static function initModule(ModuleManagerInterface $manager): void {
         /** @var \Laminas\ModuleManager\ModuleManager $manager */
         $sm = $manager->getEvent()->getParam('ServiceManager');
         /** @var \Laminas\ModuleManager\Listener\ServiceListener $serviceListener */

--- a/backend/module/eCampLib/src/Types/Doctrine/DateTimeUtcType.php
+++ b/backend/module/eCampLib/src/Types/Doctrine/DateTimeUtcType.php
@@ -12,8 +12,6 @@ class DateTimeUtcType extends DateTimeType {
     private static ?DateTimeZone $utc = null;
 
     /**
-     * @param mixed $value
-     *
      * @throws ConversionException
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string {
@@ -25,8 +23,6 @@ class DateTimeUtcType extends DateTimeType {
     }
 
     /**
-     * @param mixed $value
-     *
      * @throws ConversionException
      * @throws \Exception
      */

--- a/backend/module/eCampLib/src/Types/Doctrine/DateUtcType.php
+++ b/backend/module/eCampLib/src/Types/Doctrine/DateUtcType.php
@@ -15,8 +15,6 @@ class DateUtcType extends DateType {
     private static $utc;
 
     /**
-     * @param mixed $value
-     *
      * @throws ConversionException
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string {
@@ -28,8 +26,6 @@ class DateUtcType extends DateType {
     }
 
     /**
-     * @param mixed $value
-     *
      * @throws ConversionException
      * @throws Exception
      */

--- a/backend/module/eCampLib/test/Acl/AclTest.php
+++ b/backend/module/eCampLib/test/Acl/AclTest.php
@@ -10,14 +10,14 @@ use eCamp\LibTest\PHPUnit\AbstractTestCase;
  * @internal
  */
 class AclTest extends AbstractTestCase {
-    public function testIsAllowed() {
+    public function testIsAllowed(): void {
         /** @var Acl $acl */
         $acl = \eCampApp::GetService(Acl::class);
 
         $this->assertFalse($acl->isAllowed());
     }
 
-    public function testAssertAllowed() {
+    public function testAssertAllowed(): void {
         /** @var Acl $acl */
         $acl = \eCampApp::GetService(Acl::class);
 

--- a/backend/module/eCampLib/test/Command/LoadDataFixturesCommandTest.php
+++ b/backend/module/eCampLib/test/Command/LoadDataFixturesCommandTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * @internal
  */
 class LoadDataFixturesCommandTest extends AbstractConsoleControllerTestCase {
-    public function testLoadsFilesFromGivenPath() {
+    public function testLoadsFilesFromGivenPath(): void {
         // given
         $services = $this->getApplicationServiceLocator();
 
@@ -40,7 +40,7 @@ class LoadDataFixturesCommandTest extends AbstractConsoleControllerTestCase {
         $this->assertThat($consoleOutput, new StringContains('Fixture2'));
     }
 
-    public function testDoesNotCrashWhenGivenNonexistentLocation() {
+    public function testDoesNotCrashWhenGivenNonexistentLocation(): void {
         // given
         $services = $this->getApplicationServiceLocator();
 
@@ -66,7 +66,7 @@ class LoadDataFixturesCommandTest extends AbstractConsoleControllerTestCase {
         $this->assertThat($consoleOutput, new IsEqual(''));
     }
 
-    public function testCleansUpDoctrineProxies() {
+    public function testCleansUpDoctrineProxies(): void {
         // given
         $services = $this->getApplicationServiceLocator();
         $input = new StringInput('load-data-fixtures --path='.__DIR__.'/../data/fixtures');

--- a/backend/module/eCampLib/test/Command/RebuildDatabaseSchemaCommandTest.php
+++ b/backend/module/eCampLib/test/Command/RebuildDatabaseSchemaCommandTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Constraint\IsEqual;
  * @internal
  */
 class RebuildDatabaseSchemaCommandTest extends AbstractConsoleControllerTestCase {
-    public function testRebuildsDatabaseSchema() {
+    public function testRebuildsDatabaseSchema(): void {
         // given
         $services = $this->getApplicationServiceLocator();
 

--- a/backend/module/eCampLib/test/Command/UpdateDatabaseSchemaCommandTest.php
+++ b/backend/module/eCampLib/test/Command/UpdateDatabaseSchemaCommandTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Constraint\IsEqual;
  * @internal
  */
 class UpdateDatabaseSchemaCommandTest extends AbstractConsoleControllerTestCase {
-    public function testUpdatesDatabaseSchema() {
+    public function testUpdatesDatabaseSchema(): void {
         // given
         $services = $this->getApplicationServiceLocator();
 

--- a/backend/module/eCampLib/test/Hal/LinkExtractorTest.php
+++ b/backend/module/eCampLib/test/Hal/LinkExtractorTest.php
@@ -62,7 +62,7 @@ class LinkExtractorTest extends AbstractTestCase {
         $this->linkExtractor->setRouter($router);
     }
 
-    public function testFixSegmentLink() {
+    public function testFixSegmentLink(): void {
         /** @var Link $link */
         $link = Link::factory([
             'rel' => 'self',
@@ -74,7 +74,7 @@ class LinkExtractorTest extends AbstractTestCase {
         $this->assertEquals('https://ecamp3.ch/lit/fix', $res['href']);
     }
 
-    public function testEntityCollectionLink() {
+    public function testEntityCollectionLink(): void {
         /** @var Link $link */
         $link = Link::factory([
             'rel' => 'col',
@@ -86,7 +86,7 @@ class LinkExtractorTest extends AbstractTestCase {
         $this->assertEquals('https://ecamp3.ch/lit/entity', $res['href']);
     }
 
-    public function testEntityLink() {
+    public function testEntityLink(): void {
         /** @var Link $link */
         $link = Link::factory([
             'rel' => 'col',
@@ -103,7 +103,7 @@ class LinkExtractorTest extends AbstractTestCase {
         $this->assertEquals('https://ecamp3.ch/lit/entity/123', $res['href']);
     }
 
-    public function testTemplatedLink() {
+    public function testTemplatedLink(): void {
         $link = TemplatedLink::factory([
             'rel' => 'col',
             'route' => 'lit/entity',

--- a/backend/module/eCampLib/test/PHPUnit/AbstractApiControllerTestCase.php
+++ b/backend/module/eCampLib/test/PHPUnit/AbstractApiControllerTestCase.php
@@ -47,7 +47,7 @@ abstract class AbstractApiControllerTestCase extends LaminasAbstractHttpControll
     }
 
     /** @throws ToolsException */
-    protected function createDatabaseSchema(EntityManager $em) {
+    protected function createDatabaseSchema(EntityManager $em): void {
         $metadatas = $em->getMetadataFactory()->getAllMetadata();
 
         $schemaTool = new SchemaTool($em);
@@ -57,17 +57,13 @@ abstract class AbstractApiControllerTestCase extends LaminasAbstractHttpControll
 
     /**
      * Set request content encoded as JSON.
-     *
-     * @param mixed $content
      */
-    protected function setRequestContent($content) {
+    protected function setRequestContent($content): void {
         $this->getRequest()->setContent(json_encode($content));
     }
 
     /**
      * Get response content decoded from JSON.
-     *
-     * @return mixed
      */
     protected function getResponseContent() {
         return json_decode($this->getResponse()->getContent());
@@ -92,7 +88,7 @@ abstract class AbstractApiControllerTestCase extends LaminasAbstractHttpControll
     /**
      * Authenticates a given $user.
      */
-    protected function authenticateUser(User $user) {
+    protected function authenticateUser(User $user): void {
         /** @var AuthenticationService $auth */
         $auth = $this->getApplicationServiceLocator()->get(AuthenticationService::class);
         $auth->getStorage()->write($user->getId());
@@ -111,7 +107,7 @@ abstract class AbstractApiControllerTestCase extends LaminasAbstractHttpControll
     /**
      * Verifies HAL response.
      */
-    protected function verifyHalResourceResponse(string $rootAsJson, string $linksAsJson, array $embeddedObjectList) {
+    protected function verifyHalResourceResponse(string $rootAsJson, string $linksAsJson, array $embeddedObjectList): void {
         $response = $this->getResponseContent();
 
         // verify correctness of links
@@ -130,7 +126,7 @@ abstract class AbstractApiControllerTestCase extends LaminasAbstractHttpControll
     /**
      * loads data from Fixtures into ORM.
      */
-    protected function loadFixtures(Loader $loader) {
+    protected function loadFixtures(Loader $loader): void {
         $purger = new ORMPurger();
         $executor = new ORMExecutor($this->getEntityManager(), $purger);
         $executor->execute($loader->getFixtures());

--- a/backend/module/eCampLib/test/PHPUnit/AbstractConsoleControllerTestCase.php
+++ b/backend/module/eCampLib/test/PHPUnit/AbstractConsoleControllerTestCase.php
@@ -42,7 +42,7 @@ abstract class AbstractConsoleControllerTestCase extends LaminasAbstractConsoleC
         $this->createDatabaseSchema($em);
     }
 
-    public function runCommand(Command $command, InputInterface $input = null, OutputInterface $output = null) {
+    public function runCommand(Command $command, InputInterface $input = null, OutputInterface $output = null): void {
         $command->setApplication($this->getSymfonyApplication());
         $command->run(
             $input ?? new StringInput(''),
@@ -66,7 +66,7 @@ abstract class AbstractConsoleControllerTestCase extends LaminasAbstractConsoleC
     }
 
     /** @throws ToolsException */
-    protected function createDatabaseSchema(EntityManager $em) {
+    protected function createDatabaseSchema(EntityManager $em): void {
         $metadatas = $em->getMetadataFactory()->getAllMetadata();
 
         $schemaTool = new SchemaTool($em);
@@ -77,7 +77,7 @@ abstract class AbstractConsoleControllerTestCase extends LaminasAbstractConsoleC
     /**
      * loads data from Fixtures into ORM.
      */
-    protected function loadFixtures(Loader $loader) {
+    protected function loadFixtures(Loader $loader): void {
         $purger = new ORMPurger();
         $executor = new ORMExecutor($this->getEntityManager(), $purger);
         $executor->execute($loader->getFixtures());

--- a/backend/module/eCampLib/test/PHPUnit/AbstractDatabaseTestCase.php
+++ b/backend/module/eCampLib/test/PHPUnit/AbstractDatabaseTestCase.php
@@ -31,7 +31,7 @@ abstract class AbstractDatabaseTestCase extends TestCase {
     /**
      * @throws ToolsException
      */
-    protected function createDatabaseSchema(EntityManager $em) {
+    protected function createDatabaseSchema(EntityManager $em): void {
         $metadatas = $em->getMetadataFactory()->getAllMetadata();
 
         $schemaTool = new SchemaTool($em);

--- a/backend/module/eCampLib/test/Types/DateTimeUtcTest.php
+++ b/backend/module/eCampLib/test/Types/DateTimeUtcTest.php
@@ -27,27 +27,27 @@ class DateTimeUtcTest extends AbstractTestCase {
         date_default_timezone_set($this->initialTimeZone);
     }
 
-    public function testParsing() {
+    public function testParsing(): void {
         $date = new DateTimeUtc(self::TEST_DATETIME);
         $this->assertThat($date->__toString(), self::equalTo(self::TEST_DATETIME));
     }
 
-    public function testParsingFail() {
+    public function testParsingFail(): void {
         $this->expectException(InvalidDateFormatException::class);
         new DateTimeUtc(self::TEST_DATE);
     }
 
-    public function testTimezoneFail() {
+    public function testTimezoneFail(): void {
         $this->expectException(InvalidZoneOffsetException::class);
         new DateTimeUtc(self::TEST_DATETIME_TIMEZONE);
     }
 
-    public function testParsingCustom() {
+    public function testParsingCustom(): void {
         $date = new DateTimeUtc(self::TEST_DATETIME_CUSTOMFORMAT, null, 'Y-m-d H:i:s');
         $this->assertThat($date->__toString(), self::equalTo(self::TEST_DATETIME));
     }
 
-    public function testTimezoneDifferent() {
+    public function testTimezoneDifferent(): void {
         date_default_timezone_set('UTC');
         $dateUTC = new DateTimeUtc();
         date_default_timezone_set('CET');
@@ -55,7 +55,7 @@ class DateTimeUtcTest extends AbstractTestCase {
         $this->assertThat($dateZurich->format('G'), self::equalTo($dateUTC->format('G')));
     }
 
-    public function testTimezoneDifferentNative() {
+    public function testTimezoneDifferentNative(): void {
         date_default_timezone_set('UTC');
         $dateUTC = new \DateTime();
         date_default_timezone_set('CET');

--- a/backend/module/eCampLib/test/Types/DateUtcTest.php
+++ b/backend/module/eCampLib/test/Types/DateUtcTest.php
@@ -15,22 +15,22 @@ class DateUtcTest extends AbstractTestCase {
     const TEST_DATETIME = '2020-07-01T00:00+00:00';
     const TEST_DATETIME_CUSTOMFORMAT = '2020-07-01 00:00:00';
 
-    public function testParsing() {
+    public function testParsing(): void {
         $date = new DateUtc(self::TEST_DATE);
         $this->assertThat($date->__toString(), self::equalTo(self::TEST_DATE));
     }
 
-    public function testParsingFail() {
+    public function testParsingFail(): void {
         $this->expectException(InvalidDateFormatException::class);
         new DateUtc(self::TEST_DATETIME);
     }
 
-    public function testTimezoneFail() {
+    public function testTimezoneFail(): void {
         $this->expectException(InvalidZoneOffsetException::class);
         new DateUtc(self::TEST_DATE, new \DateTimeZone('GMT'));
     }
 
-    public function testParsingCustom() {
+    public function testParsingCustom(): void {
         $date = new DateUtc(self::TEST_DATETIME_CUSTOMFORMAT, null, 'Y-m-d H:i:s');
         $this->assertThat($date->__toString(), self::equalTo(self::TEST_DATE));
     }

--- a/backend/module/eCampLib/test/V1/Rpc/Invitation/InvitationControllerTest.php
+++ b/backend/module/eCampLib/test/V1/Rpc/Invitation/InvitationControllerTest.php
@@ -46,13 +46,13 @@ class InvitationControllerTest extends AbstractApiControllerTestCase {
         $this->campCollaborationInvited = $campCollaborationTestData->getReference(CampCollaborationTestData::$COLLAB_INVITED);
     }
 
-    public function testNotFoundForNotMatchingInviteKey() {
+    public function testNotFoundForNotMatchingInviteKey(): void {
         $this->dispatch("{$this->apiEndpoint}/find/doesNotExist", 'GET');
 
         $this->assertResponseStatusCode(404);
     }
 
-    public function testFindsInvitation() {
+    public function testFindsInvitation(): void {
         $this->dispatch("{$this->apiEndpoint}/find/{$this->campCollaborationInvited->getInviteKey()}", 'GET');
 
         $this->assertResponseStatusCode(200);
@@ -79,7 +79,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFindsInvitationWhenLoggedIn() {
+    public function testFindsInvitationWhenLoggedIn(): void {
         $this->authenticateUser($this->newUser);
         $this->dispatch("{$this->apiEndpoint}/find/{$this->campCollaborationInvited->getInviteKey()}", 'GET');
 
@@ -106,7 +106,7 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testFindsInvitationWhenAlreadyInCamp() {
+    public function testFindsInvitationWhenAlreadyInCamp(): void {
         $this->authenticateUser($this->userAlreadyInCamp);
         $this->dispatch("{$this->apiEndpoint}/find/{$this->campCollaborationInvited->getInviteKey()}", 'GET');
 
@@ -133,39 +133,39 @@ JSON;
         $this->verifyHalResourceResponse($expectedBody, $expectedLinks, $expectedEmbeddedObjects);
     }
 
-    public function testAcceptFailsWhenGetRequest() {
+    public function testAcceptFailsWhenGetRequest(): void {
         $this->dispatch("{$this->apiEndpoint}/accept/{$this->campCollaborationInvited->getInviteKey()}", 'GET');
 
         $this->assertResponseStatusCode(400);
     }
 
-    public function testRejectFailsWhenGetRequest() {
+    public function testRejectFailsWhenGetRequest(): void {
         $this->dispatch("{$this->apiEndpoint}/reject/{$this->campCollaborationInvited->getInviteKey()}", 'GET');
 
         $this->assertResponseStatusCode(400);
     }
 
-    public function testAcceptFailsWhenNotAuthenticated() {
+    public function testAcceptFailsWhenNotAuthenticated(): void {
         $this->dispatch("{$this->apiEndpoint}/accept/{$this->campCollaborationInvited->getInviteKey()}", 'POST');
 
         $this->assertResponseStatusCode(401);
     }
 
-    public function testAcceptInvitationWithUserAlreadyInCamp() {
+    public function testAcceptInvitationWithUserAlreadyInCamp(): void {
         $this->authenticateUser($this->userAlreadyInCamp);
         $this->dispatch("{$this->apiEndpoint}/accept/{$this->campCollaborationInvited->getInviteKey()}", 'POST');
 
         $this->assertResponseStatusCode(422);
     }
 
-    public function testAcceptInvitation() {
+    public function testAcceptInvitation(): void {
         $this->authenticateUser($this->newUser);
         $this->dispatch("{$this->apiEndpoint}/accept/{$this->campCollaborationInvited->getInviteKey()}", 'POST');
 
         $this->assertResponseStatusCode(200);
     }
 
-    public function testRejectInvitation() {
+    public function testRejectInvitation(): void {
         $this->dispatch("{$this->apiEndpoint}/reject/{$this->campCollaborationInvited->getInviteKey()}", 'POST');
 
         $this->assertResponseStatusCode(200);

--- a/backend/module/eCampLib/test/data/fixtures/Fixture1.php
+++ b/backend/module/eCampLib/test/data/fixtures/Fixture1.php
@@ -13,7 +13,7 @@ class Fixture1 extends AbstractFixture {
         $this->output = $output;
     }
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $this->output->writeln('Fixture1');
     }
 }

--- a/backend/module/eCampLib/test/data/fixtures/Fixture2.php
+++ b/backend/module/eCampLib/test/data/fixtures/Fixture2.php
@@ -14,7 +14,7 @@ class Fixture2 extends AbstractFixture implements DependentFixtureInterface {
         $this->output = $output;
     }
 
-    public function load(ObjectManager $manager) {
+    public function load(ObjectManager $manager): void {
         $this->output->writeln('Fixture2');
     }
 

--- a/backend/public/setup.php
+++ b/backend/public/setup.php
@@ -131,7 +131,7 @@ if (array_key_exists('drop-data', $_GET)) {
 
 //  Schema-Validation:
 // ====================
-$schemaValidation = function () use ($schemaTool, $allMetadata) {
+$schemaValidation = function () use ($schemaTool, $allMetadata): void {
     try {
         $updateSqls = $schemaTool->getUpdateSchemaSql($allMetadata, true);
         if (0 !== count($updateSqls)) {


### PR DESCRIPTION
Fixes #838 

In AuthController and Auth\BaseController, the redirect responses are necessary due to the OAuth protocol. So there, we are not able to return ViewModel. In all other places, we now return ViewModel, and also declare `void` return types. php-cs-fixer made this easy, but we can't permanently activate these rules without enabling risky rules.