### PR TITLE
Fix/existing user disclosure

### DIFF
--- a/api/src/DTO/ResetPassword.php
+++ b/api/src/DTO/ResetPassword.php
@@ -12,6 +12,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
             'security' => 'true',
             'path' => '',
             'status' => 204,
+            'output' => false,
             'denormalization_context' => ['groups' => ['create']],
             'normalization_context' => ['groups' => ['read']],
             'openapi_context' => [

--- a/api/src/DataPersister/ResetPasswordDataPersister.php
+++ b/api/src/DataPersister/ResetPasswordDataPersister.php
@@ -53,7 +53,7 @@ class ResetPasswordDataPersister implements ContextAwareDataPersisterInterface {
         $user = $this->userRepository->loadUserByIdentifier($data->email);
 
         if (null == $user) {
-            throw new HttpException(422, 'Create request failed');
+            return $data;
         }
 
         $resetKey = IdGenerator::generateRandomHexString(64);

--- a/api/tests/DataPersister/ResetPasswordDataPersisterTest.php
+++ b/api/tests/DataPersister/ResetPasswordDataPersisterTest.php
@@ -119,7 +119,6 @@ class ResetPasswordDataPersisterTest extends TestCase {
         $this->resetPassword->recaptchaToken = 'token';
         $this->resetPassword->email = self::EMAIL;
 
-        $this->expectException(Exception::class);
         $data = $this->dataPersister->beforeCreate($this->resetPassword);
     }
 


### PR DESCRIPTION
Instead of throwing an error when the user isn't found, now silently returns. HTTP response is now also empty.
fixes #2668.
to do:
 - [ ] run tests
 - [ ] run linter