### PR TITLE
Harmonize container names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     build:
       context: ./api
       target: api_platform_php_dev
+    container_name: 'ecamp3-api'
     depends_on:
       - database
       - docker-host
@@ -63,6 +64,7 @@ services:
     build:
       context: ./api
       target: api_platform_caddy
+    container_name: 'ecamp3-caddy'
     depends_on:
       - php
     environment:
@@ -114,6 +116,7 @@ services:
 
   database:
     image: postgres:14-alpine@sha256:126bcff3a868d6bc79fbd9588e276731fa634f7137dd447476662da9d655ddfc
+    container_name: 'ecamp3-database'
     environment:
       - POSTGRES_DB=ecamp3dev
       - POSTGRES_PASSWORD=ecamp3


### PR DESCRIPTION
Before:
```
Creating network "ecamp3_default" with the default driver
Creating ecamp3-docker-host-forwarder ... done
Creating ecamp3-frontend              ... done
Creating ecamp3-mail                  ... done
Creating ecamp3-browserless           ... done
Creating ecamp3_database_1            ... done
Creating ecamp3-print                 ... done
Creating ecamp3_php_1                 ... done
Creating ecamp3_caddy_1               ... done
```
After:

```
Creating network "ecamp3_default" with the default driver
Creating ecamp3-mail                  ... done
Creating ecamp3-frontend              ... done
Creating ecamp3-database              ... done
Creating ecamp3-print                 ... done
Creating ecamp3-browserless           ... done
Creating ecamp3-docker-host-forwarder ... done
Creating ecamp3-api                   ... done
Creating ecamp3-caddy                 ... done

```