### PR TITLE
fix(deps): update dependency lexik/jwt-authentication-bundle to v2.14.4

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -14,7 +14,7 @@
         "doctrine/orm": "2.10.3",
         "exercise/htmlpurifier-bundle": "3.1.0",
         "guzzlehttp/guzzle": "7.4.1",
-        "lexik/jwt-authentication-bundle": "2.14.2",
+        "lexik/jwt-authentication-bundle": "2.14.4",
         "nelmio/cors-bundle": "2.2.0",
         "phpdocumentor/reflection-docblock": "5.3.0",
         "rize/uri-template": "0.3.4",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ea502bcac8c927a16c0b16b6a771260",
+    "content-hash": "c68ccd022afaf0e84457dfc53f6265b1",
     "packages": [
         {
             "name": "api-platform/core",
@@ -2650,16 +2650,16 @@
         },
         {
             "name": "lexik/jwt-authentication-bundle",
-            "version": "v2.14.2",
+            "version": "v2.14.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lexik/LexikJWTAuthenticationBundle.git",
-                "reference": "41cd2596c77c8c20dac40ff9cdeba2645446cfb7"
+                "reference": "b08d174fc979e12f609ad075e49b46a9e30ecfac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lexik/LexikJWTAuthenticationBundle/zipball/41cd2596c77c8c20dac40ff9cdeba2645446cfb7",
-                "reference": "41cd2596c77c8c20dac40ff9cdeba2645446cfb7",
+                "url": "https://api.github.com/repos/lexik/LexikJWTAuthenticationBundle/zipball/b08d174fc979e12f609ad075e49b46a9e30ecfac",
+                "reference": "b08d174fc979e12f609ad075e49b46a9e30ecfac",
                 "shasum": ""
             },
             "require": {
@@ -2753,7 +2753,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lexik/LexikJWTAuthenticationBundle/issues",
-                "source": "https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.14.2"
+                "source": "https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v2.14.4"
             },
             "funding": [
                 {
@@ -2765,7 +2765,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-05T17:35:05+00:00"
+            "time": "2022-01-04T23:33:23+00:00"
         },
         {
             "name": "monolog/monolog",


### PR DESCRIPTION
This fixes hp.INFO: Deprecated: Return type of Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\ChainTokenExtractor::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice {"exception":"[object] (ErrorException(code: 0): Deprecated: Return type of Lexik\\Bundle\\JWTAuthenticationBundle\\TokenExtractor\\ChainTokenExtractor::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice at /srv/api/vendor/lexik/jwt-authentication-bundle/TokenExtractor/ChainTokenExtractor.php:91)"} []

Which sometimes leads to:
Attempted to load class "LineFormatter" from namespace "Monolog\Formatter".
Did you forget a "use" statement for another namespace? when api platform tries to log the first error.
