### PR TITLE
fix: frontend api errors

### DIFF
--- a/frontend/src/components/activity/ButtonNestedContentNodeAdd.vue
+++ b/frontend/src/components/activity/ButtonNestedContentNodeAdd.vue
@@ -19,7 +19,7 @@
       <v-list>
         <!-- preferred content types -->
         <v-list-item v-for="act in preferredContentTypes"
-                     :key="act.contentType.id"
+                     :key="act.contentType._meta.self"
                      @click="addContentNode(act.contentType)">
           <v-list-item-icon>
             <v-icon>{{ $tc(act.contentTypeIconKey) }}</v-icon>
@@ -33,7 +33,7 @@
 
         <!-- all other content types -->
         <v-list-item v-for="act in nonpreferredContentTypes"
-                     :key="act.contentType.id"
+                     :key="act.contentType._meta.self"
                      @click="addContentNode(act.contentType)">
           <v-list-item-icon>
             <v-icon>{{ $tc(act.contentTypeIconKey) }}</v-icon>

--- a/frontend/src/components/activity/content/LAThematicArea.vue
+++ b/frontend/src/components/activity/content/LAThematicArea.vue
@@ -3,7 +3,7 @@
     <v-list three-line class="mx-n4">
       <v-list-item-group>
         <v-list-item v-for="option in contentNode.options().items"
-                     :key="option.id"
+                     :key="option._meta.self"
                      tag="label"
                      :disabled="layoutMode || disabled">
           <v-list-item-action>

--- a/frontend/src/components/camp/CampCategories.vue
+++ b/frontend/src/components/camp/CampCategories.vue
@@ -23,7 +23,7 @@ Displays all periods of a single camp and allows to edit them & create new ones
     <v-list>
       <v-list-item
         v-for="category in categories.items"
-        :key="category.id"
+        :key="category._meta.self"
         class="px-0">
         <v-list-item-content class="pt-0 pb-2">
           <v-list-item-title>
@@ -72,10 +72,10 @@ Displays all periods of a single camp and allows to edit them & create new ones
                   <template v-if="findActivities(category).length > 0" #error>
                     {{ $tc('components.camp.CampCategories.deleteCategoryNotPossibleInUse') }}
                     <ul>
-                      <li v-for="activity in findActivities(category)" :key="activity.id">
+                      <li v-for="activity in findActivities(category)" :key="activity._meta.self">
                         {{ activity.title }}
                         <ul>
-                          <li v-for="scheduleEntry in activity.scheduleEntries().items" :key="scheduleEntry.id">
+                          <li v-for="scheduleEntry in activity.scheduleEntries().items" :key="scheduleEntry._meta.self">
                             <router-link :to="{ name: 'activity', params: { campId: camp().id, scheduleEntryId: scheduleEntry.id } }">
                               {{ scheduleEntry.startTime }} - {{ scheduleEntry.endTime }}
                             </router-link>

--- a/frontend/src/components/camp/CampMaterialLists.vue
+++ b/frontend/src/components/camp/CampMaterialLists.vue
@@ -18,7 +18,7 @@
     <v-list>
       <camp-material-lists-item
         v-for="materialList in materialLists.items"
-        :key="materialList.id"
+        :key="materialList._meta.self"
         class="px-0"
         :material-list="materialList"
         :disabled="disabled" />

--- a/frontend/src/components/camp/CampMaterialListsItem.vue
+++ b/frontend/src/components/camp/CampMaterialListsItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-list-item>
+  <v-list-item v-if="!materialList._meta.loading">
     <v-list-item-content class="pt-0 pb-2">
       <v-list-item-title>{{ materialList.name }}</v-list-item-title>
     </v-list-item-content>

--- a/frontend/src/components/camp/CampPeriods.vue
+++ b/frontend/src/components/camp/CampPeriods.vue
@@ -23,7 +23,7 @@ Displays all periods of a single camp and allows to edit them & create new ones
     <v-list>
       <period-item
         v-for="period in periods.items"
