### PR TITLE
Fix npm warnings about exact engine versions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,6 @@
     "test:unit:debug": "node --inspect-brk=0.0.0.0:9229 ./node_modules/@vue/cli-service/bin/vue-cli-service.js test:unit --no-cache --runInBand",
     "test:unit:watch": "vue-cli-service test:unit --watch"
   },
-  "engines": {
-    "npm": "~8.5.0"
-  },
   "dependencies": {
     "@intlify/core": "^9.1.9",
     "@mdi/font": "6.5.95",

--- a/print/package.json
+++ b/print/package.json
@@ -14,9 +14,6 @@
     "lint": "npm run lint:js && npm run lint:style",
     "test": "jest"
   },
-  "engines": {
-    "npm": "~8.5.0"
-  },
   "dependencies": {
     "@nuxtjs/axios": "5.13.6",
     "@nuxtjs/sentry": "5.1.7",


### PR DESCRIPTION
These engine specifiers were added when we were still on npm v6 and did not want renovate to update us to v7. But by now, we are happily using npm v8, so this is no longer needed.

Fixes the following warnings from frontend and print:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'frontend@0.1.0',
npm WARN EBADENGINE   required: { npm: '~8.5.0' },
npm WARN EBADENGINE   current: { node: 'v16.14.0', npm: '8.3.1' }
npm WARN EBADENGINE }

npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'print@1.0.0',
npm WARN EBADENGINE   required: { npm: '~8.5.0' },
npm WARN EBADENGINE   current: { node: 'v16.14.0', npm: '8.3.1' }
npm WARN EBADENGINE }
```