### PR TITLE
add link for phpunit for testexplorer

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -1,0 +1,1 @@
+backend/vendor/phpunit/phpunit/phpunit


### PR DESCRIPTION
## VS Code + PHPUnit Test Explorer
[PHPUnit Test Explorer](https://marketplace.visualstudio.com/items?itemName=recca0120.vscode-phpunit)

TestExplorer muss phpunit finden.
Es schaut an folgenden Orten: ./phpunit und ./vendor/bin/phpunit.
Da wir einen Ordner /backend  haben, wird phpunit nicht gefunden.

Eigentlich kann man den phpunit-Pfad konfigurieren. Leider muss der absolute Pfad angegeben werden.
Bei mir wäre das _/home/pimattmann/Projects/ecamp3/backend/vendor/bin/phpunit_.
Diese Konfiguration kann ich schlecht zur Verfügung stellen.

Was jedoch funktioniert:
Symbolic Link von ./phpunit auf ./backend/vendor/phpunit/phpunit/phpunit