### PR TITLE
api/Caddyfile.prod: remove experimental_http3 and use default for pro…

### DIFF
--- a/api/docker/caddy/Caddyfile.prod
+++ b/api/docker/caddy/Caddyfile.prod
@@ -5,13 +5,6 @@
     http_port 3001
     https_port 3443
     auto_https off
-
-    # HTTP/3 support
-    servers {
-        protocol {
-            experimental_http3
-        }
-    }
 }
 
 {$SERVER_NAME}


### PR DESCRIPTION
…tocols section

Also use default for whole server section.
This seems to be disabled in the new caddy version. Now the protocol section accepts space separated values of: h1 h2 h2c h3
Default is h1 h2 h3
See: https://caddyserver.com/docs/caddyfile/options#protocols

The .prod file forgotten in f8d05ca