### PR TITLE
renovate.json: give renovate a chance to merge the docker image updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -83,8 +83,9 @@
         "qoomon/docker-host"
       ],
       "groupName": "docker-images",
-      "extends": [
-        "schedule:weekly"
+      "schedule": [
+        "after 10pm every sunday",
+        "before 7am every monday"
       ]
     },
     {


### PR DESCRIPTION
Because Schedule:weekly only schedules before 03:00 on monday, only one renovate run happens.
This is enough to rebase the change, but not to merge it.
Now renovate has more time.