### PR TITLE
api/CampCollaboration: continue with missing features

### DIFF
--- a/api/fixtures/campCollaborations.yml
+++ b/api/fixtures/campCollaborations.yml
@@ -41,6 +41,13 @@ App\Entity\CampCollaboration:
     camp: '@campUnrelated'
     status: established
     role: manager
+  campCollaboration6invitedWithUser:
+    user: '@user6invited'
+    camp: '@camp2'
+    inviteKey: "myInviteKeyCamp2"
+    inviteEmail: '@user6invited->email'
+    status: invited
+    role: member
   campCollaboration1campPrototype:
     user: '@admin'
     camp: '@campPrototype'

--- a/api/fixtures/users.yml
+++ b/api/fixtures/users.yml
@@ -44,6 +44,15 @@ App\Entity\User:
     language: en
     roles: [ 'ROLE_USER' ]
     password: '\$argon2id\$v=19\$m=65536,t=4,p=1\$/RC8YWMDDXR19wB4or6bBA\$Kq5haK2SACQgo4CB7eDUibsD3QXCE32w25ZwhKg1SGw' # test
+  user6invited:
+    email: <email()>
+    username: user6invited
+    firstname: <firstName()>
+    surname: <lastName()>
+    nickname: <word()>
+    language: en
+    roles: [ 'ROLE_USER' ]
+    password: '\$argon2id\$v=19\$m=65536,t=4,p=1\$/RC8YWMDDXR19wB4or6bBA\$Kq5haK2SACQgo4CB7eDUibsD3QXCE32w25ZwhKg1SGw' # test
   admin:
     email: admin@example.com
     username: admin

--- a/api/src/DataPersister/CampCollaborationDataPersister.php
+++ b/api/src/DataPersister/CampCollaborationDataPersister.php
@@ -41,6 +41,10 @@ class CampCollaborationDataPersister implements ContextAwareDataPersisterInterfa
                 $data->inviteKey = IdGenerator::generateRandomHexString(64);
                 $this->mailService->sendInviteToCampMail($user, $data->camp, $data->inviteKey, $data->inviteEmail);
             }
+        } elseif (CampCollaboration::RESEND_INVITATION === ($context['item_operation_name'] ?? null)) {
+            /** @var User $user */
+            $user = $this->security->getUser();
+            $this->mailService->sendInviteToCampMail($user, $data->camp, $data->inviteKey, $data->inviteEmail);
         }
 
         return $this->dataPersister->persist($data, $context);

--- a/api/src/DataPersister/CampCollaborationDataPersister.php
+++ b/api/src/DataPersister/CampCollaborationDataPersister.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Service\MailService;
 use App\Util\IdGenerator;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Security;
 
 class CampCollaborationDataPersister implements ContextAwareDataPersisterInterface {
@@ -15,7 +16,8 @@ class CampCollaborationDataPersister implements ContextAwareDataPersisterInterfa
         private ContextAwareDataPersisterInterface $dataPersister,
         private Security $security,
         private UserRepository $userRepository,
-        private MailService $mailService
+        private MailService $mailService,
+        private RequestStack $requestStack,
     ) {
     }
 
