### PR TITLE
Api entity validations

### DIFF
--- a/api/fixtures/activity1.yml
+++ b/api/fixtures/activity1.yml
@@ -12,6 +12,11 @@ App\Entity\ScheduleEntry:
     activity: '@activity1'
     startOffset: 480
     endOffset: 540
+  scheduleEntry2:
+    period: '@period1'
+    activity: '@activity1'
+    startOffset: 1980
+    endOffset: 2040
 
 # Root node
 App\Entity\ContentNode\ColumnLayout:

--- a/api/fixtures/scheduleEntries.yml
+++ b/api/fixtures/scheduleEntries.yml
@@ -1,4 +1,9 @@
 App\Entity\ScheduleEntry:
+  scheduleEntry1period1camp1:
+    period: '@period1'
+    activity: '@activity2'
+    startOffset: 600
+    endOffset: 660
   scheduleEntry1period1camp2:
     period: '@period1camp2'
     activity: '@activity1camp2'

--- a/api/src/Entity/Activity.php
+++ b/api/src/Entity/Activity.php
@@ -67,6 +67,11 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
      */
     #[Assert\Valid]
     #[Assert\Count(min: 1, groups: ['create'])]
+    #[Assert\Count(
+        min: 2,
+        minMessage: 'An activity must have at least one ScheduleEntry',
+        groups: ['ScheduleEntry:delete']
+    )]
     #[ApiProperty(
         writableLink: true,
         example: '[{ "period": "/periods/1a2b3c4a", "endOffset": 1100, "startOffset": 1000 }]',

--- a/api/src/Entity/Activity.php
+++ b/api/src/Entity/Activity.php
@@ -118,6 +118,9 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
     /**
      * The physical location where this activity's programme will be carried out.
      */
+    #[InputFilter\Trim]
+    #[InputFilter\CleanHTML]
+    #[Assert\Length(max: 64)]
     #[ApiProperty(example: 'Spielwiese')]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text')]

--- a/api/src/Entity/Activity.php
+++ b/api/src/Entity/Activity.php
@@ -6,6 +6,7 @@ use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
+use App\InputFilter;
 use App\Repository\ActivityRepository;
 use App\Validator\AssertBelongsToSameCamp;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -105,6 +106,10 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
     /**
      * The title of this activity that is shown in the picasso.
      */
+    #[InputFilter\Trim]
+    #[InputFilter\CleanHTML]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Sportolympiade')]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text')]

--- a/api/src/Entity/CampCollaboration.php
+++ b/api/src/Entity/CampCollaboration.php
@@ -6,6 +6,7 @@ use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
+use App\InputFilter;
 use App\Repository\CampCollaborationRepository;
 use App\Validator\AllowTransition\AssertAllowTransitions;
 use App\Validator\AssertEitherIsNull;
@@ -126,6 +127,9 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
      * The receiver email address of the invitation email, in case the collaboration does not yet have
      * a user account. Either this field or the user field should be null.
      */
+    #[InputFilter\Trim]
+    #[Assert\Email]
+    #[Assert\Length(min: 1, max: 128)]
     #[AssertEitherIsNull(other: 'user')]
     #[ApiProperty(example: 'some-email@example.com')]
     #[Groups(['read', 'create'])]

--- a/api/src/Entity/ScheduleEntry.php
+++ b/api/src/Entity/ScheduleEntry.php
@@ -41,7 +41,10 @@ use Symfony\Component\Validator\Constraints as Assert;
             'normalization_context' => self::ITEM_NORMALIZATION_CONTEXT,
             'security' => 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)',
         ],
-        'delete' => ['security' => 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)'],
+        'delete' => [
+            'security' => 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)',
+            'validation_groups' => ['delete', 'ScheduleEntry:delete'],
+        ],
     ],
     denormalizationContext: ['groups' => ['write']],
     normalizationContext: ['groups' => ['read']],
