### PR TITLE
Frontend error toast

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -56,6 +56,7 @@
         "vue-i18n": "8.27.2",
         "vue-recaptcha-v3": "1.9.0",
         "vue-router": "3.6.5",
+        "vue-toastification": "1.7.14",
         "vuedraggable": "2.24.3",
         "vuetify": "2.6.11",
         "vuex": "3.6.2",
@@ -22053,6 +22054,14 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
+    "node_modules/vue-toastification": {
+      "version": "1.7.14",
+      "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-1.7.14.tgz",
+      "integrity": "sha512-khZR8t3NWZ/JJ2MZxXLbesHrRJ8AKa75PY5Zq8yMifF9x8lHq8ljYkC0d2PD9yahooygQB5tcFyRDkbbIPx8hw==",
+      "peerDependencies": {
+        "vue": "^2.0.0"
+      }
+    },
     "node_modules/vuedraggable": {
       "version": "2.24.3",
       "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
@@ -39437,6 +39446,12 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue-toastification": {
+      "version": "1.7.14",
+      "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-1.7.14.tgz",
+      "integrity": "sha512-khZR8t3NWZ/JJ2MZxXLbesHrRJ8AKa75PY5Zq8yMifF9x8lHq8ljYkC0d2PD9yahooygQB5tcFyRDkbbIPx8hw==",
+      "requires": {}
     },
     "vuedraggable": {
       "version": "2.24.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,6 +70,7 @@
     "vue-i18n": "8.27.2",
     "vue-recaptcha-v3": "1.9.0",
     "vue-router": "3.6.5",
+    "vue-toastification": "1.7.14",
     "vuedraggable": "2.24.3",
     "vuetify": "2.6.11",
     "vuex": "3.6.2",

--- a/frontend/src/components/activity/ButtonNestedContentNodeAdd.vue
+++ b/frontend/src/components/activity/ButtonNestedContentNodeAdd.vue
@@ -43,6 +43,7 @@
 </template>
 <script>
 import { camelCase } from 'lodash'
+import { errorToMultiLineToast } from '@/components/toast/toasts'
 
 export default {
   name: 'ButtonNestedContentNodeAdd',
@@ -95,7 +96,7 @@ export default {
 
         await this.allContentNodes().$reload()
       } catch (error) {
-        console.log(error) // TO DO: display error message in error snackbar/toast
+        this.$toast.error(errorToMultiLineToast(error))
       }
       this.isAdding = false
     },

--- a/frontend/src/components/activity/content/Storyboard.vue
+++ b/frontend/src/components/activity/content/Storyboard.vue
@@ -131,6 +131,7 @@ import ApiSortable from '@/components/form/api/ApiSortable.vue'
 import DialogRemoveSection from './StoryboardDialogRemoveSection.vue'
 
 import { v4 as uuidv4 } from 'uuid'
+import { errorToMultiLineToast } from '@/components/toast/toasts'
 
 export default {
   name: 'Storyboard',
@@ -185,7 +186,7 @@ export default {
           },
         })
       } catch (error) {
-        console.log(error) // TO DO: display error message in error snackbar/toast
+        this.$toast.error(errorToMultiLineToast(error))
       }
 
       this.isAdding = false
@@ -199,7 +200,7 @@ export default {
           },
         })
       } catch (error) {
-        console.log(error) // TO DO: display error message in error snackbar/toast
+        this.$toast.error(errorToMultiLineToast(error))
       }
     },
   },

--- a/frontend/src/components/collaborator/CollaboratorListItem.vue
+++ b/frontend/src/components/collaborator/CollaboratorListItem.vue
@@ -79,6 +79,7 @@ import ApiSelect from '@/components/form/api/ApiSelect.vue'
 import UserAvatar from '@/components/user/UserAvatar.vue'
 import IconButton from '@/components/buttons/IconButton.vue'
 import CollaboratorListItemDeactivate from '@/components/collaborator/CollaboratorListItemDeactivate.vue'
