### PR TITLE
Attempt to improve developer experience with vite

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -17,6 +17,19 @@ export default defineConfig(({ mode }) => ({
     pluginHelper(),
     worker({}),
   ],
+  optimizeDeps: {
+    include: [
+      'core-js/modules/es.symbol.js',
+      'core-js/modules/es.symbol.description.js',
+      'core-js/modules/es.function.name.js',
+      'core-js/modules/es.array.concat.js',
+      'core-js/modules/es.array.splice.js',
+      'core-js/modules/es.array.find.js',
+      'core-js/modules/es.object.to-string.js',
+      '@sentry/browser',
+      'raf/polyfill',
+    ],
+  },
   build: {
     sourcemap: mode === 'development',
     minify: mode === 'development' ? false : 'esbuild',


### PR DESCRIPTION
One big grudge I have with vite is this:
```
[vite] ✨ new dependencies optimized: core-js/modules/es.function.name.js, core-js/modules/es.array.concat.js
```
Vite routinely finds new dependencies while I click around the application, and then takes ages to optimize these and reload the page, throwing me back to the last page I was before my click.

This is especially infuriating when developing camp print features:
1. The vite dev server claims it's "ready" after a blazingly short time (e.g. 500ms), then takes about a minute before the login page is populated.
2. I log in. This usually doesn't take too long.
3. I click on a camp, and vite finds the "new" dependencies core-js/modules/es.symbol.js, core-js/modules/es.symbol.description.js, re-optimizes and reloads the page. I'm back at the camp list.
4. I click on the camp again, this time it loads.
5. I click on "Print", and vite finds the "new" dependencies core-js/modules/es.array.splice.js, @sentry/browser, raf/polyfill, re-optimizes and reloads the page. I'm back at the camp dashboard.
6. I click on "Print" again, this time it loads.

That's a lot of additional user interaction with a lot of forced pauses in between. For debugging react-pdf worker problems, I have to do all that on every (!) code change, because I have to delete the node_modules/.vite directory and restart the frontend to make sure the changes go through.

This commit forces vite to [optimize](https://vitejs.dev/config/dep-optimization-options.html#optimizedeps-include) the "newly discovered" dependencies during startup, even when it doesn't foresee yet that it will need them later. This effectively fixes steps 3 and 5 from above.

For step 1, I tried to instruct vite to use `wget` as a "browser" to open the login page as soon as it claims that it is ready. But it only seemed to help some of the time... Maybe we should use Cypress or puppeteer for this instead. My WIP is on [this branch](https://github.com/carlobeltrame/ecamp3/tree/preload-login-page) if anyone wants to have a look.