### PR TITLE
Api: entity validations 3

### DIFF
--- a/api/src/Entity/ContentNode.php
+++ b/api/src/Entity/ContentNode.php
@@ -67,6 +67,10 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
     #[Assert\NotNull(groups: ['create'])] // Root nodes have parent:null, but manually creating root nodes is not allowed
     #[AssertNoRootChange(groups: ['update'])]
     #[AssertNoLoop(groups: ['update'])]
+    #[Assert\Type(
+        type: SupportsContentNodeChildren::class,
+        message: 'This parent does not support children, only content_nodes of type column_layout support children.'
+    )]
     #[ApiProperty(example: '/content_nodes/1a2b3c4d')]
     #[Gedmo\SortableGroup]
     #[Groups(['read', 'write'])]

--- a/api/src/Entity/ContentNode/ColumnLayout.php
+++ b/api/src/Entity/ContentNode/ColumnLayout.php
@@ -5,6 +5,7 @@ namespace App\Entity\ContentNode;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use App\Entity\ContentNode;
+use App\Entity\SupportsContentNodeChildren;
 use App\Repository\ColumnLayoutRepository;
 use App\Validator\AssertJsonSchema;
 use App\Validator\ColumnLayout\AssertColumWidthsSumTo12;
@@ -40,7 +41,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     normalizationContext: ['groups' => ['read']],
 )]
 #[ORM\Entity(repositoryClass: ColumnLayoutRepository::class)]
