### PR TITLE
Client side password length check updated

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -327,7 +327,7 @@
         "requiredField": "Pflichtfeld",
         "title": "Ein Konto erstellen",
         "passwordMinLengthWarning": "Passwort muss mindestens 12 Zeichen lang sein",
-        "passwordMaxLengthWarning": "Passwort darf höchstens 64 Zeichen lang sein",
+        "passwordMaxLengthWarning": "Passwort darf höchstens 128 Zeichen lang sein",
         "passwordMismatch": "Passwörter stimmen nicht überein"
       },
       "registerDone": {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -324,8 +324,11 @@
         "login": "Anmelden",
         "passwordConfirmation": "Passwort erneut eingeben",
         "register": "Registrieren",
-        "requiredField": "Pflichtfelder",
-        "title": "Ein Konto erstellen"
+        "requiredField": "Pflichtfeld",
+        "title": "Ein Konto erstellen",
+        "passwordMinLengthWarning": "Passwort muss mindestens 12 Zeichen lang sein",
+        "passwordMaxLengthWarning": "Passwort darf höchstens 64 Zeichen lang sein",
+        "passwordMismatch": "Passwörter stimmen nicht überein"
       },
       "registerDone": {
         "login": "Anmelden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -387,7 +387,10 @@
         "passwordConfirmation": "Enter Password again",
         "register": "Register",
         "requiredField": "required field",
-        "title": "Create an account"
+        "title": "Create an account",
+        "passwordMinLengthWarning": "Password must contain at least 12 characters",
+        "passwordMaxLengthWarning": "Password length must not exceed 64 characters",
+        "passwordMismatch": "Passwords don't match"
       },
       "registerDone": {
         "login": "Login",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -389,7 +389,7 @@
         "requiredField": "required field",
         "title": "Create an account",
         "passwordMinLengthWarning": "Password must contain at least 12 characters",
-        "passwordMaxLengthWarning": "Password length must not exceed 64 characters",
+        "passwordMaxLengthWarning": "Password length must not exceed 128 characters",
         "passwordMismatch": "Passwords don't match"
       },
       "registerDone": {

--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -169,7 +169,7 @@ export default {
     pw1Rules() {
       return [
         (v) => v.length >= 12 || this.$tc('views.auth.register.passwordMinLengthWarning'),
-        (v) => v.length <= 64 || this.$tc('views.auth.register.passwordMaxLengthWarning')
+        (v) => v.length <= 128 || this.$tc('views.auth.register.passwordMaxLengthWarning')
         ]
     },
     availableLocales() {

--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -164,10 +164,13 @@ export default {
       }
     },
     pw2Rules() {
-      return [(v) => (!!v && v) === this.pw1 || 'Nicht übereinstimmend']
+      return [(v) => (!!v && v) === this.pw1 || this.$tc('views.auth.register.passwordMismatch')]
     },
     pw1Rules() {
-      return [(v) => v.length >= 8 || 'Mindestens 8 Zeichen lang sein']
+      return [
+        (v) => v.length >= 12 || this.$tc('views.auth.register.passwordMinLengthWarning'),
+        (v) => v.length <= 64 || this.$tc('views.auth.register.passwordMaxLengthWarning')
+        ]
     },
     availableLocales() {
       return VueI18n.availableLocales.map((l) => ({


### PR DESCRIPTION
addresses first point of #2563:
- min. password length is 12 characters
- max. password length is 128 characters
- error strings to indicate password length violation are now chosen depending on locale setting

remaining open issues:
- invalid forms can still be submitted.