@@ -29,9 +31,9 @@ class CampCollaborationDataPersister implements ContextAwareDataPersisterInterfa
      * @return object|void
      */
     public function persist($data, array $context = []) {
+        /** @var User $user */
+        $user = $this->security->getUser();
         if ('post' === ($context['collection_operation_name'] ?? null)) {
-            /** @var User $user */
-            $user = $this->security->getUser();
             //TODO: check if the campCollaboration already exists.
             if (CampCollaboration::STATUS_INVITED == $data->status && $data->inviteEmail) {
                 $userByInviteEmail = $this->userRepository->findOneBy(['email' => $data->inviteEmail]);
@@ -41,9 +43,30 @@ class CampCollaborationDataPersister implements ContextAwareDataPersisterInterfa
                 $data->inviteKey = IdGenerator::generateRandomHexString(64);
                 $this->mailService->sendInviteToCampMail($user, $data->camp, $data->inviteKey, $data->inviteEmail);
             }
+        } elseif ('patch' === ($context['item_operation_name'] ?? null)) {
+            /** @var CampCollaboration $campCollaborationBefore */
+            $campCollaborationBefore = $this->requestStack->getCurrentRequest()->attributes->get('previous_data');
+
+            switch ($campCollaborationBefore->status) {
+                case CampCollaboration::STATUS_INACTIVE:
+                    if (CampCollaboration::STATUS_INVITED == $data->status && ($data->inviteEmail || $data->user)) {
+                        $campCollaborationUser = $campCollaborationBefore->user;
+                        $inviteEmail = $campCollaborationBefore->inviteEmail;
+                        if (null != $campCollaborationUser) {
+                            $inviteEmail = $campCollaborationUser->email;
+                        }
+                        $data->inviteKey = IdGenerator::generateRandomHexString(64);
+                        $this->mailService->sendInviteToCampMail(
+                            $user,
+                            $campCollaborationBefore->camp,
+                            $data->inviteKey,
+                            $inviteEmail
+                        );
+                    }
+
+                    break;
+            }
         } elseif (CampCollaboration::RESEND_INVITATION === ($context['item_operation_name'] ?? null)) {
-            /** @var User $user */
-            $user = $this->security->getUser();
             $this->mailService->sendInviteToCampMail($user, $data->camp, $data->inviteKey, $data->inviteEmail);
         }
 

--- a/api/src/Entity/CampCollaboration.php
+++ b/api/src/Entity/CampCollaboration.php
@@ -7,6 +7,7 @@ use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use App\Repository\CampCollaborationRepository;
+use App\Validator\AllowTransition\AssertAllowTransitions;
 use App\Validator\AssertEitherIsNull;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -40,6 +41,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         'patch' => [
             'denormalization_context' => ['groups' => ['write', 'update']],
             'security' => '(user === object.user) or is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)',
+            'validation_groups' => ['Default', 'update'],
         ],
         'delete' => ['security' => 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)'],
         self::RESEND_INVITATION => [
@@ -142,10 +144,20 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
      * Cannot be set when creating a campCollaboration, but can be updated depending on the current status
      * and the updater's access rights.
      *
+     * The status ESTABLISHED can only be reached via the /invitations endpoint.
+     *
      * @ORM\Column(type="string", length=16, nullable=false)
      */
     #[Assert\Choice(choices: self::VALID_STATUS)]
     #[Assert\EqualTo(value: self::STATUS_INVITED, groups: ['resend_invitation'])]
+    #[AssertAllowTransitions(
+        [
+            ['from' => self::STATUS_INVITED, 'to' => [self::STATUS_INACTIVE]],
+            ['from' => self::STATUS_INACTIVE, 'to' => [self::STATUS_INVITED]],
+            ['from' => self::STATUS_ESTABLISHED, 'to' => [self::STATUS_INACTIVE]],
+        ],
+        groups: ['update']
+    )]
     #[ApiProperty(default: self::STATUS_INVITED, example: self::STATUS_INACTIVE)]
     #[Groups(['read', 'update'])]
     public string $status = self::STATUS_INVITED;

--- a/api/src/Entity/CampCollaboration.php
+++ b/api/src/Entity/CampCollaboration.php
@@ -42,12 +42,26 @@ use Symfony\Component\Validator\Constraints as Assert;
             'security' => '(user === object.user) or is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)',
         ],
         'delete' => ['security' => 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)'],
+        self::RESEND_INVITATION => [
+            'security' => '(user === object.user) or is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)',
+            'method' => 'PATCH',
+            'path' => 'camp_collaborations/{id}/'.self::RESEND_INVITATION,
+            'denormalization_context' => [
+                'groups' => ['resend_invitation'],
+            ],
+            'openapi_context' => [
+                'summary' => 'Send the invitation email for this CampCollaboration again. Only possible, if the status is already '.self::STATUS_INVITED.'.',
+            ],
+            'validation_groups' => ['Default', 'resend_invitation'],
+        ],
     ],
     denormalizationContext: ['groups' => ['write']],
     normalizationContext: ['groups' => ['read']],
 )]
 #[ApiFilter(SearchFilter::class, properties: ['camp'])]
 class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
