### PR TITLE
Insert new content nodes at the end of the column

### DIFF
--- a/backend/module/eCampApi/test/Rest/ContentNodeTest.php
+++ b/backend/module/eCampApi/test/Rest/ContentNodeTest.php
@@ -83,14 +83,13 @@ JSON;
         $this->assertEquals($this->contentNode->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateRootNodeIsNotPossible(): void {
+    public function testCreateRootNode(): void {
         $this->setRequestContent([
             'ownerId' => $this->contentNode->getOwner()->getId(),
             'contentTypeId' => $this->contentNode->getContentType()->getId(),
         ]);
         $this->dispatch("{$this->apiEndpoint}", 'POST');
-        $this->assertResponseStatusCode(422);
-        $this->assertObjectHasAttribute('required', $this->getResponseContent()->validation_messages->parentId);
+        $this->assertResponseStatusCode(201);
     }
 
     public function testCreateChildNode(): void {

--- a/backend/module/eCampApi/test/Rest/ContentNodeTest.php
+++ b/backend/module/eCampApi/test/Rest/ContentNodeTest.php
@@ -83,22 +83,39 @@ JSON;
         $this->assertEquals($this->contentNode->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateRootNode(): void {
+    public function testCreateRootNode_isNotPossible(): void {
         $this->setRequestContent([
             'ownerId' => $this->contentNode->getOwner()->getId(),
             'contentTypeId' => $this->contentNode->getContentType()->getId(),
         ]);
         $this->dispatch("{$this->apiEndpoint}", 'POST');
-        $this->assertResponseStatusCode(201);
+        $this->assertResponseStatusCode(422);
+        $this->assertObjectHasAttribute('required', $this->getResponseContent()->validation_messages->parentId);
     }
 
     public function testCreateChildNode(): void {
         $this->setRequestContent([
             'parentId' => $this->contentNode->getId(),
             'contentTypeId' => $this->contentNode->getContentType()->getId(),
+            'slot' => '1',
+            'position' => 20
         ]);
         $this->dispatch("{$this->apiEndpoint}", 'POST');
         $this->assertResponseStatusCode(201);
+
+        $this->assertEquals(20, $this->getResponseContent()->position);
+    }
+
+    public function testCreateChildNode_automaticallySetsPosition_whenNotPassed(): void {
+        $this->setRequestContent([
+            'parentId' => $this->contentNode->getId(),
+            'contentTypeId' => $this->contentNode->getContentType()->getId(),
+            'slot' => '1'
+        ]);
+        $this->dispatch("{$this->apiEndpoint}", 'POST');
+        $this->assertResponseStatusCode(201);
+
+        $this->assertEquals(1, $this->getResponseContent()->position);
     }
 
     public function testPatch(): void {

--- a/backend/module/eCampApi/test/Rest/ContentNodeTest.php
+++ b/backend/module/eCampApi/test/Rest/ContentNodeTest.php
@@ -83,7 +83,7 @@ JSON;
         $this->assertEquals($this->contentNode->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
-    public function testCreateRootNode_isNotPossible(): void {
+    public function testCreateRootNodeIsNotPossible(): void {
         $this->setRequestContent([
             'ownerId' => $this->contentNode->getOwner()->getId(),
             'contentTypeId' => $this->contentNode->getContentType()->getId(),
@@ -98,7 +98,7 @@ JSON;
             'parentId' => $this->contentNode->getId(),
             'contentTypeId' => $this->contentNode->getContentType()->getId(),
             'slot' => '1',
-            'position' => 20
+            'position' => 20,
         ]);
         $this->dispatch("{$this->apiEndpoint}", 'POST');
         $this->assertResponseStatusCode(201);
@@ -106,11 +106,11 @@ JSON;
         $this->assertEquals(20, $this->getResponseContent()->position);
     }
 
-    public function testCreateChildNode_automaticallySetsPosition_whenNotPassed(): void {
+    public function testCreateChildNodeAutomaticallySetsPositionWhenNotPassed(): void {
         $this->setRequestContent([
             'parentId' => $this->contentNode->getId(),
             'contentTypeId' => $this->contentNode->getContentType()->getId(),
-            'slot' => '1'
+            'slot' => '1',
         ]);
         $this->dispatch("{$this->apiEndpoint}", 'POST');
         $this->assertResponseStatusCode(201);

--- a/backend/module/eCampCore/src/Entity/ContentNode.php
+++ b/backend/module/eCampCore/src/Entity/ContentNode.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 use eCamp\Lib\Entity\BaseEntity;
 
 /**
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="eCamp\Core\Repository\ContentNodeRepository")
  * @ORM\HasLifecycleCallbacks
  */
 class ContentNode extends BaseEntity implements BelongsToCampInterface {

--- a/backend/module/eCampCore/src/EntityService/ContentNodeService.php
+++ b/backend/module/eCampCore/src/EntityService/ContentNodeService.php
@@ -155,6 +155,7 @@ class ContentNodeService extends AbstractEntityService {
             $entityRepository = $this->getServiceUtils()->emGetRepository(ContentNode::class);
             $this->contentNodeRepository = $entityRepository;
         }
+
         return $this->contentNodeRepository;
     }
 }

--- a/backend/module/eCampCore/src/EntityService/ContentNodeService.php
+++ b/backend/module/eCampCore/src/EntityService/ContentNodeService.php
@@ -78,17 +78,12 @@ class ContentNodeService extends AbstractEntityService {
             $parent = $this->findRelatedEntity(ContentNode::class, $data, 'parentId');
             $this->assertAllowed($parent, Acl::REST_PRIVILEGE_PATCH);
             $contentNode->setParent($parent);
-        } else {
-            throw (new EntityValidationException())->setMessages([
-                'parentId' => [
-                    'required' => 'A parent is required for a content node.',
-                ],
-            ]);
         }
 
+        $contentNode->setPosition(0);
         if (isset($data->position)) {
             $contentNode->setPosition($data->position);
-        } else {
+        } elseif (null !== $contentNode->getParent()) {
             $position = $this->getContentNodeRepository()->getHighestChildPosition($contentNode->getParent(), $contentNode->getSlot());
             $contentNode->setPosition($position + 1);
         }

--- a/backend/module/eCampCore/src/Repository/ContentNodeRepository.php
+++ b/backend/module/eCampCore/src/Repository/ContentNodeRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace eCamp\Core\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
+use eCamp\Core\Entity\ContentNode;
+
+class ContentNodeRepository extends EntityRepository {
+    public function getHighestChildPosition(ContentNode $parent, string $slot): int {
+        $q = $this->createQueryBuilder('cn');
+        $q->select('max(cn.position)');
+        $q->andWhere('cn.parent = :parent');
+        $q->andWhere('cn.slot = :slot');
+        $q->setParameters(['parent' => $parent->getId(), 'slot' => $slot]);
+
+        try {
+            return $q->getQuery()->getSingleScalarResult() ?? 0;
+        } catch (NoResultException | NonUniqueResultException $e) {
+            // This shouldn't ever happen
+            return 0;
+        }
+    }
+}

--- a/frontend/src/components/activity/ContentNode.vue
+++ b/frontend/src/components/activity/ContentNode.vue
@@ -25,7 +25,7 @@ const contentNodeComponents = {
   LAThematicArea,
   SafetyConcept,
   Storycontext,
-  Storyboard,
+  Storyboard
 }
 
 export default {

--- a/frontend/src/components/activity/ContentNode.vue
+++ b/frontend/src/components/activity/ContentNode.vue
@@ -16,6 +16,7 @@ import Material from './content/Material.vue'
 import LAThematicArea from './content/LAThematicArea.vue'
 import SafetyConcept from './content/SafetyConcept.vue'
 import Storycontext from './content/Storycontext.vue'
+import Storyboard from './content/Storyboard.vue'
 
 const contentNodeComponents = {
   ColumnLayout,
@@ -23,7 +24,8 @@ const contentNodeComponents = {
   Material,
   LAThematicArea,
   SafetyConcept,
-  Storycontext
+  Storycontext,
+  Storyboard,
 }
 
 export default {


### PR DESCRIPTION
The backend now automatically sets the position on create if it is not specified explicitly by the frontend.

~~Also, creating new root content nodes should not be supported anymore #1124~~ This is not true, the same service method is used for creating and duplicating Activities etc.

Also, an import of Storyboard.vue was forgotten during the migration to Vite.