### PR TITLE
auth.js: remove cookie of SHARED_COOKIE_DOMAIN

### DIFF
--- a/.helm/ecamp3/templates/frontend_configmap.yaml
+++ b/.helm/ecamp3/templates/frontend_configmap.yaml
@@ -15,6 +15,7 @@ data:
     {{- else }}
       SENTRY_FRONTEND_DSN: null,
     {{- end }}
+      SHARED_COOKIE_DOMAIN: '{{ .Values.sharedCookieDomain }}',
       DEPLOYMENT_TIME: '{{ .Values.deploymentTime }}',
       VERSION: '{{ .Values.deployedVersion }}',
       VERSION_LINK_TEMPLATE: '{{ .Values.versionLinkTemplate }}',

--- a/frontend/.jest/environment.js
+++ b/frontend/.jest/environment.js
@@ -2,6 +2,7 @@ window.environment = {
   API_ROOT_URL: 'http://localhost',
   PRINT_SERVER: 'http://localhost:3003',
   PRINT_FILE_SERVER: 'http://localhost:3005',
+  SHARED_COOKIE_DOMAIN: 'localhost',
   DEPLOYMENT_TIME: '',
   VERSION: '',
   VERSION_LINK_TEMPLATE: 'https://github.com/ecamp/ecamp3/commit/{version}',

--- a/frontend/public/environment.dist
+++ b/frontend/public/environment.dist
@@ -3,6 +3,7 @@ window.environment = {
   PRINT_SERVER: 'http://localhost:3003',
   PRINT_FILE_SERVER: 'http://localhost:3005',
   SENTRY_FRONTEND_DSN: null,
+  SHARED_COOKIE_DOMAIN: 'localhost',
   DEPLOYMENT_TIME: '',
   VERSION: '',
   VERSION_LINK_TEMPLATE: 'https://github.com/ecamp/ecamp3/commit/{version}',

--- a/frontend/public/environment.docker.dist
+++ b/frontend/public/environment.docker.dist
@@ -3,6 +3,7 @@ window.environment = {
   PRINT_SERVER: 'http://localhost:3003',
   PRINT_FILE_SERVER: 'http://localhost:3005',
   SENTRY_FRONTEND_DSN: null,
+  SHARED_COOKIE_DOMAIN: 'localhost',
   VERSION: '',
   VERSION_LINK_TEMPLATE: 'https://github.com/ecamp/ecamp3/commit/{version}',
 }

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -92,7 +92,7 @@ async function loginPbsMiData () {
 }
 
 export async function logout () {
-  Cookies.remove('jwt_hp')
+  Cookies.remove('jwt_hp', { domain: window.environment.SHARED_COOKIE_DOMAIN })
   return router.push({ name: 'login' })
     .then(() => apiStore.purgeAll())
     .then(() => isLoggedIn())


### PR DESCRIPTION
If the domain parameter is not provided, it deletes
the cookie on the current domain, which is on dev.ecamp3.ch
dev.ecamp3.ch.
But the cookie is stored for the domain .ecamp3.ch and thus not deleted.

Issue: #2361