### PR TITLE
Team verwalten: Rollen

### DIFF
--- a/backend/content-type/eCampMultiSelect/src/Module.php
+++ b/backend/content-type/eCampMultiSelect/src/Module.php
@@ -34,12 +34,19 @@ class Module {
             Option::class,
             [Acl::REST_PRIVILEGE_FETCH_ALL]
         );
+
+        $acl->allow(
+            User::ROLE_USER,
+            Option::class,
+            [Acl::REST_PRIVILEGE_FETCH],
+            new UserIsCollaborator([CampCollaboration::ROLE_MEMBER, CampCollaboration::ROLE_MANAGER, CampCollaboration::ROLE_GUEST])
+        );
+
         $acl->allow(
             User::ROLE_USER,
             Option::class,
             [
                 Acl::REST_PRIVILEGE_CREATE,
-                Acl::REST_PRIVILEGE_FETCH,
                 Acl::REST_PRIVILEGE_PATCH,
                 Acl::REST_PRIVILEGE_UPDATE,
                 Acl::REST_PRIVILEGE_DELETE,

--- a/backend/content-type/eCampSingleText/src/Module.php
+++ b/backend/content-type/eCampSingleText/src/Module.php
@@ -48,12 +48,19 @@ class Module {
             SingleText::class,
             [Acl::REST_PRIVILEGE_FETCH_ALL]
         );
+
+        $acl->allow(
+            User::ROLE_USER,
+            SingleText::class,
+            [Acl::REST_PRIVILEGE_FETCH],
+            new UserIsCollaborator([CampCollaboration::ROLE_MEMBER, CampCollaboration::ROLE_MANAGER, CampCollaboration::ROLE_GUEST])
+        );
+
         $acl->allow(
             User::ROLE_USER,
             SingleText::class,
             [
                 Acl::REST_PRIVILEGE_CREATE,
-                Acl::REST_PRIVILEGE_FETCH,
                 Acl::REST_PRIVILEGE_PATCH,
                 Acl::REST_PRIVILEGE_UPDATE,
                 Acl::REST_PRIVILEGE_DELETE,

--- a/backend/content-type/eCampStoryboard/src/Module.php
+++ b/backend/content-type/eCampStoryboard/src/Module.php
@@ -34,12 +34,19 @@ class Module {
             Section::class,
             [Acl::REST_PRIVILEGE_FETCH_ALL]
         );
+
+        $acl->allow(
+            User::ROLE_USER,
+            Section::class,
+            [Acl::REST_PRIVILEGE_FETCH],
+            new UserIsCollaborator([CampCollaboration::ROLE_MEMBER, CampCollaboration::ROLE_MANAGER, CampCollaboration::ROLE_GUEST])
+        );
+
         $acl->allow(
             User::ROLE_USER,
             Section::class,
             [
                 Acl::REST_PRIVILEGE_CREATE,
-                Acl::REST_PRIVILEGE_FETCH,
                 Acl::REST_PRIVILEGE_PATCH,
                 Acl::REST_PRIVILEGE_UPDATE,
                 Acl::REST_PRIVILEGE_DELETE,

--- a/backend/module/eCampApi/config/Rest/campCollaboration.config.php
+++ b/backend/module/eCampApi/config/Rest/campCollaboration.config.php
@@ -21,6 +21,7 @@ return Config::Create('CampCollaboration')
             ->addValidatorInArray([
                 CampCollaboration::ROLE_MEMBER,
                 CampCollaboration::ROLE_MANAGER,
+                CampCollaboration::ROLE_GUEST,
             ])
     )
     ->buildConfig()

--- a/backend/module/eCampApi/test/Rest/CampCollaborationTest.php
+++ b/backend/module/eCampApi/test/Rest/CampCollaborationTest.php
@@ -226,10 +226,13 @@ JSON;
         $this->assertEquals(CampCollaboration::STATUS_INVITED, $this->getResponseContent()->status);
     }
 
-    public function testCreateOnlyWithEmail(): void {
+    /**
+     * @dataProvider getRoles
+     */
+    public function testCreateOnlyWithEmail(string $role): void {
         $inviteEmail = 'my.mail@fantasy.com';
         $this->setRequestContent([
-            'role' => CampCollaboration::ROLE_MEMBER,
+            'role' => $role,
             'campId' => $this->campCollaboration1->getCamp()->getId(),
             'inviteEmail' => $inviteEmail,
             'userId' => null,
@@ -242,6 +245,10 @@ JSON;
         $this->assertThat($this->getResponseContent()->status, self::equalTo(CampCollaboration::STATUS_INVITED));
         $this->assertThat($this->getResponseContent()->inviteEmail, self::equalTo($inviteEmail));
         $this->assertThat($this->getResponseContent()->_embedded, self::logicalNot(self::classHasAttribute('user')));
+    }
+
+    public static function getRoles(): array {
+        return [[CampCollaboration::ROLE_GUEST], [CampCollaboration::ROLE_MANAGER], [CampCollaboration::ROLE_MEMBER]];
     }
 
     public function testCreateWithEmailOfExistingUser() {

--- a/backend/module/eCampCore/src/Acl/AclFactory.php
+++ b/backend/module/eCampCore/src/Acl/AclFactory.php
@@ -134,7 +134,7 @@ class AclFactory implements FactoryInterface {
             Acl::REST_PRIVILEGE_FETCH,
             AclAssertion::or(
                 new CampIsPrototype(),
-                new UserIsCollaborator([CampCollaboration::ROLE_MEMBER, CampCollaboration::ROLE_MANAGER])
+                new UserIsCollaborator([CampCollaboration::ROLE_MEMBER, CampCollaboration::ROLE_MANAGER, CampCollaboration::ROLE_GUEST])
             )
         );
         $acl->allow(

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -40,7 +40,8 @@
       "collaborators": {
         "invite": "Invite",
         "manager": "Manager",
-        "member": "Member"
+        "member": "Member",
+        "guest": "Guest"
       },
       "fields": {
         "addressCity": "City",

--- a/frontend/src/components/activity/CardContentNode.vue
+++ b/frontend/src/components/activity/CardContentNode.vue
@@ -2,7 +2,8 @@
   <v-card :elevation="draggable ? 4 : 0" :class="{ 'mx-2 my-2': draggable }">
     <v-card-title hide-actions class="pa-0 pr-sm-2">
       <v-toolbar dense flat>
-        <v-menu bottom
+        <v-menu v-if="!disabled"
+                bottom
                 right
                 offset-y>
           <template #activator="{ on, attrs }">
@@ -26,6 +27,9 @@
             </v-row>
           </v-container>
         </v-menu>
+        <v-icon v-else>
+          {{ currentIcon }}
+        </v-icon>
 
         <div
           v-if="editInstanceName"
@@ -46,7 +50,7 @@
           </v-toolbar-title>
         </div>
 
-        <v-menu v-if="!layoutMode"
+        <v-menu v-if="!layoutMode && !disabled"
                 bottom
                 left
                 offset-y>
@@ -67,7 +71,7 @@
           </v-list>
         </v-menu>
         <dialog-entity-delete
-          v-else
+          v-else-if="!disabled"
           :entity="contentNode">
           <template #activator="{ on }">
             <v-btn icon
@@ -101,7 +105,8 @@ export default {
   props: {
     contentNode: { type: Object, required: true },
     layoutMode: { type: Boolean, required: true },
-    draggable: { type: Boolean, default: false }
+    draggable: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false }
   },
   data () {
     return {
@@ -139,6 +144,9 @@ export default {
   },
   methods: {
     toggleEditInstanceName (e) {
+      if (this.disabled) {
+        return
+      }
       this.editInstanceName = !this.editInstanceName
     }
   }

--- a/frontend/src/components/activity/ContentNode.vue
+++ b/frontend/src/components/activity/ContentNode.vue
@@ -6,6 +6,7 @@
              :content-node="contentNode"
              :layout-mode="layoutMode"
              :draggable="draggable"
+             :disabled="disabled"
              v-bind="$attrs" />
 </template>
 
@@ -35,7 +36,8 @@ export default {
   props: {
     contentNode: { type: Object, required: true },
     layoutMode: { type: Boolean, required: true },
-    draggable: { type: Boolean, default: false }
+    draggable: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false }
   }
 }
 </script>

--- a/frontend/src/components/activity/DraggableContentNodes.vue
+++ b/frontend/src/components/activity/DraggableContentNodes.vue
@@ -15,7 +15,8 @@
                     class="content-node"
                     :content-node="allContentNodesById[id]"
                     :layout-mode="layoutMode"
-                    :draggable="draggingEnabled" />
+                    :draggable="draggingEnabled"
+                    :disabled="disabled" />
     </draggable>
 
     <button-nested-content-node-add v-if="layoutMode"
@@ -40,7 +41,8 @@ export default {
   props: {
     layoutMode: { type: Boolean, default: false },
     slotName: { type: String, required: true },
-    parentContentNode: { type: Object, required: true }
+    parentContentNode: { type: Object, required: true },
+    disabled: { type: Boolean, default: false }
   },
   data () {
     return {
@@ -52,7 +54,7 @@ export default {
       return keyBy(this.parentContentNode.owner().contentNodes().items, 'id')
     },
     draggingEnabled () {
-      return this.layoutMode && this.$vuetify.breakpoint.mdAndUp
+      return this.layoutMode && this.$vuetify.breakpoint.mdAndUp && !this.disabled
     },
     contentNodeIds () {
       return sortBy(

--- a/frontend/src/components/activity/content/ColumnLayout.vue
+++ b/frontend/src/components/activity/content/ColumnLayout.vue
@@ -17,7 +17,8 @@
                       @resize-stop="saveColumnWidths">
       <draggable-content-nodes :slot-name="slot"
                                :layout-mode="layoutMode"
-                               :parent-content-node="contentNode" />
+                               :parent-content-node="contentNode"
+                               :disabled="disabled" />
 
       <template #menu>
         <column-operations :content-node="contentNode" :min-column-width="minWidth(slot)" :total-width="12" />

--- a/frontend/src/components/activity/content/LAThematicArea.vue
+++ b/frontend/src/components/activity/content/LAThematicArea.vue
@@ -5,7 +5,7 @@
         <v-list-item v-for="option in contentNode.options().items"
                      :key="option.id"
                      tag="label"
-                     :disabled="layoutMode">
+                     :disabled="layoutMode || disabled">
           <v-list-item-action>
             <api-checkbox fieldname="checked" :uri="option._meta.self" />
           </v-list-item-action>

--- a/frontend/src/components/activity/content/Material.vue
+++ b/frontend/src/components/activity/content/Material.vue
@@ -5,7 +5,8 @@
                       :content-node="contentNode"
                       :layout-mode="layoutMode"
                       :material-item-collection="contentNode.materialItems()"
-                      :group-by-list="$vuetify.breakpoint.xs" />
+                      :group-by-list="$vuetify.breakpoint.xs"
+                      :disabled="disabled" />
     </div>
   </card-content-node>
 </template>

--- a/frontend/src/components/activity/content/Notes.vue
+++ b/frontend/src/components/activity/content/Notes.vue
@@ -7,7 +7,7 @@
           :label="$tc('contentNode.notes.name')"
           rows="4"
           auto-grow
-          :disabled="layoutMode"
+          :disabled="layoutMode || disabled"
           :filled="layoutMode" />
       </api-form>
     </div>

--- a/frontend/src/components/activity/content/SafetyConcept.vue
+++ b/frontend/src/components/activity/content/SafetyConcept.vue
@@ -6,7 +6,7 @@
           fieldname="text"
           :placeholder="$tc('contentNode.safetyConcept.name')"
           rows="2"
-          :disabled="layoutMode"
+          :disabled="layoutMode || disabled"
           :filled="layoutMode" />
       </api-form>
     </div>

--- a/frontend/src/components/activity/content/Storyboard.vue
+++ b/frontend/src/components/activity/content/Storyboard.vue
@@ -14,7 +14,7 @@
         <v-col cols="1" />
       </v-row>
 
-      <api-sortable v-slot="sortable" :collection="sections">
+      <api-sortable v-slot="sortable" :disabled="layoutMode || disabled" :collection="sections">
         <api-form :entity="sortable.entity">
           <v-row dense>
             <v-col cols="2">
@@ -22,7 +22,7 @@
                 fieldname="column1"
                 auto-grow
                 rows="2"
-                :disabled="layoutMode"
+                :disabled="layoutMode || disabled"
                 :filled="layoutMode" />
             </v-col>
             <v-col cols="7">
@@ -30,7 +30,7 @@
                 fieldname="column2"
                 auto-grow
                 rows="4"
-                :disabled="layoutMode"
+                :disabled="layoutMode || disabled"
                 :filled="layoutMode" />
             </v-col>
             <v-col cols="2">
@@ -38,11 +38,11 @@
                 fieldname="column3"
                 auto-grow
                 rows="2"
-                :disabled="layoutMode"
+                :disabled="layoutMode || disabled"
                 :filled="layoutMode" />
             </v-col>
             <v-col cols="1">
-              <v-container v-if="!layoutMode" class="ma-0 pa-0">
+              <v-container v-if="!layoutMode && !disabled" class="ma-0 pa-0">
                 <v-row no-gutters>
                   <v-col cols="6">
                     <div class="section-buttons">
@@ -85,7 +85,7 @@
       <!-- add at end position -->
       <v-row no-gutters justify="center">
         <v-col cols="1">
-          <v-btn v-if="!layoutMode"
+          <v-btn v-if="!layoutMode && !disabled"
                  icon
                  small
                  class="button-add"

--- a/frontend/src/components/activity/content/Storycontext.vue
+++ b/frontend/src/components/activity/content/Storycontext.vue
@@ -7,7 +7,7 @@
           :placeholder="$tc('contentNode.storycontext.name')"
           rows="2"
           auto-grow
-          :disabled="layoutMode"
+          :disabled="layoutMode || disabled"
           :filled="layoutMode" />
       </api-form>
     </div>

--- a/frontend/src/components/camp/CampAddress.vue
+++ b/frontend/src/components/camp/CampAddress.vue
@@ -9,16 +9,20 @@ Displays address and allows to edit
       <api-form :entity="camp()">
         <api-text-field
           fieldname="addressName"
-          :name="$tc('entity.camp.fields.addressName')" />
+          :name="$tc('entity.camp.fields.addressName')"
+          :disabled="disabled" />
         <api-text-field
           fieldname="addressStreet"
-          :name="$tc('entity.camp.fields.addressStreet')" />
+          :name="$tc('entity.camp.fields.addressStreet')"
+          :disabled="disabled" />
         <api-text-field
           fieldname="addressZipcode"
-          :name="$tc('entity.camp.fields.addressZipcode')" />
+          :name="$tc('entity.camp.fields.addressZipcode')"
+          :disabled="disabled" />
         <api-text-field
           fieldname="addressCity"
-          :name="$tc('entity.camp.fields.addressCity')" />
+          :name="$tc('entity.camp.fields.addressCity')"
+          :disabled="disabled" />
       </api-form>
     </div>
   </content-group>
@@ -36,6 +40,10 @@ export default {
     camp: {
       type: Function,
       required: true
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   }
 }

--- a/frontend/src/components/camp/CampCategories.vue
+++ b/frontend/src/components/camp/CampCategories.vue
@@ -7,7 +7,7 @@ Displays all periods of a single camp and allows to edit them & create new ones
     <slot name="title">
       <div class="ec-content-group__title py-1 subtitle-1">
         {{ $tc('components.camp.campCategories.title') }}
-        <dialog-category-create :camp="camp()">
+        <dialog-category-create v-if="!disabled" :camp="camp()">
           <template #activator="{ on }">
             <button-add color="secondary" text
                         :hide-label="true"
@@ -30,7 +30,7 @@ Displays all periods of a single camp and allows to edit them & create new ones
             <v-chip dark :color="category.color">
               (1.{{ category.numberingStyle }}) {{ category.short }}: {{ category.name }}
 
-              <dialog-category-edit :camp="camp()" :category="category">
+              <dialog-category-edit v-if="!disabled" :camp="camp()" :category="category">
                 <template #activator="{ on }">
                   <v-icon class="ml-2" size="150%" v-on="on">mdi-pencil</v-icon>
                 </template>
@@ -39,7 +39,7 @@ Displays all periods of a single camp and allows to edit them & create new ones
           </v-list-item-title>
         </v-list-item-content>
 
-        <v-list-item-action style="display: inline">
+        <v-list-item-action v-if="!disabled" style="display: inline">
           <v-item-group>
             <button-edit
               class="mr-1"
@@ -50,7 +50,7 @@ Displays all periods of a single camp and allows to edit them & create new ones
           </v-item-group>
         </v-list-item-action>
 
-        <v-menu offset-y>
+        <v-menu v-if="!disabled" offset-y>
           <template #activator="{ on, attrs }">
             <v-btn icon v-bind="attrs" v-on="on">
               <v-icon>mdi-dots-vertical</v-icon>
@@ -116,7 +116,8 @@ export default {
     ContentGroup
   },
   props: {
-    camp: { type: Function, required: true }
+    camp: { type: Function, required: true },
+    disabled: { type: Boolean, default: false }
   },
   data () {
     return {}

--- a/frontend/src/components/camp/CampMaterialLists.vue
+++ b/frontend/src/components/camp/CampMaterialLists.vue
@@ -3,7 +3,7 @@
     <slot name="title">
       <div class="ec-content-group__title py-1 subtitle-1">
         {{ $tc('components.camp.campMaterialLists.title') }}
-        <dialog-material-list-create :camp="camp()">
+        <dialog-material-list-create v-if="!disabled" :camp="camp()">
           <template #activator="{ on }">
             <button-add color="secondary" text
                         class="my-n1"
@@ -20,7 +20,8 @@
         v-for="materialList in materialLists.items"
         :key="materialList.id"
         class="px-0"
-        :material-list="materialList" />
+        :material-list="materialList"
+        :disabled="disabled" />
     </v-list>
   </content-group>
 </template>
@@ -35,7 +36,8 @@ export default {
   name: 'CampMaterialLists',
   components: { ContentGroup, ButtonAdd, CampMaterialListsItem, DialogMaterialListCreate },
   props: {
-    camp: { type: Function, required: true }
+    camp: { type: Function, required: true },
+    disabled: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/frontend/src/components/camp/CampMaterialListsItem.vue
+++ b/frontend/src/components/camp/CampMaterialListsItem.vue
@@ -4,7 +4,7 @@
       <v-list-item-title>{{ materialList.name }}</v-list-item-title>
     </v-list-item-content>
 
-    <v-list-item-action style="display: inline">
+    <v-list-item-action v-if="!disabled" style="display: inline">
       <v-item-group>
         <dialog-material-list-edit :material-list="materialList">
           <template #activator="{ on }">
@@ -14,7 +14,7 @@
       </v-item-group>
     </v-list-item-action>
 
-    <v-menu offset-y>
+    <v-menu v-if="!disabled" offset-y>
       <template #activator="{ on, attrs }">
         <v-btn icon v-bind="attrs" v-on="on">
           <v-icon>mdi-dots-vertical</v-icon>
@@ -52,7 +52,8 @@ export default {
   name: 'CampMaterialListsItem',
   components: { DialogEntityDelete, DialogMaterialListEdit, ButtonEdit, ButtonDelete },
   props: {
-    materialList: { type: Object, required: true }
+    materialList: { type: Object, required: true },
+    disabled: { type: Boolean, default: false }
   }
 }
 </script>

--- a/frontend/src/components/camp/CampPeriods.vue
+++ b/frontend/src/components/camp/CampPeriods.vue
@@ -7,7 +7,7 @@ Displays all periods of a single camp and allows to edit them & create new ones
     <slot name="title">
       <div class="ec-content-group__title py-1 subtitle-1">
         {{ $tc('components.camp.campPeriods.title', api.get().camps().items.length) }}
-        <dialog-period-create :camp="camp()">
+        <dialog-period-create v-if="!disabled" :camp="camp()">
           <template #activator="{ on }">
             <button-add color="secondary" text
                         class="my-n2"
@@ -25,7 +25,8 @@ Displays all periods of a single camp and allows to edit them & create new ones
         v-for="period in periods.items"
         :key="period.id"
         class="px-0"
-        :period="period" />
+        :period="period"
+        :disabled="disabled" />
     </v-list>
   </content-group>
 </template>
@@ -40,7 +41,8 @@ export default {
   name: 'CampPeriods',
   components: { ContentGroup, ButtonAdd, PeriodItem, DialogPeriodCreate },
   props: {
-    camp: { type: Function, required: true }
+    camp: { type: Function, required: true },
+    disabled: { type: Boolean, default: false }
   },
   data () {
     return {}

--- a/frontend/src/components/camp/CampPeriodsListItem.vue
+++ b/frontend/src/components/camp/CampPeriodsListItem.vue
@@ -12,7 +12,7 @@ Displays a single period as a list item including controls to edit and delete it
       </v-list-item-subtitle>
     </v-list-item-content>
 
-    <v-list-item-action style="display: inline">
+    <v-list-item-action v-if="!disabled" style="display: inline">
       <v-item-group>
         <dialog-period-edit :period="period">
           <template #activator="{ on }">
@@ -22,7 +22,7 @@ Displays a single period as a list item including controls to edit and delete it
       </v-item-group>
     </v-list-item-action>
 
-    <v-menu offset-y>
+    <v-menu v-if="!disabled" offset-y>
       <template #activator="{ on, attrs }">
         <v-btn icon v-bind="attrs" v-on="on">
           <v-icon>mdi-dots-vertical</v-icon>
@@ -65,7 +65,8 @@ export default {
   name: 'CampPeriods',
   components: { DialogEntityDelete, DialogPeriodEdit, ButtonEdit, ButtonDelete },
   props: {
-    period: { type: Object, required: true }
+    period: { type: Object, required: true },
+    disabled: { type: Boolean, default: false }
   },
   computed: {
     isLastPeriod () {

--- a/frontend/src/components/camp/CampSettings.vue
+++ b/frontend/src/components/camp/CampSettings.vue
@@ -10,14 +10,17 @@ Displays details on a single camp and allows to edit them.
         <api-text-field
           fieldname="name"
           :label="$tc('entity.camp.fields.name')"
-          vee-rules="required" />
+          vee-rules="required"
+          :disabled="disabled" />
         <api-text-field
           fieldname="title"
           :name="$tc('entity.camp.fields.title')"
-          vee-rules="required" />
+          vee-rules="required"
+          :disabled="disabled" />
         <api-text-field
           fieldname="motto"
-          :name="$tc('entity.camp.fields.motto')" />
+          :name="$tc('entity.camp.fields.motto')"
+          :disabled="disabled" />
       </api-form>
     </div>
   </content-group>
@@ -35,6 +38,10 @@ export default {
     camp: {
       type: Function,
       required: true
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   data () {

--- a/frontend/src/components/camp/CollaboratorListItem.vue
+++ b/frontend/src/components/camp/CollaboratorListItem.vue
@@ -24,29 +24,47 @@
       </icon-button>
     </v-list-item-action>
     <v-list-item-action class="ml-4">
-      <api-select
-        :value="collaborator.role"
-        :uri="collaborator._meta.self"
-        fieldname="role"
-        :items="[
-          { key: 'member', translation: $tc('entity.camp.collaborators.member') },
-          { key: 'manager', translation: $tc('entity.camp.collaborators.manager') },
-          { key: 'guest', translation: $tc('entity.camp.collaborators.guest') },
-        ]"
-        item-value="key"
-        item-text="translation"
-        :my="0"
-        dense
-        vee-rules="required"
-        :disabled="disabled || isLastManager" />
+      <v-tooltip :disabled="disabled || !isLastManager" top>
+        <template #activator="{ on, attrs }">
+          <div
+            v-bind="attrs"
+            v-on="on">
+            <api-select
+              :value="collaborator.role"
+              :uri="collaborator._meta.self"
+              fieldname="role"
+              :items="[
+                { key: 'member', translation: $tc('entity.camp.collaborators.member') },
+                { key: 'manager', translation: $tc('entity.camp.collaborators.manager') },
+                { key: 'guest', translation: $tc('entity.camp.collaborators.guest') },
+              ]"
+              item-value="key"
+              item-text="translation"
+              :my="0"
+              dense
+              vee-rules="required"
+              :disabled="disabled || isLastManager" />
+          </div>
+        </template>
+        <span>{{ $tc("components.camp.collaboratorListItem.cannotAssignAnotherRoleToLastManager") }}</span>
+      </v-tooltip>
     </v-list-item-action>
     <v-list-item-action class="ml-2">
-      <button-delete
-        :disabled="(disabled && !isOwnCampCollaboration) || isLastManager"
-        icon="mdi-cancel"
-        @click="api.del(collaborator)">
-        {{ $tc("components.camp.collaboratorListItem.deactivate") }}
-      </button-delete>
+      <v-tooltip :disabled="disabled || !isLastManager" top>
+        <template #activator="{ on, attrs }">
+          <div
+            v-bind="attrs"
+            v-on="on">
+            <button-delete
+              :disabled="(disabled && !isOwnCampCollaboration) || isLastManager"
+              icon="mdi-cancel"
+              @click="api.del(collaborator)">
+              {{ $tc("components.camp.collaboratorListItem.deactivate") }}
+            </button-delete>
+          </div>
+        </template>
+        <span>{{ $tc("components.camp.collaboratorListItem.cannotRemoveLastManager") }}</span>
+      </v-tooltip>
     </v-list-item-action>
   </v-list-item>
 </template>

--- a/frontend/src/components/camp/CollaboratorListItem.vue
+++ b/frontend/src/components/camp/CollaboratorListItem.vue
@@ -50,11 +50,12 @@
 <script>
 import ApiSelect from '@/components/form/api/ApiSelect.vue'
 import ButtonDelete from '@/components/buttons/ButtonDelete.vue'
-import UserAvatar from '../user/UserAvatar.vue'
+import UserAvatar from '@/components/user/UserAvatar.vue'
+import IconButton from '@/components/buttons/IconButton.vue'
 
 export default {
   name: 'CollaboratorListItem',
-  components: { ButtonDelete, ApiSelect, UserAvatar },
+  components: { ButtonDelete, ApiSelect, UserAvatar, IconButton },
   props: {
     collaborator: { type: Object, required: true }
   },

--- a/frontend/src/components/camp/CollaboratorListItem.vue
+++ b/frontend/src/components/camp/CollaboratorListItem.vue
@@ -30,6 +30,7 @@
         :items="[
           { key: 'member', translation: $tc('entity.camp.collaborators.member') },
           { key: 'manager', translation: $tc('entity.camp.collaborators.manager') },
+          { key: 'guest', translation: $tc('entity.camp.collaborators.guest') },
         ]"
         item-value="key"
         item-text="translation"

--- a/frontend/src/components/camp/InactiveCollaboratorListItem.vue
+++ b/frontend/src/components/camp/InactiveCollaboratorListItem.vue
@@ -44,10 +44,11 @@
 import IconButton from '@/components/buttons/IconButton.vue'
 import ButtonDelete from '@/components/buttons/ButtonDelete.vue'
 import DialogEntityDelete from '@/components/dialog/DialogEntityDelete.vue'
+import UserAvatar from '@/components/user/UserAvatar.vue'
 
 export default {
   name: 'InactiveCollaboratorListItem',
-  components: { IconButton, ButtonDelete, DialogEntityDelete },
+  components: { IconButton, ButtonDelete, DialogEntityDelete, UserAvatar },
   props: {
     collaborator: { type: Object, required: true }
   }

--- a/frontend/src/components/camp/InactiveCollaboratorListItem.vue
+++ b/frontend/src/components/camp/InactiveCollaboratorListItem.vue
@@ -12,16 +12,18 @@
       </v-list-item-subtitle>
     </v-list-item-content>
     <v-list-item-action class="ml-5">
-      <icon-button color="normal"
-                   icon="mdi-refresh"
-                   @click="api.patch(collaborator, {status: 'invited'})">
+      <icon-button
+        color="normal"
+        icon="mdi-refresh"
+        :disabled="disabled"
+        @click="api.patch(collaborator, {status: 'invited'})">
         {{ $tc('components.camp.inactiveCampCollaboratorListItem.inviteAgain') }}
       </icon-button>
     </v-list-item-action>
     <v-list-item-action>
       <dialog-entity-delete :entity="collaborator">
         <template #activator="{ on }">
-          <button-delete v-on="on" />
+          <button-delete :disabled="disabled" v-on="on" />
         </template>
         {{ $tc('components.camp.inactiveCampCollaboratorListItem.delete') }} <br>
         <ul>
@@ -50,7 +52,8 @@ export default {
   name: 'InactiveCollaboratorListItem',
   components: { IconButton, ButtonDelete, DialogEntityDelete, UserAvatar },
   props: {
-    collaborator: { type: Object, required: true }
+    collaborator: { type: Object, required: true },
+    disabled: { type: Boolean, default: false }
   }
 }
 </script>

--- a/frontend/src/components/camp/PeriodMaterialLists.vue
+++ b/frontend/src/components/camp/PeriodMaterialLists.vue
@@ -12,7 +12,8 @@
         :period="period"
         :show-content-node-material="showContentNodeMaterial"
         :group-by-list="groupByList"
-        enable-grouping />
+        enable-grouping
+        :disabled="disabled" />
     </v-expansion-panel-content>
   </v-expansion-panel>
 </template>
@@ -29,7 +30,8 @@ export default {
   props: {
     period: { type: Object, required: true },
     showContentNodeMaterial: { type: Boolean, required: true },
-    groupByList: { type: Boolean, required: true }
+    groupByList: { type: Boolean, required: true },
+    disabled: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/frontend/src/components/form/api/ApiSortable.vue
+++ b/frontend/src/components/form/api/ApiSortable.vue
@@ -5,6 +5,7 @@
     handle=".drag-and-drop-handle"
     :animation="200"
     :force-fallback="true"
+    :disabled="disabled"
     @sort="onSort"
     @start="dragging = true"
     @end="dragging = false">
@@ -30,7 +31,8 @@ export default {
   },
   props: {
     /* reference to sortable API collection */
-    collection: { type: Function, required: true }
+    collection: { type: Function, required: true },
+    disabled: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/frontend/src/components/material/MaterialTable.vue
+++ b/frontend/src/components/material/MaterialTable.vue
@@ -37,7 +37,7 @@
     <template #[`item.quantity`]="{ item }">
       <api-text-field
         v-if="!item.readonly"
-        :disabled="layoutMode"
+        :disabled="layoutMode || disabled"
         dense
         :uri="item.uri"
         fieldname="quantity" />
@@ -47,7 +47,7 @@
     <template #[`item.unit`]="{ item }">
       <api-text-field
         v-if="!item.readonly"
-        :disabled="layoutMode"
+        :disabled="layoutMode || disabled"
         dense
         :uri="item.uri"
         fieldname="unit" />
@@ -57,7 +57,7 @@
     <template #[`item.article`]="{ item }">
       <api-text-field
         v-if="!item.readonly"
-        :disabled="layoutMode"
+        :disabled="layoutMode || disabled"
         dense
         :uri="item.uri"
         fieldname="article" />
@@ -67,7 +67,7 @@
     <template #[`item.listName`]="{ item }">
       <api-select
         v-if="!item.readonly"
-        :disabled="layoutMode"
+        :disabled="layoutMode || disabled"
         dense
         :uri="item.uri"
         relation="materialList"
@@ -86,7 +86,7 @@
       <div v-if="!item.readonly" class="d-flex">
         <!-- edit dialog (mobile only) -->
         <dialog-material-item-edit
-          v-if="!$vuetify.breakpoint.smAndUp && !layoutMode"
+          v-if="!$vuetify.breakpoint.smAndUp && !layoutMode && !disabled"
           class="float-left"
           :material-item-uri="item.uri">
           <template #activator="{ on }">
@@ -98,7 +98,7 @@
         </dialog-material-item-edit>
 
         <!-- delete button (behind menu) -->
-        <v-menu v-if="!layoutMode">
+        <v-menu v-if="!layoutMode && !disabled">
           <template #activator="{ on, attrs }">
             <v-btn icon v-bind="attrs" v-on="on">
               <v-icon>mdi-dots-vertical</v-icon>
@@ -145,7 +145,7 @@
     <template #[`body.append`]="{ headers }">
       <!-- add new item (desktop view) -->
       <material-create-item
-        v-if="!layoutMode && $vuetify.breakpoint.smAndUp"
+        v-if="!layoutMode && $vuetify.breakpoint.smAndUp && !disabled"
         key="addItemRow"
         :camp="camp"
         :columns="headers.length"
@@ -154,7 +154,7 @@
 
     <template #footer>
       <!-- add new item (mobile view) -->
-      <div v-if="!layoutMode && !$vuetify.breakpoint.smAndUp" class="mt-5">
+      <div v-if="!layoutMode && !$vuetify.breakpoint.smAndUp && !disabled" class="mt-5">
         <dialog-material-item-create
           :camp="camp"
           :material-item-collection="materialItemCollection"
@@ -208,6 +208,8 @@ export default {
   props: {
     // camp Entity
     camp: { type: Object, required: true },
+
+    disabled: { type: Boolean, default: false },
 
     // layoutMode=true --> data editing is disabled
     layoutMode: { type: Boolean, required: false, default: false },
@@ -283,7 +285,7 @@ export default {
           listName: item.materialList().name,
           activity: item.contentNode ? item.contentNode().id : null,
           entityObject: item,
-          readonly: this.period && item.contentNode, // if complete component is in period overview, disable editing of material that belongs to contentNodes (Acitity material)
+          readonly: (this.period && item.contentNode), // if complete component is in period overview, disable editing of material that belongs to contentNodes (Acitity material)
           class: this.period && item.contentNode ? 'readonly' : 'period'
         }))
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -168,6 +168,8 @@
         "title": "Settings"
       },
       "collaboratorListItem": {
+        "cannotAssignAnotherRoleToLastManager": "You cannot assign another role to the last manager.",
+        "cannotRemoveLastManager": "You cannot remove the last manager.",
         "deactivate": "Deactivate",
         "resendEmail": "Resend email"
       },

--- a/frontend/src/mixins/campRoleMixin.js
+++ b/frontend/src/mixins/campRoleMixin.js
@@ -4,18 +4,24 @@ export const campRoleMixin = {
       return this.isMember || this.isManager
     },
     isGuest () {
-      return this.camp?.role === 'guest'
+      return this.role === 'guest'
     },
     isManager () {
-      return this.camp?.role === 'manager'
+      return this.role === 'manager'
     },
     isMember () {
-      return this.camp?.role === 'member'
+      return this.role === 'member'
+    },
+    role () {
+      if (typeof this.camp === 'function') {
+        return this.camp()?.role
+      }
+      return this.camp?.role
     }
   },
   mounted () {
-    if (typeof this.camp !== 'object') {
-      throw new Error('User of the campRoleMixin must expose a method/proxy camp()')
+    if (typeof this.camp !== 'object' && typeof this.camp !== 'function') {
+      throw new Error('User of the campRoleMixin must expose a camp as object proxy or function')
     }
   }
 }

--- a/frontend/src/mixins/campRoleMixin.js
+++ b/frontend/src/mixins/campRoleMixin.js
@@ -1,0 +1,21 @@
+export const campRoleMixin = {
+  computed: {
+    isContributor () {
+      return this.isMember || this.isManager
+    },
+    isGuest () {
+      return this.camp?.role === 'guest'
+    },
+    isManager () {
+      return this.camp?.role === 'manager'
+    },
+    isMember () {
+      return this.camp?.role === 'member'
+    }
+  },
+  mounted () {
+    if (typeof this.camp !== 'object') {
+      throw new Error('User of the campRoleMixin must expose a method/proxy camp()')
+    }
+  }
+}

--- a/frontend/src/mixins/contentNodeMixin.js
+++ b/frontend/src/mixins/contentNodeMixin.js
@@ -2,7 +2,8 @@ export const contentNodeMixin = {
   props: {
     contentNode: { type: Object, required: true },
     layoutMode: { type: Boolean, required: true },
-    draggable: { type: Boolean, default: false }
+    draggable: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false }
   },
   computed: {
     camp () {

--- a/frontend/src/views/activity/Activity.vue
+++ b/frontend/src/views/activity/Activity.vue
@@ -8,7 +8,7 @@ Displays a single activity
       <template #title>
         <v-toolbar-title class="font-weight-bold">
           {{ scheduleEntry().number }}
-          <v-menu v-if="!category._meta.loading" offset-y :disabled="layoutMode">
+          <v-menu v-if="!category._meta.loading" offset-y :disabled="layoutMode || !isContributor">
             <template #activator="{ on, attrs }">
               <v-chip
                 :color="category.color"
@@ -34,7 +34,7 @@ Displays a single activity
           </v-menu>
           <a v-if="!editActivityTitle"
              style="color: inherit"
-             @click="editActivityTitle = true">
+             @click="makeTitleEditable();">
             {{ activity.title }}
           </a>
         </v-toolbar-title>
@@ -54,6 +54,7 @@ Displays a single activity
         <v-btn v-if="!layoutMode"
                color="primary"
                outlined
+               :disabled="!isContributor"
                @click="layoutMode = true">
           <template v-if="$vuetify.breakpoint.smAndUp">
             <v-icon left>mdi-puzzle-edit-outline</v-icon>
@@ -61,7 +62,7 @@ Displays a single activity
           </template>
           <template v-else>{{ $tc('views.activity.activity.layout') }}</template>
         </v-btn>
-        <v-btn v-else
+        <v-btn v-else-if="isContributor"
                color="success"
                outlined
                @click="layoutMode = false">
@@ -126,7 +127,7 @@ Displays a single activity
                     :name="$tc('entity.activity.fields.location')"
                     :uri="activity._meta.self"
                     fieldname="location"
-                    :disabled="layoutMode"
+                    :disabled="layoutMode || !isContributor"
                     dense />
                 </v-col>
               </v-row>
@@ -141,7 +142,7 @@ Displays a single activity
                     small-chips
                     :uri="activity._meta.self"
                     fieldname="campCollaborations"
-                    :disabled="layoutMode"
+                    :disabled="layoutMode || !isContributor"
                     :items="availableCampCollaborations" />
                 </v-col>
               </v-row>
@@ -150,7 +151,8 @@ Displays a single activity
           <content-node
             v-if="activity.rootContentNode"
             :content-node="activity.rootContentNode()"
-            :layout-mode="layoutMode" />
+            :layout-mode="layoutMode"
+            :disabled="isContributor === false" />
         </template>
       </v-card-text>
     </content-card>
@@ -163,6 +165,7 @@ import ApiTextField from '@/components/form/api/ApiTextField.vue'
 import ApiSelect from '@/components/form/api/ApiSelect.vue'
 import ContentNode from '@/components/activity/ContentNode.vue'
 import { defineHelpers } from '@/common/helpers/scheduleEntry/dateHelperUTC.js'
+import { campRoleMixin } from '@/mixins/campRoleMixin'
 
 export default {
   name: 'Activity',
@@ -172,6 +175,7 @@ export default {
     ApiSelect,
     ContentNode
   },
+  mixins: [campRoleMixin],
   props: {
     scheduleEntry: {
       type: Function,
@@ -227,6 +231,11 @@ export default {
       return this.contentNodes.items.filter(cn => {
         return cn.contentType().id === contentType.id
       }).length
+    },
+    makeTitleEditable () {
+      if (this.isContributor) {
+        this.editActivityTitle = true
+      }
     }
   }
 }

--- a/frontend/src/views/camp/Admin.vue
+++ b/frontend/src/views/camp/Admin.vue
@@ -7,18 +7,18 @@ Admin screen of a camp: Displays details & periods of a single camp and allows t
     <v-card-text>
       <v-row>
         <v-col cols="12" lg="6">
-          <camp-settings :camp="camp" />
-          <camp-address :camp="camp" />
+          <camp-settings :camp="camp" :disabled="!isManager" />
+          <camp-address :camp="camp" :disabled="!isManager" />
 
           <v-btn v-if="$vuetify.breakpoint.xsOnly" :to="{name: 'camp/collaborators', query: {isDetail: true}}">
             {{ $tc('views.camp.admin.collaborators') }}
           </v-btn>
-          <camp-periods :camp="camp" />
+          <camp-periods :camp="camp" :disabled="!isManager" />
         </v-col>
         <v-col cols="12" lg="6">
-          <camp-categories :camp="camp" />
+          <camp-categories :camp="camp" :disabled="!isManager" />
 
-          <camp-material-lists :camp="camp" />
+          <camp-material-lists :camp="camp" :disabled="!isManager" />
         </v-col>
       </v-row>
       <v-row>
@@ -38,6 +38,7 @@ import CampMaterialLists from '@/components/camp/CampMaterialLists.vue'
 import CampCategories from '@/components/camp/CampCategories.vue'
 import ContentCard from '@/components/layout/ContentCard.vue'
 import CampDangerZone from '@/components/camp/CampDangerZone.vue'
+import { campRoleMixin } from '@/mixins/campRoleMixin'
 
 export default {
   name: 'Admin',
@@ -50,16 +51,12 @@ export default {
     CampMaterialLists,
     CampCategories
   },
+  mixins: [campRoleMixin],
   props: {
     camp: { type: Function, required: true }
   },
   data () {
     return {}
-  },
-  computed: {
-    isManager () {
-      return this.camp().role === 'manager'
-    }
   },
   mounted () {
     this.api.reload(this.camp())

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -9,7 +9,8 @@ Displays collaborators of a single camp.
           <v-skeleton-loader v-if="collaborators.length <= 0" type="list-item-avatar-two-line@3" class="px-0" />
           <collaborator-list-item
             v-for="collaborator in establishedCollaborators"
-            :key="collaborator._meta.self" :collaborator="collaborator" />
+            :key="collaborator._meta.self" :collaborator="collaborator"
+            :disabled="!isManager" />
         </v-list>
       </content-group>
 
@@ -17,7 +18,8 @@ Displays collaborators of a single camp.
         <v-list>
           <collaborator-list-item
             v-for="collaborator in invitedCollaborators"
-            :key="collaborator._meta.self" :collaborator="collaborator" />
+            :key="collaborator._meta.self" :collaborator="collaborator"
+            :disabled="!isManager" />
         </v-list>
       </content-group>
 
@@ -25,11 +27,12 @@ Displays collaborators of a single camp.
         <v-list>
           <inactive-collaborator-list-item
             v-for="collaborator in inactiveCollaborators"
-            :key="collaborator._meta.self" :collaborator="collaborator" />
+            :key="collaborator._meta.self" :collaborator="collaborator"
+            :disabled="!isManager" />
         </v-list>
       </content-group>
 
-      <content-group :title="$tc('views.camp.collaborators.invite')">
+      <content-group v-if="isManager" :title="$tc('views.camp.collaborators.invite')">
         <v-form @submit.prevent="invite">
           <v-container>
             <v-row
@@ -78,6 +81,7 @@ import ButtonAdd from '@/components/buttons/ButtonAdd.vue'
 import ETextField from '@/components/form/base/ETextField.vue'
 import ESelect from '@/components/form/base/ESelect.vue'
 import InactiveCollaboratorListItem from '@/components/camp/InactiveCollaboratorListItem.vue'
+import { campRoleMixin } from '@/mixins/campRoleMixin'
 
 const DEFAULT_INVITE_ROLE = 'member'
 
@@ -92,6 +96,7 @@ export default {
     ESelect,
     InactiveCollaboratorListItem
   },
+  mixins: [campRoleMixin],
   props: {
     camp: { type: Function, required: true }
   },

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -50,6 +50,7 @@ Displays collaborators of a single camp.
                   :items="[
                     { key: 'member', translation: $tc('entity.camp.collaborators.member') },
                     { key: 'manager', translation: $tc('entity.camp.collaborators.manager') },
+                    { key: 'guest', translation: $tc('entity.camp.collaborators.guest') },
                   ]"
                   item-value="key"
                   item-text="translation"

--- a/frontend/src/views/camp/Material.vue
+++ b/frontend/src/views/camp/Material.vue
@@ -24,7 +24,8 @@ Admin screen of a camp: Displays MaterialLists and MaterialItems
                              :key="period._meta.self"
                              :period="period"
                              :show-content-node-material="showContentNodeMaterial"
-                             :group-by-list="groupByList || $vuetify.breakpoint.xs" />
+                             :group-by-list="groupByList || $vuetify.breakpoint.xs"
+                             :disabled="!isContributor" />
     </v-expansion-panels>
   </content-card>
 </template>
@@ -32,6 +33,7 @@ Admin screen of a camp: Displays MaterialLists and MaterialItems
 <script>
 import ContentCard from '@/components/layout/ContentCard.vue'
 import PeriodMaterialLists from '@/components/camp/PeriodMaterialLists.vue'
+import { campRoleMixin } from '@/mixins/campRoleMixin'
 
 export default {
   name: 'Material',
@@ -39,6 +41,7 @@ export default {
     ContentCard,
     PeriodMaterialLists
   },
+  mixins: [campRoleMixin],
   props: {
     camp: { type: Function, required: true }
   },

--- a/frontend/src/views/camp/Story.vue
+++ b/frontend/src/views/camp/Story.vue
@@ -8,6 +8,7 @@ Admin screen of a camp: Displays details & periods of a single camp and allows t
       <template v-if="$vuetify.breakpoint.smAndUp">
         <e-switch v-model="editing" :label="$tc('global.button.editable')"
                   class="ec-story-editable ml-auto"
+                  :disabled="!isContributor"
                   @click="$event.preventDefault()" />
       </template>
       <v-menu v-else offset-y>
@@ -60,6 +61,7 @@ Admin screen of a camp: Displays details & periods of a single camp and allows t
 <script>
 import ContentCard from '@/components/layout/ContentCard.vue'
 import StoryPeriod from '@/components/camp/StoryPeriod.vue'
+import { campRoleMixin } from '@/mixins/campRoleMixin'
 
 const PRINT_SERVER = window.environment.PRINT_SERVER
 
@@ -69,6 +71,7 @@ export default {
     StoryPeriod,
     ContentCard
   },
+  mixins: [campRoleMixin],
   props: {
     camp: { type: Function, required: true }
   },

--- a/frontend/src/views/camp/__tests__/Admin.spec.js
+++ b/frontend/src/views/camp/__tests__/Admin.spec.js
@@ -62,4 +62,25 @@ describe('Admin view', () => {
     expect(queryByText('components.camp.campDangerzone.title')).not.toBeInTheDocument()
     expect(queryByText('components.camp.campDangerzone.deleteCamp.title')).not.toBeInTheDocument()
   })
+
+  it('doesn\'t show the danger zone when the user has the guest role', async () => {
+    const { queryByText } = renderWithVuetify(Admin, {
+      props: {
+        camp: () => ({
+          role: 'guest',
+          materialLists: () => {},
+          _meta: { loading: false }
+        })
+      },
+      routes: [],
+      mocks: {
+        api: { reload: () => Promise.resolve() },
+        $tc: key => key
+      },
+      stubs: ['camp-settings', 'camp-address', 'camp-periods', 'camp-categories', 'camp-material-lists']
+    })
+
+    expect(queryByText('components.camp.campDangerzone.title')).not.toBeInTheDocument()
+    expect(queryByText('components.camp.campDangerzone.deleteCamp.title')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
For Issue #1415

~~I will add commits until the features currently in the PR are approved.~~ -> this PR is finished
Currently in this PR from the Issue:
- [x] Gast hinzufügbar machen

Aktivität Detail ansicht
- Guest
  - [x] Layout bearbeiten Knopf ausblenden/disablen
  - [x] Klick auf Category -> Category Edit ausblenden
  - [x] Wenn man auf den Activity Namen klickt wird dieser editierbar -> deaktivieren
  - [x] Location Text disablen
  - [ ] ScheduleEntry Hinzufügen/löschen etc ausblenden -> needs #1379 to be merged
  - [x] Responsible DropDown disablen
  - [x] ContentNodes: Icon ändern disablen
  - [x] ContentNodes: Menu entfernen
  - [x] ContentNodes: Textareas disablen
  - [x] ContentNodes: Material + MaterialList disablen 
  - [x] ContentNodes: LAThematicArea disablen
  - [x] ContentNodes: StoryConcept disablen (Textareas, drag/drop, löschen, hinzufügen)

Story
- Guest
  - [x] Editierbar Knopf disablen

Team
- Guest/Member
  - [x] Dropdown für Rolle disablen
  - [x] Deactivate Knopf entfernen (ausser bei eigenen)
  - [x] Resend Email Knopf entfernen
  - [x] Invite Area entfernen
  - [x] Delete Knopf entfernen
- Manager
  - [x] Wenn nur noch ein Manager im Team: Dropdown für Manager disablen, deactivate Knopf disablen, beides mit Tooltip: "Es muss mindestens ein Manager im Lager verbleiben"

Materials
- Guest
  - [x]  Felder in Materiallist disablen (Auch Menu für löschen)
  - [x] Hinzufügen row entfernen

Print
- Nothing to do

Admin
- Guest/Member
  - [x] Textfelder disablen
  - [x] Periods editieren disablen (add knopf weg, edit + menu weg
  - [x] Danger Zone nicht anzeigen #1382
  - [x] Activity Categories: add weg, Edit Knopf bei der Category weg, Edit Layout weg, Delete weg
  - [x] Material-list: create/edit/delete weg

For next PR's:

- Make UX for disabled Links better:
Remove hover on disabled links -> e-href component
Remove hover on disabled buttons -> e-button

- Make Picasso readonly for Guests