### PR TITLE
fix(api/print): PHPSESSID cookie domain

### DIFF
--- a/.helm/ecamp3/templates/api_configmap.yaml
+++ b/.helm/ecamp3/templates/api_configmap.yaml
@@ -19,6 +19,6 @@ data:
   {{- if .Values.php.sentryDsn }}
   SENTRY_API_DSN: {{ .Values.php.sentryDsn | quote }}
   {{- else }}
-  SENTRY_API_DSN: null,
+  SENTRY_API_DSN: {{ "" | quote }}
   {{- end }}
   FRONTEND_BASE_URL: {{ include "frontend.url" . | quote }}

--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -1,34 +1,35 @@
 # see https://symfony.com/doc/current/reference/configuration/framework.html
 framework:
-    secret: '%env(APP_SECRET)%'
-    #csrf_protection: true
-    http_method_override: false
-    trusted_proxies: '%env(TRUSTED_PROXIES)%'
-    trusted_hosts:
-        - localhost
-        - caddy
-        - '%env(API_DOMAIN)%'
-    # See https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers
-    trusted_headers: ['x-forwarded-for', 'x-forwarded-proto']
+  secret: '%env(APP_SECRET)%'
+  #csrf_protection: true
+  http_method_override: false
+  trusted_proxies: '%env(TRUSTED_PROXIES)%'
+  trusted_hosts:
+    - localhost
+    - caddy
+    - '%env(API_DOMAIN)%'
+  # See https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers
+  trusted_headers: ['x-forwarded-for', 'x-forwarded-proto']
 
-    #esi: true
-    #fragments: true
-    php_errors:
-        log: true
+  #esi: true
+  #fragments: true
+  php_errors:
+    log: true
 
-    session:
-        # enables the support of sessions in the app
-        enabled: true # sessions are needed for oauth state parameters
-        # ID of the service used for session storage.
-        # NULL means that Symfony uses PHP default session mechanism
-        handler_id: 'session.handler.native_file'
-        save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
-        # improves the security of the cookies used for sessions
-        cookie_secure: 'auto'
-        cookie_samesite: 'lax'
+  session:
+    # enables the support of sessions in the app
+    enabled: true # sessions are needed for oauth state parameters
+    # ID of the service used for session storage.
+    # NULL means that Symfony uses PHP default session mechanism
+    handler_id: 'session.handler.native_file'
+    save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
+    # improves the security of the cookies used for sessions
+    cookie_secure: 'auto'
+    cookie_samesite: 'lax'
+    cookie_domain: '%env(resolve:SHARED_COOKIE_DOMAIN)%'
 
 when@test:
-    framework:
-        test: true
-        session:
-            enabled: false
+  framework:
+    test: true
+    session:
+      enabled: false


### PR DESCRIPTION
Quick-fix for print API authentication problem

This was either broken with https://github.com/ecamp/ecamp3/pull/2030 or with the latest symfony upgrade.

With https://github.com/ecamp/ecamp3/pull/2030 we have introduced session cookies. JWT authentication seems not to work, if the session-ID is not sent (which was the case for printing because the cookie domain was limited to the API domain only).

This is a quick-fix only. We should investigate further:
- Is this really the intended behavior that JWT auth fails if PHPSESSID is not sent
- Save handler for session is not ideal: Currently it's local file storage on the server. This will not work, as soon as we have multiple API instances for load balancing