### PR TITLE
Feature/print nuxt

### DIFF
--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -34,15 +34,15 @@ export default {
       return this.$auth.user()
     },
     deploymentTime () {
-      const timestamp = window.environment.DEPLOYMENT_TIME
+      const timestamp = window.environment?.DEPLOYMENT_TIME
       const dateTime = timestamp ? this.$date.unix(timestamp) : this.$date()
       return dateTime.format(this.$tc('global.datetime.dateTimeLong'))
     },
     version () {
-      return window.environment.VERSION || ''
+      return window.environment?.VERSION || ''
     },
     versionLink () {
-      return urltemplate.parse(window.environment.VERSION_LINK_TEMPLATE).expand({ version: this.version }) || '#'
+      return urltemplate.parse(window.environment?.VERSION_LINK_TEMPLATE).expand({ version: this.version }) || '#'
     }
   },
   created () {

--- a/frontend/src/components/camp/CampPrint.vue
+++ b/frontend/src/components/camp/CampPrint.vue
@@ -45,9 +45,9 @@
 import PrintDownloader from '@/components/camp/CampPrintDownloader.vue'
 import axios from 'axios'
 
-const PRINT_SERVER = window.environment.PRINT_SERVER
-const PRINT_FILE_SERVER = window.environment.PRINT_FILE_SERVER
-const BROWSERLESS_TOKEN = window.environment.BROWSERLESS_TOKEN
+const PRINT_SERVER = window.environment?.PRINT_SERVER
+const PRINT_FILE_SERVER = window.environment?.PRINT_FILE_SERVER
+const BROWSERLESS_TOKEN = window.environment?.BROWSERLESS_TOKEN
 
 export default {
   name: 'CampPrint',

--- a/frontend/src/plugins/store/index.js
+++ b/frontend/src/plugins/store/index.js
@@ -16,7 +16,7 @@ class StorePlugin {
     })
 
     axios.defaults.withCredentials = true
-    axios.defaults.baseURL = window.environment.API_ROOT_URL
+    axios.defaults.baseURL = window.environment?.API_ROOT_URL
     axios.defaults.headers.common.Accept = 'application/hal+json'
     axios.interceptors.request.use(function (config) {
       if (config.method === 'patch') {

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -13,7 +13,7 @@ const NavigationCamp = () => import(/* webpackChunkName: "navigationCamp" */ './
 /* istanbul ignore next */
 export default new Router({
   mode: 'history',
-  base: window.environment.BASE_URL || '/',
+  base: window.environment?.BASE_URL || '/',
   routes: [
     // Dev-Pages:
     {
@@ -24,6 +24,15 @@ export default new Router({
         default: () => import(/* webpackChunkName: "register" */ './views/dev/Controls.vue')
       }
     },
+
+    {
+      path: '/print',
+      name: 'print',
+      components: {
+        default: () => import(/* webpackChunkName: "register" */ './views/dev/Print.vue')
+      }
+    },
+
     // Prod-Pages:
     {
       path: '/register',

--- a/frontend/src/views/camp/PrintActivity.vue
+++ b/frontend/src/views/camp/PrintActivity.vue
@@ -54,7 +54,7 @@ Print preview for single Activity
 <script>
 import { throttle } from 'lodash'
 
-const PRINT_SERVER = window.environment.PRINT_SERVER
+const PRINT_SERVER = window.environment?.PRINT_SERVER
 
 export default {
   name: 'PrintActivity',

--- a/frontend/src/views/camp/Story.vue
+++ b/frontend/src/views/camp/Story.vue
@@ -63,7 +63,7 @@ import ContentCard from '@/components/layout/ContentCard.vue'
 import StoryPeriod from '@/components/camp/StoryPeriod.vue'
 import { campRoleMixin } from '@/mixins/campRoleMixin'
 
-const PRINT_SERVER = window.environment.PRINT_SERVER
+const PRINT_SERVER = window.environment?.PRINT_SERVER
 
 export default {
   name: 'Story',

--- a/frontend/src/views/dev/Print.vue
+++ b/frontend/src/views/dev/Print.vue
@@ -1,0 +1,99 @@
+<template>
+  <v-container fluid>
+    <content-card title="Print demo" max-width="800" toolbar>
+      <v-card-text>
+        <v-btn color="primary" class="mt-5"
+               :href="previewUrl"
+               target="_blank">
+          {{ $tc('components.camp.campPrint.openPrintPreview') }}
+        </v-btn>
+
+        <v-btn
+          color="primary"
+          class="mt-5 ml-5"
+          :loading="browserlessPrinting"
+          @click="printBrowserless">
+          Print via browserless.io
+        </v-btn>
+      </v-card-text>
+    </content-card>
+  </v-container>
+</template>
+
+<script>
+import ContentCard from '@/components/layout/ContentCard.vue'
+import axios from 'axios'
+
+const BROWSERLESS_TOKEN = import.meta.env.VITE_BROWSERLESS_TOKEN
+const PRINT_SERVER = import.meta.env.VITE_PRINT_SERVER
+
+export default {
+  name: 'Print',
+  components: { ContentCard },
+  data () {
+    return {
+      browserlessPrinting: false
+    }
+  },
+  computed: {
+    previewUrl () {
+      return `${PRINT_SERVER}/?pagedjs=true`
+    }
+  },
+  methods: {
+    forceFileDownload (response, title) {
+      const url = window.URL.createObjectURL(new Blob([response.data]))
+      const link = document.createElement('a')
+      link.href = url
+      link.setAttribute('download', title)
+      document.body.appendChild(link)
+      link.click()
+    },
+    printBrowserless () {
+      const title = 'PrintedByBrowserless.pdf'
+
+      this.browserlessPrinting = true
+
+      axios({
+        method: 'post',
+        url: `https://chrome.browserless.io/pdf?token=${BROWSERLESS_TOKEN}`,
+        responseType: 'arraybuffer',
+        withCredentials: false,
+        headers: {
+          'Cache-Control': 'no-cache',
+          Pragma: 'no-cache',
+          Expires: '0',
+          'Content-Type': 'application/json'
+        },
+        data: {
+          url: this.previewUrl,
+          gotoOptions: {
+            waitUntil: 'networkidle0'
+          },
+          options: {
+            displayHeaderFooter: false,
+            printBackground: true,
+            format: 'A4',
+            margin: {
+              bottom: '0px',
+              left: '0px',
+              right: '0px',
+              top: '0px'
+            }
+          }
+        }
+      })
+        .then((response) => {
+          this.browserlessPrinting = false
+          this.forceFileDownload(response, title)
+        })
+        .catch((error) => {
+          console.log(error)
+        })
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/print/components/Picasso.vue
+++ b/print/components/Picasso.vue
@@ -1,21 +1,21 @@
 <template>
   <v-row no-gutters class="picasso">
     <v-col cols="12">
-      <div class="picasso">
-        <h1>Picasso</h1>
-
+      <div :class="rotate ? 'rotate' : ''">
         <v-sheet>
+          <h1>Picasso</h1>
+
           <v-calendar
             ref="calendar"
             :now="today"
             :value="today"
             :events="events"
             color="primary"
-            type="4day"
             event-overlap-mode="column"
             first-interval="6"
             interval-count="18"
-            interval-height="25"
+            interval-height="29"
+            v-bind="$attrs"
           />
         </v-sheet>
       </div>
@@ -25,6 +25,14 @@
 
 <script>
 export default {
+  inheritAttrs: false,
+  props: {
+    rotate: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
   data: () => ({
     today: '2019-01-08',
     events: [
@@ -52,16 +60,32 @@ export default {
 }
 </script>
 
+<style lang="scss" scoped>
+.rotate {
+  -webkit-transform: rotate(-90deg);
+  -moz-transform: rotate(-90deg);
+  -o-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+
+  .v-sheet {
+    width: 1000px;
+    position: relative;
+    left: -320px;
+  }
+}
+</style>
 <style lang="scss">
 @media print {
   @page picasso {
     /* changing page orientation currently not working in pagedJS/chrome
        https://github.com/pagedjs/pagedjs/issues/6 */
     size: a4 landscape;
-    margin: 15mm 15mm;
+    margin: 10mm 10mm 10mm 10mm;
 
     @top-center {
       content: 'Picasso';
+      z-index: 100;
     }
   }
 

--- a/print/components/Picasso.vue
+++ b/print/components/Picasso.vue
@@ -4,14 +4,18 @@
       <div class="picasso">
         <h1>Picasso</h1>
 
-        <v-sheet height="500">
+        <v-sheet>
           <v-calendar
             ref="calendar"
             :now="today"
             :value="today"
             :events="events"
             color="primary"
-            type="month"
+            type="4day"
+            event-overlap-mode="column"
+            first-interval="6"
+            interval-count="18"
+            interval-height="25"
           />
         </v-sheet>
       </div>
@@ -38,6 +42,11 @@ export default {
         start: '2019-01-09 12:30',
         end: '2019-01-09 15:30',
       },
+      {
+        name: 'Spielenachmittag',
+        start: '2019-01-09 13:00',
+        end: '2019-01-09 17:30',
+      },
     ],
   }),
 }
@@ -60,5 +69,13 @@ export default {
     page-break-after: always;
     page: picasso;
   }
+}
+
+.v-calendar-daily__pane {
+  overflow-y: visible;
+}
+
+.v-calendar-daily__scroll-area {
+  overflow-y: visible;
 }
 </style>

--- a/print/components/PicassoLandscape.vue
+++ b/print/components/PicassoLandscape.vue
@@ -1,0 +1,107 @@
+<template>
+  <v-row no-gutters class="picasso">
+    <v-col cols="12">
+      <div class="picasso">
+        <h1>Picasso</h1>
+
+        <v-sheet>
+          <v-calendar
+            ref="calendar"
+            :value="today"
+            :events="events"
+            event-color="blue lighten-4"
+            type="week"
+            event-overlap-mode="column"
+            first-interval="6"
+            interval-count="18"
+            interval-height="45"
+            interval-width="100"
+            event-text-color="black"
+            event-color:
+          >
+            <template #event="{ event }">
+              <div class="font-weight-medium mb-1">
+                ({{ event.number }})&nbsp; {{ event.categoryShort }}:&nbsp;
+                {{ event.name }}
+              </div>
+              <span>[{{ event.responsibles }}]</span>
+            </template>
+          </v-calendar>
+        </v-sheet>
+      </div>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    today: '2019-01-08',
+    events: [
+      {
+        number: '2.1',
+        name: 'Weekly Meeting',
+        start: '2019-01-07 09:00',
+        end: '2019-01-07 10:00',
+        categoryShort: 'LA',
+        responsibles: 'smiley, forte',
+      },
+      {
+        name: "Thomas' Birthday",
+        start: '2019-01-10',
+      },
+      {
+        number: '4.1',
+        name: 'Mash Potatoes',
+        start: '2019-01-09 12:30',
+        end: '2019-01-09 15:30',
+        categoryShort: 'LA',
+        responsibles: 'smiley, forte',
+      },
+      {
+        number: '4.2',
+        name: 'Spielenachmittag',
+        start: '2019-01-09 13:00',
+        end: '2019-01-09 17:30',
+        categoryShort: 'LA',
+        responsibles: 'smiley, forte',
+      },
+    ],
+  }),
+}
+</script>
+
+<style lang="scss">
+@media print {
+  @page picasso {
+    /* changing page orientation currently not working in pagedJS/chrome
+       https://github.com/pagedjs/pagedjs/issues/6 */
+    size: a4 landscape;
+    margin: 15mm 15mm;
+
+    @top-center {
+      content: 'Picasso';
+    }
+  }
+
+  .picasso {
+    page-break-after: always;
+    page: picasso;
+  }
+}
+
+.v-calendar-daily__pane {
+  overflow-y: visible;
+}
+
+.v-calendar-daily__scroll-area {
+  overflow-y: visible;
+}
+
+.v-calendar .v-event-timed {
+  padding: 2px;
+  white-space: normal;
+  overflow-wrap: break-word;
+  font-size: 11px;
+}
+</style>

--- a/print/components/ProgramScheduleEntry.vue
+++ b/print/components/ProgramScheduleEntry.vue
@@ -3,7 +3,7 @@
     <v-col cols="12">
       <error v-if="$fetchState.error">{{ $fetchState.error.message }}</error>
       <div v-else-if="!$fetchState.pending" class="event">
-        <h2 :id="'activity_' + activity.id">
+        <h2 :id="'scheduleEntry_' + scheduleEntry.id">
           {{ scheduleEntry.number }}
           <v-chip dark :color="category.color">{{ category.short }}</v-chip>
           {{ activity.title }}

--- a/print/components/ProgramScheduleEntry.vue
+++ b/print/components/ProgramScheduleEntry.vue
@@ -105,7 +105,7 @@ export default {
     this.category = await this.activity.category()._meta.load
 
     /** TODO: something is not yet working here with loading scheduleEntries() from hal-json-vuex. Needs some further debugging */
-    await this.activity.scheduleEntries()._meta.load
+    // await this.activity.scheduleEntries()._meta.load
   },
   computed: {
     scheduleEntries() {

--- a/print/components/TableOfContent.vue
+++ b/print/components/TableOfContent.vue
@@ -3,9 +3,12 @@
     <v-col cols="12">
       <div class="TOC">
         <h1>Table of content</h1>
-        <p v-for="activity in activities" :key="'toc_' + activity.id">
-          <a class="link" :href="'#activity_' + activity.id">{{
-            activity.title
+        <p
+          v-for="scheduleEntry in scheduleEntries"
+          :key="'toc_' + scheduleEntry.id"
+        >
+          <a class="toclink" :href="'#scheduleEntry_' + scheduleEntry.id">{{
+            scheduleEntry.title
           }}</a>
         </p>
       </div>
@@ -16,7 +19,7 @@
 <script>
 export default {
   props: {
-    activities: { type: Array, required: true },
+    scheduleEntries: { type: Array, required: true },
   },
 }
 </script>
@@ -25,10 +28,6 @@ export default {
 @media print {
   .TOC {
     page-break-after: always;
-  }
-
-  .link::after {
-    content: ', page ' target-counter(attr(href url), page);
   }
 }
 </style>

--- a/print/components/TableOfContent.vue
+++ b/print/components/TableOfContent.vue
@@ -3,12 +3,11 @@
     <v-col cols="12">
       <div class="TOC">
         <h1>Table of content</h1>
-        <!--
         <p v-for="activity in activities" :key="'toc_' + activity.id">
           <a class="link" :href="'#activity_' + activity.id">{{
             activity.title
-          }}</a> 
-        </p>-->
+          }}</a>
+        </p>
       </div>
     </v-col>
   </v-row>

--- a/print/layouts/default.vue
+++ b/print/layouts/default.vue
@@ -60,6 +60,10 @@ export default {
                         font-size: var(--ecamp-margin-font-size);
                       }
                     }
+
+                    .toclink::after {
+                      content: ', page ' target-counter(attr(href url), page);
+                    }
                   }`,
       },
     ]

--- a/print/layouts/default.vue
+++ b/print/layouts/default.vue
@@ -50,6 +50,8 @@ export default {
 
                     @page {
                       font-family: "Roboto", sans-serif;
+                      size: A4 portrait;
+                      margin: 15mm 15mm 15mm 15mm;
                       
                       @top-center {
                         content: 'eCamp3';
@@ -115,9 +117,9 @@ export default {
   padding: 0;
 }
 
-@media print {
-  @page {
-    size: a4 portrait;
-  }
-}
+// @media print {
+//   @page {
+//     size: a4 portrait;
+//   }
+// }
 </style>

--- a/print/layouts/default.vue
+++ b/print/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
     <v-main>
-      <v-container class="container">
+      <v-container class="container" fluid>
         <nuxt />
       </v-container>
     </v-main>

--- a/print/layouts/landscapeA3.vue
+++ b/print/layouts/landscapeA3.vue
@@ -1,0 +1,126 @@
+<template>
+  <v-app>
+    <v-main>
+      <v-container class="container" fluid>
+        <nuxt />
+      </v-container>
+    </v-main>
+  </v-app>
+</template>
+
+<script>
+export default {
+  layout: 'landscapeA3',
+  data() {
+    return {
+      pagedjs: false,
+    }
+  },
+
+  head() {
+    const header = {}
+
+    header.htmlAttrs = {
+      moznomarginboxes: true,
+      mozdisallowselectionprint: true,
+    }
+
+    /**
+     * Define default footer & header
+     * This can be overridden in route views
+     */
+    header.__dangerouslyDisableSanitizersByTagID = {
+      defaultMarginBox: ['cssText'], // disable sanitzing of below inline css
+    }
+
+    const cssPageCounter = `'${this.$tc(
+      'global.margin.pageCounter.page'
+    )} ' counter(page) ' ${this.$tc(
+      'global.margin.pageCounter.of'
+    )}  ' counter(pages)`
+
+    header.style = [
+      {
+        type: 'text/css',
+        hid: 'defaultMarginBox',
+        cssText: `@media print {
+                    
+                    :root {
+                      --ecamp-margin-font-size: 10pt;
+                    }
+
+                    @page {
+                      font-family: "Roboto", sans-serif;
+                      size: A3 landscape;
+                      margin: 15mm 15mm 15mm 15mm;
+                      
+                      @top-center {
+                        content: 'eCamp3';
+                        font-size: var(--ecamp-margin-font-size);
+                      }
+                      @bottom-center {
+                        content: ${cssPageCounter};
+                        font-size: var(--ecamp-margin-font-size);
+                      }
+                    }
+
+                    .toclink::after {
+                      content: ', page ' target-counter(attr(href url), page);
+                    }
+                  }`,
+      },
+    ]
+
+    header.script = []
+
+    // inject FRONTEND_URL to client
+    header.__dangerouslyDisableSanitizersByTagID.environmentVariables = [
+      'innerHTML',
+    ]
+    header.script.push({
+      hid: 'environmentVariables',
+      type: 'application/javascript',
+      innerHTML: `window.FRONTEND_URL = '${process.env.FRONTEND_URL}'`,
+    })
+
+    if (this.$route.query.pagedjs === 'true') {
+      // confiugration JS for pagedJS
+      header.script.push({
+        src: '/pagedConfig.js',
+      })
+
+      // PagedJS
+      header.script.push({
+        src: 'https://unpkg.com/pagedjs/dist/paged.polyfill.js',
+      })
+
+      // event listener to communicate with parent when embedded in iFrame
+      header.script.push({
+        src: '/iframeEvents.js',
+      })
+
+      header.link = [
+        {
+          rel: 'stylesheet',
+          href: '/print-preview.css',
+        },
+      ]
+    }
+
+    return header
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.container {
+  margin: 0;
+  padding: 0;
+}
+
+// @media print {
+//   @page {
+//     size: a4 portrait;
+//   }
+// }
+</style>

--- a/print/nuxt.config.js
+++ b/print/nuxt.config.js
@@ -115,7 +115,7 @@ export default {
    */
   vuetify: {
     customVariables: ['~/assets/variables.scss'],
-    treeShake: true,
+    treeShake: false /** tree shaking somehow doesn't work well with injectScript=false */,
     theme: {
       dark: false,
     },
@@ -139,9 +139,9 @@ export default {
    */
   render: {
     // in production: FALSE: deactivates injecting any Javascript on client side ==> pure HTML/CSS output only (except explicit head-scripts)
-    // in development: TRUE: enable javasript injection in dev mode to support hot reloading
+    // in development: TRUE: enable javascript injection in dev mode to support hot reloading
     // injectScripts: process.env.NODE_ENV === 'development',
-    injectScripts: true,
+    injectScripts: false,
 
     csp: {
       reportOnly: false,

--- a/print/nuxt.config.js
+++ b/print/nuxt.config.js
@@ -135,8 +135,8 @@ export default {
   render: {
     // in production: FALSE: deactivates injecting any Javascript on client side ==> pure HTML/CSS output only (except explicit head-scripts)
     // in development: TRUE: enable javasript injection in dev mode to support hot reloading
-    injectScripts: process.env.NODE_ENV === 'development',
-    // injectScripts: false,
+    // injectScripts: process.env.NODE_ENV === 'development',
+    injectScripts: false,
 
     csp: {
       reportOnly: false,

--- a/print/nuxt.config.js
+++ b/print/nuxt.config.js
@@ -60,6 +60,11 @@ export default {
     '@nuxtjs/sentry',
   ],
 
+  /*
+   ** Server Middleware
+   */
+  serverMiddleware: [{ path: '/pdf', handler: '~/server-middleware' }],
+
   /**
    * Router config
    * See https://nuxtjs.org/api/configuration-router/

--- a/print/nuxt.config.js
+++ b/print/nuxt.config.js
@@ -136,7 +136,7 @@ export default {
     // in production: FALSE: deactivates injecting any Javascript on client side ==> pure HTML/CSS output only (except explicit head-scripts)
     // in development: TRUE: enable javasript injection in dev mode to support hot reloading
     // injectScripts: process.env.NODE_ENV === 'development',
-    injectScripts: false,
+    injectScripts: true,
 
     csp: {
       reportOnly: false,

--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@nuxtjs/axios": "5.13.6",
         "@nuxtjs/sentry": "5.1.5",
+        "cookie-parser": "^1.4.6",
         "cssesc": "3.0.0",
         "dayjs": "1.10.7",
         "deepmerge": "4.2.2",
@@ -5905,6 +5906,18 @@
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/cookie-signature": {
@@ -25521,6 +25534,15 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -13,9 +13,11 @@
         "cssesc": "3.0.0",
         "dayjs": "1.10.7",
         "deepmerge": "4.2.2",
+        "express": "^4.17.1",
         "hal-json-vuex": "2.0.0-alpha.11",
         "nuxt": "2.15.8",
         "pagedjs": "0.2.0",
+        "puppeteer": "^12.0.1",
         "vue-i18n": "8.26.7"
       },
       "devDependencies": {
@@ -3267,6 +3269,15 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/experimental-utils": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.25.0.tgz",
@@ -4010,6 +4021,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
     "node_modules/array-includes": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -4673,6 +4689,16 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4682,6 +4708,75 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+    },
+    "node_modules/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -4921,6 +5016,14 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -5759,6 +5862,30 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -5779,6 +5906,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/copy-concurrently": {
       "version": "1.0.5",
@@ -6450,14 +6582,19 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dependencies": {
         "ms": "2.1.2"
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decache": {
@@ -6623,6 +6760,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-2.0.1.tgz",
       "integrity": "sha512-I2TiqT5iWBEyB8GRfTDP0hiLZ0YeDJZ+upDxjBfOC2lebO5LezQMv7QvIUTzdb64jQyAKLf1AHADtGN+jw6v8Q=="
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.937139",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.937139.tgz",
+      "integrity": "sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ=="
     },
     "node_modules/diff-sequences": {
       "version": "27.0.6",
@@ -8243,6 +8385,80 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/express/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -8431,6 +8647,39 @@
         "npm": ">=2.0.0"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8490,6 +8739,14 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/figgy-pudding": {
@@ -8781,6 +9038,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -8835,6 +9100,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
@@ -10082,6 +10352,14 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-absolute-url": {
       "version": "2.1.0",
@@ -11847,6 +12125,14 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mem": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
@@ -12068,6 +12354,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
     "node_modules/merge-source-map": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
@@ -12095,6 +12386,14 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromark": {
@@ -12342,6 +12641,11 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -12553,11 +12857,33 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-html-parser": {
@@ -13367,6 +13693,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -13389,6 +13720,11 @@
       "engines": {
         "node": ">=0.12"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -14914,6 +15250,18 @@
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
       "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg=="
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -14987,6 +15335,49 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-12.0.1.tgz",
+      "integrity": "sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "debug": "4.3.2",
+        "devtools-protocol": "0.0.937139",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.0",
+        "node-fetch": "2.6.5",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.2.3"
+      },
+      "engines": {
+        "node": ">=10.18.1"
+      }
+    },
+    "node_modules/puppeteer/node_modules/ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/q": {
@@ -15071,6 +15462,48 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "node_modules/rc9": {
       "version": "1.2.0",
@@ -17310,6 +17743,37 @@
         "node": ">= 10"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -17951,6 +18415,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -18008,6 +18484,15 @@
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "node_modules/unfetch": {
@@ -20305,6 +20790,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {
@@ -22834,6 +23328,15 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "@types/yauzl": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@typescript-eslint/experimental-utils": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.25.0.tgz",
@@ -23465,6 +23968,11 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
     "array-includes": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -24012,6 +24520,16 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -24021,6 +24539,65 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
+      }
     },
     "boolbase": {
       "version": "1.0.0",
@@ -24206,6 +24783,11 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -24900,6 +25482,26 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -24919,6 +25521,11 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -25452,9 +26059,9 @@
       }
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -25591,6 +26198,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-2.0.1.tgz",
       "integrity": "sha512-I2TiqT5iWBEyB8GRfTDP0hiLZ0YeDJZ+upDxjBfOC2lebO5LezQMv7QvIUTzdb64jQyAKLf1AHADtGN+jw6v8Q=="
+    },
+    "devtools-protocol": {
+      "version": "0.0.937139",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.937139.tgz",
+      "integrity": "sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ=="
     },
     "diff-sequences": {
       "version": "27.0.6",
@@ -26924,6 +27536,73 @@
         }
       }
     },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -27075,6 +27754,27 @@
         "css": "^2.1.0"
       }
     },
+    "extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "requires": {
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -27131,6 +27831,14 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "figgy-pudding": {
@@ -27362,6 +28070,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -27412,6 +28125,11 @@
           }
         }
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "9.1.0",
@@ -28393,6 +29111,11 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-absolute-url": {
       "version": "2.1.0",
@@ -29790,6 +30513,11 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
     "mem": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
@@ -29976,6 +30704,11 @@
         }
       }
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
     "merge-source-map": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
@@ -30000,6 +30733,11 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromark": {
       "version": "2.11.4",
@@ -30192,6 +30930,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -30365,9 +31108,33 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-html-parser": {
       "version": "3.3.6",
@@ -31042,6 +31809,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -31058,6 +31830,11 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -32301,6 +33078,15 @@
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
       "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg=="
     },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -32377,6 +33163,33 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "puppeteer": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-12.0.1.tgz",
+      "integrity": "sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==",
+      "requires": {
+        "debug": "4.3.2",
+        "devtools-protocol": "0.0.937139",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.0",
+        "node-fetch": "2.6.5",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.2.3"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+          "requires": {}
+        }
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -32436,6 +33249,41 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+        },
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
+      }
     },
     "rc9": {
       "version": "1.2.0",
@@ -34264,6 +35112,36 @@
         }
       }
     },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -34747,6 +35625,15 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
       "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
     },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -34785,6 +35672,15 @@
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "unfetch": {
@@ -36637,6 +37533,15 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/print/package.json
+++ b/print/package.json
@@ -23,9 +23,11 @@
     "cssesc": "3.0.0",
     "dayjs": "1.10.7",
     "deepmerge": "4.2.2",
+    "express": "^4.17.1",
     "hal-json-vuex": "2.0.0-alpha.11",
     "nuxt": "2.15.8",
     "pagedjs": "0.2.0",
+    "puppeteer": "^12.0.1",
     "vue-i18n": "8.26.7"
   },
   "devDependencies": {

--- a/print/package.json
+++ b/print/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@nuxtjs/axios": "5.13.6",
     "@nuxtjs/sentry": "5.1.5",
+    "cookie-parser": "^1.4.6",
     "cssesc": "3.0.0",
     "dayjs": "1.10.7",
     "deepmerge": "4.2.2",

--- a/print/pages/index.vue
+++ b/print/pages/index.vue
@@ -1,6 +1,17 @@
 <template>
   <v-row no-gutters>
     <v-col cols="12">
+      <hr />
+      <h1>API connection test</h1>
+      Loading all camps from API to check API connection &amp; authentication
+      <ul>
+        <li v-for="camp in camps" :key="camp.id">
+          {{ camp.id }} / {{ camp.name }} / {{ camp.title }}
+        </li>
+      </ul>
+      <hr />
+      test
+
       <div v-if="true">
         <front-page v-if="config.showFrontpage" :camp="camp" />
       </div>
@@ -57,10 +68,11 @@ export default {
       config: {},
       pagedjs: '',
       camp: null,
+      camps: [],
       activities: null,
     }
   },
-  fetch() {
+  async fetch() {
     /*
     const query = this.$route.query
 
@@ -82,6 +94,12 @@ export default {
     this.camp = await this.$api.get().camps({ campId: query.camp })._meta.load
     this.activities = (await this.camp.activities()._meta.load).items
     */
+
+    try {
+      this.camps = (await this.$api.get().camps()._meta.load).items
+    } catch (error) {
+      console.log(error)
+    }
 
     this.config = {
       showFrontpage: true,

--- a/print/pages/index.vue
+++ b/print/pages/index.vue
@@ -5,7 +5,7 @@
         <front-page v-if="config.showFrontpage" :camp="camp" />
       </div>
 
-      <toc v-if="config.showToc" :activities="activities" />
+      <table-of-content v-if="config.showToc" :activities="activities" />
 
       <picasso v-if="config.showPicasso" :camp="camp" />
 
@@ -22,6 +22,32 @@
 </template>
 
 <script>
+function collection(items) {
+  const entityArray = items.map((item) => entity(item)())
+
+  return () => ({
+    items: entityArray,
+    _meta: {
+      load: Promise.resolve({
+        items: entityArray,
+      }),
+    },
+  })
+}
+
+function entity(item) {
+  return () =>
+    Object.assign(
+      { ...item },
+      {
+        _meta: {
+          load: Promise.resolve({ ...item }),
+          self: item.id,
+        },
+      }
+    )
+}
+
 export default {
   data() {
     return {
@@ -31,7 +57,8 @@ export default {
       activities: null,
     }
   },
-  async fetch() {
+  fetch() {
+    /*
     const query = this.$route.query
 
     this.config = {
@@ -51,6 +78,68 @@ export default {
 
     this.camp = await this.$api.get().camps({ campId: query.camp })._meta.load
     this.activities = (await this.camp.activities()._meta.load).items
+    */
+
+    this.config = {
+      showFrontpage: true,
+      showToc: true,
+      showPicasso: true,
+      showStoryline: true,
+      showDailySummary: true,
+      showActivities: true,
+    }
+
+    this.camp = {
+      name: 'Camp Name',
+      title: 'camp title',
+      motto: 'camp motto',
+      periods: collection([
+        {
+          id: '/camp/1',
+          description: 'Vorlager',
+          days: collection([
+            {
+              id: '/day/1',
+              dayOffset: 1,
+              scheduleEntries: collection([
+                {
+                  id: '/schedule_entry/1',
+                  activity: entity({
+                    location: 'Lagerplatz',
+                    category: entity({
+                      short: 'LA',
+                      color: '#55AAAA',
+                    }),
+                    scheduleEntries: collection([
+                      {
+                        id: '/schedule_entry/1',
+                        number: '1.1',
+                        periodOffset: 510,
+                        length: 45,
+                        period: entity({
+                          start: '2021-11-25',
+                        }),
+                      },
+                    ]),
+                  }),
+                },
+              ]),
+            },
+          ]),
+        },
+      ]),
+    }
+
+    this.activities = [
+      {
+        id: 'activity1',
+        title: 'Activity 1',
+      },
+      {
+        id: 'activity2',
+        title: 'Activity 2',
+      },
+    ]
   },
 }
 </script>

--- a/print/pages/index.vue
+++ b/print/pages/index.vue
@@ -5,7 +5,10 @@
         <front-page v-if="config.showFrontpage" :camp="camp" />
       </div>
 
-      <table-of-content v-if="config.showToc" :activities="activities" />
+      <table-of-content
+        v-if="config.showToc"
+        :schedule-entries="scheduleEntries"
+      />
 
       <picasso v-if="config.showPicasso" :camp="camp" />
 
@@ -103,8 +106,9 @@ export default {
               dayOffset: 1,
               scheduleEntries: collection([
                 {
-                  id: '/schedule_entry/1',
+                  id: 'scheduleEntry1',
                   activity: entity({
+                    title: 'Activity 1',
                     location: 'Lagerplatz',
                     category: entity({
                       short: 'LA',
@@ -112,7 +116,7 @@ export default {
                     }),
                     scheduleEntries: collection([
                       {
-                        id: '/schedule_entry/1',
+                        id: 'scheduleEntry1',
                         number: '1.1',
                         periodOffset: 510,
                         length: 45,
@@ -130,14 +134,10 @@ export default {
       ]),
     }
 
-    this.activities = [
+    this.scheduleEntries = [
       {
-        id: 'activity1',
+        id: 'scheduleEntry1',
         title: 'Activity 1',
-      },
-      {
-        id: 'activity2',
-        title: 'Activity 2',
       },
     ]
   },

--- a/print/pages/index.vue
+++ b/print/pages/index.vue
@@ -21,7 +21,14 @@
         :schedule-entries="scheduleEntries"
       />
 
-      <picasso v-if="config.showPicasso" :camp="camp" />
+      <picasso v-if="config.showPicasso" :camp="camp" type="4day" />
+
+      <picasso
+        v-if="config.showPicasso"
+        :camp="camp"
+        :rotate="true"
+        type="week"
+      />
 
       <storyline v-if="config.showStoryline" :camp="camp" />
 

--- a/print/pages/picasso/index.vue
+++ b/print/pages/picasso/index.vue
@@ -1,0 +1,135 @@
+<template>
+  <v-row no-gutters>
+    <v-col cols="12">
+      <picasso-landscape :camp="camp" />
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+function collection(items) {
+  const entityArray = items.map((item) => entity(item)())
+
+  return () => ({
+    items: entityArray,
+    _meta: {
+      load: Promise.resolve({
+        items: entityArray,
+      }),
+    },
+  })
+}
+
+function entity(item) {
+  return () =>
+    Object.assign(
+      { ...item },
+      {
+        _meta: {
+          load: Promise.resolve({ ...item }),
+          self: item.id,
+        },
+      }
+    )
+}
+
+export default {
+  layout: 'landscapeA3',
+  data() {
+    return {
+      config: {},
+      pagedjs: '',
+      camp: null,
+      camps: [],
+      activities: null,
+    }
+  },
+  async fetch() {
+    /*
+    const query = this.$route.query
+
+    this.config = {
+      showFrontpage:
+        query.showFrontpage && query.showFrontpage.toLowerCase() === 'true',
+      showToc: query.showToc && query.showToc.toLowerCase() === 'true',
+      showPicasso:
+        query.showPicasso && query.showPicasso.toLowerCase() === 'true',
+      showStoryline:
+        query.showStoryline && query.showStoryline.toLowerCase() === 'true',
+      showDailySummary:
+        query.showDailySummary &&
+        query.showDailySummary.toLowerCase() === 'true',
+      showActivities:
+        query.showActivities && query.showActivities.toLowerCase() === 'true',
+    }
+
+    this.camp = await this.$api.get().camps({ campId: query.camp })._meta.load
+    this.activities = (await this.camp.activities()._meta.load).items
+    */
+
+    try {
+      this.camps = (await this.$api.get().camps()._meta.load).items
+    } catch (error) {
+      console.log(error)
+    }
+
+    this.config = {
+      showFrontpage: true,
+      showToc: true,
+      showPicasso: true,
+      showStoryline: true,
+      showDailySummary: true,
+      showActivities: true,
+    }
+
+    this.camp = {
+      name: 'Camp Name',
+      title: 'camp title',
+      motto: 'camp motto',
+      periods: collection([
+        {
+          id: '/camp/1',
+          description: 'Vorlager',
+          days: collection([
+            {
+              id: '/day/1',
+              dayOffset: 1,
+              scheduleEntries: collection([
+                {
+                  id: 'scheduleEntry1',
+                  activity: entity({
+                    title: 'Activity 1',
+                    location: 'Lagerplatz',
+                    category: entity({
+                      short: 'LA',
+                      color: '#55AAAA',
+                    }),
+                    scheduleEntries: collection([
+                      {
+                        id: 'scheduleEntry1',
+                        number: '1.1',
+                        periodOffset: 510,
+                        length: 45,
+                        period: entity({
+                          start: '2021-11-25',
+                        }),
+                      },
+                    ]),
+                  }),
+                },
+              ]),
+            },
+          ]),
+        },
+      ]),
+    }
+
+    this.scheduleEntries = [
+      {
+        id: 'scheduleEntry1',
+        title: 'Activity 1',
+      },
+    ]
+  },
+}
+</script>

--- a/print/server-middleware/index.js
+++ b/print/server-middleware/index.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const cookieParser = require('cookie-parser')
 
 // Create express instance
 const app = express()
@@ -8,6 +9,8 @@ const test1 = require('./routes/test1.js')
 const test2 = require('./routes/test2.js')
 const test3 = require('./routes/test3.js')
 const test4 = require('./routes/test4.js')
+
+app.use(cookieParser())
 
 // Import API Routes
 app.use(test1)

--- a/print/server-middleware/index.js
+++ b/print/server-middleware/index.js
@@ -1,0 +1,28 @@
+const express = require('express')
+
+// Create express instance
+const app = express()
+
+// Require API routes
+const test1 = require('./routes/test1.js')
+const test2 = require('./routes/test2.js')
+const test3 = require('./routes/test3.js')
+const test4 = require('./routes/test4.js')
+
+// Import API Routes
+app.use(test1)
+app.use(test2)
+app.use(test3)
+app.use(test4)
+
+// Export express app
+module.exports = app
+
+// Start standalone server if directly running
+if (require.main === module) {
+  const port = process.env.PORT || 3001
+  app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`API server listening on port ${port}`)
+  })
+}

--- a/print/server-middleware/routes/test1.js
+++ b/print/server-middleware/routes/test1.js
@@ -1,0 +1,53 @@
+/**
+ * Browserless.io REST /pdf endpoint
+ * HTML generated via separate call from Browserless.io to our Nuxt Print App
+ */
+
+import axios from 'axios'
+const { Router } = require('express')
+
+const router = Router()
+
+// Test route
+router.use('/test1', (req, res) => {
+  // REST call to browserless.io
+  axios({
+    method: 'post',
+    url: `https://chrome.browserless.io/pdf?token=${process.env.BROWSERLESS_TOKEN}`,
+    responseType: 'arraybuffer',
+    withCredentials: false,
+    headers: {
+      'Cache-Control': 'no-cache',
+      Pragma: 'no-cache',
+      Expires: '0',
+      'Content-Type': 'application/json',
+    },
+    data: {
+      url: `${process.env.PRINT_SERVER}/?pagedjs=true`, // HTTP request back to Print App
+      gotoOptions: {
+        waitUntil: 'networkidle0',
+        // TODO: here we need to provide some sort of authentication (pass JWT)
+      },
+      options: {
+        displayHeaderFooter: false,
+        printBackground: true,
+        format: 'A4',
+        margin: {
+          bottom: '0px',
+          left: '0px',
+          right: '0px',
+          top: '0px',
+        },
+      },
+    },
+  })
+    .then((response) => {
+      res.contentType('application/pdf')
+      res.send(response.data)
+    })
+    .catch((error) => {
+      console.log(error)
+    })
+})
+
+module.exports = router

--- a/print/server-middleware/routes/test1.js
+++ b/print/server-middleware/routes/test1.js
@@ -39,6 +39,18 @@ router.use('/test1', (req, res) => {
           top: '0px',
         },
       },
+      // pass JWT cookie
+      /*
+      cookies: [
+        {
+          name: 'jwt_hp',
+          value: req.cookies.jwt_hp,
+        },
+        {
+          name: 'jwt_s',
+          value: req.cookies.jwt_s,
+        },
+      ], */
     },
   })
     .then((response) => {

--- a/print/server-middleware/routes/test2.js
+++ b/print/server-middleware/routes/test2.js
@@ -17,9 +17,7 @@ router.use('/test2', async (req, res) => {
     const nuxt = await loadNuxt({ for: 'start' })
 
     // Capture HTML via internal Nuxt render call
-    // TODO: needs some extra work to ensure pagedJs or all other dependencies are already included in generated HTML (not just as links). Browserless.io will not try to fetch additionals links.
-    // TODO: check if authentication needs to be provided (or if Nuxt is already aware)
-    const { html } = await nuxt.renderRoute('/')
+    const { html } = await nuxt.renderRoute('/', { req }) // pass `req` object to Nuxt will also pass authentication cookies automatically
 
     // REST call to browserless.io
     const response = await axios({
@@ -35,6 +33,7 @@ router.use('/test2', async (req, res) => {
       },
       data: {
         html,
+        waitFor: 1000, // this is guess-work, as we don't really know how long rendering pagedJS will take. Test4 (waiting for event) is much more robust
         options: {
           displayHeaderFooter: false,
           printBackground: true,

--- a/print/server-middleware/routes/test2.js
+++ b/print/server-middleware/routes/test2.js
@@ -1,0 +1,60 @@
+/**
+ * Browserless.io REST /pdf endpoint
+ * HTML generated internally and submitted to browserless as payload data
+ */
+
+import axios from 'axios'
+const { loadNuxt } = require('nuxt')
+const { Router } = require('express')
+
+const router = Router()
+
+// Test route
+router.use('/test2', async (req, res) => {
+  try {
+    // Get nuxt instance for start (production mode)
+    // Make sure to have run `nuxt build` before running this script
+    const nuxt = await loadNuxt({ for: 'start' })
+
+    // Capture HTML via internal Nuxt render call
+    // TODO: needs some extra work to ensure pagedJs or all other dependencies are already included in generated HTML (not just as links). Browserless.io will not try to fetch additionals links.
+    // TODO: check if authentication needs to be providfed (or if Nuxt is already aware)
+    const { html } = await nuxt.renderRoute('/')
+
+    // REST call to browserless.io
+    const response = await axios({
+      method: 'post',
+      url: `https://chrome.browserless.io/pdf?token=${process.env.BROWSERLESS_TOKEN}`,
+      responseType: 'arraybuffer',
+      withCredentials: false,
+      headers: {
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        Expires: '0',
+        'Content-Type': 'application/json',
+      },
+      data: {
+        html,
+        options: {
+          displayHeaderFooter: false,
+          printBackground: true,
+          format: 'A4',
+          margin: {
+            bottom: '0px',
+            left: '0px',
+            right: '0px',
+            top: '0px',
+          },
+        },
+      },
+    })
+
+    res.contentType('application/pdf')
+    res.send(response.data)
+  } catch (error) {
+    console.log(error)
+    res.send(error)
+  }
+})
+
+module.exports = router

--- a/print/server-middleware/routes/test2.js
+++ b/print/server-middleware/routes/test2.js
@@ -18,7 +18,7 @@ router.use('/test2', async (req, res) => {
 
     // Capture HTML via internal Nuxt render call
     // TODO: needs some extra work to ensure pagedJs or all other dependencies are already included in generated HTML (not just as links). Browserless.io will not try to fetch additionals links.
-    // TODO: check if authentication needs to be providfed (or if Nuxt is already aware)
+    // TODO: check if authentication needs to be provided (or if Nuxt is already aware)
     const { html } = await nuxt.renderRoute('/')
 
     // REST call to browserless.io

--- a/print/server-middleware/routes/test3.js
+++ b/print/server-middleware/routes/test3.js
@@ -10,6 +10,9 @@ const router = Router()
 
 // Test route
 router.use('/test3', async (req, res) => {
+  // Launch own puppeteer + Chromium
+  // const browser = await puppeteer.launch()
+
   // Connect to browserless.io (puppeteer websocket)
   const browser = await puppeteer.connect({
     browserWSEndpoint: `wss://chrome.browserless.io/?token=${process.env.BROWSERLESS_TOKEN}`,

--- a/print/server-middleware/routes/test3.js
+++ b/print/server-middleware/routes/test3.js
@@ -1,0 +1,50 @@
+/**
+ * Browserless.io puppeteer endpoint (for more granular control)
+ * HTML generated via separate call from Browserless.io to our Nuxt Print App
+ */
+
+import puppeteer from 'puppeteer'
+const { Router } = require('express')
+
+const router = Router()
+
+// Test route
+router.use('/test3', async (req, res) => {
+  // Connect to browserless.io (puppeteer websocket)
+  const browser = await puppeteer.connect({
+    browserWSEndpoint: `wss://chrome.browserless.io/?token=${process.env.BROWSERLESS_TOKEN}`,
+  })
+
+  const page = await browser.newPage()
+
+  try {
+    // HTTP request back to Print App
+    // TODO: here we need to provide some sort of authentication (pass JWT)
+    await page.goto(`${process.env.PRINT_SERVER}/?pagedjs=true`, {
+      waitUntil: 'networkidle0',
+    })
+
+    // print pdf
+    const pdf = await page.pdf({
+      displayHeaderFooter: false,
+      printBackground: true,
+      format: 'A4',
+      margin: {
+        bottom: '0px',
+        left: '0px',
+        right: '0px',
+        top: '0px',
+      },
+    })
+    browser.close()
+
+    res.contentType('application/pdf')
+    res.send(pdf)
+  } catch (error) {
+    console.error({ error }, 'Something happened!')
+    browser.close()
+    res.send(error)
+  }
+})
+
+module.exports = router

--- a/print/server-middleware/routes/test4.js
+++ b/print/server-middleware/routes/test4.js
@@ -65,9 +65,7 @@ router.use('/test4', async (req, res) => {
     const nuxt = await loadNuxt({ for: 'start' })
 
     // Capture HTML via internal Nuxt render call
-    // TODO: needs some extra work to ensure pagedJs or all other dependencies are already included in generated HTML (not just as links). Browserless.io will not try to fetch additionals links.
-    // TODO: check if authentication needs to be provided (or if Nuxt is already aware)
-    const { html } = await nuxt.renderRoute('/')
+    const { html } = await nuxt.renderRoute('/', { req }) // pass `req` object to Nuxt will also pass authentication cookies automatically
 
     // set HTML content of current page
     measurePerformance('Puppeteer set HTML content & load resources...')

--- a/print/server-middleware/routes/test4.js
+++ b/print/server-middleware/routes/test4.js
@@ -1,8 +1,8 @@
 /**
- * Running own puppeteer instance
+ * Browserless.io puppeteer endpoint (for more granular control)
  * HTML generated internally and loaded into puppeteer
  *
- * Needs the following packages on top of standard WSL2-Ubuntu:
+ * For running locally (puppeteer.launch), the following packages are needed on top of standard WSL2-Ubuntu:
  * sudo apt-get install libnss3-dev libxkbcommon0 libgbm1
  * sudo apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm-dev
  */
@@ -18,7 +18,28 @@ router.use('/test4', async (req, res) => {
   // Launch own puppeteer + Chromium
   const browser = await puppeteer.launch()
 
+  // Connect to browserless.io (puppeteer websocket)
+  /* const browser = await puppeteer.connect({
+    browserWSEndpoint: `wss://chrome.browserless.io/?token=${process.env.BROWSERLESS_TOKEN}`,
+  }) */
+
   const page = await browser.newPage()
+
+  /**
+   * Debugging puppeteer
+   */
+  page.on('request', (request) =>
+    console.log('>>', request.method(), request.url())
+  )
+  page.on('response', (response) =>
+    console.log('<<', response.status(), response.url())
+  )
+  page.on('error', (err) => {
+    console.log('error happen at the page: ', err)
+  })
+  page.on('pageerror', (pageerr) => {
+    console.log('pageerror occurred: ', pageerr)
+  })
 
   try {
     // Get nuxt instance for start (production mode)
@@ -32,6 +53,50 @@ router.use('/test4', async (req, res) => {
 
     // set HTML content of current page
     await page.setContent(html)
+
+    /**
+     * Following code snippets copied mostly from https://gitlab.pagedmedia.org/tools/pagedjs-cli/-/blob/master/src/printer.js
+     */
+
+    // add local pagedjs
+    /* const pagedjsLocation = require.resolve('pagedjs/dist/paged.polyfill.js')
+    const paths = pagedjsLocation.split('node_modules')
+    const scriptPath = paths[0] + 'node_modules' + paths[paths.length - 1] */
+    await page.addScriptTag({
+      // path: scriptPath,
+      url: 'https://unpkg.com/pagedjs/dist/paged.polyfill.js',
+    })
+
+    // create Promise to wait for rendered
+    let resolver
+    const rendered = new Promise(function (resolve, reject) {
+      resolver = resolve
+    })
+
+    // onRendered function and attach to 'rendered' event from PagedJS
+    await page.exposeFunction(
+      'onRendered',
+      (msg, width, height, orientation) => {
+        console.log(msg)
+        resolver({ msg, width, height, orientation }) // resolve promise
+      }
+    )
+    await page.evaluate(() => {
+      window.PagedPolyfill.on('rendered', (flow) => {
+        const msg =
+          'Rendering ' +
+          flow.total +
+          ' pages took ' +
+          flow.performance +
+          ' milliseconds.'
+        window.onRendered(msg, flow.width, flow.height, flow.orientation)
+      })
+    })
+
+    console.log('awaiting rendered')
+    // wait for Promise to fire
+    await rendered
+    console.log('rendered')
 
     // print pdf
     const pdf = await page.pdf({

--- a/print/server-middleware/routes/test4.js
+++ b/print/server-middleware/routes/test4.js
@@ -1,0 +1,59 @@
+/**
+ * Running own puppeteer instance
+ * HTML generated internally and loaded into puppeteer
+ *
+ * Needs the following packages on top of standard WSL2-Ubuntu:
+ * sudo apt-get install libnss3-dev libxkbcommon0 libgbm1
+ * sudo apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm-dev
+ */
+
+import puppeteer from 'puppeteer'
+const { loadNuxt } = require('nuxt')
+const { Router } = require('express')
+
+const router = Router()
+
+// Test route
+router.use('/test4', async (req, res) => {
+  // Launch own puppeteer + Chromium
+  const browser = await puppeteer.launch()
+
+  const page = await browser.newPage()
+
+  try {
+    // Get nuxt instance for start (production mode)
+    // Make sure to have run `nuxt build` before running this script
+    const nuxt = await loadNuxt({ for: 'start' })
+
+    // Capture HTML via internal Nuxt render call
+    // TODO: needs some extra work to ensure pagedJs or all other dependencies are already included in generated HTML (not just as links). Browserless.io will not try to fetch additionals links.
+    // TODO: check if authentication needs to be provided (or if Nuxt is already aware)
+    const { html } = await nuxt.renderRoute('/')
+
+    // set HTML content of current page
+    await page.setContent(html)
+
+    // print pdf
+    const pdf = await page.pdf({
+      displayHeaderFooter: false,
+      printBackground: true,
+      format: 'A4',
+      margin: {
+        bottom: '0px',
+        left: '0px',
+        right: '0px',
+        top: '0px',
+      },
+    })
+    browser.close()
+
+    res.contentType('application/pdf')
+    res.send(pdf)
+  } catch (error) {
+    console.error({ error }, 'Something happened!')
+    browser.close()
+    res.send(error)
+  }
+})
+
+module.exports = router


### PR DESCRIPTION
@manuelmeister Das ist nicht als Konkurrenz für deine Arbeit gedacht (und schon gar nicht zum mergen), sondern ein Placeholder für etwas Testing/Demo meinerseits. Wollte vor allem mal den [browserless.io](https://www.browserless.io/) Dienst ausprobieren als Alternative zu unserem eigenen weasy/puppeteer-Setup und brauchte dafür einen Branch, den ich auch deployen kann.

### Frontend
- Deployed via Netlify
- Eigene Route für Print-Demo (ohne Login) unter https://ecamp3-print-demo-frontend.netlify.app/print

### Print-Preview (Nuxt)
- Deployed via Digitalocean Apps
- https://ecamp3-print-demo-gkuce.ondigitalocean.app/?pagedjs=true
- https://ecamp3-print-demo-gkuce.ondigitalocean.app/picasso?pagedjs=true

### Browserless.io
- Im Prinzip puppeteer as a service
- Mit Registrieren erhält man gratis 6h puppeteer runtime zum Testen
- ~~Das auf netlify deployde Frontend enthält meinen API token (doof ist halt, dass der dann public ist)~~ Gelöst mit serverMiddleware von Nuxt, die PDFs können direkt vom Nuxt Server generiert werden. Siehe unten.
- Gäbe es auch als docker-image zum selber hosten (https://hub.docker.com/r/browserless/chrome)
- Response-time zum PDF Drucken je nach Load 3-7s

### Nuxt serverMiddleware
Im Prinzip ein frei programmierbarer NodeJs-Endpoint. Damit kann da Generieren von HTML, Generieren von PDF, authentication etc. alles vom Server getriggert werden. Background-Jobs nicht notwendig & browserless.io-Token bleibt sicher auf dem Server.
Verschiedene Beispiele (siehe Code-Comments für genauere Beschreibung):
- https://ecamp3-print-demo-gkuce.ondigitalocean.app/pdf/test1
- https://ecamp3-print-demo-gkuce.ondigitalocean.app/pdf/test2 (ohne pagedJS)
- https://ecamp3-print-demo-gkuce.ondigitalocean.app/pdf/test3
- https://ecamp3-print-demo-gkuce.ondigitalocean.app/pdf/test4 ~~(Funktioniert nicht mit dem Deployment. Bräuchte ein zusätzliches Dockerfile, da verschiedene Linux-Packages benötigt werden. Aber eigentlich eh keine gute, skalierbare Version gegenüber Browserless.io)~~

### Weitere notes
- Die Demo zeigt nur Mock-Daten an
- Laden von Daten via `hal-json-vuex` ist wie bereits bekannt etwas difficile: Man muss mega aufpassen, dass nicht irgendwo noch ein LoadingProxy am Laden ist, bevor Nuxt fertig ist und die Response zurück schickt. In dem Sinne ist `hal-json-vuex` eigentlich ein Overkill zum einmaligen Lesen der Daten. Wäre ein cooles Einsatzgebiet für GraphQL (dogfooding our GraphQL endpoint), wenn die dann soweit wäre.
- Vuetify calendar scheint mir nicht a priori aussichtslos (aber braucht natürlich noch etwas CSS-Investment)
