### PR TITLE
use datatype text

### DIFF
--- a/backend/module/eCampCore/src/Entity/Activity.php
+++ b/backend/module/eCampCore/src/Entity/Activity.php
@@ -34,12 +34,12 @@ class Activity extends AbstractContentNodeOwner implements BelongsToCampInterfac
     private ?Category $category = null;
 
     /**
-     * @ORM\Column(type="string", length=32)
+     * @ORM\Column(type="text")
      */
     private ?string $title = null;
 
     /**
-     * @ORM\Column(type="string", length=128)
+     * @ORM\Column(type="text")
      */
     private ?string $location = '';
 

--- a/backend/module/eCampCore/src/Entity/Camp.php
+++ b/backend/module/eCampCore/src/Entity/Camp.php
@@ -59,17 +59,17 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
     private bool $isPrototype = false;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $name = null;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $title = null;
 
     /**
-     * @ORM\Column(type="string", length=128, nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $motto = null;
 

--- a/backend/module/eCampCore/src/Entity/Camp.php
+++ b/backend/module/eCampCore/src/Entity/Camp.php
@@ -49,7 +49,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
     protected Collection $materialLists;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=true)
+     * @ORM\Column(type="string", length=16, nullable=true)
      */
     private ?string $campPrototypeId = null;
 

--- a/backend/module/eCampCore/src/Entity/CampCollaboration.php
+++ b/backend/module/eCampCore/src/Entity/CampCollaboration.php
@@ -38,12 +38,12 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
     protected Collection $activityResponsibles;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $inviteEmail = null;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="string", length=64, nullable=true)
      */
     private ?string $inviteKey = null;
 
@@ -70,7 +70,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
     private string $role;
 
     /**
-     * @ORM\Column(type="string", length=128, nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $collaborationAcceptedBy = null;
 

--- a/backend/module/eCampCore/src/Entity/Category.php
+++ b/backend/module/eCampCore/src/Entity/Category.php
@@ -29,12 +29,12 @@ class Category extends AbstractContentNodeOwner implements BelongsToCampInterfac
     private ?string $categoryPrototypeId = null;
 
     /**
-     * @ORM\Column(type="string", length=16, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $short = null;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $name = null;
 

--- a/backend/module/eCampCore/src/Entity/Category.php
+++ b/backend/module/eCampCore/src/Entity/Category.php
@@ -24,7 +24,7 @@ class Category extends AbstractContentNodeOwner implements BelongsToCampInterfac
     private Collection $categoryContentTypes;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=true)
+     * @ORM\Column(type="string", length=16, nullable=true)
      */
     private ?string $categoryPrototypeId = null;
 

--- a/backend/module/eCampCore/src/Entity/CategoryContentType.php
+++ b/backend/module/eCampCore/src/Entity/CategoryContentType.php
@@ -25,7 +25,7 @@ class CategoryContentType extends BaseEntity implements BelongsToCampInterface {
     private ?ContentType $contentType = null;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=true)
+     * @ORM\Column(type="string", length=16, nullable=true)
      */
     private ?string $categoryContentTypePrototypeId = null;
 

