### PR TITLE
Fix integer port number in helm

### DIFF
--- a/.helm/ecamp3/templates/print_secrets.yaml
+++ b/.helm/ecamp3/templates/print_secrets.yaml
@@ -13,7 +13,7 @@ data:
   {{- end }}
 
   {{- if .Values.browserless.enabled }}
-  browser-ws-endpoint: {{  printf "ws://%s:%d" (include "browserless.name" .) .Values.browserless.service.port | b64enc | quote }}
+  browser-ws-endpoint: {{  printf "ws://%s:%d" (include "browserless.name" .) (.Values.browserless.service.port | int) | b64enc | quote }}
   {{- else if .Values.print.browserWsEndpoint }}
   browser-ws-endpoint: {{ .Values.print.browserWsEndpoint | b64enc | quote }}
   {{- else}}


### PR DESCRIPTION
Fix https://github.com/ecamp/ecamp3/pull/2656#issuecomment-1125017886

Tested by checking out this branch locally, and then:
```bash
export KUBECONFIG=~/.kube/ecamp3.yaml # set up connection to the cluster
helm list # test cluster connection
cd .helm/ecamp3/
helm dependency update .
helm upgrade --reuse-values --dry-run --debug ecamp3-dev . | less
```

In the output, scroll to print_secrets.yaml and base64-decode the data of browser-ws-endpoint. It now uses the integer port number.