### PR TITLE
e2e: run e2e tests against production preview build

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -329,6 +329,24 @@ jobs:
       - run: docker run -v $PWD:/e2e -w /e2e --network host -e CYPRESS_BASE_URL=http://localhost:3000 cypress/included:9.5.1
         working-directory: frontend
 
+  test-development-setup:
+    name: "Tests: End-to-end for development setup"
+    runs-on: ubuntu-latest
+    env:
+      CI: 'false'
+    steps:
+
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3
+
+      - run: cp .env.ci .env
+
+      - run: docker-compose up -d
+
+      - run: bash wait-for-container-startup.sh
+
+      - run: docker run -v $PWD:/e2e -w /e2e --network host -e CYPRESS_BASE_URL=http://localhost:3000 cypress/included:9.5.1
+        working-directory: frontend
+
   coveralls-finished:
     name: "Finish coveralls report"
     needs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - NODE_ENV=development
       - NPM_CONFIG_UPDATE_NOTIFIER=false
       - NPM_CONFIG_CACHE=/home/node/.npm
+      - CI=${CI}
       - CYPRESS_CACHE_FOLDER=/home/node/.cache/Cypress
 
   php:

--- a/frontend/docker-setup.sh
+++ b/frontend/docker-setup.sh
@@ -10,4 +10,9 @@ fi
 
 npm ci
 
-npm run dev
+if [ $CI -eq 'true' ]; then
+  npm run build
+  npm run preview
+else
+  npm run dev
+fi

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vite --host 0.0.0.0",
+    "preview": "vite preview --host 0.0.0.0 --port 3000",
     "build": "vite build",
     "lint": "vue-cli-service lint",
     "lint-check": "vue-cli-service lint --no-fix",


### PR DESCRIPTION
That we can work again.

That vite does not incrementally build the necessary things for the e2e tests.
Keep a check for the development setup, which is not required, that we at least
see if the development setup fails to start on main too many times.