### PR TITLE
Api entity validations 2

### DIFF
--- a/api/src/Entity/Category.php
+++ b/api/src/Entity/Category.php
@@ -7,6 +7,7 @@ use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Core\Util\ClassInfoTrait;
+use App\InputFilter;
 use App\Repository\CategoryRepository;
 use App\Util\EntityMap;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -105,6 +106,10 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
      * An abbreviated name of the category, for display in tight spaces, often together with the day and
      * schedule entry number, e.g. LS 3.a, where LS is the category's short name.
      */
+    #[InputFilter\CleanHTML]
+    #[InputFilter\Trim]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 16)]
     #[ApiProperty(example: 'LS')]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: false)]

--- a/api/src/Entity/Category.php
+++ b/api/src/Entity/Category.php
@@ -118,6 +118,10 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
     /**
      * The full name of the category.
      */
+    #[InputFilter\CleanHTML]
+    #[InputFilter\Trim]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Lagersport')]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: false)]

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -6,6 +6,7 @@ use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
+use App\InputFilter;
 use App\Repository\PeriodRepository;
 use App\Serializer\Normalizer\RelatedCollectionLink;
 use App\Validator\Period\AssertGreaterThanOrEqualToLastScheduleEntryEnd;
@@ -98,7 +99,10 @@ class Period extends BaseEntity implements BelongsToCampInterface {
      *
      * TODO: Make non-nullable in the DB
      */
+    #[InputFilter\CleanHTML]
+    #[InputFilter\Trim]
     #[Assert\NotBlank]
+    #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Hauptlager')]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]

--- a/api/tests/Api/Categories/CreateCategoryTest.php
+++ b/api/tests/Api/Categories/CreateCategoryTest.php
@@ -134,10 +134,100 @@ class CreateCategoryTest extends ECampApiTestCase {
             'violations' => [
                 [
                     'propertyPath' => 'short',
-                    'message' => 'This value should not be null.',
+                    'message' => 'This value should not be blank.',
                 ],
             ],
         ]);
+    }
+
+    public function testCreateCategoryValidatesBlankShort() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/categories',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        'short' => '',
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'short',
+                    'message' => 'This value should not be blank.',
+                ],
+            ],
+        ]);
+    }
+
+    public function testCreateCategoryValidatesTooLongShort() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/categories',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        'short' => str_repeat('l', 17),
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'short',
+                    'message' => 'This value is too long. It should have 16 characters or less.',
+                ],
+            ],
+        ]);
+    }
+
+    public function testCreateCategoryTrimsShort() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/categories',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        'short' => "  \t LS\t ",
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains($this->getExampleReadPayload(
+            [
+                'short' => 'LS',
+            ]
+        ));
+    }
+
+    public function testCreateCategoryCleansHtmlForShort() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/categories',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        'short' => 'L<script>alert(1)</script>S',
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains($this->getExampleReadPayload(
+            [
+                'short' => 'LS',
+            ]
+        ));
     }
 
     public function testCreateCategoryValidatesMissingName() {

--- a/api/tests/Api/Categories/UpdateCategoryTest.php
+++ b/api/tests/Api/Categories/UpdateCategoryTest.php
@@ -178,6 +178,33 @@ class UpdateCategoryTest extends ECampApiTestCase {
         ]);
     }
 
