### PR TITLE
renovate.json: require dashboard approval for vue monorepo major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,15 @@
       "automerge": true
     },
     {
+      "extends": [
+        "monorepo:vue"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
       "matchPackageNames": [
         "sass"
       ],


### PR DESCRIPTION
Use vue monorepo preset from renovate (https://docs.renovatebot.com/presets-monorepo/#monorepovue).

From https://github.com/ecamp/ecamp3/pull/2615#issuecomment-1101574790