### PR TITLE
BugFix: Create Activity

### DIFF
--- a/frontend/src/components/dialog/DialogActivityCreate.vue
+++ b/frontend/src/components/dialog/DialogActivityCreate.vue
@@ -13,7 +13,7 @@
       <slot name="activator" v-bind="scope" />
     </template>
 
-    <dialog-activity-form v-if="!loading" :activity="entityData" :camp="scheduleEntry.period().camp" />
+    <dialog-activity-form v-if="!loading" :activity="entityData" :camp="camp" />
   </dialog-form>
 </template>
 
@@ -30,18 +30,18 @@ export default {
   },
   extends: DialogBase,
   props: {
-    scheduleEntry: {
-      type: Object,
-      required: true
-    }
+    camp: { type: Function, required: true },
+    scheduleEntry: { type: Object, required: true }
   },
   data () {
     return {
       entityProperties: [
         'title',
-        'categoryId',
-        'scheduleEntries',
-        'location'
+        'location',
+        'scheduleEntries'
+      ],
+      embeddedEntities: [
+        'category'
       ],
       entityUri: '/activities'
     }
@@ -53,7 +53,12 @@ export default {
           title: this.$tc('entity.activity.new'),
           location: '',
           scheduleEntries: [
-            this.scheduleEntry
+            {
+              period: this.scheduleEntry.period,
+              periodId: this.scheduleEntry.period().id,
+              periodOffset: this.scheduleEntry.periodOffset,
+              length: this.scheduleEntry.length
+            }
           ]
         })
       } else {

--- a/frontend/src/components/scheduleEntry/ScheduleEntries.vue
+++ b/frontend/src/components/scheduleEntry/ScheduleEntries.vue
@@ -7,6 +7,7 @@
       :showActivityEditDialog="showActivityEditDialog" />
     <dialog-activity-create
       ref="dialogActivityCreate"
+      :camp="period().camp"
       :schedule-entry="popupEntry"
       @activityCreated="afterCreateActivity($event)"
       @creationCanceled="cancelNewActivity" />


### PR DESCRIPTION
Beim erstellen einer Aktivität auf dem Picasso wird die PeriodId nicht mehr an den Server geschickt.
Ich vermute, das hat mit der neuen hal-json-vuex Version zu tun.
Dieser PR fixed DialogActivityCreate.vue, so dass PeriodId wieder geschickt wird. 
