### PR TITLE
Refresh content nodes on entering story overview

### DIFF
--- a/frontend/src/components/camp/StoryDay.vue
+++ b/frontend/src/components/camp/StoryDay.vue
@@ -85,7 +85,7 @@ export default {
     }
   },
   mounted () {
-    this.day.scheduleEntries().items.map(entry => this.api.reload(entry.activity().contentNodes()))
+    this.day.scheduleEntries().items.forEach(entry => this.api.reload(entry.activity().contentNodes()))
   },
   methods: {
     addDays (date, days) {

--- a/frontend/src/components/camp/StoryDay.vue
+++ b/frontend/src/components/camp/StoryDay.vue
@@ -84,6 +84,9 @@ export default {
       return this.entries.filter(({ storyChapters }) => storyChapters.length)
     }
   },
+  mounted () {
+    this.day.scheduleEntries().items.map(entry => this.api.reload(entry.activity().contentNodes()))
+  },
   methods: {
     addDays (date, days) {
       return Date.parse(date) + days * 24 * 60 * 60 * 1000


### PR DESCRIPTION
Fixes the following scenario:
- Create new story content node in an activity
- Navigate to story overview
- Newly created story node is not shown, only after F5

Related to #1091