### PR TITLE
CampCollaboration: add unique constraints on (user, camp) and (invite…

### DIFF
--- a/api/migrations/Version20211221131558.php
+++ b/api/migrations/Version20211221131558.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211221131558 extends AbstractMigration {
+    public function getDescription(): string {
+        return '';
+    }
+
+    public function up(Schema $schema): void {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE UNIQUE INDEX user_camp_unique ON camp_collaboration (userId, campId)');
+        $this->addSql('CREATE UNIQUE INDEX inviteEmail_camp_unique ON camp_collaboration (inviteEmail, campId)');
+    }
+
+    public function down(Schema $schema): void {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('DROP INDEX user_camp_unique');
+        $this->addSql('DROP INDEX inviteEmail_camp_unique');
+    }
+}

--- a/api/src/DataPersister/CampCollaborationDataPersister.php
+++ b/api/src/DataPersister/CampCollaborationDataPersister.php
@@ -51,6 +51,7 @@ class CampCollaborationDataPersister extends AbstractDataPersister {
             if (null != $userByInviteEmail) {
                 $data->user = $userByInviteEmail;
                 $data->inviteEmail = null;
+                $this->validator->validate($data, ['groups' => ['Default', 'create']]);
             }
             $data->inviteKey = IdGenerator::generateRandomHexString(64);
         }

--- a/api/src/DataPersister/InvitationDataPersister.php
+++ b/api/src/DataPersister/InvitationDataPersister.php
@@ -47,7 +47,6 @@ class InvitationDataPersister extends AbstractDataPersister {
 
     public function onReject($data): CampCollaboration {
         $campCollaboration = $this->campCollaborationRepository->findByInviteKey($data->inviteKey);
-        $campCollaboration->user = $this->security->getUser();
         $campCollaboration->status = CampCollaboration::STATUS_INACTIVE;
         $campCollaboration->inviteKey = null;
 

--- a/api/src/Entity/CampCollaboration.php
+++ b/api/src/Entity/CampCollaboration.php
@@ -12,6 +12,7 @@ use App\Validator\AssertEitherIsNull;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -21,7 +22,9 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @ORM\Entity(repositoryClass=CampCollaborationRepository::class)
  * @ORM\Table(uniqueConstraints={
- *     @ORM\UniqueConstraint(name="inviteKey_unique", columns={"inviteKey"})
+ *     @ORM\UniqueConstraint(name="inviteKey_unique", columns={"inviteKey"}),
+ *     @ORM\UniqueConstraint(name="user_camp_unique", fields={"user", "camp"}),
+ *     @ORM\UniqueConstraint(name="inviteEmail_camp_unique", fields={"inviteEmail", "camp"})
  * })
  */
 #[ApiResource(
@@ -67,6 +70,16 @@ use Symfony\Component\Validator\Constraints as Assert;
     normalizationContext: ['groups' => ['read']],
 )]
 #[ApiFilter(SearchFilter::class, properties: ['camp', 'activityResponsibles.activity'])]
+#[UniqueEntity(
+    fields: ['user', 'camp'],
+    message: 'This user is already present in the camp.',
+    ignoreNull: true
+)]
+#[UniqueEntity(
+    fields: ['inviteEmail', 'camp'],
+    message: 'This inviteEmail is already present in the camp.',
+    ignoreNull: true
+)]
 class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
     public const ITEM_NORMALIZATION_CONTEXT = [
         'groups' => ['read', 'CampCollaboration:Camp', 'CampCollaboration:User'],

--- a/api/tests/Api/Invitations/AcceptInvitationTest.php
+++ b/api/tests/Api/Invitations/AcceptInvitationTest.php
@@ -140,6 +140,26 @@ class AcceptInvitationTest extends ECampApiTestCase {
     }
 
     /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public function testAcceptInvitationFailsWhenUserAlreadyInCampAndUserIsAttachedToInvitation() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration6invitedWithUser'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    /**
      * @dataProvider invalidMethods
      *
      * @throws ClientExceptionInterface


### PR DESCRIPTION
…Email, camp)

That it's not possible to have the same user twice in a camp
(which leads to further problems), and to use the same
inviteEmail twice in the same camp.
Because we use postgres now, we can use a normal unique index, because postgres does not consider null values for
the unique constraints.

Because the it's not possible now to invite another user with a user reference (because a user cannot see another user),
some tests needed to be changed, and one needed to be skipped.

Remove setting the user when rejecting an invitation.