### PR TITLE
Add test.ecamp3.ch deployment

### DIFF
--- a/.github/actions/deploy/dist/docker-compose.yml
+++ b/.github/actions/deploy/dist/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.4"
 services:
   nginx:
     image: nginx@sha256:644a70516a26004c97d0d85c7fe1d0c3a67ea8ab7ddf4aff193d9f301670cf36
-    container_name: 'ecamp3-nginx'
     ports:
       - '80:80'
     volumes:
@@ -19,7 +18,6 @@ services:
 
   frontend:
     image: ecamp/ecamp3-frontend:${DOCKER_IMAGE_TAG}
-    container_name: 'ecamp3-frontend'
     volumes:
       - ./frontend-environment.js:/app/environment.js
 
@@ -54,7 +52,6 @@ services:
 
   print:
     image: ecamp/ecamp3-print:${DOCKER_IMAGE_TAG}
-    container_name: 'ecamp3-print'
     env_file:
       - print.env
 
@@ -90,7 +87,6 @@ services:
 
   mail:
     image: mailhog/mailhog@sha256:8d76a3d4ffa32a3661311944007a415332c4bb855657f4f6c57996405c009bea
-    container_name: 'ecamp3-mail'
 
 volumes:
   api-keys:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,51 @@
+name: Deploy to test.ecamp3.ch
+
+on:
+  workflow_dispatch:
+    inputs:
+      devel_commit_hash:
+        description: 'Commit hash of the commit on devel that should be deployed. Only works with commits for which the push-to-docker-hub action has run.'
+        required: true
+
+jobs:
+  deploy:
+    name: "Deploy to test.ecamp3.ch"
+    runs-on: ubuntu-latest
+    environment: test.ecamp3.ch
+    steps:
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.devel_commit_hash }}
+
+      - uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+
+      - uses: ./.github/actions/deploy
+        with:
+          commit-sha: ${{ github.event.inputs.devel_commit_hash }}
+          ssh-host: ${{ secrets.SSH_HOST }}
+          ssh-directory: ${{ secrets.SSH_DIRECTORY }}
+          db-host: ${{ secrets.DB_HOST }}
+          db-port: ${{ secrets.DB_PORT }}
+          db-user: ${{ secrets.DB_USER }}
+          db-pass: ${{ secrets.DB_PASS }}
+          db-name: ${{ secrets.DB_NAME }}
+          session-cookie-domain: ${{ secrets.SESSION_COOKIE_DOMAIN }}
+          backend-url: ${{ secrets.BACKEND_URL }}
+          frontend-url: ${{ secrets.FRONTEND_URL }}
+          print-server-url: ${{ secrets.PRINT_SERVER_URL }}
+          print-file-server-url: ${{ secrets.PRINT_FILE_SERVER_URL }}
+          mail-server-url: ${{ secrets.MAIL_SERVER_URL }}
+          sentry-backend-dsn: ${{ secrets.SENTRY_BACKEND_DSN }}
+          sentry-frontend-dsn: ${{ secrets.SENTRY_FRONTEND_DSN }}
+          sentry-print-dsn: ${{ secrets.SENTRY_PRINT_DSN }}
+          sentry-worker-print-puppeteer-dsn: ${{ secrets.SENTRY_WORKER_PRINT_PUPPETEER_DSN }}
+          sentry-worker-print-weasy-dsn: ${{ secrets.SENTRY_WORKER_PRINT_WEASY_DSN }}
+          rabbitmq-host: ${{ secrets.RABBITMQ_HOST }}
+          rabbitmq-port: ${{ secrets.RABBITMQ_PORT }}
+          rabbitmq-vhost: ${{ secrets.RABBITMQ_VHOST }}
+          rabbitmq-user: ${{ secrets.RABBITMQ_USER }}
+          rabbitmq-pass: ${{ secrets.RABBITMQ_PASS }}


### PR DESCRIPTION
Fixes #2185 

The deployment works as follows:
1. Someone goes to the Actions tab on GitHub, and triggers a new "Deploy to test.ecamp3.ch" workflow. To trigger, one must specify a Git commit SHA from devel which was once built and pushed to Docker Hub (usually a merge commit, because we build and push devel on every merge).
2. The GitHub Action workflow deploy-test.yml in devel starts running. That's why this Action needs to be merged into devel.
3. The workflow checks out the old version of the repo, given by the git commit SHA.
4. The workflow runs the old version of our custom deploy action which it just checked out, but passes in secrets according to the new workflow yml from devel.
5. The deploy action fills in the secrets into the deliverable environment files, syncs them to the Droplet and runs `docker-compose up`. This will fetch and start the old images from Docker Hub which are tagged with the git commit SHA.
6. Voilà, our environment runs. (Domains had to be added on Cloudflare, and new OAuth callback URIs had to be added on MiData and Google as well)

I had to remove the container names, because inside the same droplet, we cannot have multiple containers with the same container name (once for in the dev docker-compose.yml, once in the test docker-compose.yml). I cannot easily change the docker-compose.yml in the old pre-built images on Docker Hub, but the dev deployment can get out of the way by removing the container names from now on. With docker-compose, we can still easily refer to the individual containers via their service names, e.g. `docker-compose stop nginx` still works.

* Uses Github Environments to segregate the secrets from other deployments (see Settings -> Environments -> test.ecamp3.ch). As a bonus, the status of such environments will be visible on the start page of the project on GitHub.
* Only pre-built images from Docker Hub are supported for now, no intermediate commits, no changing history. The image is identified via a Git Commit SHA tag, which must be specified when running the GitHub action.
* Sentry is not enabled for now
* RabbitMQ uses the same VHost / the same queue as dev.ecamp3.ch
* Cookies are shared between the two environments, since they are set on the same superdomain .ecamp3.ch. This is not a problem for now, because the old backend used different cookie names than the new API platform backend.
