### PR TITLE
frontend: generate source map for production build with vite

### DIFF
--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -1,5 +1,6 @@
 {
   "pluginsFile": "tests/e2e/plugins/index.js",
   "video": false,
-  "pageLoadTimeout": 120000
+  "pageLoadTimeout": 120000,
+  "defaultCommandTimeout": 8000
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -12,6 +12,9 @@ export default defineConfig({
     }),
     createSvgPlugin()
   ],
+  build: {
+    sourcemap: true
+  },
   resolve: {
     alias: [
       // webpack alias @ (import in Vue files)


### PR DESCRIPTION
This was configured for webpack, and got lost when
we switched to vite for the production build in b4cbfeb.