### PR TITLE
frontend: fix vite build

### DIFF
--- a/frontend/src/plugins/store/index.js
+++ b/frontend/src/plugins/store/index.js
@@ -19,7 +19,11 @@ class StorePlugin {
     axios.defaults.baseURL = window.environment.API_ROOT_URL
     Vue.use(VueAxios, axios)
 
-    apiStore = HalJsonVuex(store, axios, { forceRequestedSelfLink: true })
+    let halJsonVuex = HalJsonVuex
+    if (typeof halJsonVuex !== 'function') {
+      halJsonVuex = HalJsonVuex.default
+    }
+    apiStore = halJsonVuex(store, axios, { forceRequestedSelfLink: true })
     Vue.use(apiStore)
   }
 }


### PR DESCRIPTION
In 833f01b, we updated vite.
This broke the production build with the error that
HalJsonVuex is not a function. But HalJsonVuex.default is the
expected function.
In the tests, it's still as expected, and we don't need HalJsonVuex.default.