@@ -77,6 +80,7 @@ class ScheduleEntry extends BaseEntity implements BelongsToCampInterface {
      *
      * @internal Do not set the {@see Activity} directly on the ScheduleEntry. Instead use {@see Activity::addScheduleEntry()}
      */
+    #[Assert\Valid(groups: ['ScheduleEntry:delete'])]
     #[ApiProperty(example: '/activities/1a2b3c4d')]
     #[Groups(['read', 'create'])]
     #[ORM\ManyToOne(targetEntity: Activity::class, inversedBy: 'scheduleEntries')]

--- a/api/tests/Api/Activities/CreateActivityTest.php
+++ b/api/tests/Api/Activities/CreateActivityTest.php
@@ -11,9 +11,6 @@ use App\Tests\Api\ECampApiTestCase;
  * @internal
  */
 class CreateActivityTest extends ECampApiTestCase {
-    // TODO input filter tests
-    // TODO validation tests
-
     public function testCreateActivityIsDeniedForAnonymousUser() {
         static::createBasicClient()->request('POST', '/activities', ['json' => $this->getExampleWritePayload()]);
 
@@ -252,6 +249,96 @@ class CreateActivityTest extends ECampApiTestCase {
 
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains(['location' => '']);
+    }
+
+    public function testCreateActivityValidatesNullLocation() {
+        static::createClientWithCredentials(['username' => static::$fixtures['user2member']->getUsername()])
+            ->request(
+                'POST',
+                '/activities',
+                [
+                    'json' => $this->getExampleWritePayload(
+                        [
+                            'location' => null,
+                        ]
+                    ),
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'title' => 'An error occurred',
+            'detail' => 'The type of the "location" attribute must be "string", "NULL" given.',
+        ]);
+    }
+
+    public function testCreateActivityValidatesLocationMaxLength() {
+        static::createClientWithCredentials(['username' => static::$fixtures['user2member']->getUsername()])
+            ->request(
+                'POST',
+                '/activities',
+                [
+                    'json' => $this->getExampleWritePayload(
+                        [
+                            'location' => str_repeat('a', 65),
+                        ]
+                    ),
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'location',
+                    'message' => 'This value is too long. It should have 64 characters or less.',
+                ],
+            ],
+        ]);
+    }
+
+    public function testCreateActivityCleansHtmlFromLocation() {
+        static::createClientWithCredentials(['username' => static::$fixtures['user2member']->getUsername()])
+            ->request(
+                'POST',
+                '/activities',
+                [
+                    'json' => $this->getExampleWritePayload(
+                        [
+                            'location' => 'Dschungel<script>alert(1)</script>buch',
+                        ]
+                    ),
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains($this->getExampleReadPayload([
+            'location' => 'Dschungelbuch',
+        ]));
+    }
+
+    public function testCreateActivityTrimsLocation() {
+        static::createClientWithCredentials(['username' => static::$fixtures['user2member']->getUsername()])
+            ->request(
+                'POST',
+                '/activities',
+                [
+                    'json' => $this->getExampleWritePayload(
+                        [
+                            'location' => str_repeat('a', 64)." \t",
+                        ]
+                    ),
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains($this->getExampleReadPayload([
+            'location' => str_repeat('a', 64),
+        ]));
     }
 
     public function testCreateActivityCopiesContentFromCategory() {

--- a/api/tests/Api/BaseEntity/CreateBaseEntityTest.php
+++ b/api/tests/Api/BaseEntity/CreateBaseEntityTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Tests\Api\BaseEntity;
+
+use ApiPlatform\Core\Api\OperationType;
+use App\Entity\Camp;
+use App\Tests\Api\ECampApiTestCase;
+
+/**
+ * Tests for the BaseEntity properties on the example of Camp.
+ *
+ * @internal
+ */
+class CreateBaseEntityTest extends ECampApiTestCase {
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     */
+    public function testIdIsNotWritable() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/camps',
+            [
+                'json' => $this->getExampleWritePayload([
+                    'id' => '3852c489ace7',
+                ]),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'detail' => 'Extra attributes are not allowed ("id" is unknown).',
+        ]);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     */
+    public function testCreateTimeIsNotWritable() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/camps',
+            [
+                'json' => $this->getExampleWritePayload([
+                    'createTime' => '2023-05-01T00:00:00+00:00',
+                ]),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'detail' => 'Extra attributes are not allowed ("createTime" is unknown).',
+        ]);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     */
+    public function testUpdateTimeTimeIsNotWritable() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/camps',
+            [
+                'json' => $this->getExampleWritePayload([
+                    'updateTime' => '2023-05-01T00:00:00+00:00',
+                ]),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'detail' => 'Extra attributes are not allowed ("updateTime" is unknown).',
+        ]);
+    }
+
+    public function getExampleWritePayload($attributes = [], $except = []): array {
+        return $this->getExamplePayload(Camp::class, OperationType::COLLECTION, 'post', $attributes, [], $except);
+    }
+
+    public function getExampleReadPayload($attributes = [], $except = []): array {
+        return $this->getExamplePayload(
+            Camp::class,
+            OperationType::ITEM,
+            'get',
+            $attributes,
+            ['periods'],
+            $except
+        );
+    }
+}

--- a/api/tests/Api/BaseEntity/UpdateBaseEntityTest.php
+++ b/api/tests/Api/BaseEntity/UpdateBaseEntityTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Tests\Api\BaseEntity;
+
+use App\Tests\Api\ECampApiTestCase;
+
+/**
+ * Tests for the BaseEntity properties on the example of Camp.
+ *
+ * @internal
+ */
+class UpdateBaseEntityTest extends ECampApiTestCase {
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     */
+    public function testIdNotWriteable() {
+        $camp = static::$fixtures['camp1'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/camps/'.$camp->getId(),
+            ['json' => [
+                'id' => '3852c489ace7',
+            ],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'detail' => 'Extra attributes are not allowed ("id" is unknown).',
+        ]);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     */
+    public function testCreateTimeNotWriteable() {
+        $camp = static::$fixtures['camp1'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/camps/'.$camp->getId(),
+            ['json' => [
+                'createTime' => '2023-05-01T00:00:00+00:00',
+            ],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'detail' => 'Extra attributes are not allowed ("createTime" is unknown).',
+        ]);
+    }
+
+    /**
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     */
+    public function testUpdateTimeNotWriteable() {
+        $camp = static::$fixtures['camp1'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/camps/'.$camp->getId(),
+            ['json' => [
+                'updateTime' => '2023-05-01T00:00:00+00:00',
+            ],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'detail' => 'Extra attributes are not allowed ("updateTime" is unknown).',
+        ]);
+    }
+}

--- a/api/tests/Api/CampCollaborations/UpdateCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/UpdateCampCollaborationTest.php
@@ -10,9 +10,6 @@ use App\Tests\Api\ECampApiTestCase;
  * @internal
  */
 class UpdateCampCollaborationTest extends ECampApiTestCase {
-    // TODO input filter tests
-    // TODO validation tests
-
     public function testPatchCampCollaborationIsDeniedForAnonymousUser() {
         $campCollaboration = static::$fixtures['campCollaboration1manager'];
         static::createBasicClient()->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [

--- a/api/tests/Api/ScheduleEntries/DeleteScheduleEntryTest.php
+++ b/api/tests/Api/ScheduleEntries/DeleteScheduleEntryTest.php
@@ -84,4 +84,21 @@ class DeleteScheduleEntryTest extends ECampApiTestCase {
             'detail' => 'Access Denied.',
         ]);
     }
+
+    public function testDeleteScheduleEntryIsDeniedForLastScheduleEntryOfActivity() {
+        $scheduleEntry = static::$fixtures['scheduleEntry1period1camp1'];
+        static::createClientWithCredentials()->request('DELETE', '/schedule_entries/'.$scheduleEntry->getId());
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'title' => 'An error occurred',
+            'detail' => 'activity.scheduleEntries: An activity must have at least one ScheduleEntry',
+            'violations' => [
+                0 => [
+                    'propertyPath' => 'activity.scheduleEntries',
+                    'message' => 'An activity must have at least one ScheduleEntry',
+                ],
+            ],
+        ]);
+    }
 }

--- a/api/tests/Api/ScheduleEntries/ListScheduleEntriesTest.php
+++ b/api/tests/Api/ScheduleEntries/ListScheduleEntriesTest.php
@@ -26,7 +26,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()->request('GET', '/schedule_entries');
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'totalItems' => 4,
+            'totalItems' => 6,
             '_links' => [
                 'items' => [],
             ],
@@ -36,6 +36,8 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         ]);
         $this->assertEqualsCanonicalizing([
             ['href' => $this->getIriFor('scheduleEntry1')],
+            ['href' => $this->getIriFor('scheduleEntry2')],
+            ['href' => $this->getIriFor('scheduleEntry1period1camp1')],
             ['href' => $this->getIriFor('scheduleEntry1period1camp2')],
             ['href' => $this->getIriFor('scheduleEntry1period1campPrototype')],
             ['href' => $this->getIriFor('scheduleEntry2period1campPrototype')],
@@ -47,7 +49,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?period=/periods/'.$period->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'totalItems' => 1,
+            'totalItems' => 3,
             '_links' => [
                 'items' => [],
             ],
@@ -57,6 +59,8 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         ]);
         $this->assertEqualsCanonicalizing([
             ['href' => $this->getIriFor('scheduleEntry1')],
+            ['href' => $this->getIriFor('scheduleEntry2')],
+            ['href' => $this->getIriFor('scheduleEntry1period1camp1')],
         ], $response->toArray()['_links']['items']);
     }
 
