### PR TITLE
Fail ci if files are not formatted

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -141,7 +141,13 @@ jobs:
       - run: npm ci --no-audit
         working-directory: frontend
 
-      - run: npm run lint:check
+      - run: |
+          npm run lint:check:eslint
+          result=$(npm run lint:check:prettier)
+          echo $result
+          if echo $result | grep -E "Code style issues found"; then 
+             exit 1
+          fi
         working-directory: frontend
 
   print-eslint:
@@ -165,7 +171,13 @@ jobs:
       - run: npm ci --no-audit
         working-directory: print
 
-      - run: npm run lint:check
+      - run: |
+          npm run lint:check:eslint
+          result=$(npm run lint:check:prettier)
+          echo $result
+          if echo $result | grep -E "Code style issues found"; then 
+             exit 1
+          fi
         working-directory: print
 
   api-tests:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -120,6 +120,7 @@
       "@vue/eslint-config-prettier"
     ],
     "rules": {
+      "prettier/prettier": "error",
       "vue/component-tags-order": [
         "error",
         {

--- a/frontend/src/components/print/print-react/documents/pdfDocument/prepareInMainThread.js
+++ b/frontend/src/components/print/print-react/documents/pdfDocument/prepareInMainThread.js
@@ -34,7 +34,7 @@ const picassoData = (config) => {
           periods.items.map((period) => {
             return Promise.all([
               period.scheduleEntries().$loadItems(),
-              period.contentNodes().$loadItems()
+              period.contentNodes().$loadItems(),
             ])
           })
         )
@@ -78,7 +78,7 @@ const activityData = (config) => {
           periods.items.map((period) => {
             return Promise.all([
               period.scheduleEntries().$loadItems(),
-              period.contentNodes().$loadItems()
+              period.contentNodes().$loadItems(),
             ])
           })
         )

--- a/print/package.json
+++ b/print/package.json
@@ -77,7 +77,8 @@
       "plugin:prettier/recommended"
     ],
     "rules": {
-      "no-console": "off"
+      "no-console": "off",
+      "prettier/prettier": "error"
     }
   },
   "babel": {


### PR DESCRIPTION
That we don't have to hope that the cool comments which indicate prettier or eslint violations in the PR are read and fixed.

Does not run the prettier check if the lint check fails (like it was before).

Now the CI fails on prettier violations, as can be seen in these builds:
Eslint fails because of prettier violations: https://github.com/BacLuc/ecamp3/runs/7302664989?check_suite_focus=true
prettier fails after eslint was successful: https://github.com/BacLuc/ecamp3/runs/7302695685?check_suite_focus=true
