### PR TITLE
Disable graphql in deployments (for now)

### DIFF
--- a/api/config/packages/prod/api_platform.yaml
+++ b/api/config/packages/prod/api_platform.yaml
@@ -1,0 +1,3 @@
+api_platform:
+    graphql:
+        enabled: false


### PR DESCRIPTION
Until we have time to properly review and fix security issues / traversal attacks.