+    public const RESEND_INVITATION = 'resend_invitation';
+
     public const ROLE_GUEST = 'guest';
     public const ROLE_MEMBER = 'member';
     public const ROLE_MANAGER = 'manager';
@@ -131,6 +145,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
      * @ORM\Column(type="string", length=16, nullable=false)
      */
     #[Assert\Choice(choices: self::VALID_STATUS)]
+    #[Assert\EqualTo(value: self::STATUS_INVITED, groups: ['resend_invitation'])]
     #[ApiProperty(default: self::STATUS_INVITED, example: self::STATUS_INACTIVE)]
     #[Groups(['read', 'update'])]
     public string $status = self::STATUS_INVITED;

--- a/api/src/Validator/AllowTransition/AssertAllowTransitions.php
+++ b/api/src/Validator/AllowTransition/AssertAllowTransitions.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Validator\AllowTransition;
+
+use Attribute;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validation attribute to restrict the transitions of a status properties.
+ * Due to the limitations of PHP8 attributes, only constant values can be used.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+class AssertAllowTransitions extends Constraint {
+    public function __construct(
+        public array $transitions,
+        array $options = null,
+        array $groups = null,
+        $payload = null
+    ) {
+        parent::__construct($options ?? [], $groups, $payload);
+    }
+
+    public function getTransitions(): Collection {
+        return new ArrayCollection($this->transitions);
+    }
+}

--- a/api/src/Validator/AllowTransition/AssertAllowTransitionsValidator.php
+++ b/api/src/Validator/AllowTransition/AssertAllowTransitionsValidator.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Validator\AllowTransition;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class AssertAllowTransitionsValidator extends ConstraintValidator {
+    public const TO_VIOLATION_MESSAGE = 'value must be one of {{ to }}, was {{ value }}';
+    public const FROM_VIOLATION_MESSAGE = 'This value was previously in an unexpected state,'.
+    ' expected one of {{ from }}, but was {{ previousValue }}';
+
+    public function __construct(public RequestStack $requestStack) {
+    }
+
+    public function validate($value, Constraint $constraint) {
+        if (!$constraint instanceof AssertAllowTransitions) {
+            throw new UnexpectedTypeException($constraint, AssertAllowTransitions::class);
+        }
+
+        $transitions = $constraint->getTransitions();
+        if (!$transitions->forAll(fn ($_, $elem) => self::isValidTransition($elem))) {
+            throw new InvalidArgumentException('All transitions must have a from and a to key');
+        }
+
+        $allFrom = $transitions->map(fn (array $elem) => $elem['from'])->toArray();
+        $allTo = $transitions->map(fn (array $elem) => $elem['to'])->toArray();
+        $allTo = array_merge(...$allTo);
+        if (!(new ArrayCollection($allTo))->forAll(fn ($_, $to) => in_array($to, $allFrom, true))) {
+            throw new InvalidArgumentException('All to must appear in a from again');
+        }
+
+        $previousObject = $this->requestStack->getCurrentRequest()->attributes->get('previous_data');
+        $previousValue = $previousObject->{$this->context->getPropertyName()};
+
+        if ($value === $previousValue) {
+            return;
+        }
+
+        foreach ($transitions as $transition) {
+            if ($previousValue === $transition['from']) {
+                $to = $transition['to'];
+                if (!in_array($value, $to, true)) {
+                    $this->context->buildViolation(self::TO_VIOLATION_MESSAGE)
+                        ->setParameter('{{ to }}', join(', ', $to))
+                        ->setParameter('{{ value }}', $value)
+                        ->addViolation()
+                    ;
+                }
+
+                return;
+            }
+        }
+
+        $this->context->buildViolation(self::FROM_VIOLATION_MESSAGE)
+            ->setParameter('{{ from }}', join(',', $allFrom))
+            ->setParameter('{{ previousValue }}', $previousValue)
+            ->addViolation()
+        ;
+    }
+
+    private static function isValidTransition($elem): bool {
+        return isset($elem['from']) && isset($elem['to']) && is_array($elem['to']);
+    }
+}

