### PR TITLE
Fix namespacing issue in deployment (hopefully)

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -55,6 +55,7 @@
         "psr-4": {
             "eCamp\\Lib\\": "module/eCampLib/src/",
             "eCamp\\Core\\": "module/eCampCore/src/",
+            "eCamp\\CoreData\\": "module/eCampCore/data/",
             "eCamp\\AoT\\": "module/eCampAoT/src/",
             "eCamp\\AoT\\Generated\\": "module/eCampAoT/gen/",
             "eCampApi\\": "module/eCampApi/src/eCampApi/",

--- a/backend/module/eCampCore/data/Dev/ActivityData.php
+++ b/backend/module/eCampCore/data/Dev/ActivityData.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Dev;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use eCamp\Core\Entity\Activity;
 use eCamp\Core\Entity\Camp;
 use eCamp\Core\Entity\Category;
+use eCamp\CoreData\Prod\CategoryPrototypeData;
 use eCamp\Lib\Fixture\ContainerAwareInterface;
 use eCamp\Lib\Fixture\ContainerAwareTrait;
 

--- a/backend/module/eCampCore/data/Dev/CampCollaborationData.php
+++ b/backend/module/eCampCore/data/Dev/CampCollaborationData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Dev;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/backend/module/eCampCore/data/Dev/CampData.php
+++ b/backend/module/eCampCore/data/Dev/CampData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Dev;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/backend/module/eCampCore/data/Dev/CategoryData.php
+++ b/backend/module/eCampCore/data/Dev/CategoryData.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Dev;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use eCamp\Core\Entity\Camp;
 use eCamp\Core\Entity\Category;
+use eCamp\CoreData\Prod\CategoryPrototypeData;
 
 class CategoryData extends CategoryPrototypeData implements DependentFixtureInterface {
     public static $EVENTCATEGORY_1_LS = Category::class.':EVENTCATEGORY_1_LS';

--- a/backend/module/eCampCore/data/Dev/GroupMembershipData.php
+++ b/backend/module/eCampCore/data/Dev/GroupMembershipData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Dev;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/backend/module/eCampCore/data/Dev/PeriodData.php
+++ b/backend/module/eCampCore/data/Dev/PeriodData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Dev;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/backend/module/eCampCore/data/Dev/ScheduleEntryData.php
+++ b/backend/module/eCampCore/data/Dev/ScheduleEntryData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Dev;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/backend/module/eCampCore/data/Dev/UserData.php
+++ b/backend/module/eCampCore/data/Dev/UserData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Dev;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Persistence\ObjectManager;

--- a/backend/module/eCampCore/data/Prod/AdminData.php
+++ b/backend/module/eCampCore/data/Prod/AdminData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Prod;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Persistence\ObjectManager;

--- a/backend/module/eCampCore/data/Prod/CampPrototypeData.php
+++ b/backend/module/eCampCore/data/Prod/CampPrototypeData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Prod;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/backend/module/eCampCore/data/Prod/CategoryPrototypeData.php
+++ b/backend/module/eCampCore/data/Prod/CategoryPrototypeData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Prod;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/backend/module/eCampCore/data/Prod/ContentTypeData.php
+++ b/backend/module/eCampCore/data/Prod/ContentTypeData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Prod;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Persistence\ObjectManager;

--- a/backend/module/eCampCore/data/Prod/GroupData.php
+++ b/backend/module/eCampCore/data/Prod/GroupData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Prod;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/backend/module/eCampCore/data/Prod/MaterialListPrototypeData.php
+++ b/backend/module/eCampCore/data/Prod/MaterialListPrototypeData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Prod;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/backend/module/eCampCore/data/Prod/OrganizationData.php
+++ b/backend/module/eCampCore/data/Prod/OrganizationData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eCamp\CoreData;
+namespace eCamp\CoreData\Prod;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Persistence\ObjectManager;


### PR DESCRIPTION
Locally it has always worked, but when deploying, the classes in `eCampCore/data/dev` could not read the classes in `eCampCore/data/prod` (even though we declared them to be in the same namespace). This is why currently, dev.ecamp3.ch does not work.

This commit tries to clean up the PSR-4 namespace structure somewhat, by making the distinction between dev and prod data explicit in the namespace structure.

Note: I was not able to really verify whether this resolves the issue, because I'd first need to build the containers and deploy them to check... But making the namespace structure explicit should help I think.