### PR TITLE
Fixed #675 (Picasso)

### DIFF
--- a/frontend/src/components/camp/Picasso.vue
+++ b/frontend/src/components/camp/Picasso.vue
@@ -330,7 +330,7 @@ export default {
           if (!this.extendOriginal) {
             this.showEntryInfoPopup(this.currentEntry)
           }
-        } else if (this.currentEntry.length !== this.currentEntry._storeData.length) {
+        } else if (this.currentEntry.endTime !== this.extendOriginal) {
           const patchedScheduleEntry = {
             periodOffset: this.currentEntry.periodOffset,
             length: this.currentEntry.length

--- a/frontend/src/components/camp/Picasso.vue
+++ b/frontend/src/components/camp/Picasso.vue
@@ -330,7 +330,7 @@ export default {
           if (!this.extendOriginal) {
             this.showEntryInfoPopup(this.currentEntry)
           }
-        } else {
+        } else if (this.currentEntry.length !== this.currentEntry._storeData.length) {
           const patchedScheduleEntry = {
             periodOffset: this.currentEntry.periodOffset,
             length: this.currentEntry.length


### PR DESCRIPTION
Fixed the issue from
Picasso: When clicking and releasing an activity length handle, don't save the unmodified length #675