### PR TITLE
api/composer.json: add allow-plugins section

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -63,7 +63,13 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "cweagans/composer-patches": true,
+            "symfony/flex": true,
+            "symfony/runtime": true
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
After #2401, we should add this section.
docs:
https://getcomposer.org/doc/06-config.md#allow-plugins