### PR TITLE
feat(frontend): enable richtext in activity content

### DIFF
--- a/frontend/src/components/activity/content/Notes.vue
+++ b/frontend/src/components/activity/content/Notes.vue
@@ -2,7 +2,7 @@
   <card-content-node v-bind="$props">
     <div class="mb-3">
       <api-form :entity="contentNode">
-        <api-textarea
+        <api-richtext
           fieldname="data.text"
           :label="$tc('contentNode.notes.name')"
           rows="4"
@@ -16,7 +16,6 @@
 </template>
 
 <script>
-import ApiTextarea from '@/components/form/api/ApiTextarea.vue'
 import ApiForm from '@/components/form/api/ApiForm.vue'
 import CardContentNode from '@/components/activity/CardContentNode.vue'
 import { contentNodeMixin } from '@/mixins/contentNodeMixin.js'
@@ -26,7 +25,6 @@ export default {
   components: {
     CardContentNode,
     ApiForm,
-    ApiTextarea,
   },
   mixins: [contentNodeMixin],
 }

--- a/frontend/src/components/activity/content/Storyboard.vue
+++ b/frontend/src/components/activity/content/Storyboard.vue
@@ -23,28 +23,23 @@
         <api-form :entity="contentNode">
           <v-row dense>
             <v-col cols="2">
-              <api-textarea
+              <api-text-field
                 :fieldname="`data.sections[${sortable.itemKey}].column1`"
-                auto-grow
-                rows="2"
                 :disabled="layoutMode || disabled"
                 :filled="layoutMode"
               />
             </v-col>
             <v-col cols="7">
-              <api-textarea
+              <api-richtext
                 :fieldname="`data.sections[${sortable.itemKey}].column2`"
-                auto-grow
                 rows="4"
                 :disabled="layoutMode || disabled"
                 :filled="layoutMode"
               />
             </v-col>
             <v-col cols="2">
-              <api-textarea
+              <api-text-field
                 :fieldname="`data.sections[${sortable.itemKey}].column3`"
-                auto-grow
-                rows="2"
                 :disabled="layoutMode || disabled"
                 :filled="layoutMode"
               />
@@ -107,7 +102,6 @@
 </template>
 
 <script>
-import ApiTextarea from '@/components/form/api/ApiTextarea.vue'
 import ApiForm from '@/components/form/api/ApiForm.vue'
 import CardContentNode from '@/components/activity/CardContentNode.vue'
 import { contentNodeMixin } from '@/mixins/contentNodeMixin.js'
@@ -120,7 +114,6 @@ export default {
   components: {
     CardContentNode,
     ApiForm,
-    ApiTextarea,
     ApiSortable,
   },
   mixins: [contentNodeMixin],

--- a/frontend/src/components/activity/content/Storycontext.vue
+++ b/frontend/src/components/activity/content/Storycontext.vue
@@ -2,7 +2,7 @@
   <card-content-node v-bind="$props">
     <div class="mb-3">
       <api-form :entity="contentNode">
-        <api-textarea
+        <api-richtext
           fieldname="data.text"
           :placeholder="$tc('contentNode.storycontext.name')"
           rows="2"
@@ -16,7 +16,6 @@
 </template>
 
 <script>
-import ApiTextarea from '@/components/form/api/ApiTextarea.vue'
 import ApiForm from '@/components/form/api/ApiForm.vue'
 import CardContentNode from '@/components/activity/CardContentNode.vue'
 import { contentNodeMixin } from '@/mixins/contentNodeMixin.js'
@@ -26,7 +25,6 @@ export default {
   components: {
     CardContentNode,
     ApiForm,
-    ApiTextarea,
   },
   mixins: [contentNodeMixin],
 }

--- a/frontend/src/components/form/base/__tests__/__snapshots__/ERichtext.spec.js.snap
+++ b/frontend/src/components/form/base/__tests__/__snapshots__/ERichtext.spec.js.snap
@@ -19,52 +19,28 @@ exports[`An ERichtext looks like a richtext field: empty 1`] = `
                                                                type="button">
                                                             <span class="v-btn__content">
                                                                  <i aria-hidden="true"
-                                                                    class="v-icon notranslate mdi mdi-format-header-1 theme--light"></i>
+                                                                    class="v-icon notranslate v-icon--dense mdi mdi-format-bold theme--light"></i>
                                                             </span>
                                                        </button>
                                                        <button class="v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
                                                                type="button">
                                                             <span class="v-btn__content">
                                                                  <i aria-hidden="true"
-                                                                    class="v-icon notranslate mdi mdi-format-header-2 theme--light"></i>
+                                                                    class="v-icon notranslate v-icon--dense mdi mdi-format-italic theme--light"></i>
                                                             </span>
                                                        </button>
                                                        <button class="v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
                                                                type="button">
                                                             <span class="v-btn__content">
                                                                  <i aria-hidden="true"
-                                                                    class="v-icon notranslate mdi mdi-format-header-3 theme--light"></i>
-                                                            </span>
-                                                       </button>
-                                                  </div>
-                                                  <div class="mx-1"></div>
-                                                  <div class="v-btn-toggle v-btn-toggle--dense v-item-group theme--light">
-                                                       <button class="v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
-                                                               type="button">
-                                                            <span class="v-btn__content">
-                                                                 <i aria-hidden="true"
-                                                                    class="v-icon notranslate mdi mdi-format-bold theme--light"></i>
+                                                                    class="v-icon notranslate v-icon--dense mdi mdi-format-underline theme--light"></i>
                                                             </span>
                                                        </button>
                                                        <button class="v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
                                                                type="button">
                                                             <span class="v-btn__content">
                                                                  <i aria-hidden="true"
-                                                                    class="v-icon notranslate mdi mdi-format-italic theme--light"></i>
-                                                            </span>
-                                                       </button>
-                                                       <button class="v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
-                                                               type="button">
-                                                            <span class="v-btn__content">
-                                                                 <i aria-hidden="true"
-                                                                    class="v-icon notranslate mdi mdi-format-underline theme--light"></i>
-                                                            </span>
-                                                       </button>
-                                                       <button class="v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
-                                                               type="button">
-                                                            <span class="v-btn__content">
-                                                                 <i aria-hidden="true"
-                                                                    class="v-icon notranslate mdi mdi-format-strikethrough theme--light"></i>
+                                                                    class="v-icon notranslate v-icon--dense mdi mdi-format-strikethrough theme--light"></i>
                                                             </span>
                                                        </button>
                                                   </div>

--- a/frontend/src/components/form/tiptap/TiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/TiptapEditor.vue
@@ -6,6 +6,8 @@
       :tippy-options="{ maxWidth: 'none' }"
     >
       <v-toolbar short>
+        <!-- headings currently disabled (see issue #2657) -->
+        <!--
         <v-item-group class="v-btn-toggle v-btn-toggle--dense">
           <v-btn
             :class="
@@ -39,30 +41,31 @@
           </v-btn>
         </v-item-group>
         <div class="mx-1" />
+        -->
         <v-item-group class="v-btn-toggle v-btn-toggle--dense" multiple>
           <v-btn
             :class="editor.isActive('bold') ? 'v-item--active v-btn--active' : ''"
             @click="editor.chain().focus().toggleBold().run()"
           >
-            <v-icon>mdi-format-bold</v-icon>
+            <v-icon dense>mdi-format-bold</v-icon>
           </v-btn>
           <v-btn
             :class="editor.isActive('italic') ? 'v-item--active v-btn--active' : ''"
             @click="editor.chain().focus().toggleItalic().run()"
           >
-            <v-icon>mdi-format-italic</v-icon>
+            <v-icon dense>mdi-format-italic</v-icon>
           </v-btn>
           <v-btn
             :class="editor.isActive('underline') ? 'v-item--active v-btn--active' : ''"
             @click="editor.chain().focus().toggleUnderline().run()"
           >
-            <v-icon>mdi-format-underline</v-icon>
+            <v-icon dense>mdi-format-underline</v-icon>
           </v-btn>
           <v-btn
             :class="editor.isActive('strike') ? 'v-item--active v-btn--active' : ''"
             @click="editor.chain().focus().toggleStrike().run()"
           >
-            <v-icon>mdi-format-strikethrough</v-icon>
+            <v-icon dense>mdi-format-strikethrough</v-icon>
           </v-btn>
         </v-item-group>
       </v-toolbar>
@@ -77,7 +80,7 @@ import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import BulletList from '@tiptap/extension-bullet-list'
 import HardBreak from '@tiptap/extension-hard-break'
-import Heading from '@tiptap/extension-heading'
+// import Heading from '@tiptap/extension-heading'
 import ListItem from '@tiptap/extension-list-item'
 import OrderedList from '@tiptap/extension-ordered-list'
 import Bold from '@tiptap/extension-bold'
@@ -131,7 +134,8 @@ export default {
           ListItem,
           BulletList,
           OrderedList,
-          Heading.configure({ levels: [1, 2, 3] }),
+          // headings currently disabled (see issue #2657)
+          // Heading.configure({ levels: [1, 2, 3] }),
           HardBreak,
         ]
       )

--- a/frontend/src/components/form/tiptap/VTiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/VTiptapEditor.vue
@@ -26,7 +26,7 @@ export default {
           value: this.value,
           placeholder: this.placeholder,
           withExtensions: this.withExtensions,
-          editable: !this.readonly,
+          editable: !this.readonly && !this.disabled,
         },
         on: Object.assign(listeners, {
           blur: this.onBlur,

--- a/frontend/src/components/story/StoryDay.vue
+++ b/frontend/src/components/story/StoryDay.vue
@@ -30,24 +30,18 @@
               </template>
             </router-link>
           </h4>
-          <api-form v-show="editing" :entity="chapter">
+          <api-form :entity="chapter">
             <api-richtext
               :outlined="false"
               :solo="false"
               auto-grow
               dense
+              :readonly="!editing"
               fieldname="data.text"
               aria-label="Erfassen"
               label=""
             />
           </api-form>
-          <tiptap-editor
-            v-show="!editing"
-            :class="{ readonly: !editing }"
-            :editable="false"
-            :value="chapter.data.text"
-            class="v-input mb-1"
-          />
         </div>
       </template>
     </template>
@@ -59,7 +53,6 @@
 <script>
 import { sortBy } from 'lodash'
 import ApiForm from '@/components/form/api/ApiForm.vue'
-import TiptapEditor from '@/components/form/tiptap/TiptapEditor.vue'
 import { dateLong } from '@/common/helpers/dateHelperUTCFormatted.js'
 import CategoryChip from '@/components/story/CategoryChip.vue'
 
@@ -67,7 +60,6 @@ export default {
   name: 'StoryDay',
   components: {
     CategoryChip,
-    TiptapEditor,
     ApiForm,
   },
   props: {
@@ -113,10 +105,6 @@ export default {
 </script>
 
 <style scoped>
-.readonly ::v-deep .ProseMirror-trailingBreak {
-  display: none;
-}
-
 .e-story-day + .e-story-day .e-story-day-title {
   border-top: 1px solid #eee;
   padding-top: 5px;

--- a/frontend/src/components/story/StoryDay.vue
+++ b/frontend/src/components/story/StoryDay.vue
@@ -31,7 +31,7 @@
             </router-link>
           </h4>
           <api-form v-show="editing" :entity="chapter">
-            <api-textarea
+            <api-richtext
               :outlined="false"
               :solo="false"
               auto-grow
@@ -59,7 +59,6 @@
 <script>
 import { sortBy } from 'lodash'
 import ApiForm from '@/components/form/api/ApiForm.vue'
-import ApiTextarea from '@/components/form/api/ApiTextarea.vue'
 import TiptapEditor from '@/components/form/tiptap/TiptapEditor.vue'
 import { dateLong } from '@/common/helpers/dateHelperUTCFormatted.js'
 import CategoryChip from '@/components/story/CategoryChip.vue'
@@ -70,7 +69,6 @@ export default {
     CategoryChip,
     TiptapEditor,
     ApiForm,
-    ApiTextarea,
   },
   props: {
     day: { type: Object, required: true },

--- a/frontend/src/mixins/apiPropsMixin.js
+++ b/frontend/src/mixins/apiPropsMixin.js
@@ -29,8 +29,8 @@ export const apiPropsMixin = {
     overrideDirty: { type: Boolean, default: false, required: false },
 
     /* enable/disable edit mode */
-    readonly: { type: Boolean, required: false, default: false },
-    disabled: { type: Boolean, required: false, default: false },
+    readonly: { type: Boolean, required: false, default: false }, // vuetify readonly: same look and feel as normal, but no changes possible
+    disabled: { type: Boolean, required: false, default: false }, // vuetify disabled: input greyed out, not focusable
 
     /* enable/disable auto save */
     autoSave: { type: Boolean, default: true, required: false },


### PR DESCRIPTION
**From epic https://github.com/ecamp/ecamp3/issues/1242:**
- [x] Formatierung Rich Text Felder überall wo heute Textareas sind erlauben, konkret bei Roter Faden, Notizen, SiKo, Storyboard mittlere Spalte
- [x]  Storyboard Spalten Zeit und Verantwortlich auf (single-line) plain Text umschalten, nicht mehr Textarea

**From issue #2657:**
- [x] For MVP: disable headings

### To discuss
Changing from rich-text to textfield for column1 & column3 in storyboard sections has the following effects:
- All text in current DB is wrapped in a `<p></p>` which is now displayed in frontend as raw text. Obviously this is only for the existing dev data and not for new data.
- I can still manually type HTML tags. Our API is so nice and even closes them for me 😄  --> `<strong>text` becomes `<strong>text</strong>`
- Both printers (nuxt & react) interpret this as HTML, so they print above as bold, even though we didn't enable richtext for these fields

***

<img width="420" alt="image" src="https://user-images.githubusercontent.com/449555/189625488-caab96a6-fae1-493c-8d27-ca6b9bd20c79.png">

***

<img width="419" alt="image" src="https://user-images.githubusercontent.com/449555/189625775-bf9d2e07-3aa3-46b3-8fa0-d6e59d1395c9.png">

***

<img width="412" alt="image" src="https://user-images.githubusercontent.com/449555/189626153-f630acf2-2d85-4803-806a-3b59cb84a382.png">

***

<img width="408" alt="image" src="https://user-images.githubusercontent.com/449555/189626281-90bd87d2-23aa-4118-8e9c-57ec8226bfd1.png">
