### PR TITLE
add xdebug to support codecoverage

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+          coverage: xdebug
 
       - name: Get Composer Cache Directory
         id: composer-cache


### PR DESCRIPTION
Sieht so aus, als hätte sich das Verhalten von **shivammathur/setup-php@v2** geändert.
Verhindert aktuell, dass **renovate** arbeiten kann.

Vorher:
![image](https://user-images.githubusercontent.com/470237/110036253-05e06080-7d3d-11eb-9e47-d909851b5f51.png)

Nachher:
![image](https://user-images.githubusercontent.com/470237/110036334-26101f80-7d3d-11eb-9cf5-6655bcac20c5.png)
