### PR TITLE
Ci: Validate backend dependencies more strictly

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -1,0 +1,24 @@
+name: Dependency Check
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "42 3 * * *"
+
+jobs:
+  backend-check-dependencies:
+    name: "Check dependencies"
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: xdebug
+
+      - run: composer update --lock --no-interaction --no-plugins --no-scripts --prefer-dist
+        working-directory: backend

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  backend-validate-composer-lock:
+    name: "Validate Backend composer.lock"
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: xdebug
+
+      - run: composer validate -n --no-check-all --no-check-publish --strict
+        working-directory: backend
+
   backend-cs-check:
     name: "Lint: Backend (php-cs-fixer)"
     runs-on: ubuntu-latest

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -3,6 +3,7 @@
     "description": "eCamp3",
     "type": "project",
     "homepage": "http://eCamp3.ch/",
+    "license" : "AGPL-3.0-only",
     "config": {
         "process-timeout": 5000,
         "platform": {

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -30,7 +30,7 @@
         "ocramius/proxy-manager": "2.11.1",
         "ext-json": "*",
         "zfr/zfr-cors": "2.0.0",
-        "symfony/process": "5.2.5",
+        "symfony/process": "5.2.4",
         "rwoverdijk/assetmanager": "3.0.0",
         "ezyang/htmlpurifier": "4.13.0",
         "sentry/sdk": "3.1.0",
@@ -47,7 +47,7 @@
         "laminas/laminas-test": "3.4.2",
         "friendsofphp/php-cs-fixer": "2.18.3",
         "filp/whoops": "2.9.2",
-        "symfony/filesystem": "5.2.5"
+        "symfony/filesystem": "5.2.4"
     },
     "autoload": {
         "psr-4": {

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52438465461ae3feea9864b64c4addda",
+    "content-hash": "c6c27464120543f64c685c2c5165bd36",
     "packages": [
         {
             "name": "assetic/framework",
@@ -9195,16 +9195,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.2.5",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "b8d6eff26e48187fed15970799f4b605fa7242e4"
+                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b8d6eff26e48187fed15970799f4b605fa7242e4",
-                "reference": "b8d6eff26e48187fed15970799f4b605fa7242e4",
+                "url": "https://api.github.com/repos/symfony/process/zipball/313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
+                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
                 "shasum": ""
             },
             "require": {
@@ -9237,7 +9237,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.2.5"
+                "source": "https://github.com/symfony/process/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -9253,7 +9253,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-14T15:42:36+00:00"
+            "time": "2021-01-27T10:15:41+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -12278,16 +12278,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.2.5",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b84b3a9461a96e295e3c452caae277450f89fcbe"
+                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b84b3a9461a96e295e3c452caae277450f89fcbe",
-                "reference": "b84b3a9461a96e295e3c452caae277450f89fcbe",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/710d364200997a5afde34d9fe57bd52f3cc1e108",
+                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108",
                 "shasum": ""
             },
             "require": {
@@ -12320,7 +12320,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.2.5"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -12336,7 +12336,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-12T10:47:00+00:00"
+            "time": "2021-02-12T10:38:38+00:00"
         },
         {
             "name": "symfony/finder",


### PR DESCRIPTION
In https://github.com/ecamp/ecamp3/pull/1092 we fixed that a library was suddenly not available anymore.
We monitor that by running a composer update --lock every night with commit 12ba06ed7273abcb23179c433b2d7ba9ed8e3728
We also use no cache, because our build still passed because we had symfony/process and symfony/filesystem 5.2.5 cached.

In https://github.com/ecamp/ecamp3/pull/1090 renovate said that the update of doctrine/doctrine-orm-module was successful, which it was not. It worked because the lock file was not changed and composer install just uses the lock file if there is a lock file.
(and does not check if it's up to date).
I verified that with: https://github.com/BacLuc/ecamp3/actions/runs/651834072
