### PR TITLE
Create materiallist for collaboration

### DIFF
--- a/api/fixtures/materialLists.yml
+++ b/api/fixtures/materialLists.yml
@@ -5,6 +5,9 @@ App\Entity\MaterialList:
   materialList2:
     camp: '@camp1'
     name: Packliste
+  materialList3Manager:
+    camp: '@camp1'
+    campCollaboration: '@campCollaboration1manager'
   materialList1camp2:
     camp: '@camp2'
     name: Baumarkt

--- a/api/migrations/schema/Version20220319211452.php
+++ b/api/migrations/schema/Version20220319211452.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220319211452 extends AbstractMigration {
+    public function getDescription(): string {
+        return 'Add campCollaboration to MaterialList';
+    }
+
+    public function up(Schema $schema): void {
+        $this->addSql('ALTER TABLE material_list ADD campCollaborationId VARCHAR(16) DEFAULT NULL');
+        $this->addSql('ALTER TABLE material_list ADD CONSTRAINT FK_10A0952D56778C5C FOREIGN KEY (campCollaborationId) REFERENCES camp_collaboration (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE material_list ALTER COLUMN name DROP NOT NULL');
+        $this->addSql('CREATE INDEX IDX_10A0952D56778C5C ON material_list (campCollaborationId)');
+    }
+
+    public function down(Schema $schema): void {
+        $this->addSql('ALTER TABLE material_list ALTER COLUMN name SET NOT NULL');
+        $this->addSql('ALTER TABLE material_list DROP CONSTRAINT FK_10A0952D56778C5C');
+        $this->addSql('DROP INDEX IDX_10A0952D56778C5C');
+        $this->addSql('ALTER TABLE material_list DROP campCollaborationId');
+    }
+}

--- a/api/src/DataPersister/CampDataPersister.php
+++ b/api/src/DataPersister/CampDataPersister.php
@@ -7,6 +7,7 @@ use App\DataPersister\Util\DataPersisterObservable;
 use App\Entity\BaseEntity;
 use App\Entity\Camp;
 use App\Entity\CampCollaboration;
+use App\Entity\MaterialList;
 use App\Entity\User;
 use App\Util\EntityMap;
 use Doctrine\ORM\EntityManagerInterface;
@@ -47,6 +48,7 @@ class CampDataPersister extends AbstractDataPersister {
     }
 
     public function afterCreate($data): void {
+        /** @var Camp $data */
         /** @var User $user */
         $user = $this->security->getUser();
         $collaboration = new CampCollaboration();
@@ -55,6 +57,12 @@ class CampDataPersister extends AbstractDataPersister {
         $collaboration->status = CampCollaboration::STATUS_ESTABLISHED;
         $data->addCampCollaboration($collaboration);
         $this->em->persist($collaboration);
+
+        $materialList = new MaterialList();
+        $materialList->campCollaboration = $collaboration;
+        $data->addMaterialList($materialList);
+        $this->em->persist($materialList);
+
         $this->em->flush();
     }
 }

--- a/api/src/Entity/MaterialList.php
+++ b/api/src/Entity/MaterialList.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\SerializedName;
 
 /**
  * A list of material items that someone needs to bring to the camp. A material list
@@ -57,6 +58,16 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface, CopyFro
     public ?Camp $camp = null;
 
     /**
+     * The campCollaboration this material list belongs to.
+     *
+     * @ORM\OneToOne(targetEntity="CampCollaboration")
+     * @ORM\JoinColumn(nullable=true, onDelete="SET NULL")
+     */
+    #[ApiProperty(writable: false, example: '/camp_collaborations/1a2b3c4d')]
+    #[Groups(['read'])]
+    public ?CampCollaboration $campCollaboration = null;
+
+    /**
      * The id of the material list that was used as a template for creating this camp. Internal
      * for now, is not published through the API.
      *
@@ -68,10 +79,10 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface, CopyFro
     /**
      * The human readable name of the material list.
      *
-     * @ORM\Column(type="text", nullable=false)
+     * @ORM\Column(type="text")
      */
     #[ApiProperty(example: 'Lebensmittel')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['write'])]
     public ?string $name = null;
 
     public function __construct() {
@@ -109,6 +120,16 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface, CopyFro
         return $this;
     }
 
