### PR TITLE
api: translate constraint violation messages

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -81,3 +81,5 @@ MAIL_FROM="info@ecamp3.ch"
 # https://www.google.com/recaptcha/admin
 RECAPTCHA_SECRET="disabled"
 ###< google/recaptcha ###
+
+TRANSLATE_ERRORS_TO_LOCALES="en,de,fr,it"

--- a/api/.env.test
+++ b/api/.env.test
@@ -6,3 +6,4 @@ PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
 API_DOMAIN=example.com
 COOKIE_PREFIX=example_com_
+TRANSLATE_ERRORS_TO_LOCALES="en,en_CH_scout,de,de_CH_scout,fr,fr_CH_scout,it,it_CH_scout"

--- a/api/composer.json
+++ b/api/composer.json
@@ -40,6 +40,7 @@
         "symfony/runtime": "6.1.3",
         "symfony/security-bundle": "6.1.3",
         "symfony/serializer": "6.1.5",
+        "symfony/translation": "6.1.4",
         "symfony/twig-bundle": "6.1.1",
         "symfony/validator": "6.1.5",
         "symfony/yaml": "6.1.4",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b9b158bfc43c0cb1f87404706feb120",
+    "content-hash": "fcca9a82fa6669a0eee8039d43430f3b",
     "packages": [
         {
             "name": "api-platform/core",
@@ -9393,6 +9393,102 @@
                 }
             ],
             "time": "2022-09-02T08:05:20+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v6.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "45d0f5bb8df7255651ca91c122fab604e776af03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/45d0f5bb8df7255651ca91c122fab604e776af03",
+                "reference": "45d0f5bb8df7255651ca91c122fab604e776af03",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^2.3|^3.0"
+            },
+            "conflict": {
+                "symfony/config": "<5.4",
+                "symfony/console": "<5.4",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/http-kernel": "<5.4",
+                "symfony/twig-bundle": "<5.4",
+                "symfony/yaml": "<5.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.3|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/http-client-contracts": "^1.1|^2.0|^3.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/intl": "^5.4|^6.0",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/service-contracts": "^1.1.2|^2|^3",
+                "symfony/yaml": "^5.4|^6.0"
+            },
+            "suggest": {
+                "psr/log-implementation": "To use logging capability in translator",
+                "symfony/config": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to internationalize your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/translation/tree/v6.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-08-02T16:17:38+00:00"
         },
         {
             "name": "symfony/translation-contracts",

--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -14,11 +14,9 @@ api_platform:
         html: [ 'text/html' ]
     patch_formats:
         json: [ 'application/merge-patch+json' ]
-        jsonapi: [ 'application/vnd.api+json' ]
     error_formats:
         jsonproblem: [ 'application/problem+json' ]
         jsonld: [ 'application/ld+json' ]
-        jsonapi: [ 'application/vnd.api+json' ]
     swagger:
         versions: [3]
     # Mercure integration, remove if unwanted

--- a/api/config/packages/translation.yaml
+++ b/api/config/packages/translation.yaml
@@ -1,0 +1,6 @@
+framework:
+    default_locale: en
+    translator:
+        default_path: '%kernel.project_dir%/translations'
+        fallbacks:
+            - en

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -69,6 +69,9 @@ services:
     App\Serializer\Normalizer\CollectionItemsNormalizer:
         decorates: 'api_platform.hal.normalizer.collection'
 
+    App\Serializer\Normalizer\TranslationConstraintViolationListNormalizer:
+        decorates: 'api_platform.problem.normalizer.constraint_violation_list'
+
     App\Serializer\SerializerContextBuilder:
         decorates: 'api_platform.serializer.context_builder'
 

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -134,6 +134,13 @@ services:
             - "%env(FRONTEND_BASE_URL)%"
             - "%env(MAIL_FROM)%"
 
+    App\Service\TranslateToAllLocalesService:
+        public: true
+        arguments:
+            - '@translator'
+            - '@translator'
+            - '%env(csv:TRANSLATE_ERRORS_TO_LOCALES)%'
+
     App\EventListener\JWTCreatedListener:
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_jwt_created, method: onJWTCreated }

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -70,7 +70,9 @@ services:
         decorates: 'api_platform.hal.normalizer.collection'
 
     App\Serializer\Normalizer\TranslationConstraintViolationListNormalizer:
-        decorates: 'api_platform.problem.normalizer.constraint_violation_list'
+        arguments:
+            - '@api_platform.hydra.normalizer.constraint_violation_list'
+            - '@api_platform.problem.normalizer.constraint_violation_list'
 
     App\Serializer\SerializerContextBuilder:
         decorates: 'api_platform.serializer.context_builder'

--- a/api/src/OpenApi/JwtDecorator.php
+++ b/api/src/OpenApi/JwtDecorator.php
@@ -51,11 +51,6 @@ final class JwtDecorator implements OpenApiFactoryInterface {
                                 '$ref' => '#/components/schemas/Credentials',
                             ],
                         ],
