### PR TITLE
MaterialList: align schema and entity again

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -242,6 +242,58 @@ jobs:
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: api
 
+  api-validate-migrations:
+    name: "API: validate migrations"
+    runs-on: ubuntu-latest
+    env:
+      TEST_DATABASE_URL: postgresql://ecamp3:ecamp3@localhost:5432/ecamp3test?serverVersion=13&charset=utf8
+
+    services:
+      postgres:
+        image: 'postgres:14-alpine@sha256:28e8ac42048c31694d443039d5adfe293f24eec7d8c0b4f88aaefcc8df1e5b72'
+        env:
+          POSTGRES_DB: 'ecamp3test'
+          POSTGRES_PASSWORD: 'ecamp3'
+          POSTGRES_USER: 'ecamp3'
+        ports:
+          - '5432:5432'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+
+      - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748 # tag=v3
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1.3'
+          tools: composer:2.3.0
+          coverage: xdebug
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: 'echo "::set-output name=dir::$(composer config cache-files-dir)"'
+        working-directory: api
+
+      - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # renovate: tag=v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - run: composer install --prefer-dist --no-progress --no-interaction
+        working-directory: api
+
+      - run: php bin/console doctrine:migrations:migrate --no-interaction -e test
+        working-directory: api
+
+      - run: php bin/console doctrine:schema:validate -e test
+        working-directory: api
+
   frontend-tests:
     name: "Tests: Frontend"
     runs-on: ubuntu-latest

--- a/api/migrations/schema/Version20220417142152.php
+++ b/api/migrations/schema/Version20220417142152.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220417142152 extends AbstractMigration {
+    public function getDescription(): string {
+        return 'Fix schema migration for MaterialList';
+    }
+
+    public function up(Schema $schema): void {
+        $this->addSql('DROP INDEX idx_10a0952d56778c5c');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_10A0952D56778C5C ON material_list (campCollaborationId)');
+    }
+
+    public function down(Schema $schema): void {
+        $this->addSql('DROP INDEX UNIQ_10A0952D56778C5C');
+        $this->addSql('CREATE INDEX idx_10a0952d56778c5c ON material_list (campcollaborationid)');
+    }
+}

--- a/api/src/Entity/MaterialList.php
+++ b/api/src/Entity/MaterialList.php
@@ -6,6 +6,7 @@ use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
+use App\InputFilter;
 use App\Repository\MaterialListRepository;
 use App\Util\EntityMap;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -77,7 +78,10 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface, CopyFro
      */
     #[ApiProperty(example: 'Lebensmittel')]
     #[Groups(['write'])]
+    #[InputFilter\Trim]
+    #[InputFilter\CleanHTML]
     #[Assert\NotBlank]
+    #[Assert\Length(max: 32)]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $name = null;
 

--- a/api/src/Entity/MaterialList.php
+++ b/api/src/Entity/MaterialList.php
@@ -13,6 +13,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * A list of material items that someone needs to bring to the camp. A material list
@@ -76,7 +77,8 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface, CopyFro
      */
     #[ApiProperty(example: 'Lebensmittel')]
     #[Groups(['write'])]