--- a/backend/module/eCampCore/src/Entity/ContentNode.php
+++ b/backend/module/eCampCore/src/Entity/ContentNode.php
@@ -40,7 +40,7 @@ class ContentNode extends BaseEntity implements BelongsToCampInterface {
     private Collection $children;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $slot = null;
 
@@ -61,7 +61,7 @@ class ContentNode extends BaseEntity implements BelongsToCampInterface {
     private ?ContentType $contentType = null;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $instanceName = null;
 

--- a/backend/module/eCampCore/src/Entity/ContentType.php
+++ b/backend/module/eCampCore/src/Entity/ContentType.php
@@ -11,7 +11,7 @@ use Laminas\Json\Json;
  */
 class ContentType extends BaseEntity {
     /**
-     * @ORM\Column(type="string", length=64, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $name = null;
 
@@ -21,7 +21,7 @@ class ContentType extends BaseEntity {
     private bool $active = true;
 
     /**
-     * @ORM\Column(type="string", length=128, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $strategyClass = null;
 

--- a/backend/module/eCampCore/src/Entity/Group.php
+++ b/backend/module/eCampCore/src/Entity/Group.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity(repositoryClass="eCamp\Core\Repository\GroupRepository")
  * @ORM\Table(
- *     indexes={@ORM\Index(name="group_name_idx", columns={"name"})},
+ *     indexes={@ORM\Index(name="group_name_idx", columns={"name"}, options={"lengths": {128}})},
  *     uniqueConstraints={@ORM\UniqueConstraint(
  *         name="group_parent_name_unique", columns={"parentId", "name"}
  *     )}
@@ -23,12 +23,12 @@ class Group extends AbstractCampOwner {
     protected Collection $memberships;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $name = null;
 
     /**
-     * @ORM\Column(type="string", length=64, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $description = null;
 

--- a/backend/module/eCampCore/src/Entity/GroupMembership.php
+++ b/backend/module/eCampCore/src/Entity/GroupMembership.php
@@ -35,17 +35,17 @@ class GroupMembership extends BaseEntity {
     private ?Group $group = null;
 
     /**
-     * @ORM\Column(type="string", nullable=false)
+     * @ORM\Column(type="string", length=16, nullable=false)
      */
     private string $status;
 
     /**
-     * @ORM\Column(type="string", nullable=false)
+     * @ORM\Column(type="string", length=16, nullable=false)
      */
     private string $role;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $membershipAcceptedBy = null;
 

--- a/backend/module/eCampCore/src/Entity/Job.php
+++ b/backend/module/eCampCore/src/Entity/Job.php
@@ -41,7 +41,7 @@ class Job extends BaseEntity implements BelongsToCampInterface {
     private ?Camp $camp = null;
 
     /**
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="text")
      */
     private ?string $name = null;
 

--- a/backend/module/eCampCore/src/Entity/Login.php
+++ b/backend/module/eCampCore/src/Entity/Login.php
@@ -12,17 +12,17 @@ class Login extends BaseEntity {
     const CURRENT_HASH_VERSION = 1;
 
     /**
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="text")
      */
     private ?string $password;
 
     /**
-     * @ORM\Column(type="string", length=64)
+     * @ORM\Column(type="text")
      */
     private ?string $salt;
 
     /**
-     * @ORM\Column(type="string", length=64, nullable=true, unique=true)
+     * @ORM\Column(type="text", nullable=true, unique=true)
      */
     private ?string $pwResetKey;
 

--- a/backend/module/eCampCore/src/Entity/MailAddress.php
+++ b/backend/module/eCampCore/src/Entity/MailAddress.php
@@ -20,12 +20,12 @@ class MailAddress extends BaseEntity {
     private string $state;
 
     /**
-     * @ORM\Column(type="string", length=64, nullable=false, unique=true)
+     * @ORM\Column(type="text", nullable=false, unique=true)
      */
     private ?string $mail = null;
 
     /**
-     * @ORM\Column(type="string", length=64, nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $verificationCode = null;
 

--- a/backend/module/eCampCore/src/Entity/MaterialItem.php
+++ b/backend/module/eCampCore/src/Entity/MaterialItem.php
@@ -28,7 +28,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface {
     protected ?ContentNode $contentNode = null;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $article = null;
 
@@ -38,7 +38,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface {
     private ?float $quantity = null;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $unit = null;
 

--- a/backend/module/eCampCore/src/Entity/MaterialList.php
+++ b/backend/module/eCampCore/src/Entity/MaterialList.php
@@ -23,7 +23,7 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface {
     private ?Camp $camp = null;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=true)
+     * @ORM\Column(type="string", length=16, nullable=true)
      */
     private ?string $materialListPrototypeId = null;
 

--- a/backend/module/eCampCore/src/Entity/MaterialList.php
+++ b/backend/module/eCampCore/src/Entity/MaterialList.php
@@ -28,7 +28,7 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface {
     private ?string $materialListPrototypeId = null;
 
     /**
-     * @ORM\Column(type="string", length=32, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $name = null;
 

--- a/backend/module/eCampCore/src/Entity/Organization.php
+++ b/backend/module/eCampCore/src/Entity/Organization.php
@@ -10,7 +10,7 @@ use eCamp\Lib\Entity\BaseEntity;
  */
 class Organization extends BaseEntity {
     /**
-     * @ORM\Column(type="string", length=64, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $name = null;
 

--- a/backend/module/eCampCore/src/Entity/Period.php
+++ b/backend/module/eCampCore/src/Entity/Period.php
@@ -46,7 +46,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
     private ?DateUtc $end = null;
 
     /**
-     * @ORM\Column(type="string", length=128, nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $description = null;
 

--- a/backend/module/eCampCore/src/Entity/User.php
+++ b/backend/module/eCampCore/src/Entity/User.php
@@ -43,28 +43,28 @@ class User extends AbstractCampOwner implements RoleInterface {
     /**
      * Unique username, lower alphanumeric symbols and underscores only.
      *
-     * @ORM\Column(type="string", length=32, nullable=true, unique=true)
+     * @ORM\Column(type="text", nullable=true, unique=true)
      */
     private ?string $username = null;
 
     /**
      * Users firstname.
      *
-     * @ORM\Column(type="string", length=32, nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $firstname = null;
 
     /**
      * Users surname.
      *
-     * @ORM\Column(type="string", length=32, nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $surname = null;
 
     /**
      * Users nickname.
      *
-     * @ORM\Column(type="string", length=32, nullable=true)
+     * @ORM\Column(type="text", nullable=true)
      */
     private ?string $nickname = null;
 

--- a/backend/module/eCampCore/src/Entity/UserIdentity.php
+++ b/backend/module/eCampCore/src/Entity/UserIdentity.php
@@ -21,14 +21,14 @@ class UserIdentity extends BaseEntity {
     /**
      * This is the identity provider (Facebook, Google, etc.).
      *
-     * @ORM\Column(type="string", length=255, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $provider = null;
 
     /**
      * This is the ID given by the identity provider.
      *
-     * @ORM\Column(type="string", length=255, nullable=false)
+     * @ORM\Column(type="text", nullable=false)
      */
     private ?string $providerId = null;
 

--- a/backend/module/eCampLib/src/Entity/BaseEntity.php
+++ b/backend/module/eCampLib/src/Entity/BaseEntity.php
@@ -15,7 +15,7 @@ abstract class BaseEntity implements ResourceInterface {
     /**
      * @var string
      * @ORM\Id
-     * @ORM\Column(type="string", length=32, nullable=false)
+     * @ORM\Column(type="string", length=16, nullable=false)
      */
     protected $id;
 


### PR DESCRIPTION
fixes #1121

Neben den ID-Spalten habe ich weitere Ausnahmen gemacht:
- Enum-Ähnliche Spalten wie
  - User.state
  - User.role
  - ...
- DiscriminatorColumn
  - AbstractCampOwner
  - AbstractContentNodeOwner
- CampCollaboration
  - inviteKey, weil das eigentlich eine ID ist
- Category
  - color, weil eigentlich DatenTyp "Farbe"
  - numberingStyle, weil Enum
- User
  - language, weil Enum