### PR TITLE
Set the JS-accessible cookie on the parent domain

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -18,32 +18,12 @@ inputs:
     description: 'The directory on the SSH server where to deploy'
     required: false
 
-  db-host:
-    description: 'The URL of the database server'
-    required: false
-
-  db-port:
-    description: 'The port on which the database server listens'
-    required: false
-
-  db-user:
-    description: 'The username that will be used to log in to the database'
-    required: false
-
-  db-pass:
-    description: 'The password that will be used to log in to the database'
-    required: false
-
-  db-name:
-    description: 'The database name in the database server'
-    required: false
-
-  session-cookie-domain:
-    description: 'The domain that will be used for the session cookie. All services should be on subdomains of this domain.'
+  shared-cookie-domain:
+    description: 'The domain that will be used for the cookie that is available to javascript. All javascript-based services that need to read the JWT token must be on subdomains of this domain.'
     required: true
 
   internal-api-url:
-    description: 'Domain under which the api is reachable inside the docker network'
+    description: 'The location under which the api is reachable inside the docker network'
     required: false
 
   frontend-url:
@@ -103,7 +83,7 @@ inputs:
     required: false
 
   api-url:
-    description: 'Domain under which the api is reachable'
+    description: 'The location under which the api is reachable'
     required: false
 
   api-app-secret:
@@ -130,12 +110,7 @@ runs:
         SSH_USERNAME: ${{ inputs.ssh-username || 'root' }}
         SSH_HOST: ${{ inputs.ssh-host }}
         SSH_DIRECTORY: ${{ inputs.ssh-directory || 'ecamp3' }}
-        DB_HOST: ${{ inputs.db-host || 'db' }}
-        DB_PORT: ${{ inputs.db-port || '3306' }}
-        DB_USER: ${{ inputs.db-user || 'ecamp3' }}
-        DB_PASS: ${{ inputs.db-pass || 'ecamp3' }}
-        DB_NAME: ${{ inputs.db-name || 'ecamp3dev' }}
-        SESSION_COOKIE_DOMAIN: ${{ inputs.session-cookie-domain }}
+        SHARED_COOKIE_DOMAIN: ${{ inputs.shared-cookie-domain }}
         INTERNAL_API_URL: ${{ inputs.internal-api-url || 'http://caddy:4001' }}
         FRONTEND_URL: ${{ inputs.frontend-url }}
         PRINT_SERVER_URL: ${{ inputs.print-server-url }}

--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -26,6 +26,7 @@ sed -ri "s~server_name mail-server-domain;~server_name ${MAIL_SERVER_DOMAIN};~" 
 # Inject environment variables into api env file
 cp api/.env .github/actions/deploy/dist/api.env
 sed -ri "s~API_DOMAIN=.*~API_DOMAIN=${API_DOMAIN}~" .github/actions/deploy/dist/api.env
+sed -ri "s~SHARED_COOKIE_DOMAIN=.*~SHARED_COOKIE_DOMAIN=${SHARED_COOKIE_DOMAIN}~" .github/actions/deploy/dist/api.env
 sed -ri "s~APP_ENV=.*~APP_ENV=dev~" .github/actions/deploy/dist/api.env
 sed -ri "s~APP_SECRET=.*~APP_SECRET=${API_APP_SECRET}~" .github/actions/deploy/dist/api.env
 sed -ri "s~DATABASE_URL=.*~DATABASE_URL=${API_DATABASE_URL}~" .github/actions/deploy/dist/api.env
@@ -55,7 +56,7 @@ sed -ri "s~SENTRY_PRINT_DSN=.*~SENTRY_PRINT_DSN=${SENTRY_PRINT_DSN}~" .github/ac
 # Inject environment secrets into print-worker-puppeteer config file
 cp workers/print-puppeteer/environment.js .github/actions/deploy/dist/worker-print-puppeteer-environment.js
 sed -ri "s~PRINT_SERVER: .*$~PRINT_SERVER: '${PRINT_SERVER_URL}',~" .github/actions/deploy/dist/worker-print-puppeteer-environment.js
-sed -ri "s~SESSION_COOKIE_DOMAIN: .*$~SESSION_COOKIE_DOMAIN: '${SESSION_COOKIE_DOMAIN}',~" .github/actions/deploy/dist/worker-print-puppeteer-environment.js
+sed -ri "s~SHARED_COOKIE_DOMAIN: .*$~SHARED_COOKIE_DOMAIN: '${SHARED_COOKIE_DOMAIN}',~" .github/actions/deploy/dist/worker-print-puppeteer-environment.js
 sed -ri "s~SENTRY_WORKER_PRINT_PUPPETEER_DSN: .*$~SENTRY_WORKER_PRINT_PUPPETEER_DSN: '${SENTRY_WORKER_PRINT_PUPPETEER_DSN}',~" .github/actions/deploy/dist/worker-print-puppeteer-environment.js
 sed -ri "s~AMQP_HOST: .*$~AMQP_HOST: '${RABBITMQ_HOST}',~" .github/actions/deploy/dist/worker-print-puppeteer-environment.js
 sed -ri "s~AMQP_PORT: .*$~AMQP_PORT: '${RABBITMQ_PORT}',~" .github/actions/deploy/dist/worker-print-puppeteer-environment.js

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,12 +30,7 @@ jobs:
         with:
           commit-sha: ${{ github.event.client_payload.sha }}
           ssh-host: ${{ secrets.DEVEL_SSH_HOST }}
