### PR TITLE
backend: switch to mysql:8.0.23 and limit the length of unique columns

### DIFF
--- a/backend/module/eCampCore/src/Entity/Camp.php
+++ b/backend/module/eCampCore/src/Entity/Camp.php
@@ -59,7 +59,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface {
     private bool $isPrototype = false;
 
     /**
-     * @ORM\Column(type="text", nullable=false)
+     * @ORM\Column(type="string", length=32, nullable=false)
      */
     private ?string $name = null;
 

--- a/backend/module/eCampCore/src/Entity/Group.php
+++ b/backend/module/eCampCore/src/Entity/Group.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity(repositoryClass="eCamp\Core\Repository\GroupRepository")
  * @ORM\Table(
- *     indexes={@ORM\Index(name="group_name_idx", columns={"name"}, options={"lengths": {128}})},
+ *     indexes={@ORM\Index(name="group_name_idx", columns={"name"})},
  *     uniqueConstraints={@ORM\UniqueConstraint(
  *         name="group_parent_name_unique", columns={"parentId", "name"}
  *     )}
@@ -23,12 +23,12 @@ class Group extends AbstractCampOwner {
     protected Collection $memberships;
 
     /**
-     * @ORM\Column(type="text", nullable=false)
+     * @ORM\Column(type="string", length=32, nullable=false)
      */
     private ?string $name = null;
 
     /**
-     * @ORM\Column(type="text", nullable=false)
+     * @ORM\Column(type="string", length=64, nullable=false)
      */
     private ?string $description = null;
 

--- a/backend/module/eCampCore/src/Entity/Login.php
+++ b/backend/module/eCampCore/src/Entity/Login.php
@@ -22,7 +22,7 @@ class Login extends BaseEntity {
     private ?string $salt;
 
     /**
-     * @ORM\Column(type="text", nullable=true, unique=true)
+     * @ORM\Column(type="string", length=64, nullable=true, unique=true)
      */
     private ?string $pwResetKey;
 

--- a/backend/module/eCampCore/src/Entity/MailAddress.php
+++ b/backend/module/eCampCore/src/Entity/MailAddress.php
@@ -20,12 +20,12 @@ class MailAddress extends BaseEntity {
     private string $state;
 
     /**
-     * @ORM\Column(type="text", nullable=false, unique=true)
+     * @ORM\Column(type="string", length=64, nullable=false, unique=true)
      */
     private ?string $mail = null;
 
     /**
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type="string", length=64, nullable=true)
      */
     private ?string $verificationCode = null;
 

--- a/backend/module/eCampCore/src/Entity/User.php
+++ b/backend/module/eCampCore/src/Entity/User.php
@@ -43,7 +43,7 @@ class User extends AbstractCampOwner implements RoleInterface {
     /**
      * Unique username, lower alphanumeric symbols and underscores only.
      *
-     * @ORM\Column(type="text", nullable=true, unique=true)
+     * @ORM\Column(type="string", length=32, nullable=true, unique=true)
      */
     private ?string $username = null;
 

--- a/backend/module/eCampCore/src/Entity/UserIdentity.php
+++ b/backend/module/eCampCore/src/Entity/UserIdentity.php
@@ -21,14 +21,14 @@ class UserIdentity extends BaseEntity {
     /**
      * This is the identity provider (Facebook, Google, etc.).
      *
-     * @ORM\Column(type="text", nullable=false)
+     * @ORM\Column(type="string", length=255, nullable=false)
      */
     private ?string $provider = null;
 
     /**
      * This is the ID given by the identity provider.
      *
-     * @ORM\Column(type="text", nullable=false)
+     * @ORM\Column(type="string", length=255, nullable=false)
      */
     private ?string $providerId = null;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - ./.cache/composer:/tmp/cache
 
   db:
-    image: mariadb:10.5@sha256:9c681cefe72e257c6d58f839bb504f50bf259a0221c883fcc220f0755563fa46
+    image: mysql:8.0.23@sha256:2878ca7ca986b54c948966b7103aeceb747f50b9ecf34ecf934036cca58274db
     container_name: 'ecamp3-db'
     environment:
       - MYSQL_DATABASE=ecamp3dev


### PR DESCRIPTION
Because we use MySQL for dev.ecamp3.ch.
In MySQL, you need to limit the indexed length of a
text or longtext column. But then the uniqueness is not
guaranteed on the whole length, so i just used the lengths
from before 0d98f35a31f345a7fed7a8e4facfd7f9889ab47e.

Issue: #1195