### PR TITLE
change id generator

### DIFF
--- a/backend/module/eCampLib/src/Entity/BaseEntity.php
+++ b/backend/module/eCampLib/src/Entity/BaseEntity.php
@@ -32,7 +32,7 @@ abstract class BaseEntity implements ResourceInterface {
     protected $updateTime;
 
     public function __construct() {
-        $this->id = base_convert(crc32(uniqid()), 10, 16);
+        $this->id = bin2hex(random_bytes(6));
 
         $this->createTime = new DateTimeUtc();
         $this->updateTime = new DateTimeUtc();


### PR DESCRIPTION
Ich hab mich mal schlau gemacht.
`random_bytes` sollte eine gute Wahl sein.

Mittels Skript konnte ich mit 6 Bytes nach ca. 20Mio eine erste Kollision produzieren.
-> also ein Speicherfehler, welcher den Benutzer zum wiederholen des Speichern zwingen würde.
(alter generator macht dies nach ca 2Mio)

Falls dies noch nicht reichen sollte, können wir die Bytes-Zahl weiter erhöhen.
Für den Anfang aber sicher ok.
