### PR TITLE
Fix frontend Docker image build

### DIFF
--- a/.docker-hub/frontend/Dockerfile
+++ b/.docker-hub/frontend/Dockerfile
@@ -5,7 +5,9 @@ COPY common /common
 
 WORKDIR /app
 COPY frontend/package*.json ./
-RUN npm ci
+# install and uninstall the native dependencies in one single docker RUN instruction,
+# so they do not increase the image layer size
+RUN apk --no-cache add --virtual native-deps g++ make python3 && npm ci && apk del native-deps
 COPY frontend .
 RUN npm run build
 


### PR DESCRIPTION
For some reason, last night our frontend Docker build broke, because some native dependencies (python, make, g++) are not available during `npm ci`. I have no idea how this worked before, but it first happened when updating the node:lts-alpine docker image in 8ad703896971cb68882fdba6e73bcecc088e71f6
This fixes the build and takes care not to increase the built image size, by installing the required native dependencies, running `npm ci`, and immediately uninstalling the native dependencies again, all in a single Docker `RUN` instruction.