### PR TITLE
Cleanup docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 # This file does not affect the development builds, because the contexts for those are the
 # backend and frontend directories, respectively.
 
+.cache/
 /backend/config/autoload/doctrine.local.dev.php
 /backend/config/autoload/doctrine.local.prod.php
 /frontend/data

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,9 @@
 
 /backend/config/autoload/doctrine.local.dev.php
 /backend/config/autoload/doctrine.local.prod.php
-/backend/vendor
 /frontend/data
 /frontend/dist
-/frontend/node_modules
 /frontend/.env.*
 /frontend/public/environment.*
+**/vendor/
+**/node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 # backend and frontend directories, respectively.
 
 .cache/
+.git/
 /backend/config/autoload/doctrine.local.dev.php
 /backend/config/autoload/doctrine.local.prod.php
 /frontend/data


### PR DESCRIPTION
Remove large directories which should not be copied to docker context when building production images.
Tested with:
```
docker build -t docker-show-context https://github.com/pwaller/docker-show-context.git
docker run --rm -v $PWD:/data docker-show-context
```