+    #[ApiProperty(example: 'Lebensmittel')]
+    #[SerializedName('name')]
+    #[Groups(['read'])]
+    public function getName(): ?string {
+        return $this->name
+            ?? $this->campCollaboration?->user?->getDisplayName()
+            ?? $this->campCollaboration?->inviteEmail
+            ?? 'NoName';
+    }
+
     /**
      * @param MaterialList $prototype
      * @param EntityMap    $entityMap
@@ -117,6 +138,6 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface, CopyFro
         $entityMap->add($prototype, $this);
 
         $this->materialListPrototypeId = $prototype->getId();
-        $this->name = $prototype->name;
+        $this->name = $prototype->getName();
     }
 }

--- a/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
@@ -136,6 +136,50 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
         ]));
     }
 
+    public function testCreateCampCollaborationWithUserCreatesMaterialList() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+
+        $client->request('GET', '/material_lists?camp='.$this->getIriFor('camp1'));
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'totalItems' => 3,
+            '_links' => [
+                'items' => [],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
+
+        $client->request(
+            'POST',
+            '/camp_collaborations',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        'user' => $this->getIriFor('user4unrelated'),
+                    ],
+                    ['inviteEmail']
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $client->request('GET', '/material_lists?camp='.$this->getIriFor('camp1'));
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'totalItems' => 4,
+            '_links' => [
+                'items' => [],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
+    }
+
     public function testCreateCampCollaborationInCampPrototypeIsDeniedForUnrelatedUser() {
         static::createClientWithCredentials()->request('POST', '/camp_collaborations', ['json' => $this->getExampleWritePayload([
             'camp' => $this->getIriFor('campPrototype'),

--- a/api/tests/Api/Camps/CreateCampTest.php
+++ b/api/tests/Api/Camps/CreateCampTest.php
@@ -634,7 +634,7 @@ class CreateCampTest extends ECampApiTestCase {
         $camp = $this->getEntityManager()->getRepository(Camp::class)->find($response->toArray()['id']);
         $this->assertEquals($campPrototype->getId(), $camp->campPrototypeId);
         $this->assertCount(1, $camp->categories);
-        $this->assertCount(1, $camp->materialLists);
+        $this->assertCount(2, $camp->materialLists);
     }
 
     public function testCreateCampReturnsProperDatesInTimezoneAheadOfUTC() {

--- a/api/tests/Api/MaterialLists/ListMaterialListsTest.php
+++ b/api/tests/Api/MaterialLists/ListMaterialListsTest.php
@@ -24,7 +24,7 @@ class ListMaterialListsTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()->request('GET', '/material_lists');
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'totalItems' => 4,
+            'totalItems' => 5,
             '_links' => [
                 'items' => [],
             ],
@@ -35,6 +35,7 @@ class ListMaterialListsTest extends ECampApiTestCase {
         $this->assertEqualsCanonicalizing([
             ['href' => $this->getIriFor('materialList1')],
             ['href' => $this->getIriFor('materialList2')],
+            ['href' => $this->getIriFor('materialList3Manager')],
             ['href' => $this->getIriFor('materialList1camp2')],
             ['href' => $this->getIriFor('materialList1campPrototype')],
         ], $response->toArray()['_links']['items']);
@@ -45,7 +46,7 @@ class ListMaterialListsTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()->request('GET', '/material_lists?camp=/camps/'.$camp->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'totalItems' => 2,
+            'totalItems' => 3,
             '_links' => [
                 'items' => [],
             ],
@@ -56,6 +57,7 @@ class ListMaterialListsTest extends ECampApiTestCase {
         $this->assertEqualsCanonicalizing([
             ['href' => $this->getIriFor('materialList1')],
             ['href' => $this->getIriFor('materialList2')],
+            ['href' => $this->getIriFor('materialList3Manager')],
         ], $response->toArray()['_links']['items']);
     }
 

--- a/api/tests/Api/MaterialLists/UpdateMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/UpdateMaterialListTest.php
@@ -89,6 +89,17 @@ class UpdateMaterialListTest extends ECampApiTestCase {
         ]);
     }
 
+    public function testSetNameOfMaterialListWithCampCollaborationOverwritesGeneratedName() {
+        $materialList = static::$fixtures['materialList3Manager'];
+        static::createClientWithCredentials()->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [
+            'name' => 'Something',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'name' => 'Something',
+        ]);
+    }
+
     public function testPatchMaterialListInCampPrototypeIsDeniedForUnrelatedUser() {
         $materialList = static::$fixtures['materialList1campPrototype'];
         static::createClientWithCredentials()->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [

--- a/api/tests/DataPersister/CampDataPersisterTest.php
+++ b/api/tests/DataPersister/CampDataPersisterTest.php
@@ -6,8 +6,11 @@ use App\DataPersister\CampDataPersister;
 use App\DataPersister\Util\DataPersisterObservable;
 use App\Entity\Camp;
 use App\Entity\CampCollaboration;
+use App\Entity\MaterialList;
+use App\Entity\Profile;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Security;
@@ -44,23 +47,62 @@ class CampDataPersisterTest extends TestCase {
         $this->assertEquals($user, $data->owner);
     }
 
-    public function testCreatesCampCollaborationAfterCreate() {
+    public function testCreatesCampCollaborationAndMaterialListAfterCreate() {
         // given
+        $profile = new Profile();
+        $profile->nickname = 'test';
         $user = new User();
+        $user->profile = $profile;
         $this->security->method('getUser')->willReturn($user);
 
-        // then
-        $this->em->expects($this->once())->method('persist')->will($this->returnCallback(function ($object) use ($user) {
-            $this->assertInstanceOf(CampCollaboration::class, $object);
-            $campCollaboration = $object;
-            $this->assertEquals($user, $campCollaboration->user);
-            $this->assertEquals($this->camp, $campCollaboration->camp);
-            $this->assertEquals(CampCollaboration::STATUS_ESTABLISHED, $campCollaboration->status);
-            $this->assertEquals(CampCollaboration::ROLE_MANAGER, $campCollaboration->role);
-            $this->assertContains($campCollaboration, $this->camp->collaborations);
-        }));
+        $this->em
+            ->expects($this->exactly(2))
+            ->method('persist')
+            ->withConsecutive(
+                [
+                    self::campCollaborationWith(
+                        $user,
+                        $this->camp,
+                        CampCollaboration::STATUS_ESTABLISHED,
+                        CampCollaboration::ROLE_MANAGER
+                    ),
+                ],
+                [
+                    self::materialListWith(
+                        $this->camp
+                    ),
+                ]
+            )
+        ;
 
         // when
         $this->dataPersister->afterCreate($this->camp);
+    }
+
+    private static function campCollaborationWith(User $user, Camp $camp, string $status, string $role): Callback {
+        return self::callback(function ($object) use ($user, $camp, $status, $role) {
+            if (!$object instanceof CampCollaboration) {
+                return false;
+            }
+            $campCollaboration = $object;
+
+            return $user === $campCollaboration->user
+                && $camp === $campCollaboration->camp
+                && $status === $campCollaboration->status
+                && $role === $campCollaboration->role
+                && in_array($campCollaboration, $camp->collaborations->toArray());
+        });
+    }
+
+    private static function materialListWith(Camp $camp): Callback {
+        return self::callback(function ($objectToPersist) use ($camp) {
+            if (!$objectToPersist instanceof MaterialList) {
+                return false;
+            }
+
+            return null !== $objectToPersist->campCollaboration
+                && $camp === $objectToPersist->getCamp()
+                && null === $objectToPersist->name;
+        });
     }
 }

--- a/api/tests/Entity/MaterialListTest.php
+++ b/api/tests/Entity/MaterialListTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\CampCollaboration;
+use App\Entity\MaterialList;
+use App\Entity\User;
+use function PHPUnit\Framework\assertThat;
+use function PHPUnit\Framework\equalTo;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class MaterialListTest extends TestCase {
+    public const USER_DISPLAY_NAME = 'DISPLAYNAME';
+    private MockObject|User $user;
+    private CampCollaboration $campCollaboration;
+
+    protected function setUp(): void {
+        $this->user = $this->createMock(User::class);
+        $this->user->method('getDisplayName')->willReturn(self::USER_DISPLAY_NAME);
+        $this->campCollaboration = new CampCollaboration();
+    }
+
+    public function testNameWhenNoCampCollaboration() {
+        $materialList = new MaterialList();
+        $materialList->name = 'test';
+
+        assertThat($materialList->getName(), equalTo($materialList->name));
+    }
+
+    public function testNameWhenCampCollaborationButNameIsSet() {
+        $materialList = new MaterialList();
+        $materialList->name = 'test';
+        $this->campCollaboration->inviteEmail = 'test@mail.com';
+        $materialList->campCollaboration = $this->campCollaboration;
+
+        assertThat($materialList->getName(), equalTo($materialList->name));
+    }
+
+    public function testNameWhenCampCollaborationWithUserButNameIsSet() {
+        $materialList = new MaterialList();
+        $materialList->name = 'test';
+        $this->campCollaboration->user = $this->user;
+        $materialList->campCollaboration = $this->campCollaboration;
+
+        assertThat($materialList->getName(), equalTo($materialList->name));
+    }
+
+    public function testNameWhenNoCampCollaborationAndNameNull() {
+        $materialList = new MaterialList();
+        $materialList->name = null;
+
+        assertThat($materialList->getName(), equalTo('NoName'));
+    }
+
+    public function testNameWhenCampCollaborationAndNameNull() {
+        $materialList = new MaterialList();
+        $materialList->name = null;
+        $this->campCollaboration->inviteEmail = 'test@mail.com';
+        $materialList->campCollaboration = $this->campCollaboration;
+
+        assertThat($materialList->getName(), equalTo($this->campCollaboration->inviteEmail));
+    }
+
+    public function testNameWhenCampCollaborationWithUserAndNameNull() {
+        $materialList = new MaterialList();
+        $materialList->name = null;
+        $this->campCollaboration->user = $this->user;
+        $materialList->campCollaboration = $this->campCollaboration;
+
+        assertThat($materialList->getName(), equalTo(self::USER_DISPLAY_NAME));
+    }
+}


### PR DESCRIPTION
- [x] add foreign key from materialList to campCollaboration, and use the username (new)
- [x] create Materiallist when creating a camp ~with name displayname of the creator~ with reference to the created campCollaboration
- [x] create a Materiallist when inviting an ~existing user with the displayname of the invited user~ user, with reference to the created campCollaboration
- [x] ~create a Materiallist when inviting a not existing user with the inviteEmail~ same case as above
- [x] ~rename the Materiallist when the Invitation for a previously not existing user is accepted~
- [x] Zu diskutieren: was machen wir, wenn die Invitation mit einem anderen User akzeptiert wird? -> die MaterialList übernimmt den Namen des referenzierten users
- [x] Falls 2 User den gleichen Displayname haben -> user können trotzdem den namen der liste überschreiben. Dann wird natürlich der username nicht mehr nachgeführt
- [x] Falls die CampCollaboration gelöscht wird, und die CampCollaboration keinen name hatte, wird "NoName" ausgegeben.
-> User können entweder die Liste löschen, oder sie umbenennen. 