### PR TITLE
api/Profile: don't allow changing email with patch

### DIFF
--- a/api/src/Entity/Profile.php
+++ b/api/src/Entity/Profile.php
@@ -39,6 +39,7 @@ class Profile extends BaseEntity {
 
     /**
      * Unique email of the user.
+     * Cannot be changed until we have a workflow where the changed email is validated again.
      *
      * @ORM\Column(type="string", length=64, nullable=false, unique=true)
      */
@@ -46,7 +47,7 @@ class Profile extends BaseEntity {
     #[Assert\NotBlank]
     #[Assert\Email]
     #[ApiProperty(example: self::EXAMPLE_EMAIL)]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'create'])]
     public ?string $email = null;
 
     /**

--- a/api/tests/Api/Profiles/UpdateProfileTest.php
+++ b/api/tests/Api/Profiles/UpdateProfileTest.php
@@ -78,94 +78,15 @@ class UpdateProfileTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchProfileTrimsEmail() {
+    public function testPatchProfileDisallowsChangingEmail() {
+        /** @var Profile $profile */
         $profile = static::$fixtures['profile1manager'];
         static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
-            'email' => ' trimmed@example.com',
+            'email' => 'e@mail.com',
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
-        $this->assertResponseStatusCodeSame(200);
+        $this->assertResponseStatusCodeSame(400);
         $this->assertJsonContains([
-            'email' => 'trimmed@example.com',
-        ]);
-    }
-
-    public function testPatchProfileValidatesBlankEmail() {
-        $profile = static::$fixtures['profile1manager'];
-        static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
-            'email' => '',
-        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
-        $this->assertResponseStatusCodeSame(422);
-        $this->assertJsonContains([
-            'violations' => [
-                [
-                    'propertyPath' => 'email',
-                    'message' => 'This value should not be blank.',
-                ],
-            ],
-        ]);
-    }
-
-    public function testPatchProfileValidatesInvalidEmail() {
-        $profile = static::$fixtures['profile1manager'];
-        static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
-            'email' => 'hello@sunrise',
-        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
-        $this->assertResponseStatusCodeSame(422);
-        $this->assertJsonContains([
-            'violations' => [
-                [
-                    'propertyPath' => 'email',
-                    'message' => 'This value is not a valid email address.',
-                ],
-            ],
-        ]);
-    }
-
-    public function testPatchProfileValidatesLongEmail() {
-        $profile = static::$fixtures['profile1manager'];
-        static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
-            'email' => 'test-with-a-very-long-email-address-which-is-not-really-realistic@example.com',
-        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
-        $this->assertResponseStatusCodeSame(422);
-        $this->assertJsonContains([
-            'violations' => [
-                [
-                    'propertyPath' => 'email',
-                    'message' => 'This value is too long. It should have 64 characters or less.',
-                ],
-            ],
-        ]);
-    }
-
-    public function testPatchProfileValidatesDuplicateEmail() {
-        $profile = static::$fixtures['profile1manager'];
-        static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
-            'email' => static::$fixtures['user2member']->getEmail(),
-        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
-        $this->assertResponseStatusCodeSame(422);
-        $this->assertJsonContains([
-            'violations' => [
-                [
-                    'propertyPath' => 'email',
-                    'message' => 'This value is already used.',
-                ],
-            ],
-        ]);
-    }
-
-    public function testPatchProfileTrimsFirstThenValidatesDuplicateEmail() {
-        $profile = static::$fixtures['profile1manager'];
-        static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
-            'email' => ' '.static::$fixtures['user2member']->getEmail(),
-        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
-        $this->assertResponseStatusCodeSame(422);
-        $this->assertJsonContains([
-            'violations' => [
-                [
-                    'propertyPath' => 'email',
-                    'message' => 'This value is already used.',
-                ],
-            ],
+            'detail' => 'Extra attributes are not allowed ("email" is unknown).',
         ]);
     }
 


### PR DESCRIPTION
Until we have implemented #2357.

From https://github.com/ecamp/ecamp3/pull/2241#discussion_r773972174