-          db-host: ${{ secrets.DEVEL_DB_HOST }}
-          db-port: ${{ secrets.DEVEL_DB_PORT }}
-          db-user: ${{ secrets.DEVEL_DB_USER }}
-          db-pass: ${{ secrets.DEVEL_DB_PASS }}
-          db-name: ${{ secrets.DEVEL_DB_NAME }}
-          session-cookie-domain: ${{ secrets.DEVEL_SESSION_COOKIE_DOMAIN }}
+          shared-cookie-domain: ${{ secrets.DEVEL_SHARED_COOKIE_DOMAIN }}
           frontend-url: ${{ secrets.DEVEL_FRONTEND_URL }}
           print-server-url: ${{ secrets.DEVEL_PRINT_SERVER_URL }}
           print-file-server-url: ${{ secrets.DEVEL_PRINT_FILE_SERVER_URL }}

--- a/api/.env
+++ b/api/.env
@@ -16,6 +16,7 @@
 # API Platform distribution
 TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 API_DOMAIN=localhost
+SHARED_COOKIE_DOMAIN=localhost
 MERCURE_SUBSCRIBE_URL=https://localhost/.well-known/mercure
 
 ###> symfony/framework-bundle ###

--- a/api/config/packages/lexik_jwt_authentication.yaml
+++ b/api/config/packages/lexik_jwt_authentication.yaml
@@ -24,7 +24,7 @@ lexik_jwt_authentication:
             lifetime: null
             samesite: strict
             path: /
-            domain: null
+            domain: '%env(resolve:SHARED_COOKIE_DOMAIN)'
             httpOnly: false
             split:
                 - header

--- a/workers/print-puppeteer/environment.js
+++ b/workers/print-puppeteer/environment.js
@@ -1,6 +1,6 @@
 module.exports = {
   PRINT_SERVER: process.env.PRINT_SERVER || 'http://print:3003',
-  SESSION_COOKIE_DOMAIN: process.env.SESSION_COOKIE_DOMAIN || 'print',
+  SHARED_COOKIE_DOMAIN: process.env.SHARED_COOKIE_DOMAIN || 'print',
   SENTRY_WORKER_PRINT_PUPPETEER_DSN: process.env.SENTRY_WORKER_PRINT_PUPPETEER_DSN || '',
   AMQP_HOST: process.env.AMQP_HOST || 'rabbitmq',
   AMQP_PORT: process.env.AMQP_PORT || '5672',

--- a/workers/print-puppeteer/index.js
+++ b/workers/print-puppeteer/index.js
@@ -2,7 +2,7 @@ const puppeteer = require('puppeteer');
 const amqp = require('amqplib/callback_api');
 const Sentry = require("@sentry/node");
 
-const { PRINT_SERVER, SESSION_COOKIE_DOMAIN, SENTRY_WORKER_PRINT_PUPPETEER_DSN, AMQP_HOST, AMQP_PORT, AMQP_VHOST, AMQP_USER, AMQP_PASS } = require('./environment.js');
+const { PRINT_SERVER, SHARED_COOKIE_DOMAIN, SENTRY_WORKER_PRINT_PUPPETEER_DSN, AMQP_HOST, AMQP_PORT, AMQP_VHOST, AMQP_USER, AMQP_PASS } = require('./environment.js');
 
 if (SENTRY_WORKER_PRINT_PUPPETEER_DSN) {
     Sentry.init({ dsn: SENTRY_WORKER_PRINT_PUPPETEER_DSN })
@@ -23,7 +23,7 @@ async function html2pdf(url, filename, sessionId) {
 
     const cookies = [
         {
-            "domain": SESSION_COOKIE_DOMAIN,
+            "domain": SHARED_COOKIE_DOMAIN,
             "hostOnly": true,
             "httpOnly": false,
             "name": "PHPSESSID",


### PR DESCRIPTION
This is meant as a temporary solution so at least our own API client services can access the information in the JWT token. We still plan on implementing a logout endpoint that will unset the JWT cookies and a login status flag on the API root, so that external API clients can check whether or not they are logged in.

I renamed the existing SESSION_COOKIE_DOMAIN secret to SHARED_COOKIE_DOMAIN, and already changed this in the repository secrets.