### PR TITLE
Fix console error when creating a new period

### DIFF
--- a/frontend/src/components/dialog/DialogBase.vue
+++ b/frontend/src/components/dialog/DialogBase.vue
@@ -51,20 +51,23 @@ export default {
     create () {
       this.error = null
       const _events = this._events
-      this.api.post(this.entityUri, this.entityData).then(this.close, e => this.onError(_events, e))
+      const promise = this.api.post(this.entityUri, this.entityData).then(this.close, e => this.onError(_events, e))
       this.$emit('submit')
+      return promise
     },
     update () {
       this.error = null
       const _events = this._events
-      this.api.patch(this.entityUri, this.entityData).then(this.close, e => this.onError(_events, e))
+      const promise = this.api.patch(this.entityUri, this.entityData).then(this.close, e => this.onError(_events, e))
       this.$emit('submit')
+      return promise
     },
     del () {
       this.error = null
       const _events = this._events
-      this.api.del(this.entityUri).then(this.close, e => this.onError(_events, e))
+      const promise = this.api.del(this.entityUri).then(this.close, e => this.onError(_events, e))
       this.$emit('submit')
+      return promise
     },
     onSuccess () {
       this.$emit('success')


### PR DESCRIPTION
Return the promise again. This is necessary so that specific dialogs can wait for the completion of the task.
E.g. the DialogPeriodCreate reloads the camp's periods after creating a new period.

I previously broke this when cleaning up `DialogBase` in #1388.