### PR TITLE
renovate.json: group packages which contain the name of a js/html/etc linter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,11 +35,15 @@
       "automerge": false
     },
     {
-      "matchPackageNames": [
-        "eslint",
-        "lint",
-        "stylelint",
-        "prettier"
+      "matchPackagePatterns": [
+        "^(@.*\\/|(.*-)?)eslint(-.*)?$",
+        "^(@.*\\/|(.*-)?)lint(-.*)?$",
+        "^(@.*\\/|(.*-)?)stylelint(-.*)?$",
+        "^(@.*\\/|(.*-)?)prettier(-.*)?$"
+      ],
+      "excludePackageNames": [
+        "@vue/cli-plugin-eslint",
+        "lint-staged"
       ],
       "groupName": "js-linter"
     },


### PR DESCRIPTION
Exclude packages which only start the lint process like
"@vue/cli-plugin-eslint",
"lint-staged"

Regex was tested here: https://regex101.com/r/rGeHCu/1