### PR TITLE
ci: use interpreter versions of docker-compose file

### DIFF
--- a/.docker-hub/backend/Dockerfile
+++ b/.docker-hub/backend/Dockerfile
@@ -8,7 +8,7 @@ COPY backend .
 RUN composer di-generate-aot
 
 # production stage
-FROM php:8.0.6-apache@sha256:d81e878f14116534fff49b2a8b4c2cc8b91da8f87ae715ce816a81b7ac8943b2 AS production-stage
+FROM php:7.4.19-apache@sha256:b8faa4895a39ffbf8b9d274220c341aa1864e2498bc6ba530a52a36fc19a8b85 AS production-stage
 WORKDIR /app
 ENV env=prod
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install libxml2-dev curl unzip iproute2 libonig-dev && docker-php-ext-install pdo pdo_mysql xml

--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -15,10 +15,6 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: xdebug
-
-      - run: composer update --lock --no-interaction --no-plugins --no-scripts --prefer-dist
-        working-directory: backend
+      - run: |
+          chmod +w backend
+          ./docker-compose-run-as-entrypoint.sh backend composer update --lock --no-interaction --no-plugins --no-scripts --prefer-dist

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,13 +13,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: xdebug
-
-      - run: composer validate -n --no-check-all --no-check-publish --strict
-        working-directory: backend
+      - run: sh ./docker-compose-run-as-entrypoint.sh backend composer validate -n --no-check-all --no-check-publish --strict
 
   backend-cs-check:
     name: "Lint: Backend (php-cs-fixer)"
@@ -28,9 +22,21 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: OskarStark/php-cs-fixer-ga@3.0.0
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: 'echo "::set-output name=dir::$(composer config cache-files-dir)"'
+        working-directory: backend
+
+      - uses: actions/cache@v2
         with:
-          args: --dry-run --diff --config=backend/.php-cs-fixer.php
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - run: ./docker-compose-run-as-entrypoint.sh backend composer install --no-interaction --no-plugins --no-scripts --prefer-dist
+
+      - run: ./docker-compose-run-as-entrypoint.sh backend composer cs-check
 
   frontend-eslint:
     name: "Lint: Frontend (ESLint)"
@@ -46,11 +52,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - run: npm ci
-        working-directory: frontend
+      - run: ./docker-compose-run-as-entrypoint.sh frontend npm ci
 
-      - run: npm run lint-check
-        working-directory: frontend
+      - run: ./docker-compose-run-as-entrypoint.sh frontend npm run lint-check
 
   print-eslint:
     name: "Lint: Print (ESLint)"
@@ -66,11 +70,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - run: npm ci
-        working-directory: print
+      - run: ./docker-compose-run-as-entrypoint.sh print npm ci
 
-      - run: npm run lint
-        working-directory: print
+      - run: ./docker-compose-run-as-entrypoint.sh print npm run lint
 
   backend-tests:
     name: "Tests: Backend"
@@ -78,11 +80,6 @@ jobs:
     steps:
 
       - uses: actions/checkout@v2
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: xdebug
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -96,13 +93,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
-      - run: composer install --no-interaction --no-plugins --no-scripts --prefer-dist
-        working-directory: backend
+      - run: ./docker-compose-run-as-entrypoint.sh backend composer install --no-interaction --no-plugins --no-scripts --prefer-dist
 
-      - run: composer test
-        working-directory: backend
+      - name: run tests
+        run: |
+          chmod +w backend
+          ./docker-compose-run-as-entrypoint.sh backend composer test
 
-      - run: backend/vendor/bin/php-coveralls -v --coverage_clover backend/build/logs/clover.xml --json_path backend/build/logs/coveralls-upload.json
+      - name: send coveralls report
+        run: |
+          # coveralls saves absolute paths and needs them to match again when running without docker
+          sed -i "s|/app/|$(pwd)/backend/|g" backend/build/logs/clover.xml
+          backend/vendor/bin/php-coveralls  -r backend \
+                                            -v \
+                                            --coverage_clover build/logs/clover.xml \
+                                            --json_path build/logs/coveralls-upload.json
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
@@ -122,16 +127,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - run: npm ci
-        working-directory: frontend
+      - run: ./docker-compose-run-as-entrypoint.sh frontend npm ci
 