@@ -108,7 +112,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?activity=/activities/'.$activity->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'totalItems' => 1,
+            'totalItems' => 2,
             '_links' => [
                 'items' => [],
             ],
@@ -118,6 +122,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         ]);
         $this->assertEqualsCanonicalizing([
             ['href' => $this->getIriFor('scheduleEntry1')],
+            ['href' => $this->getIriFor('scheduleEntry2')],
         ], $response->toArray()['_links']['items']);
     }
 
@@ -209,43 +214,6 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?start[after]='.urlencode($scheduleEntry->getStart()->format(DateTime::W3C)));
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'totalItems' => 2,
-            '_links' => [
-                'items' => [],
-            ],
-            '_embedded' => [
-                'items' => [],
-            ],
-        ]);
-        $this->assertEqualsCanonicalizing([
-            ['href' => $this->getIriFor('scheduleEntry1')],
-            ['href' => $this->getIriFor('scheduleEntry1period1camp2')],
-        ], $response->toArray()['_links']['items']);
-    }
-
-    public function testListScheduleEntriesFilteredByStartStrictlyAfterIsAllowedForCollaborator() {
-        /** @var ScheduleEntry $scheduleEntry */
-        $scheduleEntry = static::$fixtures['scheduleEntry1period1camp2'];
-        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?start[strictly_after]='.urlencode($scheduleEntry->getStart()->format(DateTime::W3C)));
-        $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContains([
-            'totalItems' => 1,
-            '_links' => [
-                'items' => [],
-            ],
-            '_embedded' => [
-                'items' => [],
-            ],
-        ]);
-        $this->assertEqualsCanonicalizing([
-            ['href' => $this->getIriFor('scheduleEntry1')],
-        ], $response->toArray()['_links']['items']);
-    }
-
-    public function testListScheduleEntriesFilteredByInvalidStartDoesntFilter() {
-        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?start[after]=when-I-was-young');
-        $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContains([
             'totalItems' => 4,
             '_links' => [
                 'items' => [],
@@ -256,6 +224,49 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         ]);
         $this->assertEqualsCanonicalizing([
             ['href' => $this->getIriFor('scheduleEntry1')],
+            ['href' => $this->getIriFor('scheduleEntry2')],
+            ['href' => $this->getIriFor('scheduleEntry1period1camp2')],
+            ['href' => $this->getIriFor('scheduleEntry1period1camp1')],
+        ], $response->toArray()['_links']['items']);
+    }
+
+    public function testListScheduleEntriesFilteredByStartStrictlyAfterIsAllowedForCollaborator() {
+        /** @var ScheduleEntry $scheduleEntry */
+        $scheduleEntry = static::$fixtures['scheduleEntry1period1camp2'];
+        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?start[strictly_after]='.urlencode($scheduleEntry->getStart()->format(DateTime::W3C)));
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'totalItems' => 3,
+            '_links' => [
+                'items' => [],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
+        $this->assertEqualsCanonicalizing([
+            ['href' => $this->getIriFor('scheduleEntry1')],
+            ['href' => $this->getIriFor('scheduleEntry2')],
+            ['href' => $this->getIriFor('scheduleEntry1period1camp1')],
+        ], $response->toArray()['_links']['items']);
+    }
+
+    public function testListScheduleEntriesFilteredByInvalidStartDoesntFilter() {
+        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?start[after]=when-I-was-young');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'totalItems' => 6,
+            '_links' => [
+                'items' => [],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
+        $this->assertEqualsCanonicalizing([
+            ['href' => $this->getIriFor('scheduleEntry1')],
+            ['href' => $this->getIriFor('scheduleEntry2')],
+            ['href' => $this->getIriFor('scheduleEntry1period1camp1')],
             ['href' => $this->getIriFor('scheduleEntry1period1camp2')],
             ['href' => $this->getIriFor('scheduleEntry1period1campPrototype')],
             ['href' => $this->getIriFor('scheduleEntry2period1campPrototype')],
@@ -307,43 +318,6 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?end[after]='.urlencode($scheduleEntry->getEnd()->format(DateTime::W3C)));
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'totalItems' => 2,
-            '_links' => [
-                'items' => [],
-            ],
-            '_embedded' => [
-                'items' => [],
-            ],
-        ]);
-        $this->assertEqualsCanonicalizing([
-            ['href' => $this->getIriFor('scheduleEntry1')],
-            ['href' => $this->getIriFor('scheduleEntry1period1camp2')],
-        ], $response->toArray()['_links']['items']);
-    }
-
-    public function testListScheduleEntriesFilteredByEndStrictlyAfterIsAllowedForCollaborator() {
-        /** @var ScheduleEntry $scheduleEntry */
-        $scheduleEntry = static::$fixtures['scheduleEntry1period1camp2'];
-        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?end[strictly_after]='.urlencode($scheduleEntry->getEnd()->format(DateTime::W3C)));
-        $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContains([
-            'totalItems' => 1,
-            '_links' => [
-                'items' => [],
-            ],
-            '_embedded' => [
-                'items' => [],
-            ],
-        ]);
-        $this->assertEqualsCanonicalizing([
-            ['href' => $this->getIriFor('scheduleEntry1')],
-        ], $response->toArray()['_links']['items']);
-    }
-
-    public function testListScheduleEntriesFilteredByInvalidEndDoesntFilter() {
-        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?end[before]=when-I-was-young');
-        $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContains([
             'totalItems' => 4,
             '_links' => [
                 'items' => [],
@@ -354,6 +328,49 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         ]);
         $this->assertEqualsCanonicalizing([
             ['href' => $this->getIriFor('scheduleEntry1')],
+            ['href' => $this->getIriFor('scheduleEntry2')],
+            ['href' => $this->getIriFor('scheduleEntry1period1camp2')],
+            ['href' => $this->getIriFor('scheduleEntry1period1camp1')],
+        ], $response->toArray()['_links']['items']);
+    }
+
+    public function testListScheduleEntriesFilteredByEndStrictlyAfterIsAllowedForCollaborator() {
+        /** @var ScheduleEntry $scheduleEntry */
+        $scheduleEntry = static::$fixtures['scheduleEntry1period1camp2'];
+        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?end[strictly_after]='.urlencode($scheduleEntry->getEnd()->format(DateTime::W3C)));
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'totalItems' => 3,
+            '_links' => [
+                'items' => [],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
+        $this->assertEqualsCanonicalizing([
+            ['href' => $this->getIriFor('scheduleEntry1')],
+            ['href' => $this->getIriFor('scheduleEntry2')],
+            ['href' => $this->getIriFor('scheduleEntry1period1camp1')],
+        ], $response->toArray()['_links']['items']);
+    }
+
+    public function testListScheduleEntriesFilteredByInvalidEndDoesntFilter() {
+        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?end[before]=when-I-was-young');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'totalItems' => 6,
+            '_links' => [
+                'items' => [],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
+        $this->assertEqualsCanonicalizing([
+            ['href' => $this->getIriFor('scheduleEntry1')],
+            ['href' => $this->getIriFor('scheduleEntry2')],
+            ['href' => $this->getIriFor('scheduleEntry1period1camp1')],
             ['href' => $this->getIriFor('scheduleEntry1period1camp2')],
             ['href' => $this->getIriFor('scheduleEntry1period1campPrototype')],
             ['href' => $this->getIriFor('scheduleEntry2period1campPrototype')],

--- a/frontend/src/components/program/FormScheduleEntryList.vue
+++ b/frontend/src/components/program/FormScheduleEntryList.vue
@@ -22,7 +22,7 @@
           class="transition-list-item pa-0 mb-4"
           :schedule-entry="scheduleEntry"
           :periods="periods"
-          :is-last-item="scheduleEntries.length === 1"
+          :is-last-item="scheduleEntriesWithoutDeleted.length === 1"
           @delete="deleteEntry(scheduleEntry)"
         />
       </transition-group>


### PR DESCRIPTION
I will continue adding validations of #2553 until i have review.
So far:
### Activity.php

Entity

- [x] At least one scheduleEntry must remain, or delete the activity when the last scheduleentry is deleted (else it might be difficult to delete the activity)
Properties
- [x] Title
  - [x] Length >0 and length <= 32
  - [x] cleanhtml
  - [x] trim
- [x] Location 
  - [x] ~~Length >0~~ (Default is empty string) and length <= 64
  - [x] cleanhtml
  - [x] trim


### BaseEntity.php
- [x] Id is not writable (one tests with a random entity
- [x] createTime is not writable
- [x] updateTime is not writable

### CampCollaboration.php
Properties
- [x] camp has at least one manager #2363 
- [x] inviteEmail
  - [x] valid email
  - [x] length <= 128

Attention:
If 2 delete requests for the last 2 ScheduleEntries are made, both get through
and we have an activity without ScheduleEntries.
To fix this we need a way to delete the ScheduleEntries when doing an embedded patch on /activity.
