### PR TITLE
Entity filter for ContentNode (+ some more test coverage)

### DIFF
--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -114,3 +114,11 @@ services:
     App\EventListener\JWTCreatedListener:
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_created, method: onJWTCreated }
+
+    #
+    # Entity Filter
+    #
+    App\Doctrine\FilterByCurrentUserExtension:
+        tags:
+            - { name: api_platform.doctrine.orm.query_extension.collection, priority: -20 } # FilterEagerLoadingExtension has Priority -17 and breaks the DQL generated in ContentNodeRepository => Priority -20 ensures this runs after FilterEagerLoadingExtension
+            - { name: api_platform.doctrine.orm.query_extension.item }

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -115,10 +115,9 @@ services:
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_created, method: onJWTCreated }
 
-    #
     # Entity Filter
-    #
     App\Doctrine\FilterByCurrentUserExtension:
         tags:
-            - { name: api_platform.doctrine.orm.query_extension.collection, priority: -20 } # FilterEagerLoadingExtension has Priority -17 and breaks the DQL generated in ContentNodeRepository => Priority -20 ensures this runs after FilterEagerLoadingExtension
+            # FilterEagerLoadingExtension has Priority -17 and breaks the DQL generated in ContentNodeRepository => Priority -20 ensures this runs after FilterEagerLoadingExtension
+            - { name: api_platform.doctrine.orm.query_extension.collection, priority: -20 } 
             - { name: api_platform.doctrine.orm.query_extension.item }

--- a/api/fixtures/contentNodes.yml
+++ b/api/fixtures/contentNodes.yml
@@ -97,6 +97,14 @@ App\Entity\ContentNode\SingleText:
     instanceName: <word()>
     contentType: '@contentTypeNotes'
     text: <word()>
+  singleTextCampUnrelated:
+    root: '@columnLayout1campUnrelated'
+    parent: '@columnLayout1campUnrelated'
+    slot: '1'
+    position: 1
+    instanceName: <word()>
+    contentType: '@contentTypeNotes'
+    text: <word()>
 
 App\Entity\ContentNode\MaterialNode:
   materialNode1:

--- a/api/src/Entity/ContentNode.php
+++ b/api/src/Entity/ContentNode.php
@@ -6,6 +6,7 @@ use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
+use App\Repository\ContentNodeRepository;
 use App\Validator\AssertEitherIsNull;
 use App\Validator\ContentNode\AssertBelongsToSameOwner;
 use App\Validator\ContentNode\AssertNoLoop;
@@ -23,7 +24,7 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
  * content nodes may be inserted. In return, a content node may be nested inside a slot in a parent
  * container content node. This way, a tree of content nodes makes up a complete programme.
  *
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass=ContentNodeRepository::class)
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="strategy", type="string")
  */

--- a/api/src/Entity/ContentNode/SingleText.php
+++ b/api/src/Entity/ContentNode/SingleText.php
@@ -4,6 +4,7 @@ namespace App\Entity\ContentNode;
 
 use ApiPlatform\Core\Annotation\ApiResource;
 use App\Entity\ContentNode;
+use App\InputFilter;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
@@ -36,6 +37,7 @@ class SingleText extends ContentNode {
     /**
      * @ORM\Column(type="text", nullable=true)
      */
+    #[InputFilter\CleanHTML]
     #[Groups(['read', 'write'])]
     public ?string $text = null;
 }

--- a/api/src/Entity/ContentNode/SingleText.php
+++ b/api/src/Entity/ContentNode/SingleText.php
@@ -5,11 +5,12 @@ namespace App\Entity\ContentNode;
 use ApiPlatform\Core\Annotation\ApiResource;
 use App\Entity\ContentNode;
 use App\InputFilter;
+use App\Repository\SingleTextRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass=SingleTextRepository::class)
  * @ORM\Table(name="content_node_singletext")
  */
 #[ApiResource(

