### PR TITLE
composer.json: downgrade symfony/process and symfony/filesystem to 5.…

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -30,7 +30,7 @@
         "ocramius/proxy-manager": "2.11.1",
         "ext-json": "*",
         "zfr/zfr-cors": "2.0.0",
-        "symfony/process": "5.2.5",
+        "symfony/process": "5.2.4",
         "rwoverdijk/assetmanager": "3.0.0",
         "ezyang/htmlpurifier": "4.13.0",
         "sentry/sdk": "3.1.0",
@@ -47,7 +47,7 @@
         "laminas/laminas-test": "3.4.2",
         "friendsofphp/php-cs-fixer": "2.18.3",
         "filp/whoops": "2.9.2",
-        "symfony/filesystem": "5.2.5"
+        "symfony/filesystem": "5.2.4"
     },
     "autoload": {
         "psr-4": {

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52438465461ae3feea9864b64c4addda",
+    "content-hash": "c6c27464120543f64c685c2c5165bd36",
     "packages": [
         {
             "name": "assetic/framework",
@@ -9195,16 +9195,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.2.5",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "b8d6eff26e48187fed15970799f4b605fa7242e4"
+                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b8d6eff26e48187fed15970799f4b605fa7242e4",
-                "reference": "b8d6eff26e48187fed15970799f4b605fa7242e4",
+                "url": "https://api.github.com/repos/symfony/process/zipball/313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
+                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
                 "shasum": ""
             },
             "require": {
@@ -9237,7 +9237,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.2.5"
+                "source": "https://github.com/symfony/process/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -9253,7 +9253,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-14T15:42:36+00:00"
+            "time": "2021-01-27T10:15:41+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -12278,16 +12278,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.2.5",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b84b3a9461a96e295e3c452caae277450f89fcbe"
+                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b84b3a9461a96e295e3c452caae277450f89fcbe",
-                "reference": "b84b3a9461a96e295e3c452caae277450f89fcbe",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/710d364200997a5afde34d9fe57bd52f3cc1e108",
+                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108",
                 "shasum": ""
             },
             "require": {
@@ -12320,7 +12320,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.2.5"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -12336,7 +12336,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-12T10:47:00+00:00"
+            "time": "2021-02-12T10:38:38+00:00"
         },
         {
             "name": "symfony/finder",


### PR DESCRIPTION
…2.4 again

symfony fucked up and renovate does not seem to downgrade automatically.
And our cache prevented us from getting the notification that the release is not available anymore.
See: https://github.com/symfony/process/tree/v5.2.5

First i set the versions in composer.json.
Then i ran:
docker-compose run composer composer update symfony/filesystem symfony/process --no-interaction --no-plugins --no-scripts --prefer-dist