### PR TITLE
Renovate: add groups for php linter, js linter and docker images, fix update of php docker image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,6 @@
       "matchPackageNames": [
         "php"
       ],
-      "extractVersion": "^php-(?<version>.*)$",
       "automerge": false
     },
     {
@@ -108,7 +107,8 @@
       "depNameTemplate": "php",
       "lookupNameTemplate": "php/php-src",
       "datasourceTemplate": "github-tags",
-      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>\\w+)?$"
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>\\w+)?$",
+      "extractVersionTemplate": "regex:^php-(?<version>.*)$"
     },
     {
       "fileMatch": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,21 @@
 {
   "extends": [
     "config:base",
-    "docker:pinDigests"
+    "docker:pinDigests",
+    "group:all"
   ],
+  "js": {
+    "managerBranchPrefix": "js-",
+    "commitMessageSuffix": "js"
+  },
+  "php" : {
+    "managerBranchPrefix": "php-",
+    "commitMessageSuffix": "php"
+  },
+  "docker": {
+    "managerBranchPrefix": "docker-",
+    "commitMessageSuffix": "docker tags"
+  },
   "force": {
     "constraints": {
       "node": "= 16.3.0",
@@ -30,7 +43,37 @@
         "php"
       ],
       "extractVersion": "^php-(?<version>.*)$",
-      "automerge": false
+      "automerge": false,
+      "groupName": "php"
+    },
+    {
+      "matchPackageNames": [
+        "composer"
+      ],
+      "groupName": "composer"
+    },
+    {
+      "matchPackageNames": [
+        "node"
+      ],
+      "groupName" : "node"
+    },
+    {
+      "matchPackageNames": [
+        "eslint",
+        "lint",
+        "stylelint",
+        "prettier"
+      ],
+      "groupName": "js-linter"
+    },
+    {
+      "matchPackageNames": [
+        "phpstan/phpstan",
+        "friendsofphp/php-cs-fixer",
+        "vimeo/psalm"
+      ],
+      "groupName": "php-linter"
     }
   ],
   "ignorePaths": [

--- a/renovate.json
+++ b/renovate.json
@@ -108,7 +108,7 @@
       "lookupNameTemplate": "php/php-src",
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>\\w+)?$",
-      "extractVersionTemplate": "regex:^php-(?<version>.*)$"
+      "extractVersionTemplate": "^php-(?<version>.*)$"
     },
     {
       "fileMatch": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,8 @@
 {
   "extends": [
     "config:base",
-    "docker:pinDigests",
-    "group:all",
-    "schedule:earlyMondays"
+    "docker:pinDigests"
   ],
-  "js": {
-    "managerBranchPrefix": "js-",
-    "commitMessageSuffix": "js"
-  },
-  "php" : {
-    "managerBranchPrefix": "php-",
-    "commitMessageSuffix": "php"
-  },
-  "docker": {
-    "managerBranchPrefix": "docker-",
-    "commitMessageSuffix": "docker tags"
-  },
   "force": {
     "constraints": {
       "node": "= 16.3.0",
@@ -44,20 +30,7 @@
         "php"
       ],
       "extractVersion": "^php-(?<version>.*)$",
-      "automerge": false,
-      "groupName": "php"
-    },
-    {
-      "matchPackageNames": [
-        "composer"
-      ],
-      "groupName": "composer"
-    },
-    {
-      "matchPackageNames": [
-        "node"
-      ],
-      "groupName" : "node"
+      "automerge": false
     },
     {
       "matchPackageNames": [
@@ -75,6 +48,21 @@
         "vimeo/psalm"
       ],
       "groupName": "php-linter"
+    },
+    {
+      "matchPackageNames": [
+        "caddy",
+        "krakjoe/apcu",
+        "mailhog/mailhog",
+        "phpmyadmin/phpmyadmin",
+        "postgres",
+        "python",
+        "qoomon/docker-host"
+      ],
+      "groupName": "docker-images",
+      "extends": [
+        "schedule:weekly"
+      ]
     }
   ],
   "ignorePaths": [

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     "config:base",
     "docker:pinDigests",
-    "group:all"
+    "group:all",
+    "schedule:earlyMondays"
   ],
   "js": {
     "managerBranchPrefix": "js-",


### PR DESCRIPTION
With the last 2 commits:

- [x] Add group for php-linter
- [x] Add group for js-linter
- [x] Add group for docker images and update them only once a week
- [x] fix the update of the php image