-      - run: npm run build
-        working-directory: frontend
+      - run: ./docker-compose-run-as-entrypoint.sh frontend npm run build
 
-      - run: npm run test:unit
-        working-directory: frontend
+      - run: ./docker-compose-run-as-entrypoint.sh frontend npm run test:unit
 
-      - run: cat frontend/data/coverage/lcov.info | npx coveralls .
+      - name: send coverage info
+        run: |
+          sed -i "s|/app/|$(pwd)/frontend/|g" frontend/data/coverage/lcov.info
+          cat frontend/data/coverage/lcov.info | npx coveralls .
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: github
@@ -154,14 +159,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - run: npm ci
-        working-directory: print
+      - run: ./docker-compose-run-as-entrypoint.sh print npm ci
 
-      - run: npm run build
-        working-directory: print
+      - run: ./docker-compose-run-as-entrypoint.sh print npm run build
 
-      - run: npm run test
-        working-directory: print
+      - run: ./docker-compose-run-as-entrypoint.sh print npm run test
 
       - run: cat print/coverage/lcov.info | npx coveralls .
         env:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.6-apache@sha256:d81e878f14116534fff49b2a8b4c2cc8b91da8f87ae715ce816a81b7ac8943b2
+FROM php:7.4.19-apache@sha256:b8faa4895a39ffbf8b9d274220c341aa1864e2498bc6ba530a52a36fc19a8b85
 
 WORKDIR /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,10 @@ FROM php:8.0.6-apache@sha256:d81e878f14116534fff49b2a8b4c2cc8b91da8f87ae715ce816
 WORKDIR /app
 
 RUN apt update
-RUN apt install -y iproute2
+RUN apt install -y  iproute2 \
+                    git \
+                    unzip \
+                    zip
 
 # Copy development php.ini
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
@@ -25,6 +28,13 @@ ENV XDEBUG_CONFIG="client_host=docker-host log=/var/log/xdebug.log"
 
 # Install composer for PHP dependencies
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN adduser --disabled-password --gecos "" ecamp \
+    && usermod -a -G 33 ecamp
+
+#add user 1001 for github action
+RUN adduser --disabled-password --gecos "" --uid 1001 github-action-user \
+    && usermod -a -G 33 github-action-user
 
 # Make log directory writable for arbitrary users
 RUN chmod -R 777 /var/log/apache2

--- a/docker-compose-run-as-entrypoint.sh
+++ b/docker-compose-run-as-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <service> <command> [<option>...] [<param>...]"
+  exit 1
+fi
+service=$1
+shift
+entrypoint=$@
+switch_user=
+if [ "$CI" = "true" ]; then
+  switch_user="--user 1001"
+fi
+docker-compose run --rm --no-deps $switch_user --entrypoint="$entrypoint" $service


### PR DESCRIPTION
By using the development containers to execute the checks.
Also use php-cs-fixer version defined
in composer.json.

In a570e31f the php version in the docker-compose files was updated to 8,
but not the php version in the ci.
But the test wouldn't have passed with php v8.

In 3e925d7 the php-cs-fixer package was updated in
the composer.json, but the migration guide was not followed. The checks passed, because
the github action used the old version of
php-cs-fixer.

-> The Tests don't run through with php8 -> revert update to php8.

Auch im Hinblick auf #1390.

Vorteil:
- Es werden die gleichen Versionen wie in der Entwicklung verwendet
- Dank renovate werden die gleichen Versionen wie in Produktion verwendet
- composer update / composer install mit dem development container funktionieren jetzt auch nach einem frischen Setup. 
(Das hat vorhin nicht funktioniert weil git, zip und unzip gefehlt haben, + der executing user 1000)
- Auch für php-cs wird für ci die gleiche Version verwendet wie lokal

Nachteil:
- Build time wird länger (v.a. für die lint actions, bei denen kommt eine Minute drauf, + 400%)
- Komplexität des Workflows wird erhöht