### PR TITLE
ScheduleEntryRepository.createQueryBuild add return-type

### DIFF
--- a/api/src/Repository/ScheduleEntryRepository.php
+++ b/api/src/Repository/ScheduleEntryRepository.php
@@ -21,7 +21,7 @@ class ScheduleEntryRepository extends ServiceEntityRepository implements CanFilt
         parent::__construct($registry, ScheduleEntry::class);
     }
 
-    public function createQueryBuilder($alias, $indexBy = null) {
+    public function createQueryBuilder($alias, $indexBy = null): QueryBuilder {
         $qb = parent::createQueryBuilder($alias, $indexBy);
         $qb->orderBy($alias.'.period', 'ASC')
             ->addOrderBy($alias.'.periodOffset', 'ASC')


### PR DESCRIPTION
Fehlender Return-Type verursacht in den UnitTest eine Notice:
https://github.com/ecamp/ecamp3/runs/5083781328?check_suite_focus=true#step:10:43