-    #[ORM\Column(type: 'text')]
+    #[Assert\NotBlank]
+    #[ORM\Column(type: 'text', nullable: true)]
     public ?string $name = null;
 
     public function __construct() {

--- a/api/tests/Api/MaterialLists/CreateMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/CreateMaterialListTest.php
@@ -10,9 +10,6 @@ use App\Tests\Api\ECampApiTestCase;
  * @internal
  */
 class CreateMaterialListTest extends ECampApiTestCase {
-    // TODO input filter tests
-    // TODO validation tests
-
     public function testCreateMaterialListIsDeniedForAnonymousUser() {
         static::createBasicClient()->request('POST', '/material_lists', ['json' => $this->getExampleWritePayload()]);
 
@@ -99,6 +96,25 @@ class CreateMaterialListTest extends ECampApiTestCase {
         ]);
     }
 
+    public function testCreateMaterialListDisallowsSettingCampCollaboration() {
+        static::createClientWithCredentials()
+            ->request(
+                'POST',
+                '/material_lists',
+                [
+                    'json' => $this->getExampleWritePayload([
+                        'campCollaboration' => $this->getIriFor('campCollaboration1manager'),
+                    ]),
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'detail' => 'Extra attributes are not allowed ("campCollaboration" is unknown).',
+        ]);
+    }
+
     public function testCreateMaterialListValidatesMissingName() {
         static::createClientWithCredentials()->request('POST', '/material_lists', ['json' => $this->getExampleWritePayload([], ['name'])]);
 
@@ -110,6 +126,68 @@ class CreateMaterialListTest extends ECampApiTestCase {
                     'message' => 'This value should not be blank.',
                 ],
             ],
+        ]);
+    }
+
+    public function testCreateMaterialListValidatesTooLongName() {
+        static::createClientWithCredentials()
+            ->request(
+                'POST',
+                '/material_lists',
+                [
+                    'json' => $this->getExampleWritePayload([
+                        'name' => 'a very long name with more than a',
+                    ]),
+                ]
+            )
+    ;
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'This value is too long. It should have 32 characters or less.',
+                ],
+            ],
+        ]);
+    }
+
+    public function testCreateMaterialListTrimsName() {
+        static::createClientWithCredentials()
+            ->request(
+                'POST',
+                '/material_lists',
+                [
+                    'json' => $this->getExampleWritePayload([
+                        'name' => ' Something ',
+                    ]),
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains([
+            'name' => 'Something',
+        ]);
+    }
+
+    public function testCreateMaterialListCleansHtml() {
+        static::createClientWithCredentials()
+            ->request(
+                'POST',
+                '/material_lists',
+                [
+                    'json' => $this->getExampleWritePayload([
+                        'name' => ' Some<script>alert(1)</script>thing ',
+                    ]),
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains([
+            'name' => 'Something',
         ]);
     }
 

--- a/api/tests/Api/MaterialLists/CreateMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/CreateMaterialListTest.php
@@ -107,7 +107,7 @@ class CreateMaterialListTest extends ECampApiTestCase {
             'violations' => [
                 [
                     'propertyPath' => 'name',
-                    'message' => 'This value should not be null.',
+                    'message' => 'This value should not be blank.',
                 ],
             ],
         ]);

--- a/api/tests/Api/MaterialLists/UpdateMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/UpdateMaterialListTest.php
@@ -124,15 +124,20 @@ class UpdateMaterialListTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchMaterialItemValidatesMissingArticle() {
+    public function testPatchMaterialListValidatesMissingName() {
         $materialList = static::$fixtures['materialList1'];
         static::createClientWithCredentials()->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [
             'name' => null,
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
 
-        $this->assertResponseStatusCodeSame(400);
+        $this->assertResponseStatusCodeSame(422);
         $this->assertJsonContains([
-            'detail' => 'The type of the "name" attribute must be "string", "NULL" given.',
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'This value should not be blank.',
+                ],
+            ],
         ]);
     }
 }

--- a/api/tests/Api/MaterialLists/UpdateMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/UpdateMaterialListTest.php
@@ -8,9 +8,6 @@ use App\Tests\Api\ECampApiTestCase;
  * @internal
  */
 class UpdateMaterialListTest extends ECampApiTestCase {
-    // TODO input filter tests
-    // TODO validation tests
-
     public function testPatchMaterialListIsDeniedForAnonymousUser() {
         $materialList = static::$fixtures['materialList1'];
         static::createBasicClient()->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [
@@ -124,6 +121,18 @@ class UpdateMaterialListTest extends ECampApiTestCase {
         ]);
     }
 
+    public function testPatchMaterialListDisallowsChangingCampCollaboration() {
+        $materialList = static::$fixtures['materialList3Manager'];
+        static::createClientWithCredentials()->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [
+            'campCollaboration' => $this->getIriFor('campCollaboration2member'),
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'detail' => 'Extra attributes are not allowed ("campCollaboration" is unknown).',
+        ]);
+    }
+
     public function testPatchMaterialListValidatesMissingName() {
         $materialList = static::$fixtures['materialList1'];
         static::createClientWithCredentials()->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [
@@ -138,6 +147,62 @@ class UpdateMaterialListTest extends ECampApiTestCase {
                     'message' => 'This value should not be blank.',
                 ],
             ],
+        ]);
+    }
+
+    public function testPatchMaterialListValidatesTooLongName() {
+        $materialList = static::$fixtures['materialList1'];
+        static::createClientWithCredentials()->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [
+            'name' => 'a very long name with more than a',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'name',
+                    'message' => 'This value is too long. It should have 32 characters or less.',
+                ],
+            ],
+        ]);
+    }
+
+    public function testPatchMaterialListTrimsNameBeforeValidatingLength() {
+        $materialList = static::$fixtures['materialList1'];
+        static::createClientWithCredentials(['username' => static::$fixtures['user2member']->getUsername()])
+            ->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [
+                'name' => 'a very long name with more than  ',
+            ], 'headers' => ['Content-Type' => 'application/merge-patch+json']])
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'name' => 'a very long name with more than',
+        ]);
+    }
+
+    public function testPatchMaterialListTrimsName() {
+        $materialList = static::$fixtures['materialList1'];
+        static::createClientWithCredentials(['username' => static::$fixtures['user2member']->getUsername()])
+            ->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [
+                'name' => ' Something ',
+            ], 'headers' => ['Content-Type' => 'application/merge-patch+json']])
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'name' => 'Something',
+        ]);
+    }
+
+    public function testPatchMaterialListCleansHtml() {
+        $materialList = static::$fixtures['materialList1'];
+        static::createClientWithCredentials(['username' => static::$fixtures['user2member']->getUsername()])
+            ->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [
+                'name' => ' Some<script>alert(1)</script>thing ',
+            ], 'headers' => ['Content-Type' => 'application/merge-patch+json']])
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'name' => 'Something',
         ]);
     }
 }


### PR DESCRIPTION
MaterialList: make column name nullable again

And align the schema migrations with the entities.

In 24ebe7a (#2452), the nullable:false was removed in assumption that the default is true.
(That's how it is in hibernate).
The schema migration set the field to nullable, but the entity did not.
Also add the unique index on campCollaborationId needed for the OneToOne relationship.
(i don't know how that got missing).

Issue: #2591

Also: continuous-integration.yml: check that the entities and the migrations are in sync
That this does not happen anymore.

MaterialList: add validations and tests for validations

Issue: #2553