+import { errorToMultiLineToast } from '@/components/toast/toasts'
 
 export default {
   name: 'CollaboratorListItem',
@@ -123,6 +124,7 @@ export default {
           action: 'resend_invitation',
         })
         .then((postUrl) => this.api.patch(postUrl, {}))
+        .catch((e) => this.$toast.error(errorToMultiLineToast(e)))
         .finally(() => {
           this.resendingEmail = false
         })

--- a/frontend/src/components/collaborator/CollaboratorListItemDeactivate.vue
+++ b/frontend/src/components/collaborator/CollaboratorListItemDeactivate.vue
@@ -34,6 +34,7 @@
 import DialogForm from '@/components/dialog/DialogForm.vue'
 import DialogBase from '@/components/dialog/DialogBase.vue'
 import campCollaborationDisplayName from '@/common/helpers/campCollaborationDisplayName.js'
+import { errorToMultiLineToast } from '@/components/toast/toasts'
 
 export default {
   name: 'CollaboratorListItemDeactivate',
@@ -58,7 +59,9 @@ export default {
   },
   methods: {
     deactivateUser() {
-      const ok = this.api.patch(this.entity, { status: 'inactive' })
+      const ok = this.api
+        .patch(this.entity, { status: 'inactive' })
+        .catch((e) => this.$toast.error(errorToMultiLineToast(e)))
 
       if (this.isOwnCampCollaboration) {
         // User left camp -> navigate to camp-overview

--- a/frontend/src/components/material/MaterialTable.vue
+++ b/frontend/src/components/material/MaterialTable.vue
@@ -197,6 +197,7 @@ import ScheduleEntryLinks from './ScheduleEntryLinks.vue'
 import ServerErrorContent from '@/components/form/ServerErrorContent.vue'
 import ButtonRetry from '@/components/buttons/ButtonRetry.vue'
 import ButtonCancel from '@/components/buttons/ButtonCancel.vue'
+import { errorToMultiLineToast } from '@/components/toast/toasts'
 
 export default {
   name: 'MaterialTable',
@@ -358,7 +359,9 @@ export default {
   methods: {
     // remove existing item
     deleteMaterialItem(materialItem) {
-      this.api.del(materialItem.uri)
+      this.api
+        .del(materialItem.uri)
+        .catch((e) => this.$toast.error(errorToMultiLineToast(e)))
     },
 
     // add new item to list & save to API

--- a/frontend/src/components/program/picasso/Picasso.vue
+++ b/frontend/src/components/program/picasso/Picasso.vue
@@ -104,15 +104,9 @@ Listing all given activity schedule entries in a calendar view.
       </template>
     </v-calendar>
 
-    <v-snackbar v-model="isSaving" light :color="patchError ? 'orange darken-2' : ''">
-      <template v-if="patchError">
-        <v-icon>mdi-alert</v-icon>
-        {{ patchError }}
-      </template>
-      <template v-else>
-        <v-icon class="mdi-spin">mdi-loading</v-icon>
-        {{ $tc('global.button.saving') }}
-      </template>
+    <v-snackbar v-model="isSaving" light>
+      <v-icon class="mdi-spin">mdi-loading</v-icon>
+      {{ $tc('global.button.saving') }}
     </v-snackbar>
   </div>
 </template>
@@ -126,7 +120,6 @@ import { isCssColor } from 'vuetify/lib/util/colorUtils'
 import { apiStore as api } from '@/plugins/store'
 import { scheduleEntryRoute } from '@/router.js'
 import mergeListeners from '@/helpers/mergeListeners.js'
-import { serverErrorToString } from '@/helpers/serverError.js'
 import {
   timestampToUtcString,
   utcStringToTimestamp,
@@ -134,6 +127,8 @@ import {
 
 import DialogActivityEdit from '../DialogActivityEdit.vue'
 import DayResponsibles from './DayResponsibles.vue'
+import { errorToMultiLineToast } from '@/components/toast/toasts'
+import Vue from 'vue'
 
 export default {
   name: 'Picasso',
@@ -198,7 +193,6 @@ export default {
     const { editable, scheduleEntries } = toRefs(props)
 
     const isSaving = ref(false)
-    const patchError = ref(null)
 
     // callback used to save entry to API
     const updateEntry = (scheduleEntry, startTimestamp, endTimestamp) => {
@@ -209,14 +203,11 @@ export default {
       isSaving.value = true
       api
         .patch(scheduleEntry._meta.self, patchData)
-        .then(() => {
-          patchError.value = null
-          isSaving.value = false
-        })
         .catch((error) => {
-          patchError.value = serverErrorToString(error)
+          Vue.$toast.error(errorToMultiLineToast(error))
         })
         .finally(() => {
+          isSaving.value = false
           reloadScheduleEntries()
         })
     }
@@ -313,7 +304,6 @@ export default {
       startResize: dragAndDropResize.startResize,
       onMouseleave,
       isSaving,
-      patchError,
       reloadScheduleEntries,
       loadCalenderEventsFromScheduleEntries,
       events,

--- a/frontend/src/components/toast/MultiLineToast.vue
+++ b/frontend/src/components/toast/MultiLineToast.vue
@@ -1,0 +1,35 @@
+<template>
+  <span v-if="lines.length === 0">
+    {{ generalErrorText }}
+  </span>
+  <span v-else>
+    <ul>
+      <li v-for="(line, index) in lines.slice(0, 3)" :key="index">
+        {{ line }}
+      </li>
+      <li v-if="lines.length > 3">...</li>
+    </ul>
+  </span>
+</template>
+
+<script>
+export default {
+  name: 'MultiLineToast',
+  props: {
+    lines: {
+      type: Array,
+      required: true,
+    },
+    generalErrorText: {
+      type: String,
+      required: true,
+    },
+  },
+}
+</script>
+
+<style scoped>
+li {
+  list-style: none;
+}
+</style>

--- a/frontend/src/components/toast/toasts.js
+++ b/frontend/src/components/toast/toasts.js
@@ -36,4 +36,8 @@ function violationsToFlatArray(e) {
   return result
 }
 
-export { multiLineToast, violationsToFlatArray }
+function errorToMultiLineToast(error) {
+  return multiLineToast(violationsToFlatArray(error))
+}
+
+export { errorToMultiLineToast, multiLineToast, violationsToFlatArray }

--- a/frontend/src/components/toast/toasts.js
+++ b/frontend/src/components/toast/toasts.js
@@ -1,0 +1,39 @@
+import MultiLineToast from '@/components/toast/MultiLineToast.vue'
+import i18n from '@/plugins/i18n'
+import { transformViolations } from '@/helpers/serverError'
+
+function multiLineToast(lines) {
+  return {
+    component: MultiLineToast,
+    props: {
+      lines,
+      generalErrorText: i18n.tc('components.toast.multiLineToast.generalError'),
+    },
+  }
+}
+
+function violationsToFlatArray(e) {
+  const violationsObject = transformViolations(e, i18n)
+  const violations = Object.entries(violationsObject)
+  if (violations.length === 0) {
+    return []
+  }
+  if (violations.length === 1 && violationsObject[0]) {
+    return [violationsObject[0]]
+  }
+  const toArray = (element) => {
+    if (Array.isArray(element)) {
+      return element
+    }
+    return [element]
+  }
+  const result = []
+  for (const [key, value] of Object.entries(violationsObject)) {
+    for (const message of toArray(value)) {
+      result.push(`${key}: ${message}`)
+    }
+  }
+  return result
+}
+
+export { multiLineToast, violationsToFlatArray }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -185,6 +185,11 @@
         }
       }
     },
+    "toast": {
+      "multiLineToast": {
+        "generalError": "Ein Fehler ist aufgetreten."
+      }
+    },
     "user": {
       "dialogChangeMail": {
         "error": "Leider ist ein Fehler aufgetreten.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -196,6 +196,11 @@
         "openPreview": "Open preview in new window"
       }
     },
+    "toast": {
+      "multiLineToast": {
+        "generalError": "An error has occurred."
+      }
+    },
     "user": {
       "dialogChangeMail": {
         "error": "An error has occurred.",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -78,6 +78,11 @@
         "myCamps": "Mon camp | Mes camps",
         "profile": "Profil"
       }
+    },
+    "toast": {
+      "multiLineToast": {
+        "generalError": "Une erreur est survenue."
+      }
     }
   },
   "entity": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -78,6 +78,11 @@
         "myCamps": "Il mio campo | I miei campi",
         "profile": "Profilo"
       }
+    },
+    "toast": {
+      "multiLineToast": {
+        "generalError": "Si è verificato un errore."
+      }
     }
   },
   "entity": {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -16,6 +16,8 @@ import { store } from './plugins/store'
 import { vuetify } from './plugins/vuetify'
 import VueCompositionAPI from '@vue/composition-api'
 import * as Sentry from '@sentry/vue'
+import Toast from 'vue-toastification'
+import 'vue-toastification/dist/index.css'
 
 import { Resize } from 'vuetify/lib/directives'
 
@@ -38,6 +40,9 @@ Vue.use(veeValidate)
 Vue.use(storeLoader)
 Vue.use(vuetifyLoader)
 Vue.use(dayjs)
+Vue.use(Toast, {
+  maxToasts: 2,
+})
 Vue.use(VueCompositionAPI)
 
 // manually importing necessary vuetify directives (there's no auomatic vuetify-loader for vitejs)

--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -109,7 +109,7 @@
 <script>
 import { load } from 'recaptcha-v3'
 import AuthContainer from '@/components/layout/AuthContainer.vue'
-import { multiLineToast, violationsToFlatArray } from '@/components/toast/toasts'
+import { errorToMultiLineToast } from '@/components/toast/toasts'
 import VueI18n from '@/plugins/i18n'
 
 export default {
@@ -204,7 +204,7 @@ export default {
         })
         .then(() => this.$router.push({ name: 'register-done' }))
         .catch((e) => {
-          this.$toast.error(multiLineToast(violationsToFlatArray(e)))
+          this.$toast.error(errorToMultiLineToast(e))
           this.registering = false
         })
     },

--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -109,6 +109,7 @@
 <script>
 import { load } from 'recaptcha-v3'
 import AuthContainer from '@/components/layout/AuthContainer.vue'
+import { multiLineToast, violationsToFlatArray } from '@/components/toast/toasts'
 import VueI18n from '@/plugins/i18n'
 
 export default {
@@ -202,7 +203,10 @@ export default {
           recaptchaToken: recaptchaToken,
         })
         .then(() => this.$router.push({ name: 'register-done' }))
-        .catch(() => (this.registering = false))
+        .catch((e) => {
+          this.$toast.error(multiLineToast(violationsToFlatArray(e)))
+          this.registering = false
+        })
     },
   },
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -25,6 +25,7 @@ export default defineConfig(({ mode }) => ({
       'core-js/modules/es.symbol.description.js',
       'core-js/modules/es.function.name.js',
       'core-js/modules/es.array.concat.js',
+      'core-js/modules/es.array.slice.js',
       'core-js/modules/es.array.splice.js',
       'core-js/modules/es.array.find.js',
       'core-js/modules/es.array.push.js',


### PR DESCRIPTION
 - [x] Show multiple alert messages at the same time
 - [ ] ~~Messages saved in store~~
 - [x] Dismissible messages
 - [x] Different message levels (but not used right now)

frontend: show error toast on error in Register.vue

Translate generalError in main.js,
because i could not use i18n in component which is rendered in the toast.

frontend: use toast to catch various errors

Now we have a simple way to notify a user if something went wrong.
It's better to do that in the component directly if possible.


closes: #3037 