### PR TITLE
api/Invitation: add accept and reject operation

### DIFF
--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -42,6 +42,9 @@ services:
     App\DataPersister\ContentNodeDataPersister:
         arguments: [ '@api_platform.doctrine.orm.data_persister' ]
 
+    App\DataPersister\InvitationDataPersister:
+        arguments: [ '@api_platform.doctrine.orm.data_persister' ]
+
     App\Validator\MaterialItemUpdateGroupSequence:
         public: true
 

--- a/api/src/DTO/Invitation.php
+++ b/api/src/DTO/Invitation.php
@@ -36,11 +36,24 @@ use Symfony\Component\Validator\Constraints as Assert;
             ],
             'validation_groups' => ['Default', 'accept'],
         ],
+        self::REJECT => [
+            'method' => 'PATCH',
+            'path' => '/{inviteKey}/'.self::REJECT,
+            'denormalization_context' => [
+                'groups' => ['write'],
+            ],
+            'normalization_context' => self::ITEM_NORMALIZATION_CONTEXT,
+            'openapi_context' => [
+                'summary' => 'Reject an Invitation.',
+                'description' => 'Use myInviteKey to reject an invitation in dev environment.',
+            ],
+        ],
     ],
     routePrefix: '/invitations'
 )]
 class Invitation {
     public const ACCEPT = 'accept';
+    public const REJECT = 'reject';
     public const ITEM_NORMALIZATION_CONTEXT = [
         'groups' => ['read'],
         'swagger_definition_name' => 'read',

--- a/api/src/DataPersister/InvitationDataPersister.php
+++ b/api/src/DataPersister/InvitationDataPersister.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\DataPersister;
+
+use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
+use App\DTO\Invitation;
+use App\Entity\CampCollaboration;
+use App\Repository\CampCollaborationRepository;
+use Symfony\Component\Security\Core\Security;
+
+class InvitationDataPersister implements ContextAwareDataPersisterInterface {
+    public function __construct(
+        private ContextAwareDataPersisterInterface $dataPersister,
+        private CampCollaborationRepository $campCollaborationRepository,
+        private Security $security
+    ) {
+    }
+
+    public function supports($data, array $context = []): bool {
+        return $data instanceof Invitation;
+    }
+
+    /**
+     * @param Invitation $data
+     */
+    public function persist($data, array $context = []) {
+        if (Invitation::ACCEPT === ($context['item_operation_name'] ?? null)) {
+            $campCollaboration = $this->campCollaborationRepository->findByInviteKey($data->inviteKey);
+            $campCollaboration->user = $this->security->getUser();
+            $campCollaboration->status = CampCollaboration::STATUS_ESTABLISHED;
+            $campCollaboration->inviteKey = null;
+            $campCollaboration->inviteEmail = null;
+            //TODO: add MaterialList for User
+            $this->dataPersister->persist($campCollaboration);
+
+            $data->userAlreadyInCamp = true;
+        }
+    }
+
+    public function remove($data, array $context = []) {
+        throw new \RuntimeException('remove is not supported for '.Invitation::class);
+    }
+}

--- a/api/src/DataPersister/InvitationDataPersister.php
+++ b/api/src/DataPersister/InvitationDataPersister.php
@@ -34,6 +34,12 @@ class InvitationDataPersister implements ContextAwareDataPersisterInterface {
             $this->dataPersister->persist($campCollaboration);
 
             $data->userAlreadyInCamp = true;
+        } elseif (Invitation::REJECT === ($context['item_operation_name'] ?? null)) {
+            $campCollaboration = $this->campCollaborationRepository->findByInviteKey($data->inviteKey);
+            $campCollaboration->user = $this->security->getUser();
+            $campCollaboration->status = CampCollaboration::STATUS_INACTIVE;
+            $campCollaboration->inviteKey = null;
+            $this->dataPersister->persist($campCollaboration);
         }
     }
 

--- a/api/tests/Api/Invitations/AcceptInvitationTest.php
+++ b/api/tests/Api/Invitations/AcceptInvitationTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Tests\Api\Invitations;
+
+use App\DTO\Invitation;
+use App\Entity\CampCollaboration;
+use App\Tests\Api\ECampApiTestCase;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * @internal
+ */
+class AcceptInvitationTest extends ECampApiTestCase {
+    /**
+     * @throws TransportExceptionInterface
+     */
+    public function testAcceptInvitationFailsWhenNotLoggedIn() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2invitedCampUnrelated'];
+        static::createBasicClient()->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testAcceptInvitationSuccess() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2invitedCampUnrelated'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,
+            'userDisplayName' => 'Bi-Pi',
+            'userAlreadyInCamp' => true,
+            '_links' => [
+                'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
+            ],
+        ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCannotFindInvitationAfterSuccessfulAccept() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2invitedCampUnrelated'];
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $client->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,
+            'userDisplayName' => 'Bi-Pi',
+            'userAlreadyInCamp' => true,
+            '_links' => [
+                'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
+            ],
+        ]);
+
+        $client->request('GET', "/invitations/{$campCollaboration->inviteKey}/find");
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testAcceptInvitationFailsWithExtraAttribute() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2invitedCampUnrelated'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            [
+                'json' => [
+                    'userAlreadyInCamp' => true,
+                ],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public function testAcceptInvitationFailsWhenUserAlreadyInCamp() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration1invited'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    /**
+     * @dataProvider invalidMethods
+     *
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testInvalidRequestWhenWrongMethod(string $method) {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2invitedCampUnrelated'];
+        static::createClientWithCredentials()->request($method, "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT);
+        $this->assertResponseStatusCodeSame(405);
+    }
+
+    public static function invalidMethods(): array {
+        return ['GET' => ['GET'], 'PUT' => ['PUT'], 'POST' => ['POST'], 'DELETE' => ['DELETE'], 'OPTIONS' => ['OPTIONS']];
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testNotFoundWhenInviteKeyDoesNotMatch() {
+        static::createClientWithCredentials()->request('PATCH', '/invitations/notExisting/'.Invitation::ACCEPT);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public function testNotFoundWhenNoInviteKey() {
+        static::createClientWithCredentials()->request('PATCH', '/invitations/'.Invitation::ACCEPT);
+        $this->assertResponseStatusCodeSame(404);
+    }
+}

--- a/api/tests/Api/Invitations/RejectInvitationTest.php
+++ b/api/tests/Api/Invitations/RejectInvitationTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Tests\Api\Invitations;
+
+use App\DTO\Invitation;
+use App\Entity\CampCollaboration;
+use App\Tests\Api\ECampApiTestCase;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * @internal
+ */
+class RejectInvitationTest extends ECampApiTestCase {
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testRejectInvitationSucceedsWhenNotLoggedIn() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2invitedCampUnrelated'];
+        static::createBasicClient()->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,
+            'userDisplayName' => null,
+            'userAlreadyInCamp' => null,
+            '_links' => [
+                'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
+            ],
+        ]);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testCannotFindInvitationAfterSuccessfulReject() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2invitedCampUnrelated'];
+        $client = static::createBasicClient();
+        $client->disableReboot();
+        $client->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,
+            'userDisplayName' => null,
+            'userAlreadyInCamp' => null,
+            '_links' => [
+                'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
+            ],
+        ]);
+
+        $client->request('GET', "/invitations/{$campCollaboration->inviteKey}/find");
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testRejectInvitationSucceedsWhenLoggedIn() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2invitedCampUnrelated'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,
+            'userDisplayName' => 'Bi-Pi',
+            'userAlreadyInCamp' => false,
+            '_links' => [
+                'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
+            ],
+        ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testRejectInvitationFailsWithExtraAttribute() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2invitedCampUnrelated'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::REJECT,
+            [
+                'json' => [
+                    'userAlreadyInCamp' => true,
+                ],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testRejectInvitationSucceedsWhenUserAlreadyInCamp() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration1invited'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,
+            'userDisplayName' => 'Bi-Pi',
+            'userAlreadyInCamp' => true,
+            '_links' => [
+                'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
+            ],
+        ]);
+    }
+
+    /**
+     * @dataProvider invalidMethods
+     *
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testInvalidRequestWhenWrongMethod(string $method) {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2invitedCampUnrelated'];
+        static::createClientWithCredentials()->request($method, "/invitations/{$campCollaboration->inviteKey}/".Invitation::REJECT);
+        $this->assertResponseStatusCodeSame(405);
+    }
+
+    public static function invalidMethods(): array {
+        return ['GET' => ['GET'], 'PUT' => ['PUT'], 'POST' => ['POST'], 'DELETE' => ['DELETE'], 'OPTIONS' => ['OPTIONS']];
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testNotFoundWhenInviteKeyDoesNotMatch() {
+        static::createClientWithCredentials()->request('PATCH', '/invitations/notExisting/'.Invitation::REJECT);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public function testNotFoundWhenNoInviteKey() {
+        static::createClientWithCredentials()->request('PATCH', '/invitations/'.Invitation::REJECT);
+        $this->assertResponseStatusCodeSame(404);
+    }
+}


### PR DESCRIPTION
Plan
- [x] Add Accept Invitation
- [ ] (Add GraphQL Support for Accept)
- [x] Add Reject Invitation
- [ ] (Add GraphQL Support for Reject)
- [ ] Add Resend Email
- [ ] (Add GraphQL Support for Reject)

Ich werde commits hinzufügen, bis ich 2 approves habe (Oder der Plan implementiert ist). Dann werde ich mergen und einen neuen PR anfangen.
Was ich nicht in diesem PR mache, ist: Error messages übersetzen im Backend.

Eine Änderung gibt es zur bisherigen Implementation im backend:
Es wird PATCH statt POST verwendet, Api Platform betrachtet POST als Collection Operation, und ich konnte nicht (und wollte dann auch nicht) das auf POST umbiegen.
Im Frontend wäre das beim Wechsel eine kleine Änderung, was meint ihr?

~~Weiter wird der PATCH Body auf das $data Objekt applied, obwohl die properties writable: false sind.
Ist bisschen komisch, ich habe es jetzt mit weiteren Database Queries gelöst...?~~
Es werden jetzt die richtigen normalization/denormalization contexte verwendet..ein Schritt näher daran, das zu verstehen.