+    public function testPatchCategoryIsAllowsEmptyPreferredContentTypes() {
+        $category = static::$fixtures['category1'];
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $client->request(
+            'PATCH',
+            '/categories/'.$category->getId(),
+            [
+                'json' => [
+                    'preferredContentTypes' => [],
+                ],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'], ]
+        );
+        $this->assertResponseStatusCodeSame(200);
+
+        $client->request(
+            'GET',
+            '/content_types?categories='.urlencode($this->getIriFor($category))
+        );
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains(
+            [
+                'totalItems' => 0,
+            ]
+        );
+    }
+
     public function testPatchCategoryValidatesInvalidColor() {
         $category = static::$fixtures['category1'];
         static::createClientWithCredentials()->request('PATCH', '/categories/'.$category->getId(), ['json' => [

--- a/api/tests/Api/Periods/CreatePeriodTest.php
+++ b/api/tests/Api/Periods/CreatePeriodTest.php
@@ -10,7 +10,6 @@ use App\Tests\Api\ECampApiTestCase;
  * @internal
  */
 class CreatePeriodTest extends ECampApiTestCase {
-    // TODO validation tests
     // TODO validation for no overlapping periods
 
     public function testCreatePeriodIsDeniedForAnonymousUser() {

--- a/api/tests/Api/Periods/CreatePeriodTest.php
+++ b/api/tests/Api/Periods/CreatePeriodTest.php
@@ -10,7 +10,6 @@ use App\Tests\Api\ECampApiTestCase;
  * @internal
  */
 class CreatePeriodTest extends ECampApiTestCase {
-    // TODO input filter tests
     // TODO validation tests
     // TODO validation for no overlapping periods
 
@@ -128,6 +127,72 @@ class CreatePeriodTest extends ECampApiTestCase {
                 ],
             ],
         ]);
+    }
+
+    public function testCreatePeriodValidatesTooLongDescription() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/periods',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        'description' => str_repeat('l', 33),
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'description',
+                    'message' => 'This value is too long. It should have 32 characters or less.',
+                ],
+            ],
+        ]);
+    }
+
+    public function testCreatePeriodTrimsDescription() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/periods',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        'description' => " \t Vorlager \t ",
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains($this->getExampleReadPayload(
+            [
+                'description' => 'Vorlager',
+            ]
+        ));
+    }
+
+    public function testCreatePeriodCleansHtmlForDescription() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/periods',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        'description' => 'Vorl<script>alert(1)</script>ager',
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains($this->getExampleReadPayload(
+            [
+                'description' => 'Vorlager',
+            ]
+        ));
     }
 
     public function testCreatePeriodValidatesMissingStart() {

--- a/api/tests/Api/Periods/UpdatePeriodTest.php
+++ b/api/tests/Api/Periods/UpdatePeriodTest.php
@@ -10,7 +10,7 @@ use App\Tests\Api\ECampApiTestCase;
  * @internal
  */
 class UpdatePeriodTest extends ECampApiTestCase {
-    // TODO validation tests
+    // TODO validation for no overlapping periods
     // TODO moving a period vs changing the time window
 
     public function testPatchPeriodIsDeniedForAnonymousUser() {
@@ -221,6 +221,19 @@ at position 9: Not enough data available to satisfy format',
         ]);
     }
 
+    public function testPatchPeriodValidatesInvalidStartFormat() {
+        $period = static::$fixtures['period1'];
+        static::createClientWithCredentials()->request('PATCH', '/periods/'.$period->getId(), ['json' => [
+            'start' => '2023-05-01+01:00',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'detail' => 'Parsing datetime string "2023-05-01+01:00" using format "!Y-m-d" resulted in 1 errors: 
+at position 10: Trailing data',
+        ]);
+    }
+
     public function testPatchPeriodValidatesInvalidEnd() {
         $period = static::$fixtures['period1'];
         static::createClientWithCredentials()->request('PATCH', '/periods/'.$period->getId(), ['json' => [
@@ -232,6 +245,19 @@ at position 9: Not enough data available to satisfy format',
             'detail' => 'Parsing datetime string "something" using format "!Y-m-d" resulted in 3 errors: 
 at position 0: A four digit year could not be found
 at position 9: Not enough data available to satisfy format',
+        ]);
+    }
+
+    public function testPatchPeriodValidatesInvalidEndFormat() {
+        $period = static::$fixtures['period1'];
+        static::createClientWithCredentials()->request('PATCH', '/periods/'.$period->getId(), ['json' => [
+            'end' => '2023-05-03T01:00',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'detail' => 'Parsing datetime string "2023-05-03T01:00" using format "!Y-m-d" resulted in 1 errors: 
+at position 10: Trailing data',
         ]);
     }
 


### PR DESCRIPTION
Continuation of #2553 
I will add commits to this PR until it has review.


So far:
### Category.php

- [x] short
  - [x] length > 0 && length <= 16
  - [x] cleanhtml
  - [x] trim
- [x] name
  - [x] length >0 && length <= 32
  - [x] cleanhtml
  - [x] trim


### Period.php

- [x] Description
  - [x] length >0 && length <= 32 (In the old backend it was 128)
  - [x] cleanhtml
  - [x] trim
- [x] start
  - [x] date (without time and without time zone): added Tests in UpdatePeriodTest
- [x] end
  - [x] date (without time and without time zone), added Tests in UpdatePeriodTest