### PR TITLE
Remove hardcoded sections collection link

### DIFF
--- a/frontend/src/components/activity/content/Storyboard.vue
+++ b/frontend/src/components/activity/content/Storyboard.vue
@@ -134,7 +134,7 @@ export default {
   methods: {
     async addSection () {
       this.isAdding = true
-      await this.api.post('/content-type/storyboards', {
+      await this.api.post(this.contentNode.sections(), {
         contentNodeId: this.contentNode.id,
         pos: this.contentNode.sections().items.length // add at the end of the array
       })


### PR DESCRIPTION
Now that the sections collection has a link, we can stop hardcoding the POST URL.

Fixes #1263