### PR TITLE
fix(frontend/print): react-pdf not working

### DIFF
--- a/frontend/src/components/print/print-react/components/scheduleEntry/ScheduleEntry.jsx
+++ b/frontend/src/components/print/print-react/components/scheduleEntry/ScheduleEntry.jsx
@@ -133,11 +133,7 @@ function ScheduleEntry(props) {
         </View>
       </View>
       <View style={{ marginBottom: '20pt' }}>
-        <ContentNode
-          {...props}
-          contentNode={activity.rootContentNode()}
-          allContentNodes={activity.contentNodes()}
-        />
+        <ContentNode {...props} contentNode={activity.rootContentNode()} />
       </View>
     </React.Fragment>
   )


### PR DESCRIPTION
- [x] **Fixed:** The uri /content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F4b3a5123fe45 is missing in the pre-loaded store data. Please make sure it is loaded before trying to access it using minimalHalJsonVuex

- [ ] **Open:** 2bf3e71d.iife.js:152942 Uncaught TypeError: Cannot read properties of undefined (reading 'runs')

Don't know yet about the 2nd error. I think this is thrown in react-pdf but haven't figures out the root cause yet. Anyone who feels like debugging is happy to contribute.