### PR TITLE
Bugfix: API relation check

### DIFF
--- a/frontend/src/components/form/api/ApiWrapper.vue
+++ b/frontend/src/components/form/api/ApiWrapper.vue
@@ -108,11 +108,19 @@ export default {
       // return value from API unless `value` is set explicitly
       } else {
         let val = this.api.get(this.uri)[this.fieldname]
+
+        // while loading, value is null
+        // (necessary because while loading, even normal properties are returned as functions)
+        if (val.loading) return null
+
+        // Check if val is an embedded collection
         if (val instanceof Function) {
           val = val()
-          if ('items' in val) {
-            val = val.items
+          if (!('items' in val)) {
+            console.error('You are trying to use a fieldname ' + this.fieldname + ' in an ApiFormComponent, but ' + this.fieldname + ' is a relation, not a primitive value or embedded collection.')
+            return null
           }
+          val = val.items
         }
         return val
       }

--- a/frontend/src/components/form/api/ApiWrapper.vue
+++ b/frontend/src/components/form/api/ApiWrapper.vue
@@ -111,7 +111,7 @@ export default {
 
         // while loading, value is null
         // (necessary because while loading, even normal properties are returned as functions)
-        if (val.loading) return null
+        if (val && val.loading) return null
 
         // Check if val is an embedded collection
         if (val instanceof Function) {

--- a/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
@@ -368,6 +368,40 @@ describe('Testing ApiWrapper [autoSave=true; value from API]', () => {
     expect(vm.hasLoadingError).toBe(true)
     expect(vm.errorMessages[0]).toMatch('loading error')
   })
+
+  test('shows an error when specifying a relation as fieldname', async () => {
+    // given
+    const loadingValue = () => {}
+    loadingValue.loading = true
+    apiGet.mockReturnValue({
+      [config.propsData.fieldname]: loadingValue,
+      _meta: {
+        load: Promise.resolve()
+      }
+    })
+
+    wrapper = shallowMount(ApiWrapper, config)
+    vm = wrapper.vm
+
+    apiGet.mockReturnValue({
+      [config.propsData.fieldname]: () => ({}),
+      _meta: {
+        load: Promise.resolve()
+      }
+    })
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation()
+
+    // when
+    await flushPromises() // wait for load promise to resolve
+
+    // then
+    expect(vm.hasFinishedLoading).toBe(true)
+    expect(vm.isLoading).toBe(false)
+    expect(vm.localValue).toBe(null)
+    expect(errorSpy).toHaveBeenCalledWith('You are trying to use a fieldname testField in an ApiFormComponent, but testField is a relation, not a primitive value or embedded collection.')
+
+    errorSpy.mockRestore()
+  })
 })
 
 /**

--- a/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
@@ -181,7 +181,7 @@ describe('Testing ApiWrapper [autoSave=true;  manual external value]', () => {
 
     // when
     vm.onInput('new value')
-    input.trigger('submit') // trigger submit evenet (simluates enter key)
+    input.trigger('submit') // trigger submit event (simulates enter key)
     jest.runAllTimers() // resolve lodash debounced
     await flushPromises() // resolve validation
 
@@ -312,8 +312,10 @@ describe('Testing ApiWrapper [autoSave=true; value from API]', () => {
 
   test('loads value from API', async () => {
     // given
+    const loadingValue = () => {}
+    loadingValue.loading = true
     apiGet.mockReturnValue({
-      [config.propsData.fieldname]: 'api value',
+      [config.propsData.fieldname]: loadingValue,
       _meta: {
         load: Promise.resolve()
       }
@@ -325,6 +327,15 @@ describe('Testing ApiWrapper [autoSave=true; value from API]', () => {
 
     // then
     expect(vm.isLoading).toBe(true)
+    expect(vm.localValue).toBe(null)
+
+    // given
+    apiGet.mockReturnValue({
+      [config.propsData.fieldname]: 'api value',
+      _meta: {
+        load: Promise.resolve()
+      }
+    })
 
     // when
     await flushPromises() // wait for load promise to resolve
@@ -337,8 +348,10 @@ describe('Testing ApiWrapper [autoSave=true; value from API]', () => {
 
   test('shows error when loading value from API fails', async () => {
     // given
+    const loadingValue = () => {}
+    loadingValue.loading = true
     apiGet.mockReturnValue({
-      [config.propsData.fieldname]: 'api value',
+      [config.propsData.fieldname]: loadingValue,
       _meta: {
         load: Promise.reject(new Error('loading error'))
       }


### PR DESCRIPTION
See https://sentry.io/organizations/ecamp/issues/2217910517/

The problem addressed in this PR can currently be reproduced on dev.ecamp3.ch by going to the profile page and pressing F5.

`ApiWrapper` is able to write to normal fields as well as embedded collections (e.g. in the case of an `ApiSelect` with multiple selection activated). However, the check we used to find out whether the given field is an embedded collection was flawed while the entity was still loading from the API.

The `ApiWrapper` tests didn't catch this because so far, they have not been completely honest in mocking API calls. This is fixed now, but is yet another case where proper hal-json-vuex mocking capabilities would help.