### PR TITLE
fix(frontend): Fix string interpolation for displaying time periods

### DIFF
--- a/common/helpers/dateHelperUTCFormatted.js
+++ b/common/helpers/dateHelperUTCFormatted.js
@@ -39,7 +39,7 @@ function dateRange(start, end) {
   if (dateLong(start) === dateLong(end)) {
     return dateLong(start)
   }
-  return `${dateShort(start) - dateLong()}`
+  return `${dateShort(start)} - ${dateLong(end)}`
 }
 
 export { dateShort, dateLong, hourShort, dateRange, rangeShort }


### PR DESCRIPTION
The interpolation was done in a way that actually subtracted two strings from each other instead of putting the literal '-' between them. I left the previous decision to display `shortDate - longDate` untouched but am open to change that to `longDate - longDate` or anything of the sorts if requested.

Fixes #2960 


Dropdown:

![image](https://user-images.githubusercontent.com/52202086/193370655-5be616bd-028f-4d3a-a7ae-c34e509c669b.png)

Admin dashboard:

![image](https://user-images.githubusercontent.com/52202086/193370698-6dbf9f17-44bf-41ee-b8a0-b4bdfba6f002.png)
