### PR TITLE
Improve Cypress smoke test

### DIFF
--- a/frontend/tests/e2e/specs/test.js
+++ b/frontend/tests/e2e/specs/test.js
@@ -1,7 +1,10 @@
 // https://docs.cypress.io/api/introduction/api.html
 
-describe('My First Test', () => {
-  it('Visits the app root url', () => {
+describe('Smoke test', () => {
+  it('displays the login page', () => {
     cy.visit('/')
+    cy.contains('Login')
+    cy.contains('This is the site of the new eCamp.')
+    cy.contains('Register now')
   })
 })


### PR DESCRIPTION
To prevent things like #1266 in the future, this checks that the login page actually renders correctly and displays some of the translated texts.