### PR TITLE
VS Code: use php-cs-fixer installed by composer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "php-cs-fixer.executablePath": "${workspaceFolder}/api/vendor/bin/php-cs-fixer",
     "php-cs-fixer.config": "./api/.php-cs-fixer.php",
     "javascript.format.enable": false,
     "eslint.format.enable": true,


### PR DESCRIPTION
verhindert, dass man php-cs-fixer global installieren muss