### PR TITLE
.helm: do not create/drop database if adminUrl is empty

### DIFF
--- a/.helm/ecamp3/templates/hook_db_create.yaml
+++ b/.helm/ecamp3/templates/hook_db_create.yaml
@@ -1,7 +1,7 @@
 #
 # Automatically creates the database in an external PostgreSQL when installing the chart for the first time.
 #
-{{- if and (not .Values.postgresql.enabled) (not .Values.postgresql.adminUrl | empty) }}
+{{- if and (not .Values.postgresql.enabled) (not (.Values.postgresql.adminUrl | empty)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/.helm/ecamp3/templates/hook_db_create.yaml
+++ b/.helm/ecamp3/templates/hook_db_create.yaml
@@ -1,7 +1,7 @@
 #
 # Automatically creates the database in an external PostgreSQL when installing the chart for the first time.
 #
-{{- if not .Values.postgresql.enabled }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.postgresql.adminUrl | empty) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/.helm/ecamp3/templates/hook_db_drop.yaml
+++ b/.helm/ecamp3/templates/hook_db_drop.yaml
@@ -1,7 +1,7 @@
 #
 # Automatically drops the database in an external PostgreSQL when completely uninstalling the chart.
 #
-{{- if and (not .Values.postgresql.enabled) .Values.postgresql.dropDBOnUninstall }}
+{{- if and (not .Values.postgresql.enabled) .Values.postgresql.dropDBOnUninstall (not .Values.postgresql.adminUrl | empty) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/.helm/ecamp3/templates/hook_db_drop.yaml
+++ b/.helm/ecamp3/templates/hook_db_drop.yaml
@@ -1,7 +1,7 @@
 #
 # Automatically drops the database in an external PostgreSQL when completely uninstalling the chart.
 #
-{{- if and (not .Values.postgresql.enabled) .Values.postgresql.dropDBOnUninstall (not .Values.postgresql.adminUrl | empty) }}
+{{- if and (not .Values.postgresql.enabled) .Values.postgresql.dropDBOnUninstall (not (.Values.postgresql.adminUrl | empty)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
This allows for a productive environment,
where we don't want the cluster to have admin privileges on the db cluster