--- a/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
+++ b/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
@@ -24,7 +24,7 @@ class ListCampCollaborationsTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()->request('GET', '/camp_collaborations');
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'totalItems' => 7,
+            'totalItems' => 8,
             '_links' => [
                 'items' => [],
             ],
@@ -35,6 +35,7 @@ class ListCampCollaborationsTest extends ECampApiTestCase {
         $this->assertEqualsCanonicalizing([
             ['href' => $this->getIriFor('campCollaboration1manager')],
             ['href' => $this->getIriFor('campCollaboration2member')],
+            ['href' => $this->getIriFor('campCollaboration6invitedWithUser')],
             ['href' => $this->getIriFor('campCollaboration3guest')],
             ['href' => $this->getIriFor('campCollaboration4invited')],
             ['href' => $this->getIriFor('campCollaboration5inactive')],

--- a/api/tests/Api/CampCollaborations/ResendInvitationCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/ResendInvitationCampCollaborationTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Tests\Api\CampCollaborations;
+
+use App\Entity\CampCollaboration;
+use App\Tests\Api\ECampApiTestCase;
+
+/**
+ * @internal
+ */
+class ResendInvitationCampCollaborationTest extends ECampApiTestCase {
+    public const RESEND_INVITATION = CampCollaboration::RESEND_INVITATION;
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     */
+    public function testResendInvitationSuccessful() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration4invited'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/camp_collaborations/'.$campCollaboration->getId().'/'.self::RESEND_INVITATION,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'inviteEmail' => $campCollaboration->inviteEmail,
+            'status' => $campCollaboration->status,
+            'role' => $campCollaboration->role,
+        ]);
+        self::assertEmailCount(1);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    public function testResendInvitationFailsWhenNotAuthenticated() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration4invited'];
+        static::createClient()->request(
+            'PATCH',
+            '/camp_collaborations/'.$campCollaboration->getId().'/'.self::RESEND_INVITATION,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    public function testResendInvitationFailsWhenUserNotPartOfCamp() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration4invited'];
+        static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->username])
+            ->request(
+                'PATCH',
+                '/camp_collaborations/'.$campCollaboration->getId().'/'.self::RESEND_INVITATION,
+                [
+                    'json' => [],
+                    'headers' => ['Content-Type' => 'application/merge-patch+json'],
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    public function testResendInvitationFailsWhenUserIsInvited() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration6invitedWithUser'];
+        static::createClientWithCredentials(['username' => static::$fixtures['user6invited']->username])
+            ->request(
+                'PATCH',
+                '/camp_collaborations/'.$campCollaboration->getId().'/'.self::RESEND_INVITATION,
+                [
+                    'json' => [],
+                    'headers' => ['Content-Type' => 'application/merge-patch+json'],
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    public function testResendInvitationFailsWhenUserIsInactive() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration4invited'];
+        static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->username])
+            ->request(
+                'PATCH',
+                '/camp_collaborations/'.$campCollaboration->getId().'/'.self::RESEND_INVITATION,
+                [
+                    'json' => [],
+                    'headers' => ['Content-Type' => 'application/merge-patch+json'],
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     */
+    public function testResendInvitationFailsWhenCampCollaborationIsNotInStatusInvited() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2member'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/camp_collaborations/'.$campCollaboration->getId().'/'.self::RESEND_INVITATION,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     */
+    public function testResendInvitationFailsWithAdditionalAttribute() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration2member'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/camp_collaborations/'.$campCollaboration->getId().'/'.self::RESEND_INVITATION,
+            [
+                'json' => [
+                    'status' => CampCollaboration::STATUS_INVITED,
+                ],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     */
+    public function testResendInvitationFailsWhenCampCollaborationIsNotFound() {
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/camp_collaborations/doesNotExist/'.self::RESEND_INVITATION,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+}

--- a/api/tests/Api/CampCollaborations/ResendInvitationCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/ResendInvitationCampCollaborationTest.php
@@ -18,10 +18,38 @@ class ResendInvitationCampCollaborationTest extends ECampApiTestCase {
      * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
      */
-    public function testResendInvitationSuccessful() {
+    public function testResendInvitationSuccessfulWhenUserIsManager() {
         /** @var CampCollaboration $campCollaboration */
         $campCollaboration = static::$fixtures['campCollaboration4invited'];
-        static::createClientWithCredentials()->request(
+        static::createClientWithCredentials(['username' => static::$fixtures['user1manager']->username])->request(
+            'PATCH',
+            '/camp_collaborations/'.$campCollaboration->getId().'/'.self::RESEND_INVITATION,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'inviteEmail' => $campCollaboration->inviteEmail,
+            'status' => $campCollaboration->status,
+            'role' => $campCollaboration->role,
+        ]);
+        self::assertEmailCount(1);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     */
+    public function testResendInvitationSuccessfulWhenUserIsMember() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration4invited'];
+        static::createClientWithCredentials(['username' => static::$fixtures['user2member']->username])->request(
             'PATCH',
             '/camp_collaborations/'.$campCollaboration->getId().'/'.self::RESEND_INVITATION,
             [
@@ -124,6 +152,29 @@ class ResendInvitationCampCollaborationTest extends ECampApiTestCase {
         ;
 
         $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    public function testResendInvitationFailsWhenUserIsGuest() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration4invited'];
+        static::createClientWithCredentials(['username' => static::$fixtures['user3guest']->username])
+            ->request(
+                'PATCH',
+                '/camp_collaborations/'.$campCollaboration->getId().'/'.self::RESEND_INVITATION,
+                [
+                    'json' => [],
+                    'headers' => ['Content-Type' => 'application/merge-patch+json'],
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(403);
     }
 
     /**

--- a/api/tests/DataPersister/CampCollaborationsDataPersisterTest.php
+++ b/api/tests/DataPersister/CampCollaborationsDataPersisterTest.php
@@ -23,7 +23,7 @@ class CampCollaborationsDataPersisterTest extends TestCase {
     private UserRepository|MockObject $userRepository;
     private MockObject|MailService $mailService;
     private CampCollaboration $campCollaboration;
-    private $user;
+    private User $user;
 
     protected function setUp(): void {
         $this->decoratedMock = $this->createMock(ContextAwareDataPersisterInterface::class);
@@ -127,6 +127,19 @@ class CampCollaborationsDataPersisterTest extends TestCase {
 
         $this->dataPersister->persist($this->campCollaboration, [
             'collection_operation_name' => 'post',
+        ]);
+    }
+
+    public function testSendsEmailWhenResendInvitation() {
+        $this->campCollaboration->inviteKey = 'myInviteKey';
+        $this->security->method('getUser')->willReturn($this->user);
+
+        $this->mailService->expects(self::once())
+            ->method('sendInviteToCampMail')
+        ;
+
+        $this->dataPersister->persist($this->campCollaboration, [
+            'item_operation_name' => CampCollaboration::RESEND_INVITATION,
         ]);
     }
 }

--- a/api/tests/DataPersister/CampCollaborationsDataPersisterTest.php
+++ b/api/tests/DataPersister/CampCollaborationsDataPersisterTest.php
@@ -11,6 +11,9 @@ use App\Repository\UserRepository;
 use App\Service\MailService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Security;
 
 /**
@@ -23,6 +26,7 @@ class CampCollaborationsDataPersisterTest extends TestCase {
     private UserRepository|MockObject $userRepository;
     private MockObject|MailService $mailService;
     private CampCollaboration $campCollaboration;
+    private CampCollaboration $campCollaborationBefore;
     private User $user;
 
     protected function setUp(): void {
@@ -31,6 +35,12 @@ class CampCollaborationsDataPersisterTest extends TestCase {
         $this->userRepository = $this->createMock(UserRepository::class);
         $this->mailService = $this->createMock(MailService::class);
 
+        $this->campCollaborationBefore = new CampCollaboration();
+        $requestStack = $this->createMock(RequestStack::class);
+        $request = $this->createMock(Request::class);
+        $request->attributes = new ParameterBag(['previous_data' => $this->campCollaborationBefore]);
+        $requestStack->method('getCurrentRequest')->willReturn($request);
+
         $this->campCollaboration = new CampCollaboration();
         $this->campCollaboration->status = CampCollaboration::STATUS_INVITED;
         $this->campCollaboration->inviteEmail = 'e@mail.com';
@@ -38,7 +48,13 @@ class CampCollaborationsDataPersisterTest extends TestCase {
 
         $this->user = new User();
 
-        $this->dataPersister = new CampCollaborationDataPersister($this->decoratedMock, $this->security, $this->userRepository, $this->mailService);
+        $this->dataPersister = new CampCollaborationDataPersister(
+            $this->decoratedMock,
+            $this->security,
+            $this->userRepository,
+            $this->mailService,
+            $requestStack
+        );
     }
 
     public function testDelegatesSupportCheckToDecorated() {
@@ -127,6 +143,43 @@ class CampCollaborationsDataPersisterTest extends TestCase {
 
         $this->dataPersister->persist($this->campCollaboration, [
             'collection_operation_name' => 'post',
+        ]);
+    }
+
+    public function testSendsEmailWhenPatchFromInactiveToInvitedWhenCampCollaborationHasInviteEmail() {
+        $this->campCollaborationBefore->status = CampCollaboration::STATUS_INACTIVE;
+        $this->campCollaborationBefore->camp = $this->campCollaboration->camp;
+        $this->campCollaborationBefore->inviteEmail = $this->campCollaboration->inviteEmail;
+
+        $this->campCollaboration->status = CampCollaboration::STATUS_INVITED;
+
+        $this->security->method('getUser')->willReturn($this->user);
+
+        $this->mailService->expects(self::once())
+            ->method('sendInviteToCampMail')
+        ;
+
+        $this->dataPersister->persist($this->campCollaboration, [
+            'item_operation_name' => 'patch',
+        ]);
+    }
+
+    public function testSendsEmailWhenPatchFromInactiveToInvitedWhenCampCollaborationHasUser() {
+        $this->campCollaborationBefore->status = CampCollaboration::STATUS_INACTIVE;
+        $this->campCollaborationBefore->camp = $this->campCollaboration->camp;
+        $this->campCollaborationBefore->user = $this->user;
+        $this->user->email = 'e@mail.ch';
+
+        $this->campCollaboration->status = CampCollaboration::STATUS_INVITED;
+
+        $this->security->method('getUser')->willReturn($this->user);
+
+        $this->mailService->expects(self::once())
+            ->method('sendInviteToCampMail')
+        ;
+
+        $this->dataPersister->persist($this->campCollaboration, [
+            'item_operation_name' => 'patch',
         ]);
     }
 

--- a/api/tests/Validator/AllowTransitions/AssertAllowTransitionTest.php
+++ b/api/tests/Validator/AllowTransitions/AssertAllowTransitionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Tests\Validator\AllowTransitions;
+
+use App\Validator\AllowTransition\AssertAllowTransitions;
+use App\Validator\AllowTransition\AssertAllowTransitionsValidator;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @internal
+ */
+class AssertAllowTransitionTest extends ConstraintValidatorTestCase {
+    private const TRANSITIONS = [
+        ['from' => '1', 'to' => ['2', '3']],
+        ['from' => '2', 'to' => ['3']],
+        ['from' => '3', 'to' => ['1']],
+    ];
+    private RequestStack|MockObject $requestStack;
+    private TestClass $before;
+
+    protected function setUp(): void {
+        $this->before = new TestClass('2');
+
+        $this->requestStack = $this->createMock(RequestStack::class);
+        $request = $this->createMock(Request::class);
+        $request->attributes = new ParameterBag(['previous_data' => $this->before]);
+        $this->requestStack->method('getCurrentRequest')->willReturn($request);
+
+        parent::setUp();
+    }
+
+    public function testNotValidWhenPreviousValueIsNotInFrom() {
+        $this->before->setA('4');
+        $testClass = new TestClass('1');
+        $this->setProperty($testClass, 'a');
+
+        $this->validator->validate($testClass->a, new AssertAllowTransitions(self::TRANSITIONS));
+
+        $allFrom = (new ArrayCollection(self::TRANSITIONS))->map(fn ($elem) => $elem['from'])->toArray();
+        $this->buildViolation(AssertAllowTransitionsValidator::FROM_VIOLATION_MESSAGE)
+            ->setParameter('{{ from }}', join(',', $allFrom))
+            ->setParameter('{{ previousValue }}', $this->before->a)
+            ->assertRaised()
+        ;
+    }
+
+    public function testValidWhenValueDoesNotChange() {
+        $this->before->setA('1');
+        $testClass = new TestClass('1');
+        $this->setProperty($testClass, 'a');
+
+        $this->validator->validate($testClass->a, new AssertAllowTransitions(self::TRANSITIONS));
+
+        $this->assertNoViolation();
+    }
+
+    public function testNotValidWhenValueIsNotTo() {
+        $this->before->setA('1');
+        $testClass = new TestClass('4');
+        $this->setProperty($testClass, 'a');
+
+        $this->validator->validate($testClass->a, new AssertAllowTransitions(self::TRANSITIONS));
+
+        $this->buildViolation(AssertAllowTransitionsValidator::TO_VIOLATION_MESSAGE)
+            ->setParameter('{{ to }}', join(', ', self::TRANSITIONS[0]['to']))
+            ->setParameter('{{ value }}', $testClass->a)
+            ->assertRaised()
+        ;
+    }
+
+    public function testValidWhenValueInTo() {
+        $this->before->setA('1');
+        $testClass = new TestClass('2');
+        $this->setProperty($testClass, 'a');
+
+        $this->validator->validate($testClass->a, new AssertAllowTransitions(self::TRANSITIONS));
+
+        $this->assertNoViolation();
+    }
+
+    public function testExpectsMatchingAnnotation() {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->validator->validate(null, new Email());
+    }
+
+    public function testThrowsInvalidArgumentExceptionForInvalidTransitions() {
+        $this->expectException(InvalidArgumentException::class);
+        $this->validator->validate(null, new AssertAllowTransitions([['from' => '1', 'to' => ['2', '3']], ['from' => '2']]));
+    }
+
+    public function testThrowsWhenToIsNotInFrom() {
+        $this->expectException(InvalidArgumentException::class);
+        $this->validator->validate(null, new AssertAllowTransitions([['from' => '1', 'to' => ['2']]]));
+    }
+
+    protected function createValidator(): AssertAllowTransitionsValidator {
+        return new AssertAllowTransitionsValidator($this->requestStack);
+    }
+}
+
+class TestClass {
+    #[AssertAllowTransitions([
+        ['from' => '1', 'to' => ['2', '3']],
+        ['from' => '2', 'to' => ['3']],
+        ['from' => '3', 'to' => ['1']],
+    ])]
+    public string $a;
+
+    public function __construct($a) {
+        $this->a = $a;
+    }
+
+    public function setA(string $a): TestClass {
+        $this->a = $a;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
- [ ]  (Add GraphQL Support for Accept)
- [ ]  (Add GraphQL Support for Reject)
- [x]  Add Resend Email
- [ ]  (Add GraphQL Support for Reject)
- [x]  send invitation when status is patched from inactive to invited
- [ ]  (Add GraphQL Support for send invitation when status is patched from inactive to invited)