### PR TITLE
Remove the obsolete vue-cli-plugin-i18n

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2354,6 +2354,7 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -2423,6 +2424,7 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
           "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -2496,6 +2498,7 @@
           "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
           "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
           "dev": true,
+          "optional": true,
           "requires": {
             "chalk": "^4.1.0",
             "hash-sum": "^2.0.0",
@@ -4609,50 +4612,6 @@
       "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
       "dev": true
     },
-    "cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
-      "dev": true,
-      "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
     "cli-truncate": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
@@ -4815,13 +4774,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "optional": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -6264,16 +6216,6 @@
         "domelementtype": "1"
       }
     },
-    "dot-object": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/dot-object/-/dot-object-1.9.0.tgz",
-      "integrity": "sha512-7MPN6y7XhAO4vM4eguj5+5HNKLjJYfkVG1ZR1Aput4Q4TR6SYeSjhpVQ77IzJHoSHffKbDxBC+48aCiiRurDPw==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.20.0",
-        "glob": "^7.1.4"
-      }
-    },
     "dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -7300,12 +7242,6 @@
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true
-    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -8025,12 +7961,6 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
-    },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true
     },
     "flat-cache": {
       "version": "3.0.4",
@@ -9524,12 +9454,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
-    "is-valid-glob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-      "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
       "dev": true
     },
     "is-whitespace": {
@@ -16737,33 +16661,6 @@
       "resolved": "https://registry.npmjs.org/vue-axios/-/vue-axios-3.2.4.tgz",
       "integrity": "sha512-8Dgws6dwt+1LoKEU4HDzIPfaRgWHl0xLDLW6kxrAk/z3GAJ2thkajcXC4qZgmqj0cZRx/Z/dzooKi5HWtUQwxA=="
     },
-    "vue-cli-plugin-i18n": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vue-cli-plugin-i18n/-/vue-cli-plugin-i18n-1.0.1.tgz",
-      "integrity": "sha512-sLo6YzudaWgn5dOMvrKixE5bb/onYGxcxm+0YexqoOx0QtR+7hZ/P5WPFBMM9v/2i1ec2YYe2PvKTBel7KE+tA==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.0",
-        "deepmerge": "^4.2.0",
-        "dotenv": "^8.2.0",
-        "flat": "^5.0.0",
-        "rimraf": "^3.0.0",
-        "vue": "^2.6.11",
-        "vue-i18n": "^8.17.0",
-        "vue-i18n-extract": "1.0.2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
-    },
     "vue-cli-plugin-vuetify": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.2.2.tgz",
@@ -16854,20 +16751,6 @@
       "version": "8.23.0",
       "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.23.0.tgz",
       "integrity": "sha512-mXgniaumwca8tKdp55fmvqIcW658vQQXq0zEyRHp8sgZ6t+Md+Whhu6CCPg9/erVNlvpKzsGsucGjt2N8GrFCA=="
-    },
-    "vue-i18n-extract": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vue-i18n-extract/-/vue-i18n-extract-1.0.2.tgz",
-      "integrity": "sha512-+zwDKvle4KcfloXZnj5hF01ViKDiFr5RMx5507D7oyDXpSleRpekF5YHgZa/+Ra6Go68//z0Nya58J9tKFsCjw==",
-      "dev": true,
-      "requires": {
-        "cli-table3": "^0.5.1",
-        "dot-object": "^1.7.1",
-        "esm": "^3.2.13",
-        "glob": "^7.1.3",
-        "is-valid-glob": "^1.0.0",
-        "yargs": "^13.2.2"
-      }
     },
     "vue-jest": {
       "version": "3.0.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,6 @@
     "sass": "1.32.8",
     "sass-loader": "10.1.1",
     "source-map-loader": "1.1.3",
-    "vue-cli-plugin-i18n": "1.0.1",
     "vue-cli-plugin-vuetify": "2.2.2",
     "vue-svg-loader": "0.16.0",
     "vue-template-compiler": "2.6.12",

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -44,12 +44,6 @@ module.exports = {
   },
 
   pluginOptions: {
-    i18n: {
-      locale: 'de',
-      fallbackLocale: 'en',
-      localeDir: 'locales',
-      enableInSFC: true
-    },
     jestSerializer: {
       attributesToClear: ['id'],
       formatting: {


### PR DESCRIPTION
Fixes #1033

The features of this package are:

* vue-i18n basic scaffolding
  :arrow_right: is a one-time operation, was done during i18n setup

* Locale messages in Single File components with vue-i18n-loader
  :arrow_right: we don't use `<i18n>` blocks in .vue single file components anymore since https://github.com/ecamp/ecamp3/pull/480/commits/fbf2aac04840edd87da51a4f06e72a171cc2c58e (was discussed in some meeting I can't find, probably the hackathon last summer)

* Locale messages missing & unused reporting (experimental)
  :arrow_right: was anyone using that feature? I don't think it will work well since we have dynamically constructed translation keys in some places (e.g. https://github.com/ecamp/ecamp3/blob/devel/frontend/src/components/activity/ContentNode.vue#L168)

* Env Variables containing the current locale and fallback locale
  :arrow_right: this is pretty much useless to us since the Env Variables are only available during build, while the language is determined at runtime depending on the user's browser and language preference in the API.