### PR TITLE
ECampApiTestCase: check empty lists stricter in assertJsonContainsItems

### DIFF
--- a/api/tests/Api/ECampApiTestCase.php
+++ b/api/tests/Api/ECampApiTestCase.php
@@ -246,7 +246,6 @@ abstract class ECampApiTestCase extends ApiTestCase {
             'totalItems' => count($items),
         ]);
 
-        // TODO: remove if once PR #2062 is merged
         if (!empty($items)) {
             $this->assertJsonContains([
                 '_links' => [
@@ -261,6 +260,12 @@ abstract class ECampApiTestCase extends ApiTestCase {
                 array_map(fn ($iri): array => ['href' => $iri], $items),
                 $response->toArray()['_links']['items']
             );
+        } else {
+            $this->assertJsonContains([
+                '_embedded' => [
+                    'items' => [],
+                ],
+            ]);
         }
     }
 }


### PR DESCRIPTION
It's not possible to remove the if entirely, because
the CollectionItemsNormalizer only adds an empty embedded
array with the key items,
not an empty link array with the key items.
As can be seen in
CollectionItemsNormalizerTest::testNormalizeAddsEmptyEmbeddedItemsIfTotalItemsIsZero

closes #2348