### PR TITLE
fix(frontend): picasso & scheduleEntry validations

### DIFF
--- a/frontend/src/components/campAdmin/CreateCampPeriods.vue
+++ b/frontend/src/components/campAdmin/CreateCampPeriods.vue
@@ -58,7 +58,7 @@
             v-model="period.end"
             input-class="ml-2"
             :name="$tc('entity.period.fields.end')"
-            vee-rules="required|minDate:@start"
+            vee-rules="required|greaterThanOrEqual_date:@start"
             :my="2"
             :filled="false"
             required

--- a/frontend/src/components/campAdmin/DialogPeriodForm.vue
+++ b/frontend/src/components/campAdmin/DialogPeriodForm.vue
@@ -16,7 +16,7 @@
     <e-date-picker
       v-model="localPeriod.end"
       :name="$tc('entity.period.fields.end')"
-      vee-rules="required|minDate:@start"
+      vee-rules="required|greaterThanOrEqual_date:@start"
     />
   </div>
 </template>

--- a/frontend/src/components/form/base/BasePicker.vue
+++ b/frontend/src/components/form/base/BasePicker.vue
@@ -17,6 +17,7 @@ Displays a field as a picker (can be used with v-model)
     >
       <template #activator="{ on }">
         <e-text-field
+          ref="textField"
           :value="fieldValue"
           v-bind="$attrs"
           :error-messages="combinedErrorMessages"
@@ -168,6 +169,10 @@ export default {
     savePicker() {
       this.showPicker = false
       this.setValue(this.localPickerValue)
+
+      // after closing picker --> set focus into textfield and validate value
+      this.$refs.textField.focus()
+      this.$refs.textField.$refs.validationProvider.validate(this.fieldValue)
     },
     inputPicker(val) {
       if (this.parsePicker !== null) {

--- a/frontend/src/components/form/base/ETextField.vue
+++ b/frontend/src/components/form/base/ETextField.vue
@@ -1,6 +1,7 @@
 <template>
   <ValidationProvider
     v-slot="{ errors: veeErrors }"
+    ref="validationProvider"
     tag="div"
     :name="name"
     :vid="veeId"

--- a/frontend/src/components/program/FormScheduleEntryItem.vue
+++ b/frontend/src/components/program/FormScheduleEntryItem.vue
@@ -6,6 +6,7 @@
           v-model="localScheduleEntry.start"
           value-format="YYYY-MM-DDTHH:mm:ssZ"
           :name="$tc('components.activity.createScheduleEntries.fields.start')"
+          vee-id="startDate"
           vee-rules="required"
           :allowed-dates="allowedStartDates"
           :filled="false"
@@ -16,6 +17,7 @@
         <e-time-picker
           v-model="localScheduleEntry.start"
           :name="$tc('components.activity.createScheduleEntries.fields.start')"
+          vee-id="startDatetime"
           vee-rules="required"
           :filled="false"
           class="float-left mt-0 ml-3 time-picker"
@@ -28,7 +30,8 @@
           v-model="localScheduleEntry.end"
           value-format="YYYY-MM-DDTHH:mm:ssZ"
           :name="$tc('components.activity.createScheduleEntries.fields.end')"
-          vee-rules="required"
+          vee-id="endDate"
+          vee-rules="required|greaterThanOrEqual_date:@startDate"
           :allowed-dates="allowedEndDates"
           :filled="false"
           class="float-left date-picker"
@@ -38,7 +41,8 @@
         <e-time-picker
           v-model="localScheduleEntry.end"
           :name="$tc('components.activity.createScheduleEntries.fields.end')"
-          vee-rules="required"
+          vee-id="endDatetime"
+          :vee-rules="endTimeValidation"
           :filled="false"
           class="float-left mt-0 ml-3 time-picker"
           required
@@ -96,6 +100,23 @@ export default {
           '[]'
         )
       })
+    },
+    endTimeValidation() {
+      let validator = {
+        required: true,
+      }
+
+      // only compare time if date is the same day
+      if (
+        this.$date
+          .utc(this.localScheduleEntry.start)
+          .isSame(this.$date.utc(this.localScheduleEntry.end), 'day')
+      ) {
+        validator.greaterThan_time = {
+          min: this.$date.utc(this.localScheduleEntry.start).format('HH:mm'),
+        }
+      }
+      return validator
     },
   },
   watch: {

--- a/frontend/src/components/program/picasso/Picasso.vue
+++ b/frontend/src/components/program/picasso/Picasso.vue
@@ -104,7 +104,7 @@ Listing all given activity schedule entries in a calendar view.
       </template>
     </v-calendar>
 
-    <v-snackbar v-model="isSaving" light>
+    <v-snackbar v-model="isSaving" light :color="patchError ? 'orange darken-2' : ''">
       <template v-if="patchError">
         <v-icon>mdi-alert</v-icon>
         {{ patchError }}
@@ -126,6 +126,7 @@ import { isCssColor } from 'vuetify/lib/util/colorUtils'
 import { apiStore as api } from '@/plugins/store'
 import { scheduleEntryRoute } from '@/router.js'
 import mergeListeners from '@/helpers/mergeListeners.js'
+import { serverErrorToString } from '@/helpers/serverError.js'
 import {
   timestampToUtcString,
   utcStringToTimestamp,
@@ -213,7 +214,7 @@ export default {
           isSaving.value = false
         })
         .catch((error) => {
-          patchError.value = error
+          patchError.value = serverErrorToString(error)
         })
         .finally(() => {
           reloadScheduleEntries()

--- a/frontend/src/components/program/picasso/Picasso.vue
+++ b/frontend/src/components/program/picasso/Picasso.vue
@@ -163,13 +163,13 @@ export default {
 
     // v-calendar start: starting date (first day)
     start: {
-      type: Number,
+      type: String,
       required: true,
     },
 
     // v-calender end: end date (last day)
     end: {
-      type: Number,
+      type: String,
       required: true,
     },
 
@@ -247,8 +247,22 @@ export default {
       refs[`editDialog-${scheduleEntry.id}`].open()
     }
 
-    const dragAndDropMove = useDragAndDropMove(editable, 5, updateEntry)
-    const dragAndDropResize = useDragAndDropResize(editable, updateEntry)
+    const calenderStartTimestamp = utcStringToTimestamp(props.start)
+    const calendarEndTimestamp = utcStringToTimestamp(props.end) + 24 * 60 * 60 * 1000
+
+    const dragAndDropMove = useDragAndDropMove(
+      editable,
+      5,
+      updateEntry,
+      calenderStartTimestamp,
+      calendarEndTimestamp
+    )
+    const dragAndDropResize = useDragAndDropResize(
+      editable,
+      updateEntry,
+      calenderStartTimestamp,
+      calendarEndTimestamp
+    )
     const dragAndDropNew = useDragAndDropNew(editable, createEntry)
     const clickDetector = useClickDetector(editable, 5, onClick)
 

--- a/frontend/src/components/program/picasso/useDragAndDropMove.js
+++ b/frontend/src/components/program/picasso/useDragAndDropMove.js
@@ -4,9 +4,18 @@ import { toTime, roundTimeDown } from '@/helpers/vCalendarDragAndDrop.js'
  *
  * @param ref(bool) enabled   drag & drop is disabled if enabled=false
  * @param int threshold       min. mouse movement needed to detect drag & drop
+ * @param update function     callback for update actions
+ * @param minTimestamp        minimum allowed start timestamp (calendar start)
+ * @param maxTimestamp        maximum allowed end timestamp (calender end)
  * @returns
  */
-export default function useDragAndDrop(enabled, threshold, update) {
+export default function useDragAndDrop(
+  enabled,
+  threshold,
+  update,
+  minTimestamp,
+  maxTimestamp
+) {
   /**
    * internal data (not exposed)
    */
@@ -45,8 +54,10 @@ export default function useDragAndDrop(enabled, threshold, update) {
     const newStart = roundTimeDown(mouse - mouseOffset)
     const newEnd = newStart + duration
 
-    draggedEntry.startTimestamp = newStart
-    draggedEntry.endTimestamp = newEnd
+    if (newStart >= minTimestamp && newEnd <= maxTimestamp) {
+      draggedEntry.startTimestamp = newStart
+      draggedEntry.endTimestamp = newEnd
+    }
   }
 
   const clear = () => {

--- a/frontend/src/components/program/picasso/useDragAndDropNew.js
+++ b/frontend/src/components/program/picasso/useDragAndDropNew.js
@@ -34,7 +34,7 @@ export default function useDragAndDrop(enabled, createEntry) {
   const createNewEntry = (mouse) => {
     newEntry = {
       startTimestamp: roundTimeDown(mouse),
-      endTimestamp: roundTimeDown(mouse) + 15,
+      endTimestamp: roundTimeDown(mouse),
     }
   }
 
@@ -108,7 +108,7 @@ export default function useDragAndDrop(enabled, createEntry) {
       return
     }
 
-    if (newEntry) {
+    if (newEntry && newEntry.endTimestamp - newEntry.startTimestamp > 0) {
       // placeholder for new schedule entry was created --> open dialog to create new activity
       createEntry(newEntry.startTimestamp, newEntry.endTimestamp, true)
     }

--- a/frontend/src/components/program/picasso/useDragAndDropResize.js
+++ b/frontend/src/components/program/picasso/useDragAndDropResize.js
@@ -4,9 +4,11 @@ import { toTime, roundTimeUp, roundTimeDown } from '@/helpers/vCalendarDragAndDr
  *
  * @param ref(bool) enabled   drag & drop is disabled if enabled=false
  * @param int threshold       min. mouse movement needed to detect drag & drop
+ * @param minTimestamp        minimum allowed start timestamp (calendar start)
+ * @param maxTimestamp        maximum allowed end timestamp (calender end)
  * @returns
  */
-export default function useDragAndDrop(enabled, update) {
+export default function useDragAndDrop(enabled, update, minTimestamp, maxTimestamp) {
   /**
    * internal data (not exposed)
    */
@@ -27,12 +29,14 @@ export default function useDragAndDrop(enabled, update) {
   // resize an entry (existing or new placeholder)
   const resizeEntry = (entry, mouse) => {
     const mouseRounded = roundTimeUp(mouse)
-    const min = Math.min(mouseRounded, roundTimeDown(originalStartTimestamp))
-    const max = Math.max(mouseRounded, roundTimeDown(originalStartTimestamp))
+    const newStart = Math.min(mouseRounded, roundTimeDown(originalStartTimestamp))
+    const newEnd = Math.max(mouseRounded, roundTimeDown(originalStartTimestamp))
 
-    // TODO review: Here we're changing the store value directly.
-    entry.startTimestamp = min
-    entry.endTimestamp = max
+    if (newStart >= minTimestamp && newEnd <= maxTimestamp && newEnd - newStart > 0) {
+      // TODO review: Here we're changing the store value directly.
+      entry.startTimestamp = newStart
+      entry.endTimestamp = newEnd
+    }
   }
 
   const clear = () => {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -280,7 +280,8 @@
       "short": "Serverfehler"
     },
     "validation": {
-      "minDate": "{_field_} darf nicht vor {min} liegen",
+      "greaterThanOrEqual_date": "{_field_} darf nicht vor {min} liegen",
+      "greaterThan_time": "{_field_} muss später als {min} sein",
       "pwConfirmed": "Passwort stimmt nicht überein"
     }
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -334,7 +334,8 @@
       "short": "Server error"
     },
     "validation": {
-      "minDate": "{_field_} may not be earlier than {min}",
+      "greaterThanOrEqual_date": "{_field_} may not be earlier than {min}",
+      "greaterThan_time": "{_field_} must be later than {min}",
       "pwConfirmed": "Password does not match"
     }
   },

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -178,7 +178,7 @@
       "409": "Oooops... Cette action a provoqué une erreur côté serveur."
     },
     "validation": {
-      "minDate": "{_field_} ne peut pas être antérieure à {min}"
+      "greaterThanOrEqual_date": "{_field_} ne peut pas être antérieure à {min}"
     }
   },
   "views": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -178,7 +178,7 @@
       "409": "Oooops... Questa azione ha causato un errore sul lato server."
     },
     "validation": {
-      "minDate": "{_field_} non può essere prima che {min}"
+      "greaterThanOrEqual_date": "{_field_} non può essere prima che {min}"
     }
   },
   "views": {

--- a/frontend/src/plugins/veeValidate.js
+++ b/frontend/src/plugins/veeValidate.js
@@ -24,14 +24,36 @@ class VeeValidatePlugin {
      */
 
     // check if date (value) is equal or larger than another date (min)
-    extend('minDate', {
+    extend('greaterThanOrEqual_date', {
       params: ['min'],
+      /**
+       * @param   {string}  value Dater value in local string format
+       * @param   {string}  min   comparison valye in local string format
+       * @returns {bool}          validation result
+       */
       validate: (value, { min }) => {
         const minDate = Vue.dayjs.utc(min, 'L')
         const valueDate = Vue.dayjs.utc(value, 'L')
         return valueDate.diff(minDate, 'day') >= 0
       },
-      message: (field, values) => i18n.t('global.validation.minDate', values),
+      message: (field, values) =>
+        i18n.t('global.validation.greaterThanOrEqual_date', values),
+    })
+
+    extend('greaterThan_time', {
+      params: ['min'],
+      /**
+       *
+       * @param {string} value Time value in string format 'HH:mm'
+       * @param {string} min   Comparison value in string format 'HH:mm'
+       * @returns {bool}       validation result
+       */
+      validate: (value, { min }) => {
+        const minDate = new Date('1970-01-01 ' + min)
+        const valueDate = new Date('1970-01-01 ' + value)
+        return valueDate > minDate
+      },
+      message: (field, values) => i18n.t('global.validation.greaterThan_time', values),
     })
 
     extend('pwConfirmed', {

--- a/frontend/src/views/activity/SideBarProgram.vue
+++ b/frontend/src/views/activity/SideBarProgram.vue
@@ -11,9 +11,9 @@
             v-else
             :schedule-entries="slotProps.scheduleEntries"
             :period="period()"
-            :start="startOfDay"
+            :start="currentDayAsString"
             :interval-height="36"
-            :end="endOfDay"
+            :end="currentDayAsString"
             type="day"
           />
         </template>
@@ -28,6 +28,8 @@ import SideBar from '@/components/navigation/SideBar.vue'
 import ContentCard from '@/components/layout/ContentCard.vue'
 import ScheduleEntries from '@/components/program/ScheduleEntries.vue'
 
+import { HTML5_FMT } from '@/common/helpers/dateFormat.js'
+
 export default {
   name: 'SideBarProgram',
   components: { ContentCard, SideBar, Picasso, ScheduleEntries },
@@ -38,16 +40,8 @@ export default {
     period() {
       return this.day().period
     },
-    startOfDay() {
-      return this.addDays(this.period().start, this.day().dayOffset)
-    },
-    endOfDay() {
-      return this.addDays(this.startOfDay, 1)
-    },
-  },
-  methods: {
-    addDays(date, days) {
-      return Date.parse(date) + days * 24 * 60 * 60 * 1000
+    currentDayAsString() {
+      return this.$date.utc(this.day().start).format(HTML5_FMT.DATE)
     },
   },
 }

--- a/frontend/src/views/auth/ResetPassword.vue
+++ b/frontend/src/views/auth/ResetPassword.vue
@@ -58,7 +58,6 @@
           name="Confirmation"
           vee-id="confirmation"
           vee-rules="pwConfirmed:@password"
-          vee-rules-old="confirmed:password"
           validate-on-blur
           :dense="$vuetify.breakpoint.xsOnly"
           type="password"

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -45,8 +45,8 @@ Show all activity schedule entries of a single period.
           <picasso
             :schedule-entries="slotProps.scheduleEntries"
             :period="period()"
-            :start="Date.parse(period().start)"
-            :end="Date.parse(period().end)"
+            :start="period().start"
+            :end="period().end"
             :editable="editMode"
             @newEntry="slotProps.on.newEntry"
           />


### PR DESCRIPTION
Fixes #2339 
Fixes #2424

- In picasso, scheduleEntries can now not be dragged outside of the calendar (which previously triggered a server error)
- Creating new scheduleEntries have a minimum length of 15min (click/release at the same point doesn't open dialog anymore)
- In the scheduleEntry create/edit dialog, timing is now validated to prevent scheduleEntries with a negative length (which previously triggered a server error)

<img width="443" alt="image" src="https://user-images.githubusercontent.com/449555/189496719-7eb14a01-f3d8-4db8-9faf-c8880ba4cc06.png">

<img width="448" alt="image" src="https://user-images.githubusercontent.com/449555/189496736-b1b9085f-0c1a-4b93-b5ca-cc5aebdeed77.png">


