### PR TITLE
renovate.json: keep postgres at version 13

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -176,7 +176,7 @@ jobs:
 
     services:
       postgres:
-        image: 'postgres:14-alpine@sha256:20e49432a20e1a63bb985977c32ec8f110bc609b93de35ad4f19c5486abcefaa'
+        image: 'postgres:13-alpine@sha256:0d3137d83b50573cc17d5998a62f79075d4088daec4d408a240e960a99f5da4e'
         env:
           POSTGRES_DB: 'ecamp3test'
           POSTGRES_PASSWORD: 'ecamp3'
@@ -250,7 +250,7 @@ jobs:
 
     services:
       postgres:
-        image: 'postgres:14-alpine@sha256:20e49432a20e1a63bb985977c32ec8f110bc609b93de35ad4f19c5486abcefaa'
+        image: 'postgres:13-alpine@sha256:0d3137d83b50573cc17d5998a62f79075d4088daec4d408a240e960a99f5da4e'
         env:
           POSTGRES_DB: 'ecamp3test'
           POSTGRES_PASSWORD: 'ecamp3'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
       - ./print/print.env
 
   database:
-    image: postgres:14-alpine@sha256:20e49432a20e1a63bb985977c32ec8f110bc609b93de35ad4f19c5486abcefaa
+    image: postgres:13-alpine@sha256:0d3137d83b50573cc17d5998a62f79075d4088daec4d408a240e960a99f5da4e
     container_name: 'ecamp3-database'
     environment:
       - POSTGRES_DB=ecamp3dev

--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,12 @@
       "extends": [
         "schedule:weekly"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "postgres"
+      ],
+      "allowedVersions": "13-alpine"
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
This is the version we use at digitalocean.
renovate
 - does not downgrade to allowed version
 - updates digest of the postgres image builds

Tested by:
1. generate temporary github token
2. force push config to devel branch on fork
docker run --rm -e LOG_LEVEL=debug renovate/renovate --token $TOKEN --include-forks true BacLuc/ecamp3 > /tmp/renovate.log

closes #2667