### PR TITLE
Renovate update nodejs together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,7 @@
   ],
   "force": {
     "constraints": {
-      "node": "18.7.0",
-      "npm": ">= 8.15.0"
+      "node": "18.7.0"
     }
   },
   "automergeType": "branch",
@@ -166,7 +165,20 @@
         ".nvmrc"
       ],
       "matchStrings": [
-        "(?<currentValue>[^']+).*"
+        "(?<currentValue>[^'\n]+).*"
+      ],
+      "depNameTemplate": "node",
+      "lookupNameTemplate": "nodejs/node",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).*?$",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "fileMatch": [
+        "^renovate.json$"
+      ],
+      "matchStrings": [
+        "\"node\": \"(?<currentValue>[^\"]+).*\".*"
       ],
       "depNameTemplate": "node",
       "lookupNameTemplate": "nodejs/node",

--- a/renovate.json
+++ b/renovate.json
@@ -158,7 +158,8 @@
       "depNameTemplate": "node",
       "lookupNameTemplate": "nodejs/node",
       "datasourceTemplate": "github-tags",
-      "versioningTemplate": "node"
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).*?$",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "fileMatch": [

--- a/renovate.json
+++ b/renovate.json
@@ -163,6 +163,19 @@
     },
     {
       "fileMatch": [
+        ".nvmrc"
+      ],
+      "matchStrings": [
+        "(?<currentValue>[^']+).*"
+      ],
+      "depNameTemplate": "node",
+      "lookupNameTemplate": "nodejs/node",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).*?$",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "fileMatch": [
         "^.github/workflows/.+\\.ya?ml$"
       ],
       "matchStrings": [


### PR DESCRIPTION
renovate.json: fix update of node in github actions

Somehow the versioningTemplate node does not work anymore for the github actions.

renovate.json: also update .nvmrc

renovate.json: also update renovate.json

Remove restriction on npm, because that should ship with node.

Skynet is finally here.