### PR TITLE
Add action parameter to uri templates

### DIFF
--- a/api/src/DTO/Invitation.php
+++ b/api/src/DTO/Invitation.php
@@ -12,11 +12,18 @@ use Symfony\Component\Validator\Constraints as Assert;
  * already have an account.
  */
 #[ApiResource(
-    collectionOperations: [],
+    collectionOperations: [
+        'get' => [
+            'security' => 'false',
+            'path' => '',
+            'openapi_context' => [
+                'description' => 'Not implemented. Only needed that we can show this endpoint in /index.jsonhal.',
+            ],
+        ],
+    ],
     itemOperations: [
-        'find' => [
-            'method' => 'GET',
-            'path' => '/{inviteKey}/find',
+        'get' => [
+            'path' => '/{inviteKey}/find.{_format}',
             'normalization_context' => self::ITEM_NORMALIZATION_CONTEXT,
             'openapi_context' => [
                 'description' => 'Use myInviteKey to find an invitation in the dev environment.',
@@ -25,7 +32,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         self::ACCEPT => [
             'security' => 'is_fully_authenticated()',
             'method' => 'PATCH',
-            'path' => '/{inviteKey}/'.self::ACCEPT,
+            'path' => '/{inviteKey}/'.self::ACCEPT.'.{_format}',
             'denormalization_context' => [
                 'groups' => ['write'],
             ],
@@ -38,7 +45,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         ],
         self::REJECT => [
             'method' => 'PATCH',
-            'path' => '/{inviteKey}/'.self::REJECT,
+            'path' => '/{inviteKey}/'.self::REJECT.'.{_format}',
             'denormalization_context' => [
                 'groups' => ['write'],
             ],

--- a/api/src/DataPersister/Util/DataPersisterObservable.php
+++ b/api/src/DataPersister/Util/DataPersisterObservable.php
@@ -104,6 +104,17 @@ class DataPersisterObservable {
             }
         }
 
+        $dataBefore = $this->requestStack->getCurrentRequest()->attributes->get('previous_data');
+        if (null != $dataBefore) {
+            foreach ($this->propertyChangedListeners as $listener) {
+                $propertyBefore = call_user_func($listener->getExtractProperty(), $dataBefore);
+                $propertyNow = call_user_func($listener->getExtractProperty(), $data);
+                if ($propertyBefore !== $propertyNow) {
+                    $data = call_user_func($listener->getBeforeAction(), $data);
+                }
+            }
+        }
+
         $data = $this->dataPersister->persist($data, $context);
 
         if ('post' === ($context['collection_operation_name'] ?? null)) {
@@ -120,7 +131,6 @@ class DataPersisterObservable {
             }
         }
 
-        $dataBefore = $this->requestStack->getCurrentRequest()->attributes->get('previous_data');
         if (null != $dataBefore) {
             foreach ($this->propertyChangedListeners as $listener) {
                 $propertyBefore = call_user_func($listener->getExtractProperty(), $dataBefore);

--- a/api/src/DataPersister/Util/PropertyChangeListener.php
+++ b/api/src/DataPersister/Util/PropertyChangeListener.php
@@ -8,6 +8,7 @@ use ReflectionFunction;
 class PropertyChangeListener {
     private function __construct(
         private Closure $extractProperty,
+        private Closure $beforeAction,
         private Closure $afterAction
     ) {
     }
@@ -17,8 +18,13 @@ class PropertyChangeListener {
      */
     public static function of(
         Closure $extractProperty,
+        ?Closure $beforeAction = null,
         ?Closure $afterAction = null
     ): PropertyChangeListener {
+        if (null == $beforeAction) {
+            $beforeAction = function ($data) {
+            };
+        }
         if (null == $afterAction) {
             $afterAction = function ($data) {
             };
@@ -26,15 +32,22 @@ class PropertyChangeListener {
         if (self::hasOneParameter($extractProperty)) {
             throw new \InvalidArgumentException('extractProperty must have exactly one parameter');
         }
+        if (self::hasOneParameter($beforeAction)) {
+            throw new \InvalidArgumentException('afterAction must have exactly one parameter');
+        }
         if (self::hasOneParameter($afterAction)) {
             throw new \InvalidArgumentException('afterAction must have exactly one parameter');
         }
 
-        return new PropertyChangeListener($extractProperty, $afterAction);
+        return new PropertyChangeListener($extractProperty, $beforeAction, $afterAction);
     }
 
     public function getExtractProperty(): Closure {
         return $this->extractProperty;
+    }
+
+    public function getBeforeAction(): Closure {
+        return $this->beforeAction;
     }
 
     public function getAfterAction(): Closure {

--- a/api/src/DataProvider/InvitationDataProvider.php
+++ b/api/src/DataProvider/InvitationDataProvider.php
@@ -38,7 +38,12 @@ class InvitationDataProvider implements ItemDataProviderInterface, RestrictedDat
             $username = $this->security->getUser()->getUserIdentifier();
             $user = $this->userRepository->findOneBy(['username' => $username]);
             $userDisplayName = $user->getDisplayName();
-            $userAlreadyInCamp = null !== $this->campCollaborationRepository->findByUserAndCamp($user, $camp);
+            $existingCampCollaboration = $this->campCollaborationRepository->findByUserAndCamp($user, $camp);
+            if ($existingCampCollaboration === $campCollaboration) {
+                $userAlreadyInCamp = false;
+            } else {
+                $userAlreadyInCamp = null !== $existingCampCollaboration;
+            }
         }
 
         return new Invitation($id, $camp->getId(), $camp->title, $userDisplayName, $userAlreadyInCamp);

--- a/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
@@ -76,6 +76,7 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
 
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains($this->getExampleReadPayload([
+            'inviteEmail' => null,
             '_links' => [
                 'user' => ['href' => $this->getIriFor('user2member')],
             ],
@@ -110,7 +111,12 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
         $this->assertJsonContains($this->getExampleReadPayload([
             'status' => 'invited',
             'inviteEmail' => 'someone@example.com',
-            '_links' => [],
+            '_links' => [
+                'user' => null,
+            ],
+            '_embedded' => [
+                'user' => null,
+            ],
         ]));
     }
 
@@ -124,7 +130,7 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains($this->getExampleReadPayload([
             'status' => 'invited',
-            'inviteEmail' => $userunrelated->email,
+            'inviteEmail' => null,
             '_links' => [],
             '_embedded' => [
                 'user' => [

--- a/api/tests/Api/Invitations/FindInvitationTest.php
+++ b/api/tests/Api/Invitations/FindInvitationTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Api\Invitations;
 
 use App\Entity\CampCollaboration;
+use App\Entity\User;
 use App\Tests\Api\ECampApiTestCase;
 
 /**
@@ -62,6 +63,33 @@ class FindInvitationTest extends ECampApiTestCase {
      * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
      */
+    public function testUserAlreadyInCampFalseForOwnCampCollaboration() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration6invitedWithUser'];
+        /** @var User $invitedUser */
+        $invitedUser = static::$fixtures['user6invited'];
+        static::createClientWithCredentials(['username' => $invitedUser->getUsername()])
+            ->request('GET', "/invitations/{$campCollaboration->inviteKey}/find")
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,
+            'userDisplayName' => $invitedUser->getDisplayName(),
+            'userAlreadyInCamp' => false,
+            '_links' => [
+                'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
+            ],
+        ]);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     */
     public function testUserAlreadyInCampTrueWhenUserAlreadyInCamp() {
         /** @var CampCollaboration $campCollaboration */
         $campCollaboration = static::$fixtures['campCollaboration4invited'];
@@ -71,6 +99,36 @@ class FindInvitationTest extends ECampApiTestCase {
             'campId' => $campCollaboration->camp->getId(),
             'campTitle' => $campCollaboration->camp->title,
             'userDisplayName' => 'Bi-Pi',
+            'userAlreadyInCamp' => true,
+            '_links' => [
+                'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
+            ],
+        ]);
+    }
+
+    /**
+     * A user should not accept a second invitation, because we cannot have 2 invitations with the same user attached.
+     * Thus we tell him that there is already an invitation with his user, and he should use that one.
+     *
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     */
+    public function testUserAlreadyInCampTrueWhenUserAlreadyInCampEvenIfInactive() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration4invited'];
+        /** @var User $inactiveUser */
+        $inactiveUser = static::$fixtures['user5inactive'];
+        static::createClientWithCredentials(['username' => $inactiveUser->getUsername()])
+            ->request('GET', "/invitations/{$campCollaboration->inviteKey}/find")
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,
+            'userDisplayName' => $inactiveUser->getDisplayName(),
             'userAlreadyInCamp' => true,
             '_links' => [
                 'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],

--- a/api/tests/DataPersister/Util/DataPersisterObservableTest.php
+++ b/api/tests/DataPersister/Util/DataPersisterObservableTest.php
@@ -196,8 +196,9 @@ class DataPersisterObservableTest extends TestCase {
 
         $this->parameterBag = new ParameterBag(['previous_data' => null]);
         $propertyChangeListener = PropertyChangeListener::of(
-            fn ($data) => $data->name,
-            fn ($data) => $this->closure->call($data)
+            extractProperty: fn ($data) => $data->name,
+            beforeAction: fn ($data) => $this->closure->call($data),
+            afterAction: fn ($data) => $this->closure->call($data),
         );
         $this->closure->expects(self::never())->method('call');
         $this->dataPersisterObservable->onPropertyChange($propertyChangeListener);
@@ -210,8 +211,8 @@ class DataPersisterObservableTest extends TestCase {
 
         $this->parameterBag = new ParameterBag(['previous_data' => $toPersist]);
         $propertyChangeListener = PropertyChangeListener::of(
-            fn ($data) => $data->name,
-            fn ($data) => $this->closure->call($data)
+            extractProperty: fn ($data) => $data->name,
+            afterAction: fn ($data) => $this->closure->call($data)
         );
         $this->closure->expects(self::never())->method('call');
         $this->dataPersisterObservable->onPropertyChange($propertyChangeListener);
@@ -226,8 +227,9 @@ class DataPersisterObservableTest extends TestCase {
 
         $this->parameterBag = new ParameterBag(['previous_data' => $toPersist]);
         $propertyChangeListener = PropertyChangeListener::of(
-            fn ($data) => $data->name,
-            fn ($data) => $this->closure->call($data)
+            extractProperty: fn ($data) => $data->name,
+            beforeAction: fn ($data) => $this->closure->call($data),
+            afterAction: fn ($data) => $this->closure->call($data),
         );
         $this->closure->expects(self::never())->method('call');
         $this->dataPersisterObservable->onPropertyChange($propertyChangeListener);
@@ -243,10 +245,18 @@ class DataPersisterObservableTest extends TestCase {
 
         $this->parameterBag = new ParameterBag(['previous_data' => $oldData]);
         $propertyChangeListener = PropertyChangeListener::of(
-            fn ($data) => $data->name,
-            fn ($data) => $this->closure->call($data)
+            extractProperty: fn ($data) => $data->name,
+            beforeAction: fn ($data) => $this->closure->call($data),
+            afterAction: fn ($data) => $this->closure->call($data),
         );
-        $this->closure->expects(self::once())->method('call');
+        $this->contextAwareDataPersister->expects(self::exactly(1))
+            ->method('persist')
+            ->willReturnArgument(0)
+        ;
+        $this->closure->expects(self::exactly(2))
+            ->method('call')
+            ->willReturnOnConsecutiveCalls($newData, null)
+        ;
         $this->dataPersisterObservable->onPropertyChange($propertyChangeListener);
 
         $this->dataPersisterObservable->persist($newData, []);

--- a/api/tests/Metadata/Resource/Factory/UriTemplateFactoryTest.php
+++ b/api/tests/Metadata/Resource/Factory/UriTemplateFactoryTest.php
@@ -139,6 +139,86 @@ class UriTemplateFactoryTest extends TestCase {
         self::assertThat($templated, self::isTrue());
     }
 
+    public function testCreatesTemplatedUriWithActionPathParameters() {
+        // given
+        $resource = 'Dummy';
+        $this->resourceMetadata = new ResourceMetadata(
+            'Dummy',
+            null,
+            null,
+            [
+                'get' => [],
+                'find' => [
+                    'path' => '{/inviteKey}/find',
+                ],
+                'accept' => [
+                    'path' => '/{inviteKey}/accept',
+                ],
+            ]
+        );
+        $this->createFactory();
+
+        // when
+        [$uri, $templated] = $this->uriTemplateFactory->createFromShortname($resource);
+
+        // then
+        self::assertThat($uri, self::equalTo('/dummys{/id}{/action}'));
+        self::assertThat($templated, self::isTrue());
+    }
+
+    public function testIgnoresRoutesWithNoSlashAtEnd() {
+        // given
+        $resource = 'Dummy';
+        $this->resourceMetadata = new ResourceMetadata(
+            'Dummy',
+            null,
+            null,
+            [
+                'get' => [],
+                'profiles1' => [
+                    'path' => 'profiles{/id}',
+                ],
+            ]
+        );
+        $this->createFactory();
+
+        // when
+        [$uri, $templated] = $this->uriTemplateFactory->createFromShortname($resource);
+
+        // then
+        self::assertThat($uri, self::equalTo('/dummys{/id}'));
+        self::assertThat($templated, self::isTrue());
+    }
+
+    /**
+     * This behaviour was not yet implemented, because we don't have the use case yet.
+     *
+     * @throws \ApiPlatform\Core\Exception\ResourceClassNotFoundException
+     */
+    public function testDoesNotYetIgnoreActionPathsOfOtherRouteStarts() {
+        // given
+        $resource = 'Dummy';
+        $this->resourceMetadata = new ResourceMetadata(
+            'Dummy',
+            null,
+            null,
+            [
+                'get' => [],
+                'profiles1' => [
+                    'path' => 'profiles{/id}/ignoreThis',
+                ],
+            ],
+        );
+        $this->createFactory();
+
+        // when
+        [$uri, $templated] = $this->uriTemplateFactory->createFromShortname($resource);
+
+        // then
+        self::assertThat($uri, self::equalTo('/dummys{/id}{/action}'));
+        self::assertThat($templated, self::isTrue());
+    }
+
     protected function createFactory() {
         $this->uriTemplateFactory = new UriTemplateFactory(
             $this->filterLocator,

--- a/frontend/src/components/camp/CollaboratorListItem.vue
+++ b/frontend/src/components/camp/CollaboratorListItem.vue
@@ -108,8 +108,9 @@ export default {
     resendInvitation () {
       this.resendingEmail = true
       this.api.href(this.api.get(), 'campCollaborations', {
-        id: this.collaborator.id
-      }).then(postUrl => this.api.patch(postUrl + '/resend_invitation', {}))
+        id: this.collaborator.id,
+        action: 'resend_invitation'
+      }).then(postUrl => this.api.patch(postUrl, {}))
         .finally(() => { this.resendingEmail = false })
     }
   }

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -313,7 +313,7 @@ export function campFromRoute (route) {
 
 export function invitationFromInviteKey (inviteKey) {
   return function () {
-    return this.api.get().invitation({ action: 'find', inviteKey: inviteKey })
+    return this.api.get().invitations({ action: 'find', id: inviteKey })
   }
 }
 

--- a/frontend/src/views/camp/Invitation.vue
+++ b/frontend/src/views/camp/Invitation.vue
@@ -112,20 +112,20 @@ export default {
       this.$auth.logout().then(__ => this.$router.push(loginLink))
     },
     acceptInvitation () {
-      this.api.href(this.api.get(), 'invitation', {
+      this.api.href(this.api.get(), 'invitations', {
         action: 'accept',
-        inviteKey: this.$route.params.inviteKey
-      }).then(postUrl => this.api.post(postUrl, {}))
+        id: this.$route.params.inviteKey
+      }).then(postUrl => this.api.patch(postUrl, {}))
         .then(
           _ => { this.$router.push(this.campLink) },
           () => { this.$router.push({ name: 'invitationUpdateError' }) }
         )
     },
     rejectInvitation () {
-      this.api.href(this.api.get(), 'invitation', {
+      this.api.href(this.api.get(), 'invitations', {
         action: 'reject',
-        inviteKey: this.$route.params.inviteKey
-      }).then(postUrl => this.api.post(postUrl, {}))
+        id: this.$route.params.inviteKey
+      }).then(postUrl => this.api.patch(postUrl, {}))
         .then(
           _ => { this.$router.push({ name: 'invitationRejected' }) },
           () => { this.$router.push({ name: 'invitationUpdateError' }) }

--- a/frontend/src/views/camp/Invitation.vue
+++ b/frontend/src/views/camp/Invitation.vue
@@ -71,6 +71,14 @@
 <script>
 import AuthContainer from '@/components/layout/AuthContainer.vue'
 import { loginRoute } from '@/router'
+import VueRouter from 'vue-router'
+
+const { isNavigationFailure, NavigationFailureType } = VueRouter
+const ignoreNavigationFailure = e => {
+  if (!isNavigationFailure(e, NavigationFailureType.redirected)) {
+    return Promise.reject(e)
+  }
+}
 
 export default {
   name: 'Invitation',
@@ -117,8 +125,14 @@ export default {
         id: this.$route.params.inviteKey
       }).then(postUrl => this.api.patch(postUrl, {}))
         .then(
-          _ => { this.$router.push(this.campLink) },
-          () => { this.$router.push({ name: 'invitationUpdateError' }) }
+          _ => {
+            this.$router.push(this.campLink)
+              .catch(ignoreNavigationFailure)
+          },
+          () => {
+            this.$router.push({ name: 'invitationUpdateError' })
+              .catch(ignoreNavigationFailure)
+          }
         )
     },
     rejectInvitation () {
@@ -127,8 +141,14 @@ export default {
         id: this.$route.params.inviteKey
       }).then(postUrl => this.api.patch(postUrl, {}))
         .then(
-          _ => { this.$router.push({ name: 'invitationRejected' }) },
-          () => { this.$router.push({ name: 'invitationUpdateError' }) }
+          _ => {
+            this.$router.push({ name: 'invitationRejected' })
+              .catch(ignoreNavigationFailure)
+          },
+          () => {
+            this.$router.push({ name: 'invitationUpdateError' })
+              .catch(ignoreNavigationFailure)
+          }
         )
     }
   }

--- a/frontend/src/views/camp/Invitation.vue
+++ b/frontend/src/views/camp/Invitation.vue
@@ -107,7 +107,7 @@ export default {
     }
   },
   mounted () {
-    this.api.reload(this.invitation())
+    this.invitation()._meta.load
       .then(
         () => { this.invitationFound = true },
         () => { this.invitationFound = false }


### PR DESCRIPTION
Fehler, die vielleicht noch später behoben werden (aber eigentlich nichts mit dem PR zu tun haben).
- [x] Wenn man eine Invitation reaktiviert, dann bekommt sie noch keinen inviteKey
- [x] Wenn die Invitation nicht gefunden wird auf Invitation.vue, aber man eingeloggt ist, dann erscheint nicht: invitation nicht gefunden, sondern ein komischer Fehlerzustand.
- [x] Wenn man mit status inactive/invited im Lager ist, heisst es trotzdem, dass man schon teil des lagers wäre.
- [ ] Validierung, dass es pro User/Lager nur 1 CampCollaboration gibt.