-        :key="period.id"
+        :key="period._meta.self"
         class="px-0"
         :period="period"
         :disabled="disabled" />

--- a/frontend/src/components/camp/CampPeriodsListItem.vue
+++ b/frontend/src/components/camp/CampPeriodsListItem.vue
@@ -3,7 +3,7 @@ Displays a single period as a list item including controls to edit and delete it
 -->
 
 <template>
-  <v-list-item>
+  <v-list-item v-if="!period._meta.loading">
     <v-list-item-content class="pt-0 pb-2">
       <v-list-item-title>{{ period.description }}</v-list-item-title>
       <v-list-item-subtitle>

--- a/frontend/src/components/camp/PeriodSwitcher.vue
+++ b/frontend/src/components/camp/PeriodSwitcher.vue
@@ -16,7 +16,7 @@
         </v-btn>
       </template>
       <v-list>
-        <v-list-item v-for="item in period().camp().periods().items" :key="item.id" :to="periodRoute(item)">
+        <v-list-item v-for="item in period().camp().periods().items" :key="item._meta.self" :to="periodRoute(item)">
           {{ item.description }}
         </v-list-item>
       </v-list>

--- a/frontend/src/components/form/api/ApiWrapper.vue
+++ b/frontend/src/components/form/api/ApiWrapper.vue
@@ -111,7 +111,7 @@ export default {
 
         // while loading, value is null
         // (necessary because while loading, even normal properties are returned as functions)
-        if (resource._meta.loading || val._meta?.loading) return null
+        if (resource._meta.loading || val?._meta?.loading) return null
 
         // Check if val is an (embedded) relation
         if (val instanceof Function) {

--- a/frontend/src/components/material/ScheduleEntryLinks.vue
+++ b/frontend/src/components/material/ScheduleEntryLinks.vue
@@ -1,7 +1,7 @@
 <template>
   <span>
     <span v-for="(scheduleEntry, index) in items"
-          :key="scheduleEntry.id">
+          :key="scheduleEntry._meta.self">
       <router-link
         :to="scheduleEntryRoute(scheduleEntry)"
         small

--- a/frontend/src/components/scheduleEntry/DialogActivityForm.vue
+++ b/frontend/src/components/scheduleEntry/DialogActivityForm.vue
@@ -12,7 +12,7 @@
               item-text="name"
               vee-rules="required">
       <template #item="{item, on, attrs}">
-        <v-list-item :key="item.id" v-bind="attrs" v-on="on">
+        <v-list-item :key="item._meta.self" v-bind="attrs" v-on="on">
           <v-list-item-avatar>
             <v-chip :color="item.color">{{ item.short }}</v-chip>
           </v-list-item-avatar>

--- a/frontend/src/views/Camps.vue
+++ b/frontend/src/views/Camps.vue
@@ -8,7 +8,7 @@
         </template>
         <v-list-item
           v-for="camp in upcomingCamps"
-          :key="camp.id"
+          :key="camp._meta.self"
           two-line
           :to="campRoute(camp)">
           <v-list-item-content>
@@ -44,7 +44,7 @@
             <v-list class="py-0">
               <v-list-item
                 v-for="camp in prototypeCamps"
-                :key="camp.id"
+                :key="camp._meta.self"
                 two-line
                 :to="campRoute(camp)">
                 <v-list-item-content>
@@ -67,7 +67,7 @@
             <v-list class="py-0">
               <v-list-item
                 v-for="camp in pastCamps"
-                :key="camp.id"
+                :key="camp._meta.self"
                 two-line
                 :to="campRoute(camp)">
                 <v-list-item-content>


### PR DESCRIPTION
Fixes:
- handling of null values in ApiWrapper
- avoid .id as :key --> if resource is still loading, id is a function which throws an error. Safer to use `_meta.self`