### PR TITLE
api: use ValidateDeleteRequestsListener to validate the 'delete' grou…

### DIFF
--- a/api/src/DataPersister/CampCollaborationDataPersister.php
+++ b/api/src/DataPersister/CampCollaborationDataPersister.php
@@ -68,12 +68,6 @@ class CampCollaborationDataPersister extends AbstractDataPersister {
         }
     }
 
-    public function beforeRemove($data): ?BaseEntity {
-        $this->validator->validate($data, ['groups' => ['delete']]);
-
-        return null;
-    }
-
     public function onBeforeStatusChange(CampCollaboration $data): CampCollaboration {
         if (CampCollaboration::STATUS_INVITED == $data->status && ($data->inviteEmail || $data->user)) {
             $data->inviteKey = IdGenerator::generateRandomHexString(64);

--- a/api/src/DataPersister/CategoryDataPersister.php
+++ b/api/src/DataPersister/CategoryDataPersister.php
@@ -2,7 +2,6 @@
 
 namespace App\DataPersister;
 
-use ApiPlatform\Core\Validator\ValidatorInterface;
 use App\DataPersister\Util\AbstractDataPersister;
 use App\DataPersister\Util\DataPersisterObservable;
 use App\Entity\BaseEntity;
@@ -14,7 +13,6 @@ use Doctrine\ORM\EntityManagerInterface;
 class CategoryDataPersister extends AbstractDataPersister {
     public function __construct(
         DataPersisterObservable $dataPersisterObservable,
-        private ValidatorInterface $validator,
         private EntityManagerInterface $em,
     ) {
         parent::__construct(
@@ -35,11 +33,5 @@ class CategoryDataPersister extends AbstractDataPersister {
         $data->setRootContentNode($rootContentNode);
 
         return $data;
-    }
-
-    public function beforeRemove($data): ?BaseEntity {
-        $this->validator->validate($data, ['groups' => ['delete']]);
-
-        return null;
     }
 }

--- a/api/src/DataPersister/PeriodDataPersister.php
+++ b/api/src/DataPersister/PeriodDataPersister.php
@@ -2,7 +2,6 @@
 
 namespace App\DataPersister;
 
-use ApiPlatform\Core\Validator\ValidatorInterface;
 use App\DataPersister\Util\AbstractDataPersister;
 use App\DataPersister\Util\DataPersisterObservable;
 use App\Entity\BaseEntity;
@@ -14,8 +13,7 @@ use Doctrine\ORM\EntityManagerInterface;
 class PeriodDataPersister extends AbstractDataPersister {
     public function __construct(
         DataPersisterObservable $dataPersisterObservable,
-        private EntityManagerInterface $em,
-        private ValidatorInterface $validator
+        private EntityManagerInterface $em
     ) {
         parent::__construct(
             Period::class,
@@ -35,12 +33,6 @@ class PeriodDataPersister extends AbstractDataPersister {
         static::updateDaysAndScheduleEntries($data, $orig);
 
         return $data;
-    }
-
-    public function beforeRemove($data): ?BaseEntity {
-        $this->validator->validate($data, ['groups' => ['delete', 'Period:delete']]);
-
-        return null;
     }
 
     public static function updateDaysAndScheduleEntries(Period $period, array $orig = null) {

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -43,7 +43,10 @@ use Symfony\Component\Validator\Constraints as Assert;
             'normalization_context' => self::ITEM_NORMALIZATION_CONTEXT,
         ],
         'patch' => ['security' => 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)'],
-        'delete' => ['security' => 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)'],
+        'delete' => [
+            'security' => 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)',
+            'validation_groups' => ['delete', 'Period:delete'],
+        ],
     ],
     denormalizationContext: ['groups' => ['write']],
     normalizationContext: ['groups' => ['read']],

--- a/api/src/EventListener/ValidateDeleteRequestsListener.php
+++ b/api/src/EventListener/ValidateDeleteRequestsListener.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\EventListener;
+
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use ApiPlatform\Core\Util\RequestAttributesExtractor;
+use ApiPlatform\Core\Validator\ValidatorInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ValidateDeleteRequestsListener implements EventSubscriberInterface {
+    public function __construct(
+        private ValidatorInterface $validator,
+        private ResourceMetadataFactoryInterface $resourceMetadataFactory
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array {
+        return [
+            // Run this event with the same priority as the ValidateListener
+            // ValidateListener currently does not validate DELETE Request
+            KernelEvents::VIEW => ['validateDeleteRequest', 64],
+        ];
+    }
+
+    /**
+     * @throws \ApiPlatform\Core\Exception\ResourceClassNotFoundException
+     */
+    public function validateDeleteRequest(ViewEvent $event): void {
+        $controllerResult = $event->getControllerResult();
+        $request = $event->getRequest();
+
+        if (!$request->isMethod('DELETE')
+            || !($attributes = RequestAttributesExtractor::extractAttributes($request))
+            || !$attributes['receive']
+        ) {
+            return;
+        }
+
+        $resourceMetadata = $this->resourceMetadataFactory->create($attributes['resource_class']);
+
+        $validationGroups = $resourceMetadata->getOperationAttribute($attributes, 'validation_groups', ['delete'], true);
+        $this->validator->validate($controllerResult, ['groups' => $validationGroups]);
+    }
+}

--- a/api/tests/DataPersister/CategoryDataPersisterTest.php
+++ b/api/tests/DataPersister/CategoryDataPersisterTest.php
@@ -2,17 +2,13 @@
 
 namespace App\Tests\DataPersister;
 
-use ApiPlatform\Core\Validator\ValidatorInterface;
 use App\DataPersister\CategoryDataPersister;
 use App\DataPersister\Util\DataPersisterObservable;
 use App\Entity\Category;
 use App\Entity\ContentType;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
-use function PHPUnit\Framework\assertThat;
-use function PHPUnit\Framework\isNull;
 use PHPUnit\Framework\MockObject\MockObject;
-use function PHPUnit\Framework\once;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,7 +16,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CategoryDataPersisterTest extends TestCase {
     private CategoryDataPersister $dataPersister;
-    private MockObject|ValidatorInterface $validator;
     private MockObject|EntityManagerInterface $entityManagerMock;
     private Category $category;
 
@@ -28,11 +23,9 @@ class CategoryDataPersisterTest extends TestCase {
         $this->category = new Category();
 
         $this->entityManagerMock = $this->createMock(EntityManagerInterface::class);
-        $this->validator = $this->createMock(ValidatorInterface::class);
         $dataPersisterObservable = $this->createMock(DataPersisterObservable::class);
         $this->dataPersister = new CategoryDataPersister(
             $dataPersisterObservable,
-            $this->validator,
             $this->entityManagerMock
         );
     }
@@ -55,13 +48,5 @@ class CategoryDataPersisterTest extends TestCase {
         // then
         $this->assertNotNull($data->getRootContentNode());
         $this->assertEquals('ColumnLayout', $data->getRootContentNode()->contentType->name);
-    }
-
-    public function testCallsValidatorOnRemove() {
-        $this->validator->expects(once())->method('validate');
-
-        $remove = $this->dataPersister->beforeRemove($this->category);
-
-        assertThat($remove, isNull());
     }
 }


### PR DESCRIPTION
…p for delete requests

Instead of creating a DataPersister for each entity which needs this validation.

From https://github.com/ecamp/ecamp3/pull/2536#discussion_r830431400