--- a/api/src/Repository/ContentNodeRepository.php
+++ b/api/src/Repository/ContentNodeRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Activity;
+use App\Entity\Category;
+use App\Entity\ContentNode;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method null|ContentNode find($id, $lockMode = null, $lockVersion = null)
+ * @method null|ContentNode findOneBy(array $criteria, array $orderBy = null)
+ * @method ContentNode[]    findAll()
+ * @method ContentNode[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ContentNodeRepository extends ServiceEntityRepository implements CanFilterByUserInterface {
+    use FiltersByCampCollaboration;
+
+    public function __construct(ManagerRegistry $registry, string $entityClass = null) {
+        if (null === $entityClass) {
+            parent::__construct($registry, ContentNode::class);
+        } else {
+            parent::__construct($registry, $entityClass);
+        }
+    }
+
+    public function filterByUser(QueryBuilder $queryBuilder, User $user): void {
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $queryBuilder->innerJoin("{$rootAlias}.root", 'root');
+        $queryBuilder->innerJoin('root.owner', 'owner');
+
+        // add camp filter in case the ContentNode owner is an Activity
+        $queryBuilder->leftJoin(Activity::class, 'activity', Join::WITH, 'activity.id = owner.id');
+        $queryBuilder->leftJoin('activity.camp', 'camp_via_activity');
+        $this->filterByCampCollaboration($queryBuilder, $user, 'camp_via_activity');
+
+        // add camp filter in case the ContentNode owner is a category
+        $queryBuilder->leftJoin(Category::class, 'category', Join::WITH, 'category.id = owner.id');
+        $queryBuilder->leftJoin('category.camp', 'camp_via_category');
+        $this->filterByCampCollaboration($queryBuilder, $user, 'camp_via_category');
+    }
+}

--- a/api/src/Repository/ContentNodeRepository.php
+++ b/api/src/Repository/ContentNodeRepository.php
@@ -20,12 +20,8 @@ use Doctrine\Persistence\ManagerRegistry;
 class ContentNodeRepository extends ServiceEntityRepository implements CanFilterByUserInterface {
     use FiltersByCampCollaboration;
 
-    public function __construct(ManagerRegistry $registry, string $entityClass = null) {
-        if (null === $entityClass) {
-            parent::__construct($registry, ContentNode::class);
-        } else {
-            parent::__construct($registry, $entityClass);
-        }
+    public function __construct(ManagerRegistry $registry, string $entityClass = ContentNode::class) {
+        parent::__construct($registry, $entityClass);
     }
 
     public function filterByUser(QueryBuilder $queryBuilder, User $user): void {

--- a/api/src/Repository/FiltersByCampCollaboration.php
+++ b/api/src/Repository/FiltersByCampCollaboration.php
@@ -14,8 +14,22 @@ trait FiltersByCampCollaboration {
      * the alias of the camp as the third argument if it's anything other than "camp".
      */
     public function filterByCampCollaboration(QueryBuilder $queryBuilder, User $user, string $campAlias = 'camp'): void {
-        $queryBuilder->leftJoin("{$campAlias}.collaborations", 'filter_campCollaboration');
-        $queryBuilder->andWhere("(filter_campCollaboration.user = :current_user and filter_campCollaboration.status = :established) or {$campAlias}.isPrototype = :true");
+        $queryBuilder->leftJoin("{$campAlias}.collaborations", "filter_{$campAlias}_campCollaboration");
+        $queryBuilder->andWhere(
+            $queryBuilder->expr()->orX(
+                // user is established collaborator in the camp
+                $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->eq("filter_{$campAlias}_campCollaboration.user", ':current_user'),
+                    $queryBuilder->expr()->eq("filter_{$campAlias}_campCollaboration.status", ':established'),
+                ),
+
+                // camp is a Prototype = all Prototypes are readable
+                $queryBuilder->expr()->eq("{$campAlias}.isPrototype", ':true'),
+
+                // property $campAlias is not loaded in current DQL (needed for AbstractContentNodeOwner, where the camp is loaded twice - once via category and once via activity)
+                $queryBuilder->expr()->isNull("{$campAlias}")
+            )
+        );
         $queryBuilder->setParameter('current_user', $user);
         $queryBuilder->setParameter('established', CampCollaboration::STATUS_ESTABLISHED);
         $queryBuilder->setParameter('true', true);

--- a/api/src/Repository/SingleTextRepository.php
+++ b/api/src/Repository/SingleTextRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ContentNode\SingleText;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method null|SingleText find($id, $lockMode = null, $lockVersion = null)
+ * @method null|SingleText findOneBy(array $criteria, array $orderBy = null)
+ * @method SingleText[]    findAll()
+ * @method SingleText[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class SingleTextRepository extends ContentNodeRepository {
+    public function __construct(ManagerRegistry $registry) {
+        parent::__construct($registry, SingleText::class);
+    }
+}

--- a/api/tests/Api/ContentNodes/ColumnLayout/CreateColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/CreateColumnLayoutTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Api\ColumnLayouts;
+namespace App\Tests\Api\ContentNodes\ColumnLayout;
 
 use ApiPlatform\Core\Api\OperationType;
 use App\Entity\ContentNode\ColumnLayout;

--- a/api/tests/Api/ContentNodes/ColumnLayout/DeleteColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/DeleteColumnLayoutTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Api\ColumnLayouts;
+namespace App\Tests\Api\ContentNodes\ColumnLayout;
 
 use App\Entity\ContentNode\ColumnLayout;
 use App\Tests\Api\ECampApiTestCase;

--- a/api/tests/Api/ContentNodes/ColumnLayout/ReadColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/ReadColumnLayoutTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Api\ColumnLayouts;
+namespace App\Tests\Api\ContentNodes\ColumnLayout;
 
 use App\Entity\ColumnLayout;
 use App\Tests\Api\ECampApiTestCase;

--- a/api/tests/Api/ContentNodes/ColumnLayout/UpdateColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/UpdateColumnLayoutTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Api\ColumnLayouts;
+namespace App\Tests\Api\ContentNodes\ColumnLayout;
 
 use App\Tests\Api\ECampApiTestCase;
 

--- a/api/tests/Api/ContentNodes/ContentNode/CreateContentNodeTest.php
+++ b/api/tests/Api/ContentNodes/ContentNode/CreateContentNodeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Api\ContentNodes;
+namespace App\Tests\Api\ContentNodes\ContentNode;
 
 use App\Tests\Api\ECampApiTestCase;
 

--- a/api/tests/Api/ContentNodes/ContentNode/DeleteContentNodeTest.php
+++ b/api/tests/Api/ContentNodes/ContentNode/DeleteContentNodeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Api\ContentNodes;
+namespace App\Tests\Api\ContentNodes\ContentNode;
 
 use App\Tests\Api\ECampApiTestCase;
 

--- a/api/tests/Api/ContentNodes/ContentNode/ListContentNodesTest.php
+++ b/api/tests/Api/ContentNodes/ContentNode/ListContentNodesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Api\ContentNodes;
+namespace App\Tests\Api\ContentNodes\ContentNode;
 
 use App\Tests\Api\ECampApiTestCase;
 

--- a/api/tests/Api/ContentNodes/ContentNode/ListContentNodesTest.php
+++ b/api/tests/Api/ContentNodes/ContentNode/ListContentNodesTest.php
@@ -14,7 +14,7 @@ class ListContentNodesTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()->request('GET', '/content_nodes');
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'totalItems' => 15,
+            'totalItems' => 13,
             '_links' => [
                 'items' => [],
             ],
@@ -36,9 +36,6 @@ class ListContentNodesTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('materialNode1')],
             ['href' => $this->getIriFor('materialNode2')],
             ['href' => $this->getIriFor('storyboard1')],
-            // The next two should not be visible once we implement proper entity filtering for content nodes
-            ['href' => $this->getIriFor('columnLayout1campUnrelated')],
-            ['href' => $this->getIriFor('columnLayout2campUnrelated')],
         ], $response->toArray()['_links']['items']);
     }
 

--- a/api/tests/Api/ContentNodes/ContentNode/ReadContentNodeTest.php
+++ b/api/tests/Api/ContentNodes/ContentNode/ReadContentNodeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Api\ContentNodes;
+namespace App\Tests\Api\ContentNodes\ContentNode;
 
 use App\Entity\ContentNode;
 use App\Tests\Api\ECampApiTestCase;

--- a/api/tests/Api/ContentNodes/ContentNode/UpdateContentNodeTest.php
+++ b/api/tests/Api/ContentNodes/ContentNode/UpdateContentNodeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Api\ContentNodes;
+namespace App\Tests\Api\ContentNodes\ContentNode;
 
 use App\Tests\Api\ECampApiTestCase;
 

--- a/api/tests/Api/ContentNodes/CreateContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/CreateContentNodeTestCase.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Tests\Api\ContentNodes;
+
+use ApiPlatform\Core\Api\OperationType;
+use App\Entity\ContentNode;
+use App\Entity\ContentType;
+use App\Entity\User;
+use App\Tests\Api\ECampApiTestCase;
+
+/**
+ * Base CREATE (post) test case to be used for various ContentNode types.
+ *
+ * This test class covers all tests that are the same across all content node implementations
+ *
+ * @internal
+ */
+abstract class CreateContentNodeTestCase extends ECampApiTestCase {
+    protected string $contentNodeClass;
+
+    protected string $endpoint;
+
+    protected ContentType $defaultContentType;
+
+    protected ContentNode $defaultParent;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->defaultParent = static::$fixtures['columnLayout1'];
+    }
+
+    public function testCreateIsDeniedForAnonymousUser() {
+        static::createBasicClient()->request('POST', "/content_node/{$this->endpoint}", ['json' => $this->getExampleWritePayload()]);
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertJsonContains([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    public function testCreateIsDeniedForInvitedCollaborator() {
+        $this->create(user: static::$fixtures['user6invited']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testCreateIsDeniedForInactiveCollaborator() {
+        $this->create(user: static::$fixtures['user5inactive']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testCreateIsDeniedForUnrelatedUser() {
+        $this->create(user: static::$fixtures['user4unrelated']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testCreateIsDeniedForGuest() {
+        $this->create(user: static::$fixtures['user3guest']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testCreateIsAllowedForMember() {
+        $this->create(user: static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testCreateIsAllowedForManager() {
+        // when
+        $response = $this->create(user: static::$fixtures['user1manager']);
+        $id = json_decode($response->getContent())->id;
+        $newContentNode = $this->getEntityManager()->getRepository($this->contentNodeClass)->find($id);
+
+        // then
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains($this->getExampleReadPayload($newContentNode), true);
+    }
+
+    protected function create(array $payload = null, ?User $user = null) {
+        $credentials = null;
+        if (null !== $user) {
+            $credentials = ['username' => $user->getUsername()];
+        }
+
+        if (null === $payload) {
+            $payload = $this->getExampleWritePayload();
+        }
+
+        return static::createClientWithCredentials($credentials)->request('POST', "/content_node/{$this->endpoint}", ['json' => $payload]);
+    }
+
+    protected function getExampleWritePayload($attributes = [], $except = []) {
+        return $this->getExamplePayload(
+            $this->contentNodeClass,
+            OperationType::COLLECTION,
+            'post',
+            array_merge([
+                'parent' => $this->getIriFor($this->defaultParent),
+                'contentType' => $this->getIriFor($this->defaultContentType),
+                'position' => 10,
+                'prototype' => null,
+            ], $attributes),
+            [],
+            $except
+        );
+    }
+
+    protected function getExampleReadPayload(ContentNode $self, $attributes = [], $except = []) {
+        /** @var ContentNode $parent */
+        $parent = $this->defaultParent;
+
+        /** @var ContentType $contentType */
+        $contentType = $this->defaultContentType;
+
+        return [
+            'slot' => 'footer',
+            'position' => 10,
+            'instanceName' => 'Schlechtwetterprogramm',
+            'contentTypeName' => $contentType->name,
+            '_links' => [
+                'self' => [
+                    'href' => $this->getIriFor($self),
+                ],
+                'root' => [
+                    'href' => $this->getIriFor($parent->root),
+                ],
+                'parent' => [
+                    'href' => $this->getIriFor($parent),
+                ],
+                'children' => [
+                    'href' => '/content_nodes?parent='.$this->getIriFor($self),
+                ],
+                'contentType' => [
+                    'href' => $this->getIriFor($contentType),
+                ],
+                'owner' => [
+                    'href' => $this->getIriFor($parent->getRootOwner()),
+                ],
+                'ownerCategory' => [
+                    'href' => $this->getIriFor($parent->getOwnerCategory()),
+                ],
+            ],
+        ];
+
+        /*
+        return $this->getExamplePayload(
+            $this->contentNodeClass,
+            OperationType::ITEM,
+            'get',
+            array_merge([
+            ], $attributes),
+            [],
+            $except
+        );*/
+    }
+}

--- a/api/tests/Api/ContentNodes/CreateContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/CreateContentNodeTestCase.php
@@ -67,7 +67,7 @@ abstract class CreateContentNodeTestCase extends ECampApiTestCase {
     public function testCreateIsAllowedForManager() {
         // when
         $response = $this->create(user: static::$fixtures['user1manager']);
-        $id = json_decode($response->getContent())->id;
+        $id = $response->toArray()['id'];
         $newContentNode = $this->getEntityManager()->getRepository($this->contentNodeClass)->find($id);
 
         // then
@@ -140,16 +140,5 @@ abstract class CreateContentNodeTestCase extends ECampApiTestCase {
                 ],
             ],
         ];
-
-        /*
-        return $this->getExamplePayload(
-            $this->contentNodeClass,
-            OperationType::ITEM,
-            'get',
-            array_merge([
-            ], $attributes),
-            [],
-            $except
-        );*/
     }
 }

--- a/api/tests/Api/ContentNodes/DeleteContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/DeleteContentNodeTestCase.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Tests\Api\ContentNodes;
+
+use App\Entity\ContentNode;
+use App\Entity\User;
+use App\Tests\Api\ECampApiTestCase;
+
+/**
+ * Base UPDATE (patch) test case to be used for various ContentNode types.
+ *
+ * This test class covers all tests that are the same across all content node implementations
+ *
+ * @internal
+ */
+abstract class DeleteContentNodeTestCase extends ECampApiTestCase {
+    protected $defaultContentNode;
+
+    protected $endpoint = '';
+
+    public function testDeleteIsDeniedForAnonymousUser() {
+        static::createBasicClient()->request('DELETE', "/content_node/{$this->endpoint}/".$this->defaultContentNode->getId());
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertJsonContains([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+
+        $this->assertEntityStillExists();
+    }
+
+    public function testDeleteIsDeniedForInvitedCollaborator() {
+        $this->delete(user: static::$fixtures['user6invited']);
+        $this->assertResponseStatusCodeSame(403);
+        $this->assertEntityStillExists();
+    }
+
+    public function testDeleteIsDeniedForInactiveCollaborator() {
+        $this->delete(user: static::$fixtures['user5inactive']);
+        $this->assertResponseStatusCodeSame(403);
+        $this->assertEntityStillExists();
+    }
+
+    public function testDeleteIsDeniedForUnrelatedUser() {
+        $this->delete(user: static::$fixtures['user4unrelated']);
+        $this->assertResponseStatusCodeSame(403);
+        $this->assertEntityStillExists();
+    }
+
+    public function testDeleteIsDeniedForGuest() {
+        $this->delete(user: static::$fixtures['user3guest']);
+        $this->assertResponseStatusCodeSame(403);
+        $this->assertEntityStillExists();
+    }
+
+    public function testDeleteIsAllowedForMember() {
+        $this->delete(user: static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(204);
+        $this->assertEntityWasRemoved();
+    }
+
+    public function testDeleteIsAllowedForManager() {
+        $this->delete(user: static::$fixtures['user1manager']);
+        $this->assertResponseStatusCodeSame(204);
+        $this->assertEntityWasRemoved();
+    }
+
+    protected function delete(?ContentNode $contentNode = null, ?User $user = null) {
+        $credentials = null;
+        if (null !== $user) {
+            $credentials = ['username' => $user->getUsername()];
+        }
+
+        $contentNode ??= $this->defaultContentNode;
+
+        static::createClientWithCredentials($credentials)->request('DELETE', "/content_node/{$this->endpoint}/".$this->defaultContentNode->getId());
+    }
+
+    protected function assertEntityWasRemoved(?ContentNode $contentNode = null) {
+        $contentNode ??= $this->defaultContentNode;
+
+        $this->assertNull($this->getEntityManager()->getRepository(get_class($contentNode))->find($contentNode->getId()));
+    }
+
+    protected function assertEntityStillExists(?ContentNode $contentNode = null) {
+        $contentNode ??= $this->defaultContentNode;
+
+        $this->assertNotNull($this->getEntityManager()->getRepository(get_class($contentNode))->find($contentNode->getId()));
+    }
+}

--- a/api/tests/Api/ContentNodes/DeleteContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/DeleteContentNodeTestCase.php
@@ -31,19 +31,19 @@ abstract class DeleteContentNodeTestCase extends ECampApiTestCase {
 
     public function testDeleteIsDeniedForInvitedCollaborator() {
         $this->delete(user: static::$fixtures['user6invited']);
-        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseStatusCodeSame(404);
         $this->assertEntityStillExists();
     }
 
     public function testDeleteIsDeniedForInactiveCollaborator() {
         $this->delete(user: static::$fixtures['user5inactive']);
-        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseStatusCodeSame(404);
         $this->assertEntityStillExists();
     }
 
     public function testDeleteIsDeniedForUnrelatedUser() {
         $this->delete(user: static::$fixtures['user4unrelated']);
-        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseStatusCodeSame(404);
         $this->assertEntityStillExists();
     }
 

--- a/api/tests/Api/ContentNodes/DeleteContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/DeleteContentNodeTestCase.php
@@ -7,7 +7,7 @@ use App\Entity\User;
 use App\Tests\Api\ECampApiTestCase;
 
 /**
- * Base UPDATE (patch) test case to be used for various ContentNode types.
+ * Base DELETE test case to be used for various ContentNode types.
  *
  * This test class covers all tests that are the same across all content node implementations
  *

--- a/api/tests/Api/ContentNodes/ListContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/ListContentNodeTestCase.php
@@ -86,6 +86,7 @@ abstract class ListContentNodeTestCase extends ECampApiTestCase {
             'totalItems' => count($items),
         ]);
 
+        // TODO: remove if once PR #2062 is merged
         if (!empty($items)) {
             $this->assertJsonContains([
                 '_links' => [

--- a/api/tests/Api/ContentNodes/ListContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/ListContentNodeTestCase.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Tests\Api\ContentNodes;
+
+use App\Entity\ContentNode;
+use App\Entity\User;
+use App\Tests\Api\ECampApiTestCase;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Base LIST (get) test case to be used for various ContentNode types.
+ *
+ * This test class covers all tests that are the same across all content node implementations
+ *
+ * @internal
+ */
+abstract class ListContentNodeTestCase extends ECampApiTestCase {
+    protected $defaultContentNode;
+
+    protected $endpoint = '';
+
+    protected array $contentNodesCamp1 = [];
+
+    protected array $contentNodesCampUnrelated = [];
+
+    public function testListForAnonymousUser() {
+        static::createBasicClient()->request('GET', "/content_node/{$this->endpoint}");
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertJsonContains([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    public function testListForInvitedCollaborator() {
+        $response = $this->list(user: static::$fixtures['user6invited']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp1);
+
+        // TODO: The next line should be the correct assertion once we implement proper entity filtering for content nodes
+        // $this->assertJsonContainsItems($response, []);
+    }
+
+    public function testListForInactiveCollaborator() {
+        $response = $this->list(user: static::$fixtures['user5inactive']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp1);
+
+        // TODO: The next line should be the correct assertion once we implement proper entity filtering for content nodes
+        // $this->assertJsonContainsItems($response, []);
+    }
+
+    public function testListForUnrelatedUser() {
+        $response = $this->list(user: static::$fixtures['user4unrelated']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampUnrelated);
+    }
+
+    public function testListForGuest() {
+        $response = $this->list(user: static::$fixtures['user3guest']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp1);
+    }
+
+    public function testListForMember() {
+        $response = $this->list(user: static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp1);
+    }
+
+    public function testListForManager() {
+        $response = $this->list(user: static::$fixtures['user1manager']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp1);
+    }
+
+    protected function list(?User $user = null) {
+        $credentials = null;
+        if (null !== $user) {
+            $credentials = ['username' => $user->getUsername()];
+        }
+
+        return static::createClientWithCredentials($credentials)->request('GET', "/content_node/{$this->endpoint}");
+    }
+
+    /**
+     * @param ResponseInterface $response Response from API
+     * @param array             $items    array of IRIs
+     */
+    protected function assertJsonContainsItems(ResponseInterface $response, array $items = []) {
+        $this->assertJsonContains([
+            'totalItems' => count($items),
+            '_links' => [
+                'items' => [],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
+        $this->assertEqualsCanonicalizing(
+            array_map(fn ($iri): array => ['href' => $iri], $items),
+            $response->toArray()['_links']['items']
+        );
+    }
+}

--- a/api/tests/Api/ContentNodes/ListContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/ListContentNodeTestCase.php
@@ -35,19 +35,13 @@ abstract class ListContentNodeTestCase extends ECampApiTestCase {
     public function testListForInvitedCollaborator() {
         $response = $this->list(user: static::$fixtures['user6invited']);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContainsItems($response, $this->contentNodesCamp1);
-
-        // TODO: The next line should be the correct assertion once we implement proper entity filtering for content nodes
-        // $this->assertJsonContainsItems($response, []);
+        $this->assertJsonContainsItems($response, []);
     }
 
     public function testListForInactiveCollaborator() {
         $response = $this->list(user: static::$fixtures['user5inactive']);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContainsItems($response, $this->contentNodesCamp1);
-
-        // TODO: The next line should be the correct assertion once we implement proper entity filtering for content nodes
-        // $this->assertJsonContainsItems($response, []);
+        $this->assertJsonContainsItems($response, []);
     }
 
     public function testListForUnrelatedUser() {
@@ -90,16 +84,22 @@ abstract class ListContentNodeTestCase extends ECampApiTestCase {
     protected function assertJsonContainsItems(ResponseInterface $response, array $items = []) {
         $this->assertJsonContains([
             'totalItems' => count($items),
-            '_links' => [
-                'items' => [],
-            ],
-            '_embedded' => [
-                'items' => [],
-            ],
         ]);
-        $this->assertEqualsCanonicalizing(
-            array_map(fn ($iri): array => ['href' => $iri], $items),
-            $response->toArray()['_links']['items']
-        );
+
+        if (!empty($items)) {
+            $this->assertJsonContains([
+                '_links' => [
+                    'items' => [],
+                ],
+                '_embedded' => [
+                    'items' => [],
+                ],
+            ]);
+
+            $this->assertEqualsCanonicalizing(
+                array_map(fn ($iri): array => ['href' => $iri], $items),
+                $response->toArray()['_links']['items']
+            );
+        }
     }
 }

--- a/api/tests/Api/ContentNodes/ReadContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/ReadContentNodeTestCase.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Tests\Api\ContentNodes;
+
+use App\Entity\ContentNode;
+use App\Entity\User;
+use App\Tests\Api\ECampApiTestCase;
+
+/**
+ * Base READ (get) test case to be used for various ContentNode types.
+ *
+ * This test class covers all tests that are the same across all content node implementations
+ *
+ * @internal
+ */
+abstract class ReadContentNodeTestCase extends ECampApiTestCase {
+    protected $defaultContentNode;
+
+    protected $endpoint = '';
+
+    public function testGetIsDeniedForAnonymousUser() {
+        static::createBasicClient()->request('GET', "/content_node/{$this->endpoint}/".$this->defaultContentNode->getId());
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertJsonContains([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    public function testGetIsDeniedForInvitedCollaborator() {
+        $this->get(user: static::$fixtures['user6invited']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGetIsDeniedForInactiveCollaborator() {
+        $this->get(user: static::$fixtures['user5inactive']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGetIsDeniedForUnrelatedUser() {
+        $this->get(user: static::$fixtures['user4unrelated']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGetIsAllowedForGuest() {
+        $this->get(user: static::$fixtures['user3guest']);
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    public function testGetIsAllowedForMember() {
+        $this->get(user: static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    public function testGetIsAllowedForManager() {
+        $this->get(user: static::$fixtures['user1manager']);
+        $this->assertResponseStatusCodeSame(200);
+
+        $this->assertJsonContains([
+            'id' => $this->defaultContentNode->getId(),
+            'instanceName' => $this->defaultContentNode->instanceName,
+            'slot' => $this->defaultContentNode->slot,
+            'position' => $this->defaultContentNode->position,
+            'contentTypeName' => $this->defaultContentNode->getContentTypeName(),
+
+            '_links' => [
+                'parent' => ['href' => $this->getIriFor($this->defaultContentNode->parent)],
+                'owner' => ['href' => $this->getIriFor('activity1')],
+                'ownerCategory' => ['href' => $this->getIriFor('category1')],
+            ],
+        ]);
+    }
+
+    protected function get(?ContentNode $contentNode = null, ?User $user = null) {
+        $credentials = null;
+        if (null !== $user) {
+            $credentials = ['username' => $user->getUsername()];
+        }
+
+        $contentNode ??= $this->defaultContentNode;
+
+        static::createClientWithCredentials($credentials)->request('GET', "/content_node/{$this->endpoint}/".$contentNode->getId());
+    }
+}

--- a/api/tests/Api/ContentNodes/ReadContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/ReadContentNodeTestCase.php
@@ -29,17 +29,17 @@ abstract class ReadContentNodeTestCase extends ECampApiTestCase {
 
     public function testGetIsDeniedForInvitedCollaborator() {
         $this->get(user: static::$fixtures['user6invited']);
-        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseStatusCodeSame(404);
     }
 
     public function testGetIsDeniedForInactiveCollaborator() {
         $this->get(user: static::$fixtures['user5inactive']);
-        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseStatusCodeSame(404);
     }
 
     public function testGetIsDeniedForUnrelatedUser() {
         $this->get(user: static::$fixtures['user4unrelated']);
-        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseStatusCodeSame(404);
     }
 
     public function testGetIsAllowedForGuest() {

--- a/api/tests/Api/ContentNodes/SingleText/CreateSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/CreateSingleTextTest.php
@@ -2,67 +2,65 @@
 
 namespace App\Tests\Api\ContentNodes\SingleText;
 
-use ApiPlatform\Core\Api\OperationType;
 use App\Entity\ContentNode\SingleText;
-use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Api\ContentNodes\CreateContentNodeTestCase;
 
 /**
  * @internal
  */
-class CreateSingleTextTest extends ECampApiTestCase {
-    // TODO security tests when not logged in or not collaborator
-    // TODO input filter tests
-    // TODO validation tests
+class CreateSingleTextTest extends CreateContentNodeTestCase {
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->endpoint = 'single_texts';
+        $this->contentNodeClass = SingleText::class;
+        $this->defaultContentType = static::$fixtures['contentTypeNotes'];
+    }
 
     public function testCreateSingleTextFromString() {
+        // given
         $text = 'TestText';
-        static::createClientWithCredentials()->request('POST', '/content_node/single_texts', ['json' => $this->getExampleWritePayload(['text' => $text])]);
 
+        // when
+        $this->create($this->getExampleWritePayload(['text' => $text]));
+
+        // then
         $this->assertResponseStatusCodeSame(201);
-        $this->assertJsonContains($this->getExampleReadPayload());
         $this->assertJsonContains(['text' => $text]);
     }
 
     public function testCreateSingleTextFromNull() {
-        static::createClientWithCredentials()->request('POST', '/content_node/single_texts', ['json' => $this->getExampleWritePayload(['text' => null])]);
+        // when
+        $this->create($this->getExampleWritePayload(['text' => null]));
 
+        // then
         $this->assertResponseStatusCodeSame(201);
-        $this->assertJsonContains($this->getExampleReadPayload());
         $this->assertJsonContains(['text' => null]);
     }
 
-    public function testCreateSingleTextFromPrototype() {
-        $prototype = static::$fixtures['singleText2'];
-        static::createClientWithCredentials()->request('POST', '/content_node/single_texts', ['json' => $this->getExampleWritePayload(['prototype' => $this->getIriFor('singleText2')])]);
+    public function testCreateSingleTextCleansHTMLFromText() {
+        // given
+        $text = ' testText<script>alert(1)</script>';
 
+        // when
+        $this->create($this->getExampleWritePayload(['text' => $text]));
+
+        // then
         $this->assertResponseStatusCodeSame(201);
-        $this->assertJsonContains($this->getExampleReadPayload());
+        $this->assertJsonContains([
+            'text' => ' testText',
+        ]);
+    }
+
+    public function testCreateSingleTextFromPrototype() {
+        // given
+        $prototype = static::$fixtures['singleText2'];
+
+        // when
+        $this->create($this->getExampleWritePayload(['prototype' => $this->getIriFor('singleText2')]));
+
+        // then
+        $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains(['text' => $prototype->text]);
-    }
-
-    public function getExampleWritePayload($attributes = [], $except = []) {
-        return $this->getExamplePayload(
-            SingleText::class,
-            OperationType::COLLECTION,
-            'post',
-            array_merge([
-                'parent' => $this->getIriFor('columnLayout1'),
-                'contentType' => $this->getIriFor('contentTypeNotes'),
-                'prototype' => null,
-            ], $attributes),
-            [],
-            $except
-        );
-    }
-
-    public function getExampleReadPayload($attributes = [], $except = []) {
-        return $this->getExamplePayload(
-            SingleText::class,
-            OperationType::ITEM,
-            'get',
-            $attributes,
-            ['parent', 'contentType'],
-            $except
-        );
     }
 }

--- a/api/tests/Api/ContentNodes/SingleText/DeleteSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/DeleteSingleTextTest.php
@@ -2,19 +2,16 @@
 
 namespace App\Tests\Api\ContentNodes\SingleText;
 
-use App\Entity\ContentNode\SingleText;
-use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Api\ContentNodes\DeleteContentNodeTestCase;
 
 /**
  * @internal
  */
-class DeleteSingleTextTest extends ECampApiTestCase {
-    // TODO security tests when not logged in or not collaborator
+class DeleteSingleTextTest extends DeleteContentNodeTestCase {
+    public function setUp(): void {
+        parent::setUp();
 
-    public function testDeleteSingleTextIsAllowedForCollaborator() {
-        $contentNode = static::$fixtures['singleText1'];
-        static::createClientWithCredentials()->request('DELETE', '/content_node/single_texts/'.$contentNode->getId());
-        $this->assertResponseStatusCodeSame(204);
-        $this->assertNull($this->getEntityManager()->getRepository(SingleText::class)->find($contentNode->getId()));
+        $this->endpoint = 'single_texts';
+        $this->defaultContentNode = static::$fixtures['singleText1'];
     }
 }

--- a/api/tests/Api/ContentNodes/SingleText/ListSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/ListSingleTextTest.php
@@ -2,47 +2,39 @@
 
 namespace App\Tests\Api\ContentNodes\SingleText;
 
-use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Api\ContentNodes\ListContentNodeTestCase;
 
 /**
  * @internal
  */
-class ListSingleTextTest extends ECampApiTestCase {
-    // TODO security tests when not logged in or not collaborator
+class ListSingleTextTest extends ListContentNodeTestCase {
+    public function setUp(): void {
+        parent::setUp();
 
-    public function testListSingleTextsIsAllowedForCollaborator() {
-        $response = static::createClientWithCredentials()->request('GET', '/content_node/single_texts');
-        $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContains([
-            'totalItems' => 2,
-            '_links' => [
-                'items' => [],
-            ],
-            '_embedded' => [
-                'items' => [],
-            ],
-        ]);
-        $this->assertEqualsCanonicalizing([
-            ['href' => $this->getIriFor('singleText1')],
-            ['href' => $this->getIriFor('singleText2')],
-        ], $response->toArray()['_links']['items']);
+        $this->endpoint = 'single_texts';
+        $this->contentNodeClass = SingleText::class;
+        $this->defaultContentType = static::$fixtures['contentTypeNotes'];
+
+        $this->contentNodesCamp1 = [
+            $this->getIriFor('singleText1'),
+            $this->getIriFor('singleText2'),
+            // TODO: The next two should not be visible once we implement proper entity filtering for content nodes
+            $this->getIriFor('singleTextCampUnrelated'),
+        ];
+
+        $this->contentNodesCampUnrelated = [
+            $this->getIriFor('singleTextCampUnrelated'),
+            // TODO: The next two should not be visible once we implement proper entity filtering for content nodes
+            $this->getIriFor('singleText1'),
+            $this->getIriFor('singleText2'),
+        ];
     }
 
-    public function testListSingleTextsFilteredByParentIsAllowedForCollaborator() {
+    public function testListSingleTextsFilteredByParent() {
         $parent = static::$fixtures['columnLayout1'];
-        $response = static::createClientWithCredentials()->request('GET', '/content_node/single_texts?parent='.$this->getIriFor('columnLayout1'));
+        $response = static::createClientWithCredentials()->request('GET', "/content_node/{$this->endpoint}?parent=".$this->getIriFor('columnLayout1'));
         $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContains([
-            'totalItems' => 1,
-            '_links' => [
-                'items' => [],
-            ],
-            '_embedded' => [
-                'items' => [],
-            ],
-        ]);
-        $this->assertEqualsCanonicalizing([
-            ['href' => $this->getIriFor('singleText1')],
-        ], $response->toArray()['_links']['items']);
+
+        $this->assertJsonContainsItems($response, [$this->getIriFor('singleText1')]);
     }
 }

--- a/api/tests/Api/ContentNodes/SingleText/ListSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/ListSingleTextTest.php
@@ -18,15 +18,10 @@ class ListSingleTextTest extends ListContentNodeTestCase {
         $this->contentNodesCamp1 = [
             $this->getIriFor('singleText1'),
             $this->getIriFor('singleText2'),
-            // TODO: The next two should not be visible once we implement proper entity filtering for content nodes
-            $this->getIriFor('singleTextCampUnrelated'),
         ];
 
         $this->contentNodesCampUnrelated = [
             $this->getIriFor('singleTextCampUnrelated'),
-            // TODO: The next two should not be visible once we implement proper entity filtering for content nodes
-            $this->getIriFor('singleText1'),
-            $this->getIriFor('singleText2'),
         ];
     }
 

--- a/api/tests/Api/ContentNodes/SingleText/ReadSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/ReadSingleTextTest.php
@@ -2,32 +2,32 @@
 
 namespace App\Tests\Api\ContentNodes\SingleText;
 
-use App\Entity\ContentNode;
-use App\Tests\Api\ECampApiTestCase;
+use App\Entity\ContentNode\SingleText;
+use App\Tests\Api\ContentNodes\ReadContentNodeTestCase;
 
 /**
  * @internal
  */
-class ReadSingleTextTest extends ECampApiTestCase {
-    // TODO security tests when not logged in or not collaborator
+class ReadSingleTextTest extends ReadContentNodeTestCase {
+    public function setUp(): void {
+        parent::setUp();
 
-    public function testGetSingleTextIsAllowedForCollaborator() {
-        /** @var ContentNode $contentNode */
-        $contentNode = static::$fixtures['singleText1'];
-        static::createClientWithCredentials()->request('GET', '/content_node/single_texts/'.$contentNode->getId());
+        $this->endpoint = 'single_texts';
+        $this->defaultContentNode = static::$fixtures['singleText1'];
+    }
+
+    public function testGetSingleText() {
+        // given
+        /** @var SingleText $contentNode */
+        $contentNode = $this->defaultContentNode;
+
+        // when
+        $this->get($contentNode);
+
+        // then
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'id' => $contentNode->getId(),
-            'instanceName' => $contentNode->instanceName,
-            'slot' => $contentNode->slot,
-            'position' => $contentNode->position,
-            'contentTypeName' => $contentNode->getContentTypeName(),
             'text' => $contentNode->text,
-            '_links' => [
-                'parent' => ['href' => $this->getIriFor($contentNode->parent)],
-                'owner' => ['href' => $this->getIriFor('activity1')],
-                'ownerCategory' => ['href' => $this->getIriFor('category1')],
-            ],
         ]);
     }
 }

--- a/api/tests/Api/ContentNodes/SingleText/UpdateSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/UpdateSingleTextTest.php
@@ -16,10 +16,8 @@ class UpdateSingleTextTest extends UpdateContentNodeTestCase {
     }
 
     public function testPatchText() {
-        $contentNode = static::$fixtures['singleText1'];
-
         // when
-        $this->patch($contentNode, ['text' => 'testText']);
+        $this->patch($this->defaultContentNode, ['text' => 'testText']);
 
         // then
         $this->assertResponseStatusCodeSame(200);
@@ -29,10 +27,8 @@ class UpdateSingleTextTest extends UpdateContentNodeTestCase {
     }
 
     public function testPatchCleansHTMLFromText() {
-        $contentNode = static::$fixtures['singleText1'];
-
         // when
-        $this->patch($contentNode, ['text' => ' testText<script>alert(1)</script>']);
+        $this->patch($this->defaultContentNode, ['text' => ' testText<script>alert(1)</script>']);
 
         // then
         $this->assertResponseStatusCodeSame(200);

--- a/api/tests/Api/ContentNodes/SingleText/UpdateSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/UpdateSingleTextTest.php
@@ -1,26 +1,43 @@
 <?php
 
-namespace App\Tests\Api\SingleTexts;
+namespace App\Tests\Api\ContentNodes\SingleText;
 
-use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Api\ContentNodes\UpdateContentNodeTestCase;
 
 /**
  * @internal
  */
-class UpdateSingleTextTest extends ECampApiTestCase {
-    // TODO security tests when not logged in or not collaborator
-    // TODO input filter tests
-    // TODO validation tests
+class UpdateSingleTextTest extends UpdateContentNodeTestCase {
+    public function setUp(): void {
+        parent::setUp();
 
-    public function testPatchSingleText() {
-        $testText = 'TEST_TEXT';
+        $this->endpoint = 'single_texts';
+        $this->defaultContentNode = static::$fixtures['singleText1'];
+    }
+
+    public function testPatchText() {
         $contentNode = static::$fixtures['singleText1'];
-        static::createClientWithCredentials()->request('PATCH', '/content_node/single_texts/'.$contentNode->getId(), ['json' => [
-            'text' => $testText,
-        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+
+        // when
+        $this->patch($contentNode, ['text' => 'testText']);
+
+        // then
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'text' => $testText,
+            'text' => 'testText',
+        ]);
+    }
+
+    public function testPatchCleansHTMLFromText() {
+        $contentNode = static::$fixtures['singleText1'];
+
+        // when
+        $this->patch($contentNode, ['text' => ' testText<script>alert(1)</script>']);
+
+        // then
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'text' => ' testText',
         ]);
     }
 }

--- a/api/tests/Api/ContentNodes/UpdateContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/UpdateContentNodeTestCase.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Tests\Api\ContentNodes;
+
+use App\Tests\Api\ECampApiTestCase;
+
+/**
+ * Base UPDATE (patch) test case to be used for various ContentNode types.
+ *
+ * This test class covers all tests that are the same across all content node implementations
+ *
+ * @internal
+ */
+abstract class UpdateContentNodeTestCase extends ECampApiTestCase {
+    protected $defaultContentNode;
+
+    protected $endpoint = '';
+
+    public function testPatchIsDeniedForAnonymousUser() {
+        static::createBasicClient()->request('PATCH', "/content_node/{$this->endpoint}/".$this->defaultContentNode->getId(), ['json' => [], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertJsonContains([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    public function testPatchIsDeniedForInvitedCollaborator() {
+        $this->patch($this->defaultContentNode, [], static::$fixtures['user6invited']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testPatchIsDeniedForInactiveCollaborator() {
+        $this->patch($this->defaultContentNode, [], static::$fixtures['user5inactive']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testPatchIsDeniedForUnrelatedUser() {
+        $this->patch($this->defaultContentNode, [], static::$fixtures['user4unrelated']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testPatchIsDeniedForGuest() {
+        $this->patch($this->defaultContentNode, [], static::$fixtures['user3guest']);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testPatchIsAllowedForMember() {
+        $this->patch($this->defaultContentNode, [], static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    public function testPatchIsAllowedForManager() {
+        $this->patch($this->defaultContentNode, [], static::$fixtures['user1manager']);
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    protected function patch($contentNode, $payload = [], $user = null) {
+        $credentials = null !== $user ? ['username' => $user->getUsername()] : null;
+        static::createClientWithCredentials($credentials)->request('PATCH', "/content_node/{$this->endpoint}/".$this->defaultContentNode->getId(), ['json' => $payload, 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+    }
+}

--- a/api/tests/Api/ContentNodes/UpdateContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/UpdateContentNodeTestCase.php
@@ -2,6 +2,8 @@
 
 namespace App\Tests\Api\ContentNodes;
 
+use App\Entity\ContentNode;
+use App\Entity\User;
 use App\Tests\Api\ECampApiTestCase;
 
 /**
@@ -26,37 +28,43 @@ abstract class UpdateContentNodeTestCase extends ECampApiTestCase {
     }
 
     public function testPatchIsDeniedForInvitedCollaborator() {
-        $this->patch($this->defaultContentNode, [], static::$fixtures['user6invited']);
+        $this->patch(user: static::$fixtures['user6invited']);
         $this->assertResponseStatusCodeSame(403);
     }
 
     public function testPatchIsDeniedForInactiveCollaborator() {
-        $this->patch($this->defaultContentNode, [], static::$fixtures['user5inactive']);
+        $this->patch(user: static::$fixtures['user5inactive']);
         $this->assertResponseStatusCodeSame(403);
     }
 
     public function testPatchIsDeniedForUnrelatedUser() {
-        $this->patch($this->defaultContentNode, [], static::$fixtures['user4unrelated']);
+        $this->patch(user: static::$fixtures['user4unrelated']);
         $this->assertResponseStatusCodeSame(403);
     }
 
     public function testPatchIsDeniedForGuest() {
-        $this->patch($this->defaultContentNode, [], static::$fixtures['user3guest']);
+        $this->patch(user: static::$fixtures['user3guest']);
         $this->assertResponseStatusCodeSame(403);
     }
 
     public function testPatchIsAllowedForMember() {
-        $this->patch($this->defaultContentNode, [], static::$fixtures['user2member']);
+        $this->patch(user: static::$fixtures['user2member']);
         $this->assertResponseStatusCodeSame(200);
     }
 
     public function testPatchIsAllowedForManager() {
-        $this->patch($this->defaultContentNode, [], static::$fixtures['user1manager']);
+        $this->patch(user: static::$fixtures['user1manager']);
         $this->assertResponseStatusCodeSame(200);
     }
 
-    protected function patch($contentNode, $payload = [], $user = null) {
-        $credentials = null !== $user ? ['username' => $user->getUsername()] : null;
+    protected function patch(?ContentNode $contentNode = null, array $payload = [], ?User $user = null) {
+        $credentials = null;
+        if (null !== $user) {
+            $credentials = ['username' => $user->getUsername()];
+        }
+
+        $contentNode ??= $this->defaultContentNode;
+
         static::createClientWithCredentials($credentials)->request('PATCH', "/content_node/{$this->endpoint}/".$this->defaultContentNode->getId(), ['json' => $payload, 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
     }
 }

--- a/api/tests/Api/ContentNodes/UpdateContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/UpdateContentNodeTestCase.php
@@ -29,17 +29,17 @@ abstract class UpdateContentNodeTestCase extends ECampApiTestCase {
 
     public function testPatchIsDeniedForInvitedCollaborator() {
         $this->patch(user: static::$fixtures['user6invited']);
-        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseStatusCodeSame(404);
     }
 
     public function testPatchIsDeniedForInactiveCollaborator() {
         $this->patch(user: static::$fixtures['user5inactive']);
-        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseStatusCodeSame(404);
     }
 
     public function testPatchIsDeniedForUnrelatedUser() {
         $this->patch(user: static::$fixtures['user4unrelated']);
-        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseStatusCodeSame(404);
     }
 
     public function testPatchIsDeniedForGuest() {


### PR DESCRIPTION
Related to #1732 

Deckt folgende 2 Bereiche ab:

- Basis Klassen für API-Tests der ContentNodes
- Entity filter für ContentNode 

### Test-Basisklassen
Erlaubt den Testcode DRY zu halten. In der Basisklasse sind hauptsächlich die security-Checks abdeckt. Da die Edit-Berechtigungen im einem ersten Schritt vermutlich dieselben sind für alle ContentNodes, spart das eine Menge Code. Implementiert habe ich erst für SingleText. Wenn ok, kann ich dann für die anderen auch übernehmen.

### Entity filter
Das war ein wenig eine Zangengeburt inkl. Debugging-Hell. Springender Punkt war das Auflösen von `AbstractContentNodeOwner` zu `Camp`, damit der `FilterByCurrentUserExtension` dann sauber ausfiltern kann.

Problem ist, dass DQLs aufbauen über Inheritance-Klassen sicher ein Edge-Case ist von Doctrine. Es funktioniert irgendwie, aber viel Docu dazu gibt es nicht.

Zusätzlich gibt es eine Extension von API-Platform, welche den DQL dann wieder zerschiesst (namentlich die `FilterEagerLoadingExtension`). Ich hab's jetzt so gelöst, dass unsere `FilterByCurrentUserExtension` erst nach der `FilterEagerLoadingExtension` von API-Platform läuft. Nach meinem bisherigen Wissensstand dürfte das keine nachteiligen Nebeneffekte mitbringen.

Eine **Alternative 1**, die ich mir zu Beginn mal angeschaut habe: Verschieben des `camp` Properties aus den Entities `Activitiy` und `Category` in the `AbstractContentNodeOwner`-Klasse. Das hat dann aber einen Rattenschwanz von anderen Problemen mit sich gezogen. Ergo hab ich diese Idee wieder verworfen.

Eine andere **Alternative 2** wäre, den `AbstractContentNodeOwner` fallen zu lassen, und auf dem `ContentNode` beide Relationen manuell abzubilden (inkl. einer Validation, dass nur `contentNode.activity` oder `contentNode.category` gesetzt werden darf). Haben wir zum Beispiel ähnlich schon im `MaterialItem` --> das `MaterialItem` kann sowohl auf eine `Period` als auch auf einen `MaterialNode` zeigen, aber nicht auf beides gleichzeitig.