### PR TITLE
Use InMemory-MailTransport

### DIFF
--- a/backend/config/autoload/mail.global.test.php
+++ b/backend/config/autoload/mail.global.test.php
@@ -4,9 +4,6 @@ return [
     'laminas_mail' => [
         'transport' => [
             'type' => 'InMemory',
-            'options' => [
-                'path' => __DIR__.'/../../data/mail',
-            ],
         ],
     ],
 ];

--- a/backend/config/autoload/mail.global.test.php
+++ b/backend/config/autoload/mail.global.test.php
@@ -3,7 +3,7 @@
 return [
     'laminas_mail' => [
         'transport' => [
-            'type' => 'file',
+            'type' => 'InMemory',
             'options' => [
                 'path' => __DIR__.'/../../data/mail',
             ],

--- a/backend/module/eCampCore/test/Service/UserServiceTest.php
+++ b/backend/module/eCampCore/test/Service/UserServiceTest.php
@@ -7,6 +7,8 @@ use eCamp\Core\EntityService\UserService;
 use eCamp\Lib\Service\EntityNotFoundException;
 use eCamp\LibTest\PHPUnit\AbstractDatabaseTestCase;
 use Laminas\Authentication\AuthenticationService;
+use Laminas\Mail\Transport\InMemory;
+use Laminas\Mail\Transport\TransportInterface;
 use PHPUnit\Framework\Constraint\Constraint;
 
 /**
@@ -19,6 +21,8 @@ class UserServiceTest extends AbstractDatabaseTestCase {
     public function testCreateUser(): void {
         /** @var UserService $userService */
         $userService = \eCampApp::GetService(UserService::class);
+        /** @var InMemory $mailTransport */
+        $mailTransport = \eCampApp::GetService(TransportInterface::class);
 
         /** @var User $user */
         $user = $userService->create((object) [
@@ -27,6 +31,11 @@ class UserServiceTest extends AbstractDatabaseTestCase {
         ]);
 
         $this->assertEquals(User::STATE_NONREGISTERED, $user->getState());
+
+        $message = $mailTransport->getLastMessage();
+        $this->assertCount(1, $message->getTo());
+        $to = $message->getTo()->current();
+        $this->assertEquals(self::EMAIL, $to->getEmail());
     }
 
     public function testGetUser(): void {


### PR DESCRIPTION
Use InMemory-MailTransport
1. /backend/data/mail wird nicht von UnitTests sinnlos geflutet
2. Es erlaubt UnitTests zu prüfen, ob Mail versendet wurde