### PR TITLE
Invitation: reference known user

### DIFF
--- a/backend/module/eCampApi/test/Rest/CampCollaborationTest.php
+++ b/backend/module/eCampApi/test/Rest/CampCollaborationTest.php
@@ -196,7 +196,7 @@ JSON;
 
         $this->assertThat($this->getResponseContent()->status, self::equalTo(CampCollaboration::STATUS_INVITED));
         $this->assertThat($this->getResponseContent()->inviteEmail, self::equalTo($inviteEmail));
-        $this->assertThat($this->getResponseContent()->user, self::isNull());
+        $this->assertThat($this->getResponseContent()->_embedded, self::logicalNot(self::classHasAttribute('user')));
     }
 
     public function testCreateWithEmailOfExistingUser() {

--- a/backend/module/eCampCore/src/EntityService/CampCollaborationService.php
+++ b/backend/module/eCampCore/src/EntityService/CampCollaborationService.php
@@ -19,12 +19,14 @@ use Laminas\Authentication\AuthenticationService;
 class CampCollaborationService extends AbstractEntityService {
     private MaterialListService $materialListService;
     private SendmailService $sendmailService;
+    private UserService $userService;
 
     public function __construct(
         ServiceUtils $serviceUtils,
         AuthenticationService $authenticationService,
         MaterialListService $materialListService,
-        SendmailService $sendmailService
+        SendmailService $sendmailService,
+        UserService $userService
     ) {
         parent::__construct(
             $serviceUtils,
@@ -35,6 +37,7 @@ class CampCollaborationService extends AbstractEntityService {
 
         $this->materialListService = $materialListService;
         $this->sendmailService = $sendmailService;
+        $this->userService = $userService;
     }
 
     /**
@@ -120,6 +123,10 @@ class CampCollaborationService extends AbstractEntityService {
         }
 
         if (CampCollaboration::STATUS_INVITED == $campCollaboration->getStatus() && $campCollaboration->getInviteEmail()) {
+            $userByInviteEmail = $this->userService->findByTrustedMail($inviteEmail);
+            if (null != $userByInviteEmail) {
+                $campCollaboration->setUser($userByInviteEmail);
+            }
             $this->sendInviteEmail($campCollaboration, $authUser, $camp);
         }
 


### PR DESCRIPTION
This PR implements the following feature of #631:

- [x] Wenn die E-Mail Addresse schon einem User zugewiesen ist, kann man diesen auch gleich auf der CampCollaboration referenzieren