### PR TITLE
Collaborators: Keep last manager

### DIFF
--- a/backend/module/eCampApi/test/Rest/CampTest.php
+++ b/backend/module/eCampApi/test/Rest/CampTest.php
@@ -80,10 +80,9 @@ JSON;
 
         $this->assertResponseStatusCode(200);
 
-        $this->assertEquals(1, $this->getResponseContent()->total_items);
+        $this->assertEquals(2, $this->getResponseContent()->total_items);
         $this->assertEquals(10, $this->getResponseContent()->page_size);
         $this->assertEquals("http://{$this->host}/api/camps?page_size=10&page=1", $this->getResponseContent()->_links->self->href);
-        $this->assertEquals($this->camp->getId(), $this->getResponseContent()->_embedded->items[0]->id);
     }
 
     public function testCreateWithoutName(): void {

--- a/backend/module/eCampCore/test/Data/CampCollaborationTestData.php
+++ b/backend/module/eCampCore/test/Data/CampCollaborationTestData.php
@@ -18,7 +18,19 @@ class CampCollaborationTestData extends AbstractFixture implements DependentFixt
     public static $COLLAB_INVITED_AS_GUEST = CampCollaboration::class.':COLLAB_INVITED_AS_GUEST';
     public static $COLLAB_INACTIVE = CampCollaboration::class.':COLLAB_INACTIVE';
 
+    public static $CAMP2_USER1_ESTABLISHED_MANAGER = CampCollaboration::class.':CAMP2_USER1_ESTABLISHED_MANAGER';
+    public static $CAMP2_USER2_ESTABLISHED_MANAGER = CampCollaboration::class.':CAMP2_USER2_ESTABLISHED_MANAGER';
+
     public function load(ObjectManager $manager): void {
+        $this->createCampCollaborationsForCamp1($manager);
+        $this->createCampCollaborationsForCamp2($manager);
+    }
+
+    public function getDependencies() {
+        return [CampTestData::class, UserTestData::class];
+    }
+
+    private function createCampCollaborationsForCamp1(ObjectManager $manager): void {
         /** @var Camp $camp */
         $camp = $this->getReference(CampTestData::$CAMP1);
         $this->addReference(
@@ -93,8 +105,30 @@ class CampCollaborationTestData extends AbstractFixture implements DependentFixt
         );
     }
 
-    public function getDependencies() {
-        return [CampTestData::class, UserTestData::class];
+    private function createCampCollaborationsForCamp2(ObjectManager $manager): void {
+        /** @var Camp $camp */
+        $camp = $this->getReference(CampTestData::$CAMP2);
+        $this->addReference(
+            self::$CAMP2_USER1_ESTABLISHED_MANAGER,
+            $this->createCampCollaboration(
+                $manager,
+                $camp,
+                UserTestData::$USER1,
+                CampCollaboration::ROLE_MANAGER,
+                CampCollaboration::STATUS_ESTABLISHED
+            )
+        );
+
+        $this->addReference(
+            self::$CAMP2_USER2_ESTABLISHED_MANAGER,
+            $this->createCampCollaboration(
+                $manager,
+                $camp,
+                UserTestData::$USER2,
+                CampCollaboration::ROLE_MANAGER,
+                CampCollaboration::STATUS_ESTABLISHED
+            )
+        );
     }
 
     private function createCampCollaboration(

--- a/backend/module/eCampCore/test/Data/CampCollaborationTestData.php
+++ b/backend/module/eCampCore/test/Data/CampCollaborationTestData.php
@@ -8,6 +8,7 @@ use Doctrine\Persistence\ObjectManager;
 use eCamp\Core\Entity\Camp;
 use eCamp\Core\Entity\CampCollaboration;
 use eCamp\Core\Entity\User;
+use RuntimeException;
 
 class CampCollaborationTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $COLLAB1 = CampCollaboration::class.':COLLAB1';
@@ -20,86 +21,114 @@ class CampCollaborationTestData extends AbstractFixture implements DependentFixt
     public function load(ObjectManager $manager): void {
         /** @var Camp $camp */
         $camp = $this->getReference(CampTestData::$CAMP1);
+        $this->addReference(
+            self::$COLLAB1,
+            $this->createCampCollaboration(
+                $manager,
+                $camp,
+                UserTestData::$USER1,
+                CampCollaboration::ROLE_MEMBER,
+                CampCollaboration::STATUS_ESTABLISHED
+            )
+        );
 
-        /** @var User $user */
-        $user = $this->getReference(UserTestData::$USER1);
+        $this->addReference(
+            self::$COLLAB_GUEST,
+            $this->createCampCollaboration(
+                $manager,
+                $camp,
+                UserTestData::$USER3,
+                CampCollaboration::ROLE_GUEST,
+                CampCollaboration::STATUS_ESTABLISHED
+            )
+        );
 
-        $campCollaboration = new CampCollaboration();
-        $campCollaboration->setCamp($camp);
-        $campCollaboration->setUser($user);
-        $campCollaboration->setRole(CampCollaboration::ROLE_MEMBER);
-        $campCollaboration->setStatus(CampCollaboration::STATUS_ESTABLISHED);
+        $this->addReference(
+            self::$COLLAB_MANAGER,
+            $this->createCampCollaboration(
+                $manager,
+                $camp,
+                UserTestData::$USER4,
+                CampCollaboration::ROLE_MANAGER,
+                CampCollaboration::STATUS_ESTABLISHED
+            )
+        );
 
-        $manager->persist($campCollaboration);
-        $manager->flush();
+        $this->addReference(
+            self::$COLLAB_INVITED,
+            $this->createCampCollaboration(
+                $manager,
+                $camp,
+                null,
+                CampCollaboration::ROLE_MEMBER,
+                CampCollaboration::STATUS_INVITED,
+                'e.mail@test.com',
+                'myInviteKey'
+            )
+        );
 
-        $this->addReference(self::$COLLAB1, $campCollaboration);
+        $this->addReference(
+            self::$COLLAB_INVITED_AS_GUEST,
+            $this->createCampCollaboration(
+                $manager,
+                $camp,
+                null,
+                CampCollaboration::ROLE_GUEST,
+                CampCollaboration::STATUS_INVITED,
+                'e.mail.guest@test.com',
+                'myInviteKeyGuest'
+            )
+        );
 
-        /** @var User $userForGuest */
-        $userForGuest = $this->getReference(UserTestData::$USER3);
-
-        $campCollaborationGuest = new CampCollaboration();
-        $campCollaborationGuest->setCamp($camp);
-        $campCollaborationGuest->setUser($userForGuest);
-        $campCollaborationGuest->setRole(CampCollaboration::ROLE_GUEST);
-        $campCollaborationGuest->setStatus(CampCollaboration::STATUS_ESTABLISHED);
-
-        $manager->persist($campCollaborationGuest);
-        $manager->flush();
-
-        $this->addReference(self::$COLLAB_GUEST, $campCollaborationGuest);
-
-        /** @var User $userForManager */
-        $userForManager = $this->getReference(UserTestData::$USER4);
-
-        $campCollaborationManager = new CampCollaboration();
-        $campCollaborationManager->setCamp($camp);
-        $campCollaborationManager->setUser($userForManager);
-        $campCollaborationManager->setRole(CampCollaboration::ROLE_MANAGER);
-        $campCollaborationManager->setStatus(CampCollaboration::STATUS_ESTABLISHED);
-
-        $manager->persist($campCollaborationManager);
-        $manager->flush();
-
-        $this->addReference(self::$COLLAB_MANAGER, $campCollaborationManager);
-
-        $campCollaborationInvited = new CampCollaboration();
-        $campCollaborationInvited->setCamp($camp);
-        $campCollaborationInvited->setInviteEmail('e.mail@test.com');
-        $campCollaborationInvited->setRole(CampCollaboration::ROLE_MEMBER);
-        $campCollaborationInvited->setStatus(CampCollaboration::STATUS_INVITED);
-        $campCollaborationInvited->setInviteKey('myInviteKey');
-
-        $manager->persist($campCollaborationInvited);
-        $manager->flush();
-
-        $this->addReference(self::$COLLAB_INVITED, $campCollaborationInvited);
-
-        $campCollaborationInvitedAsGuest = new CampCollaboration();
-        $campCollaborationInvitedAsGuest->setCamp($camp);
-        $campCollaborationInvitedAsGuest->setInviteEmail('e.mail.guest@test.com');
-        $campCollaborationInvitedAsGuest->setRole(CampCollaboration::ROLE_GUEST);
-        $campCollaborationInvitedAsGuest->setStatus(CampCollaboration::STATUS_INVITED);
-        $campCollaborationInvitedAsGuest->setInviteKey('myInviteKeyGuest');
-
-        $manager->persist($campCollaborationInvitedAsGuest);
-        $manager->flush();
-
-        $this->addReference(self::$COLLAB_INVITED_AS_GUEST, $campCollaborationInvitedAsGuest);
-
-        $campCollaborationInactive = new CampCollaboration();
-        $campCollaborationInactive->setCamp($camp);
-        $campCollaborationInactive->setInviteEmail('e.mail.inactive@test.com');
-        $campCollaborationInactive->setRole(CampCollaboration::ROLE_MEMBER);
-        $campCollaborationInactive->setStatus(CampCollaboration::STATUS_INACTIVE);
-
-        $manager->persist($campCollaborationInactive);
-        $manager->flush();
-
-        $this->addReference(self::$COLLAB_INACTIVE, $campCollaborationInactive);
+        $this->addReference(
+            self::$COLLAB_INACTIVE,
+            $this->createCampCollaboration(
+                $manager,
+                $camp,
+                null,
+                CampCollaboration::ROLE_MEMBER,
+                CampCollaboration::STATUS_INACTIVE,
+                'e.mail.inactive@test.com'
+            )
+        );
     }
 
     public function getDependencies() {
         return [CampTestData::class, UserTestData::class];
+    }
+
+    private function createCampCollaboration(
+        ObjectManager $manager,
+        Camp $camp,
+        ?string $userReference,
+        string $role,
+        string $status,
+        ?string $inviteEmail = null,
+        ?string $inviteKey = null
+    ): CampCollaboration {
+        $campCollaboration = new CampCollaboration();
+
+        if (null != $userReference) {
+            /** @var User $user */
+            $user = $this->getReference($userReference);
+
+            $campCollaboration->setUser($user);
+        }
+
+        $campCollaboration->setCamp($camp);
+
+        try {
+            $campCollaboration->setRole($role);
+            $campCollaboration->setStatus($status);
+        } catch (\Exception $e) {
+            throw new RuntimeException($e);
+        }
+        $campCollaboration->setInviteEmail($inviteEmail);
+        $campCollaboration->setInviteKey($inviteKey);
+
+        $manager->persist($campCollaboration);
+        $manager->flush();
+
+        return $campCollaboration;
     }
 }

--- a/backend/module/eCampCore/test/Data/CampTestData.php
+++ b/backend/module/eCampCore/test/Data/CampTestData.php
@@ -10,10 +10,23 @@ use eCamp\Core\Entity\User;
 
 class CampTestData extends AbstractFixture implements DependentFixtureInterface {
     public static $CAMP1 = Camp::class.':CAMP1';
+    public static $CAMP2 = Camp::class.':CAMP2';
 
     public function load(ObjectManager $manager): void {
+        $this->addReference(self::$CAMP1, $this->createCamp1($manager));
+        $this->addReference(self::$CAMP2, $this->createCamp2($manager));
+    }
+
+    public function getDependencies() {
+        return [UserTestData::class];
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function createCamp1(ObjectManager $manager): Camp {
         /** @var User $user */
-        $user1 = $this->getReference(UserTestData::$USER1);
+        $user = $this->getReference(UserTestData::$USER1);
 
         $camp = new Camp();
         $camp->setName('CampName');
@@ -23,16 +36,36 @@ class CampTestData extends AbstractFixture implements DependentFixtureInterface 
         $camp->setAddressStreet('AdrStreet');
         $camp->setAddressZipcode('AdrZipcode');
         $camp->setAddressCity('AdrCity');
-        $camp->setCreator($user1);
-        $camp->setOwner($user1);
+        $camp->setCreator($user);
+        $camp->setOwner($user);
 
         $manager->persist($camp);
         $manager->flush();
 
-        $this->addReference(self::$CAMP1, $camp);
+        return $camp;
     }
 
-    public function getDependencies() {
-        return [UserTestData::class];
+    /**
+     * @throws \Exception
+     */
+    private function createCamp2(ObjectManager $manager): Camp {
+        /** @var User $user */
+        $user = $this->getReference(UserTestData::$USER1);
+
+        $camp = new Camp();
+        $camp->setName('Camp2Name');
+        $camp->setTitle('Camp2Title');
+        $camp->setMotto('Camp2Motto');
+        $camp->setAddressName('AdrName2');
+        $camp->setAddressStreet('AdrStreet2');
+        $camp->setAddressZipcode('AdrZipcode2');
+        $camp->setAddressCity('AdrCity2');
+        $camp->setCreator($user);
+        $camp->setOwner($user);
+
+        $manager->persist($camp);
+        $manager->flush();
+
+        return $camp;
     }
 }


### PR DESCRIPTION
Return a validation Error if a patch of the role or a delete request would lead to camp which has no manager.
In the role select is a feedback that it failed, but not why.
For the delete button, there is no feedback yet.
I would solve that when we have the global toast.