### PR TITLE
Use consistent naming for the frontend subdomain

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -204,7 +204,7 @@ jobs:
             --set imageTag=${{ matrix.deployment.sha }} \
             --set sharedCookieDomain=.ecamp3.ch \
             --set api.domain=api-${{ matrix.deployment.name }}.ecamp3.ch \
-            --set frontend.domain=${{ matrix.deployment.name }}.ecamp3.ch \
+            --set frontend.domain=app-${{ matrix.deployment.name }}.ecamp3.ch \
             --set print.domain=print-${{ matrix.deployment.name }}.ecamp3.ch \
             --set mail.domain=mail-${{ matrix.deployment.name }}.ecamp3.ch \
             --set postgresql.enabled=false \

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ eCamp v3 is made up of a backend based on the PHP framework API Platform (Symfon
 
 Thanks for helping! There are a few ways to get started.
 
-- Visit our test environment at https://dev.ecamp3.ch. If you discover a bug, [open an issue](https://github.com/ecamp/ecamp3/issues/new) for it.
+- Visit our test environment at https://app-dev.ecamp3.ch. If you discover a bug, [open an issue](https://github.com/ecamp/ecamp3/issues/new) for it.
 - To run the project on your computer for development, follow one of our installation guides:
   - [Installation with Docker on Linux](https://github.com/ecamp/ecamp3/wiki/installation-development-linux) (German only)
   - [Installation with Docker on Windows + WSL 2](https://github.com/ecamp/ecamp3/wiki/installation-development-windows)
@@ -58,7 +58,7 @@ eCamp v3 besteht aus einem Backend basierend auf dem PHP-Framework API Platform 
 
 Danke dass du mithelfen möchtest! Es gibt ein paar verschiedene Arten wie du beginnen kannst.
 
-- Besuche unsere Testumgebung auf https://dev.ecamp3.ch. Wenn du einen Fehler entdeckst, [eröffne ein Issue dafür](https://github.com/ecamp/ecamp3/issues/new).
+- Besuche unsere Testumgebung auf https://app-dev.ecamp3.ch. Wenn du einen Fehler entdeckst, [eröffne ein Issue dafür](https://github.com/ecamp/ecamp3/issues/new).
 - Um das Projekt bei dir auf dem Computer laufen zu lassen, folge einer der Installationsanleitungen:
   - [Installation mit Docker auf Linux](https://github.com/ecamp/ecamp3/wiki/installation-development-linux)
   - [Installation mit Docker auf Windows + WSL2](https://github.com/ecamp/ecamp3/wiki/installation-development-windows) (nur englisch)


### PR DESCRIPTION
Our other services use the following format:
```
  api-dev.ecamp3.ch
print-dev.ecamp3.ch
 mail-dev.ecamp3.ch
```
So to be consistent, we decided to change the frontend subdomain to:
```
  app-dev.ecamp3.ch
```