### PR TITLE
fix(api): properly encode URLs in RelatedCollectionLinkNormalizer

### DIFF
--- a/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
+++ b/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
@@ -177,7 +177,7 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
             throw new UnsupportedRelationException('The resource '.$relatedResourceClass.' does not have a search filter for the relation '.$relatedFilterName.'.');
         }
 
-        return $this->router->generate($this->routeNameResolver->getRouteName($relatedResourceClass, OperationType::COLLECTION), [$relatedFilterName => $this->iriConverter->getIriFromItem($object)], UrlGeneratorInterface::ABS_PATH);
+        return $this->router->generate($this->routeNameResolver->getRouteName($relatedResourceClass, OperationType::COLLECTION), [$relatedFilterName => urlencode($this->iriConverter->getIriFromItem($object))], UrlGeneratorInterface::ABS_PATH);
     }
 
     protected function getRelatedCollectionLinkAnnotation(string $className, string $propertyName): ?RelatedCollectionLink {

--- a/api/tests/Api/Activities/ListActivitiesTest.php
+++ b/api/tests/Api/Activities/ListActivitiesTest.php
@@ -42,7 +42,7 @@ class ListActivitiesTest extends ECampApiTestCase {
 
     public function testListActivitiesFilteredByCampIsAllowedForCollaborator() {
         $camp = static::$fixtures['camp1'];
-        $response = static::createClientWithCredentials()->request('GET', '/activities?camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/activities?camp=%2Fcamps%2F'.$camp->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 2,
@@ -62,7 +62,7 @@ class ListActivitiesTest extends ECampApiTestCase {
     public function testListActivitiesFilteredByCampIsDeniedForUnrelatedUser() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/activities?camp=/camps/'.$camp->getId())
+            ->request('GET', '/activities?camp=%2Fcamps%2F'.$camp->getId())
         ;
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains(['totalItems' => 0]);
@@ -72,7 +72,7 @@ class ListActivitiesTest extends ECampApiTestCase {
     public function testListActivitiesFilteredByCampIsDeniedForInactiveCollaborator() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/activities?camp=/camps/'.$camp->getId())
+            ->request('GET', '/activities?camp=%2Fcamps%2F'.$camp->getId())
         ;
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains(['totalItems' => 0]);
@@ -81,7 +81,7 @@ class ListActivitiesTest extends ECampApiTestCase {
 
     public function testListActivitiesFilteredByCampPrototypeIsAllowedForUnrelatedUser() {
         $camp = static::$fixtures['campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/activities?camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/activities?camp=%2Fcamps%2F'.$camp->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains(['totalItems' => 1]);
         $this->assertEqualsCanonicalizing([

--- a/api/tests/Api/Activities/ReadActivityTest.php
+++ b/api/tests/Api/Activities/ReadActivityTest.php
@@ -59,11 +59,11 @@ class ReadActivityTest extends ECampApiTestCase {
             'location' => $activity->location,
             '_links' => [
                 'rootContentNode' => ['href' => $this->getIriFor('columnLayout1')],
-                // 'contentNodes' => ['href' => '/content_nodes?owner=/activities/'.$activity->getId()],
+                // 'contentNodes' => ['href' => '/content_nodes?owner=%2Factivities%2F'.$activity->getId()],
                 'category' => ['href' => $this->getIriFor('category1')],
                 'camp' => ['href' => $this->getIriFor('camp1')],
-                'scheduleEntries' => ['href' => '/schedule_entries?activity=/activities/'.$activity->getId()],
-                'activityResponsibles' => ['href' => '/activity_responsibles?activity=/activities/'.$activity->getId()],
+                'scheduleEntries' => ['href' => '/schedule_entries?activity=%2Factivities%2F'.$activity->getId()],
+                'activityResponsibles' => ['href' => '/activity_responsibles?activity=%2Factivities%2F'.$activity->getId()],
             ],
         ]);
     }
@@ -81,11 +81,11 @@ class ReadActivityTest extends ECampApiTestCase {
             'location' => $activity->location,
             '_links' => [
                 'rootContentNode' => ['href' => $this->getIriFor('columnLayout1')],
-                // 'contentNodes' => ['href' => '/content_nodes?owner=/activities/'.$activity->getId()],
+                // 'contentNodes' => ['href' => '/content_nodes?owner=%2Factivities%2F'.$activity->getId()],
                 'category' => ['href' => $this->getIriFor('category1')],
                 'camp' => ['href' => $this->getIriFor('camp1')],
-                'scheduleEntries' => ['href' => '/schedule_entries?activity=/activities/'.$activity->getId()],
-                'activityResponsibles' => ['href' => '/activity_responsibles?activity=/activities/'.$activity->getId()],
+                'scheduleEntries' => ['href' => '/schedule_entries?activity=%2Factivities%2F'.$activity->getId()],
+                'activityResponsibles' => ['href' => '/activity_responsibles?activity=%2Factivities%2F'.$activity->getId()],
             ],
         ]);
     }
@@ -101,11 +101,11 @@ class ReadActivityTest extends ECampApiTestCase {
             'location' => $activity->location,
             '_links' => [
                 'rootContentNode' => ['href' => $this->getIriFor('columnLayout1')],
-                // 'contentNodes' => ['href' => '/content_nodes?owner=/activities/'.$activity->getId()],
+                // 'contentNodes' => ['href' => '/content_nodes?owner=%2Factivities%2F'.$activity->getId()],
                 'category' => ['href' => $this->getIriFor('category1')],
                 'camp' => ['href' => $this->getIriFor('camp1')],
-                'scheduleEntries' => ['href' => '/schedule_entries?activity=/activities/'.$activity->getId()],
-                'activityResponsibles' => ['href' => '/activity_responsibles?activity=/activities/'.$activity->getId()],
+                'scheduleEntries' => ['href' => '/schedule_entries?activity=%2Factivities%2F'.$activity->getId()],
+                'activityResponsibles' => ['href' => '/activity_responsibles?activity=%2Factivities%2F'.$activity->getId()],
             ],
         ]);
     }

--- a/api/tests/Api/ActivityResponsibles/ListActivityResponsiblesTest.php
+++ b/api/tests/Api/ActivityResponsibles/ListActivityResponsiblesTest.php
@@ -41,7 +41,7 @@ class ListActivityResponsiblesTest extends ECampApiTestCase {
 
     public function testListActivityResponsiblesFilteredByActivityIsAllowedForCollaborator() {
         $activity = static::$fixtures['activity1'];
-        $response = static::createClientWithCredentials()->request('GET', '/activity_responsibles?activity=/activities/'.$activity->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/activity_responsibles?activity=%2Factivities%2F'.$activity->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 1,
@@ -60,7 +60,7 @@ class ListActivityResponsiblesTest extends ECampApiTestCase {
     public function testListActivityResponsiblesFilteredByActivityIsDeniedForUnrelatedUser() {
         $activity = static::$fixtures['activity1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/activity_responsibles?activity=/activities/'.$activity->getId())
+            ->request('GET', '/activity_responsibles?activity=%2Factivities%2F'.$activity->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -72,7 +72,7 @@ class ListActivityResponsiblesTest extends ECampApiTestCase {
     public function testListActivityResponsiblesFilteredByActivityIsDeniedForInactiveCollaborator() {
         $activity = static::$fixtures['activity1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/activity_responsibles?activity=/activities/'.$activity->getId())
+            ->request('GET', '/activity_responsibles?activity=%2Factivities%2F'.$activity->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -83,7 +83,7 @@ class ListActivityResponsiblesTest extends ECampApiTestCase {
 
     public function testListActivityResponsiblesFilteredByActivityInCampPrototypeIsAllowedForUnrelatedUser() {
         $activity = static::$fixtures['activity1campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/activity_responsibles?activity=/activities/'.$activity->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/activity_responsibles?activity=%2Factivities%2F'.$activity->getId());
 
         $this->assertResponseStatusCodeSame(200);
 
@@ -95,7 +95,7 @@ class ListActivityResponsiblesTest extends ECampApiTestCase {
 
     public function testListActivityResponsiblesFilteredByCampIsAllowedForCollaborator() {
         $camp = static::$fixtures['camp1'];
-        $response = static::createClientWithCredentials()->request('GET', '/activity_responsibles?activity.camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/activity_responsibles?activity.camp=%2Fcamps%2F'.$camp->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 2,
@@ -115,7 +115,7 @@ class ListActivityResponsiblesTest extends ECampApiTestCase {
     public function testListActivityResponsiblesFilteredByCampIsDeniedForUnrelatedUser() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/activity_responsibles?activity.camp=/camps/'.$camp->getId())
+            ->request('GET', '/activity_responsibles?activity.camp=%2Fcamps%2F'.$camp->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -126,7 +126,7 @@ class ListActivityResponsiblesTest extends ECampApiTestCase {
 
     public function testListActivityResponsiblesFilteredByCampPrototypeIsAllowedForUnrelatedUser() {
         $camp = static::$fixtures['campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/activity_responsibles?activity.camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/activity_responsibles?activity.camp=%2Fcamps%2F'.$camp->getId());
 
         $this->assertResponseStatusCodeSame(200);
 

--- a/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
+++ b/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
@@ -49,7 +49,7 @@ class ListCampCollaborationsTest extends ECampApiTestCase {
 
     public function testListCampCollaborationsFilteredByCampIsAllowedForCollaborator() {
         $camp = static::$fixtures['camp1'];
-        $response = static::createClientWithCredentials()->request('GET', '/camp_collaborations?camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/camp_collaborations?camp=%2Fcamps%2F'.$camp->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 6,
@@ -73,7 +73,7 @@ class ListCampCollaborationsTest extends ECampApiTestCase {
     public function testListCampCollaborationsFilteredByCampIsDeniedForUnrelatedUser() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/camp_collaborations?camp=/camps/'.$camp->getId())
+            ->request('GET', '/camp_collaborations?camp=%2Fcamps%2F'.$camp->getId())
         ;
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains(['totalItems' => 0]);
@@ -83,7 +83,7 @@ class ListCampCollaborationsTest extends ECampApiTestCase {
     public function testListCampCollaborationsFilteredByCampIsDeniedForInactiveCollaborator() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/camp_collaborations?camp=/camps/'.$camp->getId())
+            ->request('GET', '/camp_collaborations?camp=%2Fcamps%2F'.$camp->getId())
         ;
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains(['totalItems' => 0]);
@@ -92,7 +92,7 @@ class ListCampCollaborationsTest extends ECampApiTestCase {
 
     public function testListCampCollaborationsFilteredByCampPrototypeIsAllowedForUnrelatedUser() {
         $camp = static::$fixtures['campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/camp_collaborations?camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/camp_collaborations?camp=%2Fcamps%2F'.$camp->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 1,

--- a/api/tests/Api/Camps/ReadCampTest.php
+++ b/api/tests/Api/Camps/ReadCampTest.php
@@ -60,11 +60,11 @@ class ReadCampTest extends ECampApiTestCase {
             'isPrototype' => false,
             '_links' => [
                 'creator' => ['href' => $this->getIriFor('user2member')],
-                'activities' => ['href' => '/activities?camp=/camps/'.$camp->getId()],
-                'materialLists' => ['href' => '/material_lists?camp=/camps/'.$camp->getId()],
-                'campCollaborations' => ['href' => '/camp_collaborations?camp=/camps/'.$camp->getId()],
-                'periods' => ['href' => '/periods?camp=/camps/'.$camp->getId()],
-                'categories' => ['href' => '/categories?camp=/camps/'.$camp->getId()],
+                'activities' => ['href' => '/activities?camp=%2Fcamps%2F'.$camp->getId()],
+                'materialLists' => ['href' => '/material_lists?camp=%2Fcamps%2F'.$camp->getId()],
+                'campCollaborations' => ['href' => '/camp_collaborations?camp=%2Fcamps%2F'.$camp->getId()],
+                'periods' => ['href' => '/periods?camp=%2Fcamps%2F'.$camp->getId()],
+                'categories' => ['href' => '/categories?camp=%2Fcamps%2F'.$camp->getId()],
             ],
         ]);
     }
@@ -88,11 +88,11 @@ class ReadCampTest extends ECampApiTestCase {
             'isPrototype' => false,
             '_links' => [
                 'creator' => ['href' => $this->getIriFor('user2member')],
-                'activities' => ['href' => '/activities?camp=/camps/'.$camp->getId()],
-                'materialLists' => ['href' => '/material_lists?camp=/camps/'.$camp->getId()],
-                'campCollaborations' => ['href' => '/camp_collaborations?camp=/camps/'.$camp->getId()],
-                'periods' => ['href' => '/periods?camp=/camps/'.$camp->getId()],
-                'categories' => ['href' => '/categories?camp=/camps/'.$camp->getId()],
+                'activities' => ['href' => '/activities?camp=%2Fcamps%2F'.$camp->getId()],
+                'materialLists' => ['href' => '/material_lists?camp=%2Fcamps%2F'.$camp->getId()],
+                'campCollaborations' => ['href' => '/camp_collaborations?camp=%2Fcamps%2F'.$camp->getId()],
+                'periods' => ['href' => '/periods?camp=%2Fcamps%2F'.$camp->getId()],
+                'categories' => ['href' => '/categories?camp=%2Fcamps%2F'.$camp->getId()],
             ],
         ]);
     }
@@ -115,11 +115,11 @@ class ReadCampTest extends ECampApiTestCase {
             'isPrototype' => false,
             '_links' => [
                 'creator' => ['href' => $this->getIriFor('user2member')],
-                'activities' => ['href' => '/activities?camp=/camps/'.$camp->getId()],
-                'materialLists' => ['href' => '/material_lists?camp=/camps/'.$camp->getId()],
-                'campCollaborations' => ['href' => '/camp_collaborations?camp=/camps/'.$camp->getId()],
-                'periods' => ['href' => '/periods?camp=/camps/'.$camp->getId()],
-                'categories' => ['href' => '/categories?camp=/camps/'.$camp->getId()],
+                'activities' => ['href' => '/activities?camp=%2Fcamps%2F'.$camp->getId()],
+                'materialLists' => ['href' => '/material_lists?camp=%2Fcamps%2F'.$camp->getId()],
+                'campCollaborations' => ['href' => '/camp_collaborations?camp=%2Fcamps%2F'.$camp->getId()],
+                'periods' => ['href' => '/periods?camp=%2Fcamps%2F'.$camp->getId()],
+                'categories' => ['href' => '/categories?camp=%2Fcamps%2F'.$camp->getId()],
             ],
         ]);
     }

--- a/api/tests/Api/Categories/ListCategoriesTest.php
+++ b/api/tests/Api/Categories/ListCategoriesTest.php
@@ -43,7 +43,7 @@ class ListCategoriesTest extends ECampApiTestCase {
 
     public function testListCategoriesFilteredByCampIsAllowedForCollaborator() {
         $camp = static::$fixtures['camp1'];
-        $response = static::createClientWithCredentials()->request('GET', '/categories?camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/categories?camp=%2Fcamps%2F'.$camp->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 3,
@@ -64,7 +64,7 @@ class ListCategoriesTest extends ECampApiTestCase {
     public function testListCategoriesFilteredByCampIsDeniedForUnrelatedUser() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/categories?camp=/camps/'.$camp->getId())
+            ->request('GET', '/categories?camp=%2Fcamps%2F'.$camp->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -76,7 +76,7 @@ class ListCategoriesTest extends ECampApiTestCase {
     public function testListCategoriesFilteredByCampIsDeniedForInactiveCollaborator() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/categories?camp=/camps/'.$camp->getId())
+            ->request('GET', '/categories?camp=%2Fcamps%2F'.$camp->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -87,7 +87,7 @@ class ListCategoriesTest extends ECampApiTestCase {
 
     public function testListCategoriesFilteredByCampPrototypeIsAllowedForUnrelatedUser() {
         $camp = static::$fixtures['campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/categories?camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/categories?camp=%2Fcamps%2F'.$camp->getId());
 
         $this->assertResponseStatusCodeSame(200);
 

--- a/api/tests/Api/Categories/ReadCategoryTest.php
+++ b/api/tests/Api/Categories/ReadCategoryTest.php
@@ -63,7 +63,7 @@ class ReadCategoryTest extends ECampApiTestCase {
                 'camp' => ['href' => $this->getIriFor('camp1')],
                 'rootContentNode' => ['href' => $this->getIriFor('columnLayout2')],
                 'preferredContentTypes' => [],
-                // 'contentNodes' => ['href' => '/content_nodes?owner=/categories/'.$category->getId()],
+                // 'contentNodes' => ['href' => '/content_nodes?owner=%2Fcategories%2F'.$category->getId()],
             ],
         ]);
     }
@@ -85,7 +85,7 @@ class ReadCategoryTest extends ECampApiTestCase {
                 'camp' => ['href' => $this->getIriFor('camp1')],
                 'rootContentNode' => ['href' => $this->getIriFor('columnLayout2')],
                 'preferredContentTypes' => [],
-                // 'contentNodes' => ['href' => '/content_nodes?owner=/categories/'.$category->getId()],
+                // 'contentNodes' => ['href' => '/content_nodes?owner=%2Fcategories%2F'.$category->getId()],
             ],
         ]);
     }
@@ -105,7 +105,7 @@ class ReadCategoryTest extends ECampApiTestCase {
                 'camp' => ['href' => $this->getIriFor('camp1')],
                 'rootContentNode' => ['href' => $this->getIriFor('columnLayout2')],
                 'preferredContentTypes' => [],
-                // 'contentNodes' => ['href' => '/content_nodes?owner=/categories/'.$category->getId()],
+                // 'contentNodes' => ['href' => '/content_nodes?owner=%2Fcategories%2F'.$category->getId()],
             ],
         ]);
     }
@@ -124,7 +124,7 @@ class ReadCategoryTest extends ECampApiTestCase {
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('campPrototype')],
                 'rootContentNode' => ['href' => $this->getIriFor('columnLayout2campPrototype')],
-                // 'contentNodes' => ['href' => '/content_nodes?owner=/categories/'.$category->getId()],
+                // 'contentNodes' => ['href' => '/content_nodes?owner=%2Fcategories%2F'.$category->getId()],
             ],
         ]);
     }

--- a/api/tests/Api/Categories/UpdateCategoryTest.php
+++ b/api/tests/Api/Categories/UpdateCategoryTest.php
@@ -115,7 +115,7 @@ class UpdateCategoryTest extends ECampApiTestCase {
             'numberingStyle' => 'I',
             '_links' => [
                 'preferredContentTypes' => [
-                    'href' => '/content_types?categories='.$this->getIriFor($category),
+                    'href' => '/content_types?categories='.urlencode($this->getIriFor($category)),
                 ],
             ],
         ]);
@@ -141,7 +141,7 @@ class UpdateCategoryTest extends ECampApiTestCase {
             'numberingStyle' => 'I',
             '_links' => [
                 'preferredContentTypes' => [
-                    'href' => '/content_types?categories='.$this->getIriFor($category),
+                    'href' => '/content_types?categories='.urlencode($this->getIriFor($category)),
                 ],
             ],
         ]);

--- a/api/tests/Api/ContentNodes/ContentNode/ReadContentNodeTest.php
+++ b/api/tests/Api/ContentNodes/ContentNode/ReadContentNodeTest.php
@@ -63,7 +63,7 @@ class ReadContentNodeTest extends ECampApiTestCase {
         // then the response still includes content-node (here:storyboard) specific relation links (injected from RelatedCollectionLinkNormalizer)
         $this->assertJsonContains([
             '_links' => [
-                'sections' => ['href' => '/content_node/storyboard_sections?storyboard='.$this->getIriFor($contentNode)],
+                'sections' => ['href' => '/content_node/storyboard_sections?storyboard='.urlencode($this->getIriFor($contentNode))],
             ],
         ]);
         $this->assertResponseStatusCodeSame(200);

--- a/api/tests/Api/ContentNodes/MaterialNode/ReadMaterialNodeTest.php
+++ b/api/tests/Api/ContentNodes/MaterialNode/ReadMaterialNodeTest.php
@@ -34,7 +34,7 @@ class ReadMaterialNodeTest extends ReadContentNodeTestCase {
         $this->assertJsonContains([
             '_links' => [
                 'materialItems' => [
-                    'href' => '/material_items?materialNode='.$this->getIriFor($contentNode),
+                    'href' => '/material_items?materialNode='.urlencode($this->getIriFor($contentNode)),
                 ],
             ],
             '_embedded' => [

--- a/api/tests/Api/ContentNodes/MultiSelect/ReadMultiSelectTest.php
+++ b/api/tests/Api/ContentNodes/MultiSelect/ReadMultiSelectTest.php
@@ -33,7 +33,7 @@ class ReadMultiSelectTest extends ReadContentNodeTestCase {
 
         $this->assertJsonContains([
             '_links' => [
-                'options' => ['href' => '/content_node/multi_select_options?multiSelect='.$this->getIriFor($multiSelect)],
+                'options' => ['href' => '/content_node/multi_select_options?multiSelect='.urlencode($this->getIriFor($multiSelect))],
             ],
             '_embedded' => [
                 'options' => [

--- a/api/tests/Api/ContentNodes/Storyboard/ReadStoryboardTest.php
+++ b/api/tests/Api/ContentNodes/Storyboard/ReadStoryboardTest.php
@@ -33,7 +33,7 @@ class ReadStoryboardTest extends ReadContentNodeTestCase {
 
         $this->assertJsonContains([
             '_links' => [
-                'sections' => ['href' => '/content_node/storyboard_sections?storyboard='.$this->getIriFor($storyboard)],
+                'sections' => ['href' => '/content_node/storyboard_sections?storyboard='.urlencode($this->getIriFor($storyboard))],
             ],
             '_embedded' => [
                 'sections' => [

--- a/api/tests/Api/DayResponsibles/ListDayResponsiblesTest.php
+++ b/api/tests/Api/DayResponsibles/ListDayResponsiblesTest.php
@@ -40,7 +40,7 @@ class ListDayResponsiblesTest extends ECampApiTestCase {
 
     public function testListDayResponsiblesFilteredByDayIsAllowedForCollaborator() {
         $day = static::$fixtures['day1period1'];
-        $response = static::createClientWithCredentials()->request('GET', '/day_responsibles?day=/days/'.$day->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/day_responsibles?day=%2Fdays%2F'.$day->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 1,
@@ -59,7 +59,7 @@ class ListDayResponsiblesTest extends ECampApiTestCase {
     public function testListDayResponsiblesFilteredByDayIsDeniedForUnrelatedUser() {
         $day = static::$fixtures['day1period1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/day_responsibles?day=/days/'.$day->getId())
+            ->request('GET', '/day_responsibles?day=%2Fdays%2F'.$day->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -71,7 +71,7 @@ class ListDayResponsiblesTest extends ECampApiTestCase {
     public function testListDayResponsiblesFilteredByDayIsDeniedForInactiveCollaborator() {
         $day = static::$fixtures['day1period1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/day_responsibles?day=/days/'.$day->getId())
+            ->request('GET', '/day_responsibles?day=%2Fdays%2F'.$day->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -82,7 +82,7 @@ class ListDayResponsiblesTest extends ECampApiTestCase {
 
     public function testListDayResponsiblesFilteredByDayInCampPrototypeIsAllowedForUnrelatedUser() {
         $day = static::$fixtures['day1period1campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/day_responsibles?day=/days/'.$day->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/day_responsibles?day=%2Fdays%2F'.$day->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 1,

--- a/api/tests/Api/Days/ListDaysTest.php
+++ b/api/tests/Api/Days/ListDaysTest.php
@@ -45,7 +45,7 @@ class ListDaysTest extends ECampApiTestCase {
 
     public function testListDaysFilteredByPeriodIsAllowedForCollaborator() {
         $period = static::$fixtures['period1'];
-        $response = static::createClientWithCredentials()->request('GET', '/days?period=/periods/'.$period->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/days?period=%2Fperiods%2F'.$period->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 3,
@@ -66,7 +66,7 @@ class ListDaysTest extends ECampApiTestCase {
     public function testListDaysFilteredByPeriodIsDeniedForUnrelatedUser() {
         $period = static::$fixtures['period1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/days?period=/periods/'.$period->getId())
+            ->request('GET', '/days?period=%2Fperiods%2F'.$period->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -78,7 +78,7 @@ class ListDaysTest extends ECampApiTestCase {
     public function testListDaysFilteredByPeriodIsDeniedForInactiveCollaborator() {
         $period = static::$fixtures['period1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/days?period=/periods/'.$period->getId())
+            ->request('GET', '/days?period=%2Fperiods%2F'.$period->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -103,7 +103,7 @@ class ListDaysTest extends ECampApiTestCase {
 
     public function testListDaysFilteredByPeriodInCampPrototypeIsAllowedForCollaborator() {
         $period = static::$fixtures['period1campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/days?period=/periods/'.$period->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/days?period=%2Fperiods%2F'.$period->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 1,

--- a/api/tests/Api/Days/ReadDayTest.php
+++ b/api/tests/Api/Days/ReadDayTest.php
@@ -63,7 +63,7 @@ class ReadDayTest extends ECampApiTestCase {
             '_links' => [
                 'period' => ['href' => $this->getIriFor('period1')],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$day->period->getId().'&start%5Bstrictly_before%5D='.urlencode($end).'&end%5Bafter%5D='.urlencode($start)],
-                'dayResponsibles' => ['href' => '/day_responsibles?day=/days/'.$day->getId()],
+                'dayResponsibles' => ['href' => '/day_responsibles?day=%2Fdays%2F'.$day->getId()],
             ],
         ]);
     }
@@ -84,7 +84,7 @@ class ReadDayTest extends ECampApiTestCase {
             '_links' => [
                 'period' => ['href' => $this->getIriFor('period1')],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$day->period->getId().'&start%5Bstrictly_before%5D='.urlencode($end).'&end%5Bafter%5D='.urlencode($start)],
-                'dayResponsibles' => ['href' => '/day_responsibles?day=/days/'.$day->getId()],
+                'dayResponsibles' => ['href' => '/day_responsibles?day=%2Fdays%2F'.$day->getId()],
             ],
         ]);
     }
@@ -103,7 +103,7 @@ class ReadDayTest extends ECampApiTestCase {
             '_links' => [
                 'period' => ['href' => $this->getIriFor('period1')],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$day->period->getId().'&start%5Bstrictly_before%5D='.urlencode($end).'&end%5Bafter%5D='.urlencode($start)],
-                'dayResponsibles' => ['href' => '/day_responsibles?day=/days/'.$day->getId()],
+                'dayResponsibles' => ['href' => '/day_responsibles?day=%2Fdays%2F'.$day->getId()],
             ],
         ]);
     }
@@ -122,7 +122,7 @@ class ReadDayTest extends ECampApiTestCase {
             '_links' => [
                 'period' => ['href' => $this->getIriFor('period1campPrototype')],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$day->period->getId().'&start%5Bstrictly_before%5D='.urlencode($end).'&end%5Bafter%5D='.urlencode($start)],
-                'dayResponsibles' => ['href' => '/day_responsibles?day=/days/'.$day->getId()],
+                'dayResponsibles' => ['href' => '/day_responsibles?day=%2Fdays%2F'.$day->getId()],
             ],
         ]);
     }

--- a/api/tests/Api/MaterialItems/ListMaterialItemsTest.php
+++ b/api/tests/Api/MaterialItems/ListMaterialItemsTest.php
@@ -42,7 +42,7 @@ class ListMaterialItemsTest extends ECampApiTestCase {
 
     public function testListMaterialItemsFilteredByMaterialListIsAllowedForCollaborator() {
         $materialList = static::$fixtures['materialList1'];
-        $response = static::createClientWithCredentials()->request('GET', '/material_items?materialList=/material_lists/'.$materialList->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/material_items?materialList=%2Fmaterial_lists%2F'.$materialList->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 2,
@@ -62,7 +62,7 @@ class ListMaterialItemsTest extends ECampApiTestCase {
     public function testListMaterialItemsFilteredByMaterialListIsDeniedForUnrelatedUser() {
         $materialList = static::$fixtures['materialList1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/material_items?materialList=/material_lists/'.$materialList->getId())
+            ->request('GET', '/material_items?materialList=%2Fmaterial_lists%2F'.$materialList->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -74,7 +74,7 @@ class ListMaterialItemsTest extends ECampApiTestCase {
     public function testListMaterialItemsFilteredByMaterialListIsDeniedForInactiveCollaborator() {
         $materialList = static::$fixtures['materialList1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/material_items?materialList=/material_lists/'.$materialList->getId())
+            ->request('GET', '/material_items?materialList=%2Fmaterial_lists%2F'.$materialList->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -85,7 +85,7 @@ class ListMaterialItemsTest extends ECampApiTestCase {
 
     public function testListMaterialItemsFilteredByMaterialListInCampPrototypeIsAllowedForUnrelatedUser() {
         $materialList = static::$fixtures['materialList1campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/material_items?materialList=/material_lists/'.$materialList->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/material_items?materialList=%2Fmaterial_lists%2F'.$materialList->getId());
         $this->assertJsonContains([
             'totalItems' => 1,
             '_links' => [
@@ -102,7 +102,7 @@ class ListMaterialItemsTest extends ECampApiTestCase {
 
     public function testListMaterialItemsFilteredByPeriodIsAllowedForCollaborator() {
         $period = static::$fixtures['period1'];
-        $response = static::createClientWithCredentials()->request('GET', '/material_items?period=/periods/'.$period->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/material_items?period=%2Fperiods%2F'.$period->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 2,
@@ -122,7 +122,7 @@ class ListMaterialItemsTest extends ECampApiTestCase {
     public function testListMaterialItemsFilteredByPeriodIsDeniedForUnrelatedUser() {
         $period = static::$fixtures['period1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/material_items?period=/periods/'.$period->getId())
+            ->request('GET', '/material_items?period=%2Fperiods%2F'.$period->getId())
         ;
 
         $this->assertResponseStatusCodeSame(400);
@@ -136,7 +136,7 @@ class ListMaterialItemsTest extends ECampApiTestCase {
     public function testListMaterialItemsFilteredByPeriodIsDeniedForInactiveCollaborator() {
         $period = static::$fixtures['period1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/material_items?period=/periods/'.$period->getId())
+            ->request('GET', '/material_items?period=%2Fperiods%2F'.$period->getId())
         ;
 
         $this->assertResponseStatusCodeSame(400);
@@ -149,7 +149,7 @@ class ListMaterialItemsTest extends ECampApiTestCase {
 
     public function testListMaterialItemsFilteredByPeriodInCampPrototypeIsAllowedForUnrelatedUser() {
         $period = static::$fixtures['period1campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/material_items?period=/periods/'.$period->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/material_items?period=%2Fperiods%2F'.$period->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 1,

--- a/api/tests/Api/MaterialLists/ListMaterialListsTest.php
+++ b/api/tests/Api/MaterialLists/ListMaterialListsTest.php
@@ -43,7 +43,7 @@ class ListMaterialListsTest extends ECampApiTestCase {
 
     public function testListMaterialListsFilteredByCampIsAllowedForCollaborator() {
         $camp = static::$fixtures['camp1'];
-        $response = static::createClientWithCredentials()->request('GET', '/material_lists?camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/material_lists?camp=%2Fcamps%2F'.$camp->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 3,
@@ -64,7 +64,7 @@ class ListMaterialListsTest extends ECampApiTestCase {
     public function testListMaterialListsFilteredByCampIsDeniedForUnrelatedUser() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/material_lists?camp=/camps/'.$camp->getId())
+            ->request('GET', '/material_lists?camp=%2Fcamps%2F'.$camp->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -76,7 +76,7 @@ class ListMaterialListsTest extends ECampApiTestCase {
     public function testListMaterialListsFilteredByCampIsDeniedForInactiveCollaborator() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/material_lists?camp=/camps/'.$camp->getId())
+            ->request('GET', '/material_lists?camp=%2Fcamps%2F'.$camp->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -87,7 +87,7 @@ class ListMaterialListsTest extends ECampApiTestCase {
 
     public function testListMaterialListsFilteredByCampPrototypeIsAllowedForUnrelatedUser() {
         $camp = static::$fixtures['campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/material_lists?camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/material_lists?camp=%2Fcamps%2F'.$camp->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 1,

--- a/api/tests/Api/MaterialLists/ReadMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/ReadMaterialListTest.php
@@ -58,7 +58,7 @@ class ReadMaterialListTest extends ECampApiTestCase {
             'name' => $materialList->name,
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('camp1')],
-                'materialItems' => ['href' => '/material_items?materialList=/material_lists/'.$materialList->getId()],
+                'materialItems' => ['href' => '/material_items?materialList=%2Fmaterial_lists%2F'.$materialList->getId()],
             ],
         ]);
     }
@@ -75,7 +75,7 @@ class ReadMaterialListTest extends ECampApiTestCase {
             'name' => $materialList->name,
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('camp1')],
-                'materialItems' => ['href' => '/material_items?materialList=/material_lists/'.$materialList->getId()],
+                'materialItems' => ['href' => '/material_items?materialList=%2Fmaterial_lists%2F'.$materialList->getId()],
             ],
         ]);
     }
@@ -90,7 +90,7 @@ class ReadMaterialListTest extends ECampApiTestCase {
             'name' => $materialList->name,
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('camp1')],
-                'materialItems' => ['href' => '/material_items?materialList=/material_lists/'.$materialList->getId()],
+                'materialItems' => ['href' => '/material_items?materialList=%2Fmaterial_lists%2F'.$materialList->getId()],
             ],
         ]);
     }
@@ -105,7 +105,7 @@ class ReadMaterialListTest extends ECampApiTestCase {
             'name' => $materialList->name,
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('campPrototype')],
-                'materialItems' => ['href' => '/material_items?materialList=/material_lists/'.$materialList->getId()],
+                'materialItems' => ['href' => '/material_items?materialList=%2Fmaterial_lists%2F'.$materialList->getId()],
             ],
         ]);
     }

--- a/api/tests/Api/Periods/ListPeriodsTest.php
+++ b/api/tests/Api/Periods/ListPeriodsTest.php
@@ -42,7 +42,7 @@ class ListPeriodsTest extends ECampApiTestCase {
 
     public function testListPeriodsFilteredByCampIsAllowedForCollaborator() {
         $camp = static::$fixtures['camp1'];
-        $response = static::createClientWithCredentials()->request('GET', '/periods?camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/periods?camp=%2Fcamps%2F'.$camp->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 2,
@@ -62,7 +62,7 @@ class ListPeriodsTest extends ECampApiTestCase {
     public function testListPeriodsFilteredByCampIsDeniedForUnrelatedUser() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/periods?camp=/camps/'.$camp->getId())
+            ->request('GET', '/periods?camp=%2Fcamps%2F'.$camp->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -74,7 +74,7 @@ class ListPeriodsTest extends ECampApiTestCase {
     public function testListPeriodsFilteredByCampIsDeniedForInactiveCollaborator() {
         $camp = static::$fixtures['camp1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/periods?camp=/camps/'.$camp->getId())
+            ->request('GET', '/periods?camp=%2Fcamps%2F'.$camp->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -85,7 +85,7 @@ class ListPeriodsTest extends ECampApiTestCase {
 
     public function testListPeriodsFilteredByCampPrototypeIsAllowedForUnrelatedUser() {
         $camp = static::$fixtures['campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/periods?camp=/camps/'.$camp->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/periods?camp=%2Fcamps%2F'.$camp->getId());
 
         $this->assertResponseStatusCodeSame(200);
 

--- a/api/tests/Api/Periods/ReadPeriodTest.php
+++ b/api/tests/Api/Periods/ReadPeriodTest.php
@@ -62,8 +62,8 @@ class ReadPeriodTest extends ECampApiTestCase {
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('camp1')],
                 'materialItems' => ['href' => '/material_items?period=%2Fperiods%2F'.$period->getId()], // TODO: fix encoding with https://github.com/ecamp/ecamp3/issues/2289
-                'days' => ['href' => '/days?period=/periods/'.$period->getId()],
-                'scheduleEntries' => ['href' => '/schedule_entries?period=/periods/'.$period->getId()],
+                'days' => ['href' => '/days?period=%2Fperiods%2F'.$period->getId()],
+                'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$period->getId()],
             ],
         ]);
     }
@@ -84,8 +84,8 @@ class ReadPeriodTest extends ECampApiTestCase {
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('camp1')],
                 'materialItems' => ['href' => '/material_items?period=%2Fperiods%2F'.$period->getId()],  // TODO: fix encoding with https://github.com/ecamp/ecamp3/issues/2289
-                'days' => ['href' => '/days?period=/periods/'.$period->getId()],
-                'scheduleEntries' => ['href' => '/schedule_entries?period=/periods/'.$period->getId()],
+                'days' => ['href' => '/days?period=%2Fperiods%2F'.$period->getId()],
+                'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$period->getId()],
             ],
         ]);
     }
@@ -103,8 +103,8 @@ class ReadPeriodTest extends ECampApiTestCase {
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('camp1')],
                 'materialItems' => ['href' => '/material_items?period=%2Fperiods%2F'.$period->getId()], // TODO: fix encoding with https://github.com/ecamp/ecamp3/issues/2289
-                'days' => ['href' => '/days?period=/periods/'.$period->getId()],
-                'scheduleEntries' => ['href' => '/schedule_entries?period=/periods/'.$period->getId()],
+                'days' => ['href' => '/days?period=%2Fperiods%2F'.$period->getId()],
+                'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$period->getId()],
             ],
         ]);
     }

--- a/api/tests/Api/Periods/ReadPeriodTest.php
+++ b/api/tests/Api/Periods/ReadPeriodTest.php
@@ -61,7 +61,7 @@ class ReadPeriodTest extends ECampApiTestCase {
             'end' => $period->end->format('Y-m-d'),
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('camp1')],
-                'materialItems' => ['href' => '/material_items?period=%2Fperiods%2F'.$period->getId()], // TODO: fix encoding with https://github.com/ecamp/ecamp3/issues/2289
+                'materialItems' => ['href' => '/material_items?period=%2Fperiods%2F'.$period->getId()],
                 'days' => ['href' => '/days?period=%2Fperiods%2F'.$period->getId()],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$period->getId()],
             ],
@@ -83,7 +83,7 @@ class ReadPeriodTest extends ECampApiTestCase {
             'end' => $period->end->format('Y-m-d'),
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('camp1')],
-                'materialItems' => ['href' => '/material_items?period=%2Fperiods%2F'.$period->getId()],  // TODO: fix encoding with https://github.com/ecamp/ecamp3/issues/2289
+                'materialItems' => ['href' => '/material_items?period=%2Fperiods%2F'.$period->getId()],
                 'days' => ['href' => '/days?period=%2Fperiods%2F'.$period->getId()],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$period->getId()],
             ],
@@ -102,7 +102,7 @@ class ReadPeriodTest extends ECampApiTestCase {
             'end' => $period->end->format('Y-m-d'),
             '_links' => [
                 'camp' => ['href' => $this->getIriFor('camp1')],
-                'materialItems' => ['href' => '/material_items?period=%2Fperiods%2F'.$period->getId()], // TODO: fix encoding with https://github.com/ecamp/ecamp3/issues/2289
+                'materialItems' => ['href' => '/material_items?period=%2Fperiods%2F'.$period->getId()],
                 'days' => ['href' => '/days?period=%2Fperiods%2F'.$period->getId()],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$period->getId()],
             ],

--- a/api/tests/Api/ScheduleEntries/ListScheduleEntriesTest.php
+++ b/api/tests/Api/ScheduleEntries/ListScheduleEntriesTest.php
@@ -44,7 +44,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
 
     public function testListScheduleEntriesFilteredByPeriodIsAllowedForCollaborator() {
         $period = static::$fixtures['period1'];
-        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?period=/periods/'.$period->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?period=%2Fperiods%2F'.$period->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 1,
@@ -63,7 +63,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
     public function testListScheduleEntriesFilteredByPeriodIsDeniedForUnrelatedUser() {
         $period = static::$fixtures['period1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/schedule_entries?period=/periods/'.$period->getId())
+            ->request('GET', '/schedule_entries?period=%2Fperiods%2F'.$period->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -75,7 +75,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
     public function testListScheduleEntriesFilteredByPeriodIsDeniedForInactiveCollaborator() {
         $period = static::$fixtures['period1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/schedule_entries?period=/periods/'.$period->getId())
+            ->request('GET', '/schedule_entries?period=%2Fperiods%2F'.$period->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -86,7 +86,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
 
     public function testListScheduleEntriesFilteredByPeriodInCampPrototypeIsAllowedForUnrelatedUser() {
         $period = static::$fixtures['period1campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?period=/periods/'.$period->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?period=%2Fperiods%2F'.$period->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 2,
@@ -105,7 +105,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
 
     public function testListScheduleEntriesFilteredByActivityIsAllowedForCollaborator() {
         $activity = static::$fixtures['activity1'];
-        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?activity=/activities/'.$activity->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?activity=%2Factivities%2F'.$activity->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 1,
@@ -124,7 +124,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
     public function testListScheduleEntriesFilteredByActivityIsDeniedForUnrelatedUser() {
         $activity = static::$fixtures['activity1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user4unrelated']->getUsername()])
-            ->request('GET', '/schedule_entries?activity=/activities/'.$activity->getId())
+            ->request('GET', '/schedule_entries?activity=%2Factivities%2F'.$activity->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -136,7 +136,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
     public function testListScheduleEntriesFilteredByActivityIsDeniedForInactiveCollaborator() {
         $activity = static::$fixtures['activity1'];
         $response = static::createClientWithCredentials(['username' => static::$fixtures['user5inactive']->getUsername()])
-            ->request('GET', '/schedule_entries?activity=/activities/'.$activity->getId())
+            ->request('GET', '/schedule_entries?activity=%2Factivities%2F'.$activity->getId())
         ;
 
         $this->assertResponseStatusCodeSame(200);
@@ -147,7 +147,7 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
 
     public function testListScheduleEntriesFilteredByActivityInCampPrototypeIsAllowedForUnrelatedUser() {
         $activity = static::$fixtures['activity1campPrototype'];
-        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?activity=/activities/'.$activity->getId());
+        $response = static::createClientWithCredentials()->request('GET', '/schedule_entries?activity=%2Factivities%2F'.$activity->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'totalItems' => 2,

--- a/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
@@ -242,7 +242,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->assertEquals([
             'hello' => 'world',
             '_links' => [
-                'childrenWithSerializedName' => ['href' => '/children?parent=/parents/123'],
+                'childrenWithSerializedName' => ['href' => '/children?parent=%2Fparents%2F123'],
                 'firstBorn' => ['href' => '/children/1'],
             ],
         ], $result);
@@ -444,7 +444,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->filterInstance->method('getDescription')->willReturn($description);
     }
 
-    protected function shouldReplaceChildrenWithLink($result, $link = '/children?parent=/parents/123') {
+    protected function shouldReplaceChildrenWithLink($result, $link = '/children?parent=%2Fparents%2F123') {
         $this->assertEquals([
             'hello' => 'world',
             '_links' => [
@@ -467,7 +467,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         ], $result);
     }
 
-    protected function mockGeneratedRoute($generated = '/children?parent=/parents/123') {
+    protected function mockGeneratedRoute($generated = '/children?parent=%2Fparents%2F123') {
         $this->routerMock->method('generate')->willReturn($generated);
     }
 }


### PR DESCRIPTION
Fixes #2289 

After https://github.com/symfony/symfony/pull/45658 made it into the release of symfony 6.1, we can now properly encode query parameters in `RelatedCollectionLinkNormalizer`

Also tested Frontend side. Everything still working.