### PR TITLE
Increase Cypress timeout

### DIFF
--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -1,4 +1,5 @@
 {
   "pluginsFile": "tests/e2e/plugins/index.js",
-  "video": false
+  "video": false,
+  "pageLoadTimeout": 120000
 }


### PR DESCRIPTION
When using vite, the build goes much faster, but the initial page load takes longer, up to 1 minute on CI. Cypress has a default timeout of 1 Minute for `cy.visit()` commands. This should fix the flaky e2e tests for now.

A more permanent solution would involve running the frontend in production mode for the e2e tests. But then we would start maintaining 3 versions of deploying the app: One in the local Docker setup with vite dev server, one for e2e tests and one for the deployment. So this needs some more thought. For now, increasing the timeout will let renovate keep doing its thing.