### PR TITLE
renovate.json: activate lockFileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,9 @@
     }
   },
   "automergeType": "branch",
+  "lockFileMaintenance": {
+    "enabled": true,
+  },
   "vulnerabilityAlerts": {
     "automerge": true
   },
@@ -19,7 +22,8 @@
         "minor",
         "patch",
         "pin",
-        "digest"
+        "digest",
+        "lockFileMaintenance"
       ],
       "automerge": true
     },


### PR DESCRIPTION
Per default scheduled "before 5am on monday".
https://docs.renovatebot.com/configuration-options/#lockfilemaintenance Used command to test:
docker run --rm -e LOG_LEVEL=debug renovate/renovate --token $TOKEN --include-forks true --pr-hourly-limit 0 --pr-concurrent-limit 0 --binary-source install BacLuc/ecamp3 | less