### PR TITLE
feat(frontend): edit/add/remove schedule entries of an existing activity

### DIFF
--- a/frontend/src/components/camp/picasso/Picasso.vue
+++ b/frontend/src/components/camp/picasso/Picasso.vue
@@ -48,7 +48,8 @@ Listing all given activity schedule entries in a calendar view.
           v-if="editable && !event.tmpEvent"
           :ref="`editDialog-${event.id}`"
           :schedule-entry="event"
-          @activityUpdated="afterUpdateActivity()">
+          @activityUpdated="reloadScheduleEntries()"
+          @error="reloadScheduleEntries()">
           <template #activator="{ on }">
             <v-btn absolute
                    top
@@ -294,7 +295,7 @@ export default {
     weekdayFormat () {
       return ''
     },
-    afterUpdateActivity () {
+    reloadScheduleEntries () {
       this.api.reload(this.period.scheduleEntries())
     },
     scheduleEntryRoute

--- a/frontend/src/components/camp/picasso/Picasso.vue
+++ b/frontend/src/components/camp/picasso/Picasso.vue
@@ -47,7 +47,8 @@ Listing all given activity schedule entries in a calendar view.
         <dialog-activity-edit
           v-if="editable && !event.tmpEvent"
           :ref="`editDialog-${event.id}`"
-          :schedule-entry="event">
+          :schedule-entry="event"
+          @activityUpdated="afterUpdateActivity()">
           <template #activator="{ on }">
             <v-btn absolute
                    top
@@ -292,6 +293,9 @@ export default {
     },
     weekdayFormat () {
       return ''
+    },
+    afterUpdateActivity () {
+      this.api.reload(this.period.scheduleEntries())
     },
     scheduleEntryRoute
   }

--- a/frontend/src/components/dialog/DialogBase.vue
+++ b/frontend/src/components/dialog/DialogBase.vue
@@ -3,9 +3,18 @@ export default {
   name: 'DialogBase',
   data () {
     return {
+      // specifies entity properties available in the form
       entityProperties: [],
+
+      // single selection of related entities (e.g. activity.category)
+      // suitable for ManyToOne relations. Property is sent as IRI to the API.
       embeddedEntities: [],
+
+      // multi selection of related entities (e.g. category.preferredContentTypes)
+      // suitable for ManyToMany relations. Property is sent as array of IRIs to the API
+      // not suitable, if data of the embedded entities should be edited as well (e.g. OneToMany relations)
       embeddedCollections: [],
+
       entityData: {},
       entityUri: '',
       showDialog: false,

--- a/frontend/src/components/scheduleEntry/DialogActivityCreate.vue
+++ b/frontend/src/components/scheduleEntry/DialogActivityCreate.vue
@@ -15,7 +15,7 @@
       <slot name="activator" v-bind="scope" />
     </template>
 
-    <dialog-activity-form :activity="entityData" :camp="camp" :period="period" />
+    <dialog-activity-form :activity="entityData" :period="period" />
   </dialog-form>
 </template>
 
@@ -33,7 +33,6 @@ export default {
   },
   extends: DialogBase,
   props: {
-    camp: { type: Function, required: true },
     scheduleEntry: { type: Object, required: true },
 
     // currently visible period
@@ -81,6 +80,7 @@ export default {
     createActivity () {
       const payloadData = {
         ...this.entityData,
+
         scheduleEntries: this.entityData.scheduleEntries?.map(entry => ({
           period: entry.period()._meta.self,
           periodOffset: entry.periodOffset,
@@ -91,10 +91,8 @@ export default {
       return this.create(payloadData)
     },
     onSuccess (activity) {
-      activity.scheduleEntries()._meta.load.then(() => {
-        this.close()
-        this.$emit('activityCreated', activity)
-      })
+      this.close()
+      this.$emit('activityCreated', activity)
     }
   }
 }

--- a/frontend/src/components/scheduleEntry/DialogActivityCreate.vue
+++ b/frontend/src/components/scheduleEntry/DialogActivityCreate.vue
@@ -62,7 +62,8 @@ export default {
               period: this.scheduleEntry.period,
               periodOffset: this.scheduleEntry.periodOffset,
               length: this.scheduleEntry.length,
-              key: uniqueId()
+              key: uniqueId(),
+              deleted: false
             }
           ]
         })
@@ -81,7 +82,7 @@ export default {
       const payloadData = {
         ...this.entityData,
 
-        scheduleEntries: this.entityData.scheduleEntries?.map(entry => ({
+        scheduleEntries: this.entityData.scheduleEntries?.filter(entry => !entry.deleted).map(entry => ({
           period: entry.period()._meta.self,
           periodOffset: entry.periodOffset,
           length: entry.length

--- a/frontend/src/components/scheduleEntry/DialogActivityForm.vue
+++ b/frontend/src/components/scheduleEntry/DialogActivityForm.vue
@@ -39,7 +39,7 @@
       v-if="activity.scheduleEntries"
       :schedule-entries="activity.scheduleEntries"
       :period="period"
-      :periods="camp().periods().items" />
+      :periods="camp.periods().items" />
   </div>
 </template>
 
@@ -52,10 +52,6 @@ export default {
   props: {
     activity: {
       type: Object,
-      required: true
-    },
-    camp: {
-      type: Function,
       required: true
     },
 
@@ -72,7 +68,10 @@ export default {
   },
   computed: {
     categories () {
-      return this.camp().categories()
+      return this.camp.categories()
+    },
+    camp () {
+      return this.period().camp()
     }
   }
 }

--- a/frontend/src/components/scheduleEntry/FormScheduleEntryList.vue
+++ b/frontend/src/components/scheduleEntry/FormScheduleEntryList.vue
@@ -15,13 +15,13 @@
         </v-col>
       </v-row>
       <transition-group name="transition-list" tag="div" class="row no-gutters">
-        <form-schedule-entry-item v-for="(scheduleEntry, index) in scheduleEntries"
+        <form-schedule-entry-item v-for="scheduleEntry in scheduleEntriesWithoutDeleted"
                                   :key="scheduleEntry.key"
                                   class="transition-list-item pa-0 mb-4"
                                   :schedule-entry="scheduleEntry"
                                   :periods="periods"
                                   :is-last-item="scheduleEntries.length === 1"
-                                  @delete="deleteEntry(index)" />
+                                  @delete="deleteEntry(scheduleEntry)" />
       </transition-group>
       <v-row>
         <v-col cols="12" class="text-center" />
@@ -60,17 +60,23 @@ export default {
       localScheduleEntries: this.scheduleEntries
     }
   },
+  computed: {
+    scheduleEntriesWithoutDeleted () {
+      return this.scheduleEntries.filter(entry => !entry.deleted)
+    }
+  },
   methods: {
     addScheduleEntry () {
       this.localScheduleEntries.push({
         period: () => (this.period)(),
         periodOffset: 420, // 7am
         length: 60, // 1 hours
-        key: uniqueId()
+        key: uniqueId(),
+        deleted: false
       })
     },
-    deleteEntry (index) {
-      this.localScheduleEntries.splice(index, 1)
+    deleteEntry (scheduleEntry) {
+      this.$set(scheduleEntry, 'deleted', true)
     }
   }
 }

--- a/frontend/src/components/scheduleEntry/ScheduleEntries.vue
+++ b/frontend/src/components/scheduleEntry/ScheduleEntries.vue
@@ -6,7 +6,6 @@
       :on="eventHandlers" />
     <dialog-activity-create
       ref="dialogActivityCreate"
-      :camp="period().camp"
       :period="period"
       :schedule-entry="newEntryPlaceholder"
       @activityCreated="afterCreateActivity($event)"


### PR DESCRIPTION
Fixes #2350 
Fixes #1375 

This is currently implemented with individual post/patch/delete and not with embedded collection patch. As a side effect, the update action is not atomic, e.g. some schedule entries might be updated/inserted/removed successfully while others fail. If we want this to be atomic we need embedded collection patch, which needs either:

- This API platform bug to be fixed: https://github.com/api-platform/core/issues/4630
- Or: Change to use put instead of patch (which would be weird and not very sustainable)
- Or: Do this [workaround ](https://github.com/api-platform/core/issues/4293#issuecomment-831252083) (already [tried once with sorting](https://github.com/ecamp/ecamp3/pull/2196/files#diff-7fa3272b232d11cbfcdb7391a536535f061f82a5c5fbdb44d3b649fe1b4c269dR54)), until the bug is fixed
- Or: Accept that scheduleEntries would not keep their ID/IRI when patching (new entries will be created every time and the old ones removed) - also very weird


Validation is not yet properly covered. This will come in #2339.