### PR TITLE
reset sass version to 1.32

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -53,7 +53,7 @@
         "jest-canvas-mock": "2.3.1",
         "jest-serializer-vue-tjw": "3.19.0",
         "lint-staged": "12.1.2",
-        "sass": "1.43.4",
+        "sass": "1.32.13",
         "vite": "2.6.14",
         "vite-plugin-components": "0.13.3",
         "vite-plugin-vue2": "1.9.0",
@@ -26668,9 +26668,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.43.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.4.tgz",
-      "integrity": "sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==",
+      "version": "1.32.13",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
+      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -52568,9 +52568,9 @@
       }
     },
     "sass": {
-      "version": "1.43.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.4.tgz",
-      "integrity": "sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==",
+      "version": "1.32.13",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
+      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
     "jest-canvas-mock": "2.3.1",
     "jest-serializer-vue-tjw": "3.19.0",
     "lint-staged": "12.1.2",
-    "sass": "1.43.4",
+    "sass": "1.32.13",
     "vite": "2.6.14",
     "vite-plugin-components": "0.13.3",
     "vite-plugin-vue2": "1.9.0",


### PR DESCRIPTION
Fixes deprecation warning "Using / for division is deprecated and will be removed in Dart Sass 2.0.0"

More details here:
https://github.com/vuetifyjs/vuetify/issues/13694#issuecomment-852957010

Is there a way to tell renovate to not upgrade sass in the future?