-                        'application/vnd.api+json' => [
-                            'schema' => [
-                                '$ref' => '#/components/schemas/Credentials',
-                            ],
-                        ],
                         'application/json' => [
                             'schema' => [
                                 '$ref' => '#/components/schemas/Credentials',

--- a/api/src/Serializer/Normalizer/Error/TranslationInfo.php
+++ b/api/src/Serializer/Normalizer/Error/TranslationInfo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Serializer\Normalizer\Error;
+
+class TranslationInfo {
+    public function __construct(public readonly string $key, public readonly array $parameters) {
+    }
+}

--- a/api/src/Serializer/Normalizer/Error/TranslationInfoOfConstraintViolation.php
+++ b/api/src/Serializer/Normalizer/Error/TranslationInfoOfConstraintViolation.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Serializer\Normalizer\Error;
+
+use Symfony\Component\Validator\ConstraintViolation;
+
+class TranslationInfoOfConstraintViolation {
+    public function extract(ConstraintViolation $constraintViolation): TranslationInfo {
+        $constraint = $constraintViolation->getConstraint();
+        $constraintClass = get_class($constraint);
+        $key = str_replace('\\', '.', $constraintClass);
+        $key = strtolower($key);
+        $paramsWithoutCurlyBraces = self::removeCurlyBraces($constraintViolation->getParameters());
+
+        return new TranslationInfo($key, $paramsWithoutCurlyBraces);
+    }
+
+    public static function removeCurlyBraces(array $parameters): array {
+        $paramsWithoutCurlyBraces = [];
+        foreach ($parameters as $key => $value) {
+            $key = str_replace('{{ ', '', $key);
+            $key = str_replace(' }}', '', $key);
+            $paramsWithoutCurlyBraces[$key] = $value;
+        }
+
+        return $paramsWithoutCurlyBraces;
+    }
+}

--- a/api/src/Serializer/Normalizer/TranslationConstraintViolationListNormalizer.php
+++ b/api/src/Serializer/Normalizer/TranslationConstraintViolationListNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+/** @noinspection PhpInternalEntityUsedInspection */
+
+namespace App\Serializer\Normalizer;
+
+use ApiPlatform\Core\Serializer\AbstractConstraintViolationListNormalizer;
+use App\Serializer\Normalizer\Error\TranslationInfoOfConstraintViolation;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+class TranslationConstraintViolationListNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface {
+    public function __construct(
+        private readonly AbstractConstraintViolationListNormalizer $decorated,
+        private readonly TranslationInfoOfConstraintViolation $translationInfoOfConstraintViolation
+    ) {
+    }
+
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool {
+        return $this->decorated->supportsNormalization($data, $format);
+    }
+
+    public function normalize(mixed $object, string $format = null, array $context = []): float|int|bool|\ArrayObject|array|string|null {
+        $result = $this->decorated->normalize($object, $format, $context);
+
+        /** @var ConstraintViolationList $object */
+        foreach ($object as $violation) {
+            foreach ($result['violations'] as &$resultItem) {
+                $code = $resultItem['code'];
+                $propertyPath = $resultItem['propertyPath'];
+                $message = $resultItem['message'];
+
+                if ($violation->getPropertyPath() === $propertyPath
+                    && $violation->getCode() === $code
+                    && $violation->getMessage() == $message) {
+                    $translationInfo = [];
+                    if ($violation instanceof ConstraintViolation) {
+                        $translationInfo = $this->translationInfoOfConstraintViolation->extract($violation);
+                    }
+                    $resultItem = ['i18n' => [...(array) $translationInfo], ...$resultItem];
+
+                    break;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    public function hasCacheableSupportsMethod(): bool {
+        return $this->decorated->hasCacheableSupportsMethod();
+    }
+}

--- a/api/src/Service/TranslateToAllLocalesService.php
+++ b/api/src/Service/TranslateToAllLocalesService.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Service;
+
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class TranslateToAllLocalesService {
+    public const VALIDATORS_DOMAIN = 'validators';
+
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly TranslatorBagInterface $translatorBag,
+        private readonly array $translateToLocales
+    ) {
+    }
+
+    public function translate(string $message, array $params): array {
+        $result = [];
+        foreach ($this->translateToLocales as $locale) {
+            $catalogue = $this->translatorBag->getCatalogue($locale);
+            if ($catalogue->defines($message, self::VALIDATORS_DOMAIN)) {
+                $result[$locale] = $this->translator->trans($message, $params, self::VALIDATORS_DOMAIN, $locale);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/api/symfony.lock
+++ b/api/symfony.lock
@@ -783,6 +783,19 @@
     "symfony/string": {
         "version": "v5.2.6"
     },
+    "symfony/translation": {
+        "version": "6.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "5.3",
+            "ref": "da64f5a2b6d96f5dc24914517c0350a5f91dee43"
+        },
+        "files": [
+            "config/packages/translation.yaml",
+            "translations/.gitignore"
+        ]
+    },
     "symfony/translation-contracts": {
         "version": "v2.3.0"
     },

--- a/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
@@ -338,7 +338,7 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
         $this->assertResponseStatusCodeSame(422);
         $this->assertJsonContains([
             'title' => 'An error occurred',
-            'detail' => 'user: This user is already present in the camp.',
+            'detail' => 'user: This user or a user with this email address is already participating in the camp.',
         ]);
     }
 

--- a/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
@@ -381,6 +381,7 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
                         'parameters' => [
                             'other' => 'user',
                         ],
+                        'translations' => [],
                     ],
                 ],
                 [
@@ -389,6 +390,7 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
                         'parameters' => [
                             'other' => 'inviteEmail',
                         ],
+                        'translations' => [],
                     ],
                 ],
             ],

--- a/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
@@ -369,6 +369,32 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
         ]);
     }
 
+    public function testCreateCampCollaborationValidatesMissingUserAndInviteEmailAndIncludesTranslationInfo() {
+        static::createClientWithCredentials()->request('POST', '/camp_collaborations', ['json' => $this->getExampleWritePayload([], ['user'])]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'i18n' => [
+                        'key' => 'app.validator.asserteitherisnull',
+                        'parameters' => [
+                            'other' => 'user',
+                        ],
+                    ],
+                ],
+                [
+                    'i18n' => [
+                        'key' => 'app.validator.asserteitherisnull',
+                        'parameters' => [
+                            'other' => 'inviteEmail',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public function testCreateCampCollaborationValidatesIfUserAndInviteEmailAreNull() {
         static::createClientWithCredentials()->request(
             'POST',

--- a/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
@@ -381,7 +381,12 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
                         'parameters' => [
                             'other' => 'user',
                         ],
-                        'translations' => [],
+                        'translations' => [
+                            'en' => 'Either this value or user should not be null.',
+                            'de' => 'Dieser Wert und user dürfen nicht beide null sein.',
+                            'fr' => 'Cette valeur ou user ne doit pas être nulle.',
+                            'it' => 'Questo valore o user non deve essere nullo.',
+                        ],
                     ],
                 ],
                 [
@@ -390,7 +395,12 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
                         'parameters' => [
                             'other' => 'inviteEmail',
                         ],
-                        'translations' => [],
+                        'translations' => [
+                            'en' => 'Either this value or inviteEmail should not be null.',
+                            'de' => 'Dieser Wert und inviteEmail dürfen nicht beide null sein.',
+                            'fr' => 'Cette valeur ou inviteEmail ne doit pas être nulle.',
+                            'it' => 'Questo valore o inviteEmail non deve essere nullo.',
+                        ],
                     ],
                 ],
             ],

--- a/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
+++ b/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
@@ -92,9 +92,9 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
                 'i18n' => [
                     'translations' => [
                         'en' => 'value must be one of inactive, was established',
-                        'de' => 'value must be one of inactive, was established',
-                        'fr' => 'value must be one of inactive, was established',
-                        'it' => 'value must be one of inactive, was established',
+                        'de' => 'Der Wert muss einer aus inactive sein, aber er war established',
+                        'fr' => 'La valeur doit être l\'une des suivantes : inactive, a été established',
+                        'it' => 'deve essere uno dei seguenti valori: inactive, è established',
                     ],
                 ],
             ],

--- a/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
+++ b/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Tests\Integration\Serializer\Normalizer;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestAssertionsTrait;
+use ApiPlatform\Core\Problem\Serializer\ConstraintViolationListNormalizer;
+use App\Entity\CampCollaboration;
+use App\Serializer\Normalizer\TranslationConstraintViolationListNormalizer;
+use App\Validator\AllowTransition\AssertAllowTransitions;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * @internal
+ */
+class TranslationConstraintViolationListNormalizerIntegrationTest extends KernelTestCase {
+    use ApiTestAssertionsTrait;
+
+    private TranslationConstraintViolationListNormalizer $translationConstraintViolationListNormalizer;
+
+    /**
+     * @throws \Exception
+     */
+    protected function setUp(): void {
+        self::bootKernel();
+        parent::setUp();
+
+        /** @var TranslationConstraintViolationListNormalizer $obj */
+        $obj = self::getContainer()->get('api_platform.problem.normalizer.constraint_violation_list');
+        $this->translationConstraintViolationListNormalizer = $obj;
+    }
+
+    /**
+     * @throws ExceptionInterface
+     * @throws \Exception
+     */
+    public function testAddsTranslationKeyAndParameters() {
+        $constraintViolationList = new ConstraintViolationList(self::getConstraintViolations());
+
+        $result = $this->translationConstraintViolationListNormalizer->normalize(
+            $constraintViolationList,
+            ConstraintViolationListNormalizer::FORMAT,
+            []
+        );
+
+        self::assertArraySubset(['violations' => [
+            [
+                'i18n' => [
+                    'key' => 'app.validator.allowtransition.assertallowtransitions',
+                    'parameters' => [
+                        'to' => 'inactive',
+                        'value' => 'established',
+                    ],
+                ],
+            ],
+            [
+                'i18n' => [
+                    'key' => 'symfony.component.validator.constraints.notblank',
+                    'parameters' => [
+                        'value' => '""',
+                    ],
+                ],
+            ],
+            [
+                'i18n' => [
+                    'key' => 'symfony.component.validator.constraints.notnull',
+                    'parameters' => [],
+                ],
+            ],
+        ]], $result);
+    }
+
+    public static function getConstraintViolations(): array {
+        return [
+            new ConstraintViolation(
+                message: 'value must be one of inactive, was established',
+                messageTemplate: 'value must be one of {{ to }}, was {{ value }}',
+                parameters: ['{{ to }}' => 'inactive', '{{ value }}' => 'established'],
+                root: new CampCollaboration(),
+                propertyPath: 'status',
+                invalidValue: 'established',
+                plural: null,
+                code: null,
+                constraint: new AssertAllowTransitions(transitions: [])
+            ),
+            new ConstraintViolation(
+                message: 'This value should not be blank.',
+                messageTemplate: 'This value should not be blank.',
+                parameters: ['{{ value }}' => '""'],
+                root: new CampCollaboration(),
+                propertyPath: 'name',
+                invalidValue: '',
+                plural: null,
+                code: 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                constraint: new NotBlank()
+            ),
+            new ConstraintViolation(
+                message: 'This value should not be null.',
+                messageTemplate: 'This value should not be null.',
+                parameters: [],
+                root: new CampCollaboration(),
+                propertyPath: 'name',
+                invalidValue: '',
+                plural: null,
+                code: 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                constraint: new NotNull()
+            ),
+        ];
+    }
+}

--- a/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
+++ b/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
@@ -9,6 +9,7 @@ use App\Serializer\Normalizer\TranslationConstraintViolationListNormalizer;
 use App\Validator\AllowTransition\AssertAllowTransitions;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -71,6 +72,12 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
                     'parameters' => [],
                 ],
             ],
+            [
+                'i18n' => [
+                    'key' => 'app.tests.integration.serializer.normalizer.myconstraint',
+                    'parameters' => [],
+                ],
+            ],
         ]], $result);
     }
 
@@ -118,6 +125,20 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
                     ],
                 ],
             ],
+            [
+                'i18n' => [
+                    'translations' => [
+                        'en' => 'en',
+                        'en_CH_scout' => 'en_CH_scout',
+                        'de' => 'de',
+                        'de_CH_scout' => 'de_CH_scout',
+                        'fr' => 'fr',
+                        'fr_CH_scout' => 'fr_CH_scout',
+                        'it' => 'it',
+                        'it_CH_scout' => 'it_CH_scout',
+                    ],
+                ],
+            ],
         ]], $result);
     }
 
@@ -156,6 +177,27 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
                 code: 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 constraint: new NotNull()
             ),
+            new ConstraintViolation(
+                message: 'This is a test message for i18n variants',
+                messageTemplate: 'This is a test message for i18n variants',
+                parameters: [],
+                root: new CampCollaboration(),
+                propertyPath: 'name',
+                invalidValue: '',
+                plural: null,
+                code: 'c1051bb4-d103-4f74-8988-acbcafc7fdc5',
+                constraint: new MyConstraint()
+            ),
         ];
+    }
+}
+
+class MyConstraint extends Constraint {
+    public function __construct(
+        array $options = null,
+        array $groups = null,
+        $payload = null
+    ) {
+        parent::__construct($options ?? [], $groups, $payload);
     }
 }

--- a/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
+++ b/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
@@ -3,7 +3,8 @@
 namespace App\Tests\Integration\Serializer\Normalizer;
 
 use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestAssertionsTrait;
-use ApiPlatform\Core\Problem\Serializer\ConstraintViolationListNormalizer;
+use ApiPlatform\Core\Hydra\Serializer\ConstraintViolationListNormalizer as HydraConstraintViolationListNormalizer;
+use ApiPlatform\Core\Problem\Serializer\ConstraintViolationListNormalizer as JsonProblemConstraintViolationListNormalizer;
 use App\Entity\CampCollaboration;
 use App\Serializer\Normalizer\TranslationConstraintViolationListNormalizer;
 use App\Validator\AllowTransition\AssertAllowTransitions;
@@ -31,20 +32,22 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
         parent::setUp();
 
         /** @var TranslationConstraintViolationListNormalizer $obj */
-        $obj = self::getContainer()->get('api_platform.problem.normalizer.constraint_violation_list');
+        $obj = self::getContainer()->get('App\Serializer\Normalizer\TranslationConstraintViolationListNormalizer');
         $this->translationConstraintViolationListNormalizer = $obj;
     }
 
     /**
      * @throws ExceptionInterface
      * @throws \Exception
+     *
+     * @dataProvider getFormats()
      */
-    public function testAddsTranslationKeyAndParameters() {
+    public function testAddsTranslationKeyAndParameters(string $format) {
         $constraintViolationList = new ConstraintViolationList(self::getConstraintViolations());
 
         $result = $this->translationConstraintViolationListNormalizer->normalize(
             $constraintViolationList,
-            ConstraintViolationListNormalizer::FORMAT,
+            $format,
             []
         );
 
@@ -84,13 +87,15 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
     /**
      * @throws ExceptionInterface
      * @throws \Exception
+     *
+     * @dataProvider getFormats()
      */
-    public function testAddsTranslations() {
+    public function testAddsTranslations(string $format) {
         $constraintViolationList = new ConstraintViolationList(self::getConstraintViolations());
 
         $result = $this->translationConstraintViolationListNormalizer->normalize(
             $constraintViolationList,
-            ConstraintViolationListNormalizer::FORMAT,
+            $format,
             []
         );
 
@@ -140,6 +145,16 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
                 ],
             ],
         ]], $result);
+    }
+
+    public static function getFormats() {
+        $hydra = HydraConstraintViolationListNormalizer::FORMAT;
+        $problem = JsonProblemConstraintViolationListNormalizer::FORMAT;
+
+        return [
+            $hydra => [$hydra],
+            $problem => [$problem],
+        ];
     }
 
     public static function getConstraintViolations(): array {

--- a/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
+++ b/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
@@ -74,6 +74,53 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
         ]], $result);
     }
 
+    /**
+     * @throws ExceptionInterface
+     * @throws \Exception
+     */
+    public function testAddsTranslations() {
+        $constraintViolationList = new ConstraintViolationList(self::getConstraintViolations());
+
+        $result = $this->translationConstraintViolationListNormalizer->normalize(
+            $constraintViolationList,
+            ConstraintViolationListNormalizer::FORMAT,
+            []
+        );
+
+        self::assertArraySubset(['violations' => [
+            [
+                'i18n' => [
+                    'translations' => [
+                        'en' => 'value must be one of inactive, was established',
+                        'de' => 'value must be one of inactive, was established',
+                        'fr' => 'value must be one of inactive, was established',
+                        'it' => 'value must be one of inactive, was established',
+                    ],
+                ],
+            ],
+            [
+                'i18n' => [
+                    'translations' => [
+                        'en' => 'This value should not be blank.',
+                        'de' => 'Dieser Wert sollte nicht leer sein.',
+                        'fr' => 'Cette valeur ne doit pas être vide.',
+                        'it' => 'Questo valore non dovrebbe essere vuoto.',
+                    ],
+                ],
+            ],
+            [
+                'i18n' => [
+                    'translations' => [
+                        'en' => 'This value should not be null.',
+                        'de' => 'Dieser Wert sollte nicht null sein.',
+                        'fr' => 'Cette valeur ne doit pas être nulle.',
+                        'it' => 'Questo valore non dovrebbe essere nullo.',
+                    ],
+                ],
+            ],
+        ]], $result);
+    }
+
     public static function getConstraintViolations(): array {
         return [
             new ConstraintViolation(

--- a/api/tests/Serializer/Normalizer/Error/TranslationInfoOfConstraintViolationTest.php
+++ b/api/tests/Serializer/Normalizer/Error/TranslationInfoOfConstraintViolationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Tests\Serializer\Normalizer\Error;
+
+use App\Entity\CampCollaboration;
+use App\Serializer\Normalizer\Error\TranslationInfoOfConstraintViolation;
+use App\Validator\AllowTransition\AssertAllowTransitions;
+
+use function PHPUnit\Framework\assertThat;
+use function PHPUnit\Framework\equalTo;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintViolation;
+
+/**
+ * @internal
+ */
+class TranslationInfoOfConstraintViolationTest extends TestCase {
+    private TranslationInfoOfConstraintViolation $translationInfoOfConstraintViolation;
+
+    protected function setUp(): void {
+        $this->translationInfoOfConstraintViolation = new TranslationInfoOfConstraintViolation();
+    }
+
+    /**
+     * @dataProvider constraintViolations()
+     */
+    public function testExtractsTranslationInfoFromConstraintViolation(ConstraintViolation $violation, string $key): void {
+        $translationInfo = $this->translationInfoOfConstraintViolation->extract($violation);
+        $parametersWithoutCurlyBraces = TranslationInfoOfConstraintViolation::removeCurlyBraces($violation->getParameters());
+
+        assertThat($translationInfo->key, equalTo($key));
+        assertThat($translationInfo->parameters, equalTo($parametersWithoutCurlyBraces));
+    }
+
+    public function constraintViolations(): array {
+        return [
+            AssertAllowTransitions::class => [
+                'violation' => new ConstraintViolation(
+                    message: 'value must be one of inactive, was established',
+                    messageTemplate: 'value must be one of {{ to }}, was {{ value }}',
+                    parameters: ['{{ to }}' => 'inactive', '{{ value }}' => 'established'],
+                    root: new CampCollaboration(),
+                    propertyPath: 'status',
+                    invalidValue: 'established',
+                    plural: null,
+                    code: null,
+                    constraint: new AssertAllowTransitions(transitions: [])
+                ),
+                'key' => 'app.validator.allowtransition.assertallowtransitions',
+            ],
+            NotBlank::class => [
+                'violation' => new ConstraintViolation(
+                    message: 'This value should not be blank.',
+                    messageTemplate: 'This value should not be blank.',
+                    parameters: ['{{ value }}' => '""'],
+                    root: new CampCollaboration(),
+                    propertyPath: 'name',
+                    invalidValue: '',
+                    plural: null,
+                    code: 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                    constraint: new NotBlank()
+                ),
+                'key' => 'symfony.component.validator.constraints.notblank',
+            ],
+            NotBlank::class.' without parameters' => [
+                'violation' => new ConstraintViolation(
+                    message: 'This value should not be blank.',
+                    messageTemplate: 'This value should not be blank.',
+                    parameters: [],
+                    root: new CampCollaboration(),
+                    propertyPath: 'name',
+                    invalidValue: '',
+                    plural: null,
+                    code: 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                    constraint: new NotBlank()
+                ),
+                'key' => 'symfony.component.validator.constraints.notblank',
+            ],
+        ];
+    }
+}

--- a/api/translations/README.md
+++ b/api/translations/README.md
@@ -1,0 +1,11 @@
+# Symfony translation files
+
+Docs: [https://symfony.com/doc/current/translation.html#message-format](https://symfony.com/doc/current/translation.html#message-format)
+
+We use the english message as the translation key because symfony does that as well for their validation messages.
+[https://github.com/symfony/validator/blob/v6.1.4/Resources/translations/validators.en.xlf](https://github.com/symfony/validator/blob/v6.1.4/Resources/translations/validators.en.xlf)
+We still add the english translation, that external translators could improve the maybe
+not perfect english of the developers.
+
+Please **alphasort** the keys, that we don't have to discuss their order.
+Also use quotes for the values in languages which don't require it that it's consistent in all languages.

--- a/api/translations/validators.de.yml
+++ b/api/translations/validators.de.yml
@@ -1,4 +1,5 @@
 Either this value or {{ other }} should not be null.: "Dieser Wert und {{ other }} dürfen nicht beide null sein."
 This inviteEmail is already present in the camp.: "Diese E-Mail Adresse wurde schon für dieses Lager verwendet."
 This is a test message for i18n variants: "de"
+This user is already present in the camp.: "Dieser User oder ein User mit dieser E-Mail Adresse nimmt schon am Lager teil."
 value must be one of {{ to }}, was {{ value }}: "Der Wert muss einer aus {{ to }} sein, aber er war {{ value }}"

--- a/api/translations/validators.de.yml
+++ b/api/translations/validators.de.yml
@@ -1,0 +1,2 @@
+Either this value or {{ other }} should not be null.: "Dieser Wert und {{ other }} dürfen nicht beide null sein."
+value must be one of {{ to }}, was {{ value }}: "Der Wert muss einer aus {{ to }} sein, aber er war {{ value }}"

--- a/api/translations/validators.de.yml
+++ b/api/translations/validators.de.yml
@@ -1,2 +1,3 @@
 Either this value or {{ other }} should not be null.: "Dieser Wert und {{ other }} dürfen nicht beide null sein."
+This is a test message for i18n variants: "de"
 value must be one of {{ to }}, was {{ value }}: "Der Wert muss einer aus {{ to }} sein, aber er war {{ value }}"

--- a/api/translations/validators.de.yml
+++ b/api/translations/validators.de.yml
@@ -1,3 +1,4 @@
 Either this value or {{ other }} should not be null.: "Dieser Wert und {{ other }} dürfen nicht beide null sein."
+This inviteEmail is already present in the camp.: "Diese E-Mail Adresse wurde schon für dieses Lager verwendet."
 This is a test message for i18n variants: "de"
 value must be one of {{ to }}, was {{ value }}: "Der Wert muss einer aus {{ to }} sein, aber er war {{ value }}"

--- a/api/translations/validators.de_CH_scout.yml
+++ b/api/translations/validators.de_CH_scout.yml
@@ -1,0 +1,1 @@
+This is a test message for i18n variants: "de_CH_scout"

--- a/api/translations/validators.en.yml
+++ b/api/translations/validators.en.yml
@@ -1,4 +1,5 @@
 Either this value or {{ other }} should not be null.: "Either this value or {{ other }} should not be null."
 This inviteEmail is already present in the camp.: "This inviteEmail is already present in the camp."
 This is a test message for i18n variants: "en"
+This user is already present in the camp.: "This user or a user with this email address is already participating in the camp."
 value must be one of {{ to }}, was {{ value }}: "value must be one of {{ to }}, was {{ value }}"

--- a/api/translations/validators.en.yml
+++ b/api/translations/validators.en.yml
@@ -1,2 +1,3 @@
 Either this value or {{ other }} should not be null.: "Either this value or {{ other }} should not be null."
+This is a test message for i18n variants: "en"
 value must be one of {{ to }}, was {{ value }}: "value must be one of {{ to }}, was {{ value }}"

--- a/api/translations/validators.en.yml
+++ b/api/translations/validators.en.yml
@@ -1,0 +1,2 @@
+Either this value or {{ other }} should not be null.: "Either this value or {{ other }} should not be null."
+value must be one of {{ to }}, was {{ value }}: "value must be one of {{ to }}, was {{ value }}"

--- a/api/translations/validators.en.yml
+++ b/api/translations/validators.en.yml
@@ -1,3 +1,4 @@
 Either this value or {{ other }} should not be null.: "Either this value or {{ other }} should not be null."
+This inviteEmail is already present in the camp.: "This inviteEmail is already present in the camp."
 This is a test message for i18n variants: "en"
 value must be one of {{ to }}, was {{ value }}: "value must be one of {{ to }}, was {{ value }}"

--- a/api/translations/validators.en_CH_scout.yml
+++ b/api/translations/validators.en_CH_scout.yml
@@ -1,0 +1,1 @@
+This is a test message for i18n variants: "en_CH_scout"

--- a/api/translations/validators.fr.yml
+++ b/api/translations/validators.fr.yml
@@ -1,2 +1,3 @@
 Either this value or {{ other }} should not be null.: "Cette valeur ou {{ other }} ne doit pas être nulle."
+This is a test message for i18n variants: "fr"
 value must be one of {{ to }}, was {{ value }}: "La valeur doit être l'une des suivantes : {{ to }}, a été {{ value }}"

--- a/api/translations/validators.fr.yml
+++ b/api/translations/validators.fr.yml
@@ -1,0 +1,2 @@
+Either this value or {{ other }} should not be null.: "Cette valeur ou {{ other }} ne doit pas être nulle."
+value must be one of {{ to }}, was {{ value }}: "La valeur doit être l'une des suivantes : {{ to }}, a été {{ value }}"

--- a/api/translations/validators.fr.yml
+++ b/api/translations/validators.fr.yml
@@ -1,3 +1,4 @@
 Either this value or {{ other }} should not be null.: "Cette valeur ou {{ other }} ne doit pas être nulle."
+This inviteEmail is already present in the camp.: "Cette adresse e-mail a déjà été utilisée pour ce camp."
 This is a test message for i18n variants: "fr"
 value must be one of {{ to }}, was {{ value }}: "La valeur doit être l'une des suivantes : {{ to }}, a été {{ value }}"

--- a/api/translations/validators.fr.yml
+++ b/api/translations/validators.fr.yml
@@ -1,4 +1,5 @@
 Either this value or {{ other }} should not be null.: "Cette valeur ou {{ other }} ne doit pas être nulle."
 This inviteEmail is already present in the camp.: "Cette adresse e-mail a déjà été utilisée pour ce camp."
 This is a test message for i18n variants: "fr"
+This user is already present in the camp.: "Cet utilisateur ou un utilisateur avec cette adresse e-mail participe déjà au camp."
 value must be one of {{ to }}, was {{ value }}: "La valeur doit être l'une des suivantes : {{ to }}, a été {{ value }}"

--- a/api/translations/validators.fr_CH_scout.yml
+++ b/api/translations/validators.fr_CH_scout.yml
@@ -1,0 +1,1 @@
+This is a test message for i18n variants: "fr_CH_scout"

--- a/api/translations/validators.it.yml
+++ b/api/translations/validators.it.yml
@@ -1,0 +1,2 @@
+Either this value or {{ other }} should not be null.: "Questo valore o {{ other }} non deve essere nullo."
+value must be one of {{ to }}, was {{ value }}: "deve essere uno dei seguenti valori: {{ to }}, è {{ value }}"

--- a/api/translations/validators.it.yml
+++ b/api/translations/validators.it.yml
@@ -1,4 +1,5 @@
 Either this value or {{ other }} should not be null.: "Questo valore o {{ other }} non deve essere nullo."
 This inviteEmail is already present in the camp.: "Questo indirizzo e-mail è già stato utilizzato per questo campo."
 This is a test message for i18n variants: "it"
+This user is already present in the camp.: "Questo utente o un utente con questo indirizzo e-mail sta già partecipando al campo."
 value must be one of {{ to }}, was {{ value }}: "deve essere uno dei seguenti valori: {{ to }}, è {{ value }}"

--- a/api/translations/validators.it.yml
+++ b/api/translations/validators.it.yml
@@ -1,2 +1,3 @@
 Either this value or {{ other }} should not be null.: "Questo valore o {{ other }} non deve essere nullo."
+This is a test message for i18n variants: "it"
 value must be one of {{ to }}, was {{ value }}: "deve essere uno dei seguenti valori: {{ to }}, è {{ value }}"

--- a/api/translations/validators.it.yml
+++ b/api/translations/validators.it.yml
@@ -1,3 +1,4 @@
 Either this value or {{ other }} should not be null.: "Questo valore o {{ other }} non deve essere nullo."
+This inviteEmail is already present in the camp.: "Questo indirizzo e-mail è già stato utilizzato per questo campo."
 This is a test message for i18n variants: "it"
 value must be one of {{ to }}, was {{ value }}: "deve essere uno dei seguenti valori: {{ to }}, è {{ value }}"

--- a/api/translations/validators.it_CH_scout.yml
+++ b/api/translations/validators.it_CH_scout.yml
@@ -1,0 +1,1 @@
+This is a test message for i18n variants: "it_CH_scout"

--- a/frontend/src/helpers/__tests__/serverError.spec.js
+++ b/frontend/src/helpers/__tests__/serverError.spec.js
@@ -1,0 +1,222 @@
+import { transformViolations } from '@/helpers/serverError'
+import cloneDeep from 'lodash/cloneDeep'
+import { fallbackLocale } from '@/plugins/i18n'
+
+describe('transformViolations', () => {
+  describe('without i18n', () => {
+    it('returns server errors as 0 property of object', () => {
+      expect(transformViolations(unauthorizedError)).toEqual({ 0: 'Unauthorized' })
+    })
+
+    it('returns a map of propertyPath => violations[]', () => {
+      const validationError = createValidationError()
+        .withViolation({
+          message: 'first message',
+          propertyPath: 'parent.property',
+        })
+        .withViolation({
+          message: 'second message',
+          propertyPath: 'parent.property',
+        })
+        .withViolation({
+          message: 'third message',
+          propertyPath: 'property2',
+        })
+        .build()
+      expect(transformViolations(validationError)).toEqual({
+        'parent.property': ['first message', 'second message'],
+        property2: ['third message'],
+      })
+    })
+  })
+
+  describe('with i18n', () => {
+    const te = jest.fn()
+    const tc = jest.fn()
+    const i18n = { te, tc }
+
+    beforeEach(() => {
+      delete i18n.locale
+      te.mockReset()
+      tc.mockReset()
+    })
+
+    describe('still uses the message property of violations', () => {
+      it('if the locale is null and translation does not exist', () => {
+        const validationError = createValidationError()
+          .withViolation({
+            message: 'first message',
+            propertyPath: 'property',
+            i18n: {
+              key: 'not.exists',
+            },
+          })
+          .build()
+        expect(transformViolations(validationError, i18n)).toEqual({
+          property: ['first message'],
+        })
+      })
+
+      it('if the translation for the locale is not in the response and translation does not exist', () => {
+        i18n.locale = 'it'
+        const validationError = createValidationError()
+          .withViolation({
+            message: 'first message',
+            propertyPath: 'property',
+            i18n: {
+              key: 'not.exists',
+              translations: {
+                fr: 'will not be used',
+              },
+            },
+          })
+          .build()
+        expect(transformViolations(validationError, i18n)).toEqual({
+          property: ['first message'],
+        })
+      })
+    })
+
+    describe('uses the frontend translation', () => {
+      it('if the key is available in the translations', () => {
+        const validationError = createValidationError()
+          .withViolation({
+            message: 'first message',
+            propertyPath: 'property',
+            i18n: {
+              key: 'key.exists',
+              translations: {
+                fr: 'will not be used',
+              },
+            },
+          })
+          .build()
+        te.mockReturnValue(true)
+        const translation = 'a translation'
+        tc.mockReturnValue(translation)
+
+        expect(transformViolations(validationError, i18n)).toEqual({
+          property: [translation],
+        })
+      })
+
+      it('even if there are translations in the response', () => {
+        const validationError = createValidationError()
+          .withViolation({
+            message: 'first message',
+            propertyPath: 'property',
+            i18n: {
+              key: 'key.exists',
+              translations: {
+                en: 'will not be used',
+              },
+            },
+          })
+          .build()
+        te.mockReturnValue(true)
+        const translation = 'a translation'
+        tc.mockReturnValue(translation)
+        i18n.locale = 'en'
+
+        expect(transformViolations(validationError, i18n)).toEqual({
+          property: [translation],
+        })
+      })
+    })
+
+    describe('uses the translations in the response', () => {
+      it(' if the keys are not known in the frontend', () => {
+        const validationError = createValidationError()
+          .withViolation({
+            message: 'first message',
+            propertyPath: 'property',
+            i18n: {
+              key: 'not.exists',
+              translations: {
+                fr_CH_scout: 'fr_CH_scout',
+              },
+            },
+          })
+          .build()
+        te.mockReturnValue(false)
+        i18n.locale = 'fr-CH-scout'
+
+        expect(transformViolations(validationError, i18n)).toEqual({
+          property: ['fr_CH_scout'],
+        })
+      })
+
+      it('uses the direct fallback', () => {
+        const validationError = createValidationError()
+          .withViolation({
+            message: 'first message',
+            propertyPath: 'property',
+            i18n: {
+              translations: {
+                de_CH: 'de_CH',
+              },
+            },
+          })
+          .build()
+        te.mockReturnValue(false)
+        i18n.locale = 'de-CH-scout'
+
+        expect(transformViolations(validationError, i18n)).toEqual({
+          property: ['de_CH'],
+        })
+      })
+
+      it('uses fallbackLocale', () => {
+        const validationError = createValidationError()
+          .withViolation({
+            message: 'first message',
+            propertyPath: 'property',
+            i18n: {
+              translations: {
+                [fallbackLocale]: fallbackLocale,
+                de: 'de',
+              },
+            },
+          })
+          .build()
+        te.mockReturnValue(false)
+        i18n.locale = 'it'
+
+        expect(transformViolations(validationError, i18n)).toEqual({
+          property: [fallbackLocale],
+        })
+      })
+    })
+  })
+})
+
+const unauthorizedError = {
+  name: 'ServerException',
+  response: {
+    status: 401,
+    data: {
+      message: 'Unauthorized',
+      detail: 'Unauthorized',
+    },
+  },
+}
+
+function createValidationError() {
+  const validationError = {
+    name: 'ServerException',
+    response: {
+      status: 422,
+      data: {
+        violations: [],
+      },
+    },
+  }
+
+  return {
+    withViolation: function (violation) {
+      validationError.response.data.violations.push(violation)
+      return this
+    },
+    build: () => cloneDeep(validationError),
+  }
+}

--- a/frontend/src/helpers/serverError.js
+++ b/frontend/src/helpers/serverError.js
@@ -1,11 +1,15 @@
 /**
  * Parses an error object returned by hal-json-vuex and returns as message string
  */
+import fallbackLocalesFor from '@/plugins/i18n/apiFallbackLocalesFor'
+
 const serverErrorToString = (error) => {
   // API error
   // error.response is in API Problem Details format: https://www.rfc-editor.org/rfc/rfc7807
   if (error.name === 'ServerException' && error.response) {
-    if (error.response?.headers['content-type'].startsWith('application/problem+json')) {
+    if (
+      error.response?.headers?.['content-type']?.startsWith('application/problem+json')
+    ) {
       return error.response.data.detail
     }
 
@@ -16,27 +20,50 @@ const serverErrorToString = (error) => {
   return error.message
 }
 
+function getApiTranslation(locale, violation) {
+  if (!locale) {
+    return null
+  }
+  const matchingTranslation = [locale, ...fallbackLocalesFor(locale)]
+    .map((locale) => violation?.i18n?.translations?.[locale])
+    .find((value) => value !== undefined)
+  return matchingTranslation ?? null
+}
+
 /**
- * Parses an error object returned by hal-json-vuex and returns as message array
+ * Parses an error object returned by hal-json-vuex and returns an object of propertypath => violationMessages[]
+ * i18n is nullable if someone wants to use it without initialized localisation
  */
-const serverErrorToArray = (error, fieldname) => {
-  let serverErrorMessages = []
+const transformViolations = (error, i18n = null) => {
+  const serverErrorMessages = {}
 
   if (error.name === 'ServerException' && error.response?.status !== 422) {
     serverErrorMessages[0] = serverErrorToString(error)
     return serverErrorMessages
   }
 
-  // Validation Error(422): build message array from violations array
-  error.response.data.violations.forEach((violation) => {
-    if (violation.propertyPath === fieldname) {
-      serverErrorMessages.push(`${violation.message}`)
-    } else {
-      serverErrorMessages.push(`${violation.propertyPath}: ${violation.message}`)
-    }
-  })
+  const violations = error.response?.data?.violations ?? []
 
+  for (const i in violations) {
+    const violation = violations[i]
+    const propertyPath = violation.propertyPath
+    if (!serverErrorMessages[propertyPath]) {
+      serverErrorMessages[propertyPath] = []
+    }
+    const i18nKey = `api.${violation.i18n?.key}`
+    const locale = i18n?.locale?.replaceAll('-', '_')
+    const apiTranslation = getApiTranslation(locale, violation)
+
+    if (i18n?.te(i18nKey)) {
+      const parameters = violation.i18n?.parameters ?? {}
+      serverErrorMessages[propertyPath].push(i18n.tc(i18nKey, parameters))
+    } else if (apiTranslation) {
+      serverErrorMessages[propertyPath].push(apiTranslation)
+    } else {
+      serverErrorMessages[propertyPath].push(violation.message)
+    }
+  }
   return serverErrorMessages
 }
 
-export { serverErrorToString, serverErrorToArray }
+export { serverErrorToString, transformViolations }

--- a/frontend/src/plugins/i18n/__tests__/apiFallbackLocalesFor.spec.js
+++ b/frontend/src/plugins/i18n/__tests__/apiFallbackLocalesFor.spec.js
@@ -1,0 +1,31 @@
+import { fallbackLocale } from '@/plugins/i18n'
+import fallbackLocalesFor from '@/plugins/i18n/apiFallbackLocalesFor'
+
+describe('apiFallbackLocales', () => {
+  ;[null, undefined, 1, [], {}].forEach((param) => {
+    it(`returns fallbackLocale if input is not a string, but ${param}`, () => {
+      expect([...fallbackLocalesFor(param)]).toStrictEqual([fallbackLocale])
+    })
+
+    it('returns fallbackLocale if string does not contain dashes', () => {
+      expect([...fallbackLocalesFor('de')]).toStrictEqual([fallbackLocale])
+    })
+
+    Object.entries({
+      de_CH_scout: ['de_CH', 'de', fallbackLocale],
+      de_CH: ['de', fallbackLocale],
+      fr_CH_scout: ['fr_CH', 'fr', fallbackLocale],
+      fr_CH: ['fr', fallbackLocale],
+      it_CH_scout: ['it_CH', 'it', fallbackLocale],
+      it_CH: ['it', fallbackLocale],
+      en_CH_scout: ['en_CH', 'en', fallbackLocale],
+      en_CH: ['en', fallbackLocale],
+    }).forEach((entry) => {
+      const locale = entry[0]
+      const result = entry[1]
+      it(`returns correct fallbacks [${result}] for locale ${locale}`, () => {
+        expect([...fallbackLocalesFor(locale)]).toStrictEqual(result)
+      })
+    })
+  })
+})

--- a/frontend/src/plugins/i18n/apiFallbackLocalesFor.js
+++ b/frontend/src/plugins/i18n/apiFallbackLocalesFor.js
@@ -1,0 +1,13 @@
+import { fallbackLocale } from '@/plugins/i18n/index'
+
+export default function* (locale) {
+  if (typeof locale !== 'string') {
+    yield fallbackLocale
+    return
+  }
+  const parts = locale.split('_')
+  for (let i = parts.length - 1; i > 0; i--) {
+    yield parts.slice(0, i).join('_')
+  }
+  yield fallbackLocale
+}

--- a/frontend/src/plugins/i18n/index.js
+++ b/frontend/src/plugins/i18n/index.js
@@ -32,9 +32,10 @@ import vuetifyIt from 'vuetify/lib/locale/it'
 
 Vue.use(VueI18n)
 
+const fallbackLocale = 'en'
 const i18n = new VueI18n({
   locale: 'de',
-  fallbackLocale: 'en',
+  fallbackLocale,
   messages: deepmerge.all([
     // vee-validate locales
     {
@@ -109,4 +110,4 @@ Object.defineProperty(i18n, 'browserPreferredLocale', {
 
 export default i18n
 
-export { i18n }
+export { i18n, fallbackLocale }

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -165,7 +165,10 @@ export default {
         .then(this.refreshCamp, this.handleError)
     },
     handleError(e) {
-      this.inviteEmailMessages = transformViolations(e, this.$i18n)['inviteEmail']
+      const violations = transformViolations(e, this.$i18n)
+      this.inviteEmailMessages = Object.values(violations).flatMap(
+        (violationsOfProperty) => violationsOfProperty
+      )
     },
     refreshCamp() {
       this.inviteEmail = null

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -107,7 +107,7 @@ import ETextField from '@/components/form/base/ETextField.vue'
 import ESelect from '@/components/form/base/ESelect.vue'
 import InactiveCollaboratorListItem from '@/components/collaborator/InactiveCollaboratorListItem.vue'
 import { campRoleMixin } from '@/mixins/campRoleMixin'
-import { serverErrorToArray } from '@/helpers/serverError'
+import { transformViolations } from '@/helpers/serverError'
 
 const DEFAULT_INVITE_ROLE = 'member'
 
@@ -165,7 +165,7 @@ export default {
         .then(this.refreshCamp, this.handleError)
     },
     handleError(e) {
-      this.inviteEmailMessages = serverErrorToArray(e, 'inviteEmail')
+      this.inviteEmailMessages = transformViolations(e, this.$i18n)['inviteEmail']
     },
     refreshCamp() {
       this.inviteEmail = null


### PR DESCRIPTION
This PR implements #2902

Tasks in this PR:
- [x] Generate translation key from Constraint class name and expose in payload to frontend
- [x] Also expose the parameters for this translation to the frontend
- [x] Translate the messages into all configured locales and expose payload to frontend
- [x] Test that the frontend receives these translations and the translation key with parameters
- [x] Use the available translations already provided by symfony for the Constraints provided by symfony
- [x] Test support for self defined Translations for self defined Constraints
- [x] Test support for self defined Translations for variants like de_CH_scout
- [x] Integrate with lokalise (Lokalise can pull our files, so i will check that after merge): https://app.lokalise.com/project/177816575f917f180c4c07.19252326/?view=single&reference_lang_id=640&single_lang_id=10001&search=mail
- [x] Use Translation in Frontend
- [x] Support jsonapi and hydra format
- [x] ~~Maybe make support for jsonapi and hydra better by not using subclasses
(This is currently the only idea to share the functionality between the formats)~~

Not in this PR, will implement later
- switch to symfony translations for E-Mail

Sure not in this PR, and maybe we don't implement it at all:
- Translation of 400, 401, 403 and 404 Messages in the api
- Translation of 50x Messages in the api
- Translate constants which are exposed in the api (like CampCollaboration::status: invited, established...), because in some places we have concatenated values, which would increase the number of translations.

Is currently a draft, that you may look at it before everything is implemented.

Questions:

1. Why did we name our variants with dashes instead of underscores?
I know it with underscores (en_GB, en_US)
2. Do we really want to support jsonapi. Their error format is a little different than hydra and json+problem
https://github.com/api-platform/core/issues/3042
-> we don't support jsonapi (removed complicated code with: 415daa2c4e844089826d9714f20a522a18ef8fee)