### PR TITLE
Environment specific cookies

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -10,7 +10,7 @@ If you ever need to get an API token for manual use, you can use the following c
 docker-compose exec php bin/console lexik:jwt:generate-token test-user --no-debug
 ```
 
-The token must then be split and sent in two cookies to the API. The header and payload (from `ey` until before the second period `.`) must be sent in a cookie named `jwt_hp`. The signature (everything after the second period `.`) must be sent in a cookie called `jwt_s`.
+The token must then be split and sent in two cookies to the API. The header and payload (from `ey` until before the second period `.`) must be sent in a cookie named `[api-domain]_jwt_hp`. The signature (everything after the second period `.`) must be sent in a cookie called `[api-domain]_jwt_s` (replace [api-domain] with the domain where the API is served, e.g. `localhost_jwt_hp` or `pr1234.ecamp3.ch_jwt_s`).
 See https://jwt.io for more info on the structure of JWT tokens, and https://medium.com/lightrail/getting-token-authentication-right-in-a-stateless-single-page-application-57d0c6474e3 for more info on why this split cookie approach is a good idea for SPAs.
 
 

--- a/api/config/packages/lexik_jwt_authentication.yaml
+++ b/api/config/packages/lexik_jwt_authentication.yaml
@@ -7,20 +7,20 @@ lexik_jwt_authentication:
     # Of course it would be even better to have only short-lived tokens but renew them on every request.
     token_ttl: 43200
 
-    # Read the JWT token from a split cookie: The jwt_hp and jwt_s cookies are combined with a period (.)
+    # Read the JWT token from a split cookie: The [api-domain]_jwt_hp and [api-domain]_jwt_s cookies are combined with a period (.)
     # to form the full JWT token.
     token_extractors:
         split_cookie:
             enabled: true
             cookies:
-                - jwt_hp
-                - jwt_s
+                - '%env(API_DOMAIN)%_jwt_hp'
+                - '%env(API_DOMAIN)%_jwt_s'
 
-    # When logging in, set the two cookies. The header and payload cookie jwt_hp is available in JavaScript,
-    # while the signature jwt_s is HttpOnly. This is considered safer than handing the whole token to JavaScript:
+    # When logging in, set the two cookies. The header and payload cookie [api-domain]_jwt_hp is available in JavaScript,
+    # while the signature [api-domain]_jwt_s is HttpOnly. This is considered safer than handing the whole token to JavaScript:
     # https://medium.com/lightrail/getting-token-authentication-right-in-a-stateless-single-page-application-57d0c6474e3
     set_cookies:
-        jwt_hp:
+        '%env(API_DOMAIN)%_jwt_hp':
             lifetime: null
             samesite: lax
             path: /
@@ -29,7 +29,7 @@ lexik_jwt_authentication:
             split:
                 - header
                 - payload
-        jwt_s:
+        '%env(API_DOMAIN)%_jwt_s':
             lifetime: null
             samesite: lax
             path: /

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -84,6 +84,9 @@ services:
 
     App\OpenApi\JwtDecorator:
         decorates: 'api_platform.openapi.factory'
+        arguments:
+            - '@.inner'
+            - '%env(API_DOMAIN)%'
 
     App\OpenApi\OAuthDecorator:
         decorates: 'api_platform.openapi.factory'

--- a/api/src/OpenApi/JwtDecorator.php
+++ b/api/src/OpenApi/JwtDecorator.php
@@ -10,7 +10,7 @@ use ApiPlatform\Core\OpenApi\OpenApi;
  * Decorates the OpenApi factory to add API docs for the login endpoint.
  */
 final class JwtDecorator implements OpenApiFactoryInterface {
-    public function __construct(private OpenApiFactoryInterface $decorated) {
+    public function __construct(private OpenApiFactoryInterface $decorated, private string $apiDomain) {
     }
 
     public function __invoke(array $context = []): OpenApi {
@@ -31,6 +31,7 @@ final class JwtDecorator implements OpenApiFactoryInterface {
             ],
         ]);
 
+        $apiDomain = $this->apiDomain;
         $pathItem = new Model\PathItem(
             ref: 'JWT Token',
             post: new Model\Operation(
@@ -38,7 +39,7 @@ final class JwtDecorator implements OpenApiFactoryInterface {
                 tags: ['Login'],
                 responses: [
                     '204' => [
-                        'description' => 'Get a JWT token split across the two cookies [api-domain]_jwt_hp and [api-domain]_jwt_s',
+                        'description' => "Get a JWT token split across the two cookies {$apiDomain}_jwt_hp and {$apiDomain}_jwt_s",
                     ],
                 ],
                 summary: 'Log in using username and password.',

--- a/api/src/OpenApi/JwtDecorator.php
+++ b/api/src/OpenApi/JwtDecorator.php
@@ -38,7 +38,7 @@ final class JwtDecorator implements OpenApiFactoryInterface {
                 tags: ['Login'],
                 responses: [
                     '204' => [
-                        'description' => 'Get a JWT token split across the two cookies jwt_hp and jwt_s',
+                        'description' => 'Get a JWT token split across the two cookies [api-domain]_jwt_hp and [api-domain]_jwt_s',
                     ],
                 ],
                 summary: 'Log in using username and password.',

--- a/api/src/OpenApi/OAuthDecorator.php
+++ b/api/src/OpenApi/OAuthDecorator.php
@@ -67,7 +67,7 @@ final class OAuthDecorator implements OpenApiFactoryInterface {
         $pathItemCevidb = new Model\PathItem(
             ref: 'CeviDB OAuth',
             get: new Model\Operation(
-                operationId: 'oauthPbsmidataRedirect',
+                operationId: 'oauthCevidbRedirect',
                 tags: ['OAuth'],
                 parameters: [
                     new Model\Parameter(

--- a/api/tests/Api/ECampApiTestCase.php
+++ b/api/tests/Api/ECampApiTestCase.php
@@ -74,8 +74,8 @@ abstract class ECampApiTestCase extends ApiTestCase {
         $jwtSignature = substr($jwtToken, $lastPeriodPosition + 1);
 
         $cookies = $client->getCookieJar();
-        $cookies->set(new Cookie('jwt_hp', $jwtHeaderAndPayload, null, null, 'example.com', false, false, false, 'strict'));
-        $cookies->set(new Cookie('jwt_s', $jwtSignature, null, null, 'example.com', false, true, false, 'strict'));
+        $cookies->set(new Cookie('example.com_jwt_hp', $jwtHeaderAndPayload, null, null, 'example.com', false, false, false, 'strict'));
+        $cookies->set(new Cookie('example.com_jwt_s', $jwtSignature, null, null, 'example.com', false, true, false, 'strict'));
 
         return $client;
     }

--- a/frontend/src/plugins/__tests__/auth.spec.js
+++ b/frontend/src/plugins/__tests__/auth.spec.js
@@ -24,14 +24,14 @@ expect.extend({
 describe('authentication logic', () => {
   afterEach(() => {
     jest.restoreAllMocks()
-    Cookies.remove('jwt_hp')
+    Cookies.remove('localhost_jwt_hp')
   })
 
   describe('isLoggedIn()', () => {
     it('returns true if JWT payload is not expired', () => {
       // given
       store.replaceState(createState())
-      Cookies.set('jwt_hp', validJWTPayload)
+      Cookies.set('localhost_jwt_hp', validJWTPayload)
 
       // when
       const result = auth.isLoggedIn()
@@ -43,7 +43,7 @@ describe('authentication logic', () => {
     it('returns false if JWT payload is expired', () => {
       // given
       store.replaceState(createState())
-      Cookies.set('jwt_hp', expiredJWTPayload)
+      Cookies.set('localhost_jwt_hp', expiredJWTPayload)
 
       // when
       const result = auth.isLoggedIn()
@@ -55,7 +55,7 @@ describe('authentication logic', () => {
     it('returns false if JWT cookie is missing', () => {
       // given
       store.replaceState(createState())
-      Cookies.set('jwt_hp', expiredJWTPayload)
+      Cookies.set('localhost_jwt_hp', expiredJWTPayload)
 
       // when
       const result = auth.isLoggedIn()
@@ -89,7 +89,7 @@ describe('authentication logic', () => {
       // given
       store.replaceState(createState())
       jest.spyOn(apiStore, 'post').mockImplementation(async () => {
-        Cookies.set('jwt_hp', validJWTPayload)
+        Cookies.set('localhost_jwt_hp', validJWTPayload)
       })
 
       // when
@@ -145,7 +145,7 @@ describe('authentication logic', () => {
         _meta: {},
       }
       user._meta.load = new Promise(() => user)
-      Cookies.set('jwt_hp', validJWTPayload)
+      Cookies.set('localhost_jwt_hp', validJWTPayload)
 
       jest.spyOn(apiStore, 'get').mockImplementation(() => user)
 
@@ -163,7 +163,7 @@ describe('authentication logic', () => {
       async (status) => {
         // given
         store.replaceState(createState())
-        Cookies.set('jwt_hp', validJWTPayload)
+        Cookies.set('localhost_jwt_hp', validJWTPayload)
 
         const user = {
           _meta: {
@@ -265,7 +265,7 @@ describe('authentication logic', () => {
   describe('logout()', () => {
     it('resolves to false if the user successfully logs out', async () => {
       // given
-      Cookies.set('jwt_hp', validJWTPayload)
+      Cookies.set('localhost_jwt_hp', validJWTPayload)
 
       // when
       const result = await auth.logout()

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -110,7 +110,9 @@ async function loginCeviDB() {
 }
 
 export async function logout() {
-  Cookies.remove(headerAndPayloadCookieName(), { domain: window.environment.SHARED_COOKIE_DOMAIN })
+  Cookies.remove(headerAndPayloadCookieName(), {
+    domain: window.environment.SHARED_COOKIE_DOMAIN,
+  })
   return router
     .push({ name: 'login' })
     .then(() => apiStore.purgeAll())
@@ -118,7 +120,7 @@ export async function logout() {
 }
 
 function headerAndPayloadCookieName() {
-  return `${apiDomain()}_jwt_hp`;
+  return `${apiDomain()}_jwt_hp`
 }
 
 function apiDomain() {

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -11,7 +11,7 @@ axios.interceptors.response.use(null, (error) => {
 })
 
 function getJWTPayloadFromCookie() {
-  const jwtHeaderAndPayload = Cookies.get('jwt_hp')
+  const jwtHeaderAndPayload = Cookies.get(headerAndPayloadCookieName())
   if (!jwtHeaderAndPayload) return ''
 
   return jwtHeaderAndPayload.split('.')[1]
@@ -110,11 +110,19 @@ async function loginCeviDB() {
 }
 
 export async function logout() {
-  Cookies.remove('jwt_hp', { domain: window.environment.SHARED_COOKIE_DOMAIN })
+  Cookies.remove(headerAndPayloadCookieName(), { domain: window.environment.SHARED_COOKIE_DOMAIN })
   return router
     .push({ name: 'login' })
     .then(() => apiStore.purgeAll())
     .then(() => isLoggedIn())
+}
+
+function headerAndPayloadCookieName() {
+  return `${apiDomain()}_jwt_hp`;
+}
+
+function apiDomain() {
+  return new URL(window.environment.API_ROOT_URL).hostname
 }
 
 export const auth = {

--- a/frontend/src/views/Camps.vue
+++ b/frontend/src/views/Camps.vue
@@ -135,7 +135,10 @@ export default {
     },
   },
   mounted() {
-    this.api.reload(this.camps)
+    // Only reload camps if they were loaded before, to avoid console error
+    if (this.camps._meta.self !== null) {
+      this.api.reload(this.camps)
+    }
   },
   methods: {
     campRoute,


### PR DESCRIPTION
Fixes #2772. I opted for prefixing the api domain, so it will look like `localhost_jwt_hp` or `api-pr1234.ecamp3.ch_jwt_s`. This way, the cookies from the same origin will be grouped together when sorting alphabetically in the cookie inspector of the browser. Also I chose to prefix the whole domain of the API (`api-pr1234.ecamp3.ch`) rather than only the environment (`pr1234`), because the API domain is easily accessible in both frontend and API, and this approach is more generic for other people who do not use the same exact naming conventions for feature branch deployments as we do.

Also fixes one of our most common sentry errors, and a typo in the OAuth API docs.