### PR TITLE
chore(deps): update npm to v8.0.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,7 +62,7 @@
         "vue-template-compiler": "2.6.14"
       },
       "engines": {
-        "npm": "~7.24.0"
+        "npm": "~8.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "test:unit:watch": "vue-cli-service test:unit --watch"
   },
   "engines": {
-    "npm": "~7.24.0"
+    "npm": "~8.0.0"
   },
   "dependencies": {
     "@mdi/font": "6.3.95",

--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -43,7 +43,7 @@
         "vue-template-compiler": "2.6.14"
       },
       "engines": {
-        "npm": "~7.24.0"
+        "npm": "~8.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/print/package.json
+++ b/print/package.json
@@ -15,7 +15,7 @@
     "test": "jest"
   },
   "engines": {
-    "npm": "~7.24.0"
+    "npm": "~8.0.0"
   },
   "dependencies": {
     "@nuxtjs/axios": "5.13.6",

--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,8 @@
   ],
   "force": {
     "constraints": {
-      "node": "= 16.3.0",
-      "npm": ">= 7.15.1"
+      "node": "= 16.11.1",
+      "npm": ">= 8.0.0"
     }
   },
   "packageRules": [


### PR DESCRIPTION
As it is provided with node 16.11.1.
Also update renovate's npm and node.
Fixes error
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: frontend@0.1.0
npm ERR! notsup Not compatible with your version of node/npm: frontend@0.1.0
npm ERR! notsup Required: {"npm":"~7.24.0"}
npm ERR! notsup Actual:   {"npm":"8.0.0","node":"v16.11.1"}