### PR TITLE
Simplify the way we retrieve the entity state before denormalization

### DIFF
--- a/api/src/Validator/AssertBelongsToSameCampValidator.php
+++ b/api/src/Validator/AssertBelongsToSameCampValidator.php
@@ -2,16 +2,15 @@
 
 namespace App\Validator;
 
-use App\Entity\BaseEntity;
 use App\Entity\BelongsToCampInterface;
-use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 class AssertBelongsToSameCampValidator extends ConstraintValidator {
-    public function __construct(public EntityManagerInterface $entityManager) {
+    public function __construct(public RequestStack $requestStack) {
     }
 
     public function validate($value, Constraint $constraint) {
@@ -33,26 +32,14 @@ class AssertBelongsToSameCampValidator extends ConstraintValidator {
         }
 
         if ($constraint->compareToPrevious) {
-            if (!$object instanceof BaseEntity) {
-                throw new UnexpectedValueException($object, BaseEntity::class);
-            }
-
             // Get the old state of the entity before the changes were applied.
-            $unitOfWork = $this->entityManager->getUnitOfWork();
-            $oldData = $unitOfWork->getOriginalEntityData($object);
-            $oldData['id'] = 'reset to make Doctrine ignore the cache';
-            $object = $unitOfWork->createEntity(get_class($object), $oldData);
+            $object = $this->requestStack->getCurrentRequest()->attributes->get('previous_data');
         }
 
         if ($value->getCamp()?->getId() !== $object->getCamp()?->getId() || null === $value->getCamp()?->getId()) {
             $this->context->buildViolation($constraint->message)
                 ->addViolation()
             ;
-        }
-
-        if ($constraint->compareToPrevious) {
-            // Clean up our temporary old copy of the object, to make sure it is not persisted
-            $this->entityManager->detach($object);
         }
     }
 }


### PR DESCRIPTION
When writing security rules for the entities, I stumbled upon https://api-platform.com/docs/core/security/#executing-access-control-rules-after-denormalization which mentions the `previous_data` request attribute. This allows us to replace my EntityManager hack in the `AssertBelongsToSameCampValidator` and resolve some deprecation warnings :partying_face: 

The downside of this is that the Validator is now tied to having access to the request. But Symfony even recommend this way of getting access to the request anywhere in the code, so it can't be *that* bad: https://symfony.com/doc/current/service_container/request.html