### PR TITLE
fix(api): allow null values in json schema for storyboard

### DIFF
--- a/api/src/Entity/ContentNode/Storyboard.php
+++ b/api/src/Entity/ContentNode/Storyboard.php
@@ -70,13 +70,13 @@ class Storyboard extends ContentNode {
                 'required' => ['column1', 'column2', 'column3', 'position'],
                 'properties' => [
                     'column1' => [
-                        'type' => 'string',
+                        'type' => ['string', 'null'],
                     ],
                     'column2' => [
-                        'type' => 'string',
+                        'type' => ['string', 'null'],
                     ],
                     'column3' => [
-                        'type' => 'string',
+                        'type' => ['string', 'null'],
                     ],
                     'position' => [
                         'type' => 'integer',

--- a/frontend/src/components/activity/content/Storyboard.vue
+++ b/frontend/src/components/activity/content/Storyboard.vue
@@ -134,7 +134,14 @@ export default {
   },
   computed: {
     sections() {
-      return this.api.get(this.contentNode).data.sections
+      const sections = this.api.get(this.contentNode).data.sections
+
+      // workaround because our API return an empty array instead of empty object
+      if (Array.isArray(sections) && sections.length === 0) {
+        return {}
+      }
+
+      return sections
     },
   },
   methods: {


### PR DESCRIPTION
This is mainly to deal with migrated data, as we previously allowed null values, which now results in invalid json in the DB.

New values are coming as empty strings by default.

Not much difference for the frontend. It can deal with both null values and empty strings anyway.