-class ColumnLayout extends ContentNode {
+class ColumnLayout extends ContentNode implements SupportsContentNodeChildren {
     public const JSON_SCHEMA = [
         'type' => 'object',
         'additionalProperties' => false,

--- a/api/src/Entity/SupportsContentNodeChildren.php
+++ b/api/src/Entity/SupportsContentNodeChildren.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace App\Entity;
+
+interface SupportsContentNodeChildren {
+}

--- a/api/tests/Api/ContentNodes/ColumnLayout/UpdateColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/UpdateColumnLayoutTest.php
@@ -111,9 +111,9 @@ class UpdateColumnLayoutTest extends UpdateContentNodeTestCase {
     }
 
     public function testPatchColumnLayoutValidatesNoParentLoop() {
-        $contentNode = static::$fixtures['columnLayoutChild1'];
+        $contentNode = static::$fixtures['columnLayout1'];
         static::createClientWithCredentials()->request('PATCH', $this->endpoint.'/'.$contentNode->getId(), ['json' => [
-            'parent' => $this->getIriFor('singleText2'),
+            'parent' => $this->getIriFor('columnLayoutChild1'),
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
 
         $this->assertResponseStatusCodeSame(422);

--- a/api/tests/Api/ContentNodes/CreateContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/CreateContentNodeTestCase.php
@@ -81,6 +81,24 @@ abstract class CreateContentNodeTestCase extends ECampApiTestCase {
         $this->assertJsonContains($this->getExampleReadPayload($newContentNode), true);
     }
 
+    /**
+     * @dataProvider getContentNodesWhichCannotHaveChildren
+     */
+    public function testCreateRejectsParentsWhichDontSupportChildren(string $idOfParentFixture) {
+        $this->defaultParent = static::$fixtures[$idOfParentFixture];
+
+        $this->create(user: static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                0 => [
+                    'propertyPath' => 'parent',
+                    'message' => 'This parent does not support children, only content_nodes of type column_layout support children.',
+                ],
+            ],
+        ]);
+    }
+
     public function testCreateValidatesIncompatibleContentType() {
         // given
         /** @var ContentType $contentType */
@@ -141,6 +159,23 @@ abstract class CreateContentNodeTestCase extends ECampApiTestCase {
                 'contentType' => [
                     'href' => $this->getIriFor($contentType),
                 ],
+            ],
+        ];
+    }
+
+    private static function getContentNodesWhichCannotHaveChildren(): array {
+        return [
+            ContentNode\MaterialNode::class => [
+                'materialNode1',
+            ],
+            ContentNode\MultiSelect::class => [
+                'multiSelect1',
+            ],
+            ContentNode\SingleText::class => [
+                'singleText1',
+            ],
+            ContentNode\StoryBoard::class => [
+                'storyboard1',
             ],
         ];
     }

--- a/api/tests/Api/ContentNodes/MultiSelect/CreateMultiSelectTest.php
+++ b/api/tests/Api/ContentNodes/MultiSelect/CreateMultiSelectTest.php
@@ -19,7 +19,7 @@ class CreateMultiSelectTest extends CreateContentNodeTestCase {
 
     public function testCreateMultiSelectCopiesOptionsFromContentType() {
         // when
-        $response = $this->create($this->getExampleWritePayload());
+        $this->create($this->getExampleWritePayload());
 
         // then
         $this->assertResponseStatusCodeSame(201);

--- a/api/tests/Api/ContentNodes/MultiSelect/CreateMultiSelectTest.php
+++ b/api/tests/Api/ContentNodes/MultiSelect/CreateMultiSelectTest.php
@@ -37,6 +37,25 @@ class CreateMultiSelectTest extends CreateContentNodeTestCase {
         ]);
     }
 
+    public function testCreateDoesNotAcceptOptions() {
+        $this->create($this->getExampleWritePayload([
+            'data' => [
+                'options' => [
+                ],
+            ],
+        ]));
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                0 => [
+                    'propertyPath' => 'data',
+                    'message' => 'This value should be null.',
+                ],
+            ],
+        ]);
+    }
+
     protected function getExampleWritePayload($attributes = [], $except = []) {
         return parent::getExampleWritePayload(
             array_merge([

--- a/api/tests/Api/ContentNodes/MultiSelect/UpdateMultiSelectTest.php
+++ b/api/tests/Api/ContentNodes/MultiSelect/UpdateMultiSelectTest.php
@@ -45,4 +45,44 @@ class UpdateMultiSelectTest extends UpdateContentNodeTestCase {
         $this->assertResponseStatusCodeSame(422);
         $this->assertJsonSchemaError($response, 'data');
     }
+
+    public function testPatchMultiSelectDoesNotSetDataToNull() {
+        $this->patch($this->defaultEntity, ['data' => null]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'data' => [
+                'options' => [
+                    'key1' => ['checked' => true],
+                    'key2' => ['checked' => true],
+                ],
+            ],
+        ]);
+    }
+
+    public function testPatchMultiSelectDoesNotSetDataToEmptyArray() {
+        $this->patch($this->defaultEntity, ['data' => []]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'data' => [
+                'options' => [
+                    'key1' => ['checked' => true],
+                    'key2' => ['checked' => true],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Because the empty array is not a valid JSON Object.
+     */
+    public function testPatchMultiSelectAccidentallyDoesNotAcceptEmptyOptions() {
+        $response = $this->patch($this->defaultEntity, ['data' => [
+            'options' => [],
+        ]]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonSchemaError($response, 'data');
+    }
 }

--- a/api/tests/Api/ContentNodes/UpdateContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/UpdateContentNodeTestCase.php
@@ -51,4 +51,39 @@ abstract class UpdateContentNodeTestCase extends ECampApiTestCase {
         $this->patch(user: static::$fixtures['user1manager']);
         $this->assertResponseStatusCodeSame(200);
     }
+
+    /**
+     * @dataProvider getContentNodesWhichCannotHaveChildren
+     */
+    public function testPatchRejectsParentsWhichDontSupportChildren(string $idOfParentFixture) {
+        $parentIri = static::getIriFor($idOfParentFixture);
+
+        $this->patch(payload: ['parent' => $parentIri], user: static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                0 => [
+                    'propertyPath' => 'parent',
+                    'message' => 'This parent does not support children, only content_nodes of type column_layout support children.',
+                ],
+            ],
+        ]);
+    }
+
+    private static function getContentNodesWhichCannotHaveChildren(): array {
+        return [
+            ContentNode\MaterialNode::class => [
+                'materialNode1',
+            ],
+            ContentNode\MultiSelect::class => [
+                'multiSelect1',
+            ],
+            ContentNode\SingleText::class => [
+                'singleText1',
+            ],
+            ContentNode\StoryBoard::class => [
+                'storyboard1',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Continuation of https://github.com/ecamp/ecamp3/issues/2553
I will add commits to this PR until it has review.

### MultiSelectOption.php
- [x] options must be null on create


### ContentNode.php
Properties
 - [x] Validate that the parent content node supports children