### PR TITLE
Load scheduleEntries per day instead of whole period

### DIFF
--- a/frontend/src/components/program/ScheduleEntries.vue
+++ b/frontend/src/components/program/ScheduleEntries.vue
@@ -41,6 +41,10 @@ export default {
   props: {
     period: { type: Function, required: true },
     showButton: { type: Boolean, required: true },
+    day: {
+      type: Function,
+      required: false,
+    },
   },
   data() {
     return {
@@ -56,15 +60,23 @@ export default {
   },
   computed: {
     scheduleEntries() {
-      // TODO for SideBar, add filtering for the current day, now that the API supports it
-      return this.period().scheduleEntries()
+      if (this.date) {
+        return this.day().scheduleEntries()
+      } else {
+        return this.period().scheduleEntries()
+      }
     },
   },
   mounted() {
-    this.period().scheduleEntries().$reload()
-    this.period().camp().activities().$reload()
+    if (this.date) {
+      this.day().scheduleEntries().$reload()
+      // TODO which elements need a reload here and how?
+    } else {
+      this.period().scheduleEntries().$reload()
+      this.period().camp().activities().$reload()
+      this.period().days().$reload()
+    }
     this.period().camp().categories().$reload()
-    this.period().days().$reload()
   },
 
   methods: {

--- a/frontend/src/components/program/ScheduleEntries.vue
+++ b/frontend/src/components/program/ScheduleEntries.vue
@@ -44,6 +44,7 @@ export default {
     day: {
       type: Function,
       required: false,
+      default: undefined,
     },
   },
   data() {
@@ -60,7 +61,7 @@ export default {
   },
   computed: {
     scheduleEntries() {
-      if (this.date) {
+      if (this.day) {
         return this.day().scheduleEntries()
       } else {
         return this.period().scheduleEntries()
@@ -68,7 +69,7 @@ export default {
     },
   },
   mounted() {
-    if (this.date) {
+    if (this.day) {
       this.day().scheduleEntries().$reload()
       // TODO which elements need a reload here and how?
     } else {

--- a/frontend/src/views/activity/SideBarProgram.vue
+++ b/frontend/src/views/activity/SideBarProgram.vue
@@ -4,7 +4,7 @@
       <v-subheader class="text-uppercase subtitle-2">
         {{ $tc('views.activity.sideBarProgram.title') }}
       </v-subheader>
-      <schedule-entries :period="period" :show-button="false">
+      <schedule-entries :period="period" :show-button="false" :day="day">
         <template #default="slotProps">
           <v-skeleton-loader v-if="slotProps.loading" class="ma-3" type="list-item@6" />
           <picasso


### PR DESCRIPTION
Previously the whole period was fetched even if only one day of it was displayed in the sidebar. Now the schedule-entries component has an optional prop `day`, which is used instead of the period for fetching the entries if it's defined.

Fixes #680

TODO:

- what's the reason for reloading scheduleEntries, days and activites? and what are the correct approaches for a single day solution, because for example `day().activities()` doesn't exist
- are there any automated or manual tests to be done?
- for another issue but day-responsibles seems to have issues with the day as well. There are many errors in the browser console like `[Vue warn]: Error in render: "TypeError: this.day is undefined"` or `TypeError: this.day is undefined`