### PR TITLE
Camp: assert at least one period in camp

### DIFF
--- a/api/src/DataPersister/PeriodDataPersister.php
+++ b/api/src/DataPersister/PeriodDataPersister.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\DataPersister;
+
+use ApiPlatform\Core\Validator\ValidatorInterface;
+use App\DataPersister\Util\AbstractDataPersister;
+use App\DataPersister\Util\DataPersisterObservable;
+use App\Entity\BaseEntity;
+use App\Entity\Period;
+
+class PeriodDataPersister extends AbstractDataPersister {
+    public function __construct(
+        DataPersisterObservable $dataPersisterObservable,
+        private ValidatorInterface $validator
+    ) {
+        parent::__construct(
+            Period::class,
+            $dataPersisterObservable,
+        );
+    }
+
+    public function beforeRemove($data): ?BaseEntity {
+        $this->validator->validate($data, ['groups' => ['delete', 'Period:delete']]);
+
+        return null;
+    }
+}

--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -72,6 +72,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      */
     #[Assert\Valid]
     #[Assert\Count(min: 1, groups: ['create'])]
+    #[Assert\Count(min: 2, minMessage: 'A camp must have at least one period.', groups: ['Period:delete'])]
     #[ApiProperty(
         writableLink: true,
         example: '[{ "description": "Hauptlager", "start": "2022-01-01", "end": "2022-01-08" }]',

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -85,6 +85,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
      * @ORM\ManyToOne(targetEntity="Camp", inversedBy="periods")
      * @ORM\JoinColumn(nullable=false)
      */
+    #[Assert\Valid]
     #[ApiProperty(example: '/camps/1a2b3c4d')]
     #[Groups(['read', 'create'])]
     public ?Camp $camp = null;

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -85,7 +85,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
      * @ORM\ManyToOne(targetEntity="Camp", inversedBy="periods")
      * @ORM\JoinColumn(nullable=false)
      */
-    #[Assert\Valid(groups: ['delete'])]
+    #[Assert\Valid(groups: ['Period:delete'])]
     #[ApiProperty(example: '/camps/1a2b3c4d')]
     #[Groups(['read', 'create'])]
     public ?Camp $camp = null;

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -85,7 +85,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
      * @ORM\ManyToOne(targetEntity="Camp", inversedBy="periods")
      * @ORM\JoinColumn(nullable=false)
      */
-    #[Assert\Valid]
+    #[Assert\Valid(groups: ['delete'])]
     #[ApiProperty(example: '/camps/1a2b3c4d')]
     #[Groups(['read', 'create'])]
     public ?Camp $camp = null;

--- a/api/tests/Api/Periods/DeletePeriodTest.php
+++ b/api/tests/Api/Periods/DeletePeriodTest.php
@@ -84,4 +84,20 @@ class DeletePeriodTest extends ECampApiTestCase {
             'detail' => 'Access Denied.',
         ]);
     }
+
+    public function testDeleteLastPeriodIsRejected() {
+        $period = static::$fixtures['period1camp2'];
+        static::createClientWithCredentials()
+            ->request('DELETE', '/periods/'.$period->getId())
+        ;
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'camp.periods',
+                    'message' => 'A camp must have at least one period.',
+                ],
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
It looks a little hacky, the reason is:
For a delete request, the validations are normally not processed
The camp looses the period only after the delete operation, not before.
If we remove the period from the camp before running the validation, the #[Assert\Valid] is not processes, because the camp property on period is null.
But if we want to delete 1 Period from a camp, there has to be at least one other,
so i added this validation on Camp.

Issue: #2405

Here we have the discussion of #2363 where we want to put the validation.
The object oriented approach by defining it on the camp sounds good.
But because of the nature of Api Platform/Doctrine, it looks a little silly that we need 2 Periods that we can delete 1...