### PR TITLE
Add alpha deployment GitHub Action

### DIFF
--- a/.github/workflows/alpha-deployment.yml
+++ b/.github/workflows/alpha-deployment.yml
@@ -1,0 +1,182 @@
+name: Deploy alpha
+
+on:
+  repository_dispatch:
+    types: [ ci-passed ]
+  workflow_dispatch:       # Allow triggering manually
+    inputs:
+      confirmDeployWithoutCI:
+        description: 'I confirm that I want to deploy to ALPHA without running CI on the alpha branch first.'
+        required: true
+        type: boolean
+
+jobs:
+  select-env-to-deploy:
+    name: Prepare metadata for the branch to deploy
+    if: ${{ (inputs.confirmDeployWithoutCI == true) || (github.event.client_payload.ref == 'refs/heads/alpha') }}
+    runs-on: ubuntu-latest
+    outputs:
+      to-deploy: ${{ steps.to-deploy.outputs.list }}
+    steps:
+
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
+        with:
+          ref: alpha
+
+      - name: Construct metadata for the alpha branch deployment
+        id: deployment-candidates
+        # create a list of JSON objects like:
+        # [
+        #  {"name": "alpha", "env": "alpha", "sha": "..."}
+        # ]
+        run: |
+          ALPHA=$(printf '[{"name":"alpha","env":"alpha","sha":"%s"}]' $(git rev-parse alpha))
+          echo "Deployment candidates: $ALPHA"
+          echo ::set-output name=list::$ALPHA
+
+      - name: Read the list of all currently active deployments
+        id: current-deployments
+        run: |
+          # Setup authentication
+          mkdir ~/.kube && echo '${{ secrets.KUBECONFIG }}' > ~/.kube/config && chmod go-r ~/.kube/config
+          # Read list of deployments using helm, and remove the leading ecamp3- from each of the names.
+          # Creates a list of objects like [{"name": "alpha", "sha": "..."}]
+          LIST=$(helm list -o json | jq 'map(.name|=sub("^ecamp3-";""))' | jq 'map({name:.name,sha:.app_version})')
+          echo "Currently active deployments: $LIST"
+          echo ::set-output name=list::$LIST
+
+      - name: Check if the alpha deployment is up to date with the branch status
+        id: to-deploy
+        env:
+          deployments: ${{ steps.current-deployments.outputs.list }}
+          prs: ${{ steps.deployment-candidates.outputs.list }}
+        run: |
+          TO_INSTALL=$(jq --null-input --argjson prs '${{ env.prs }}' --argjson deployments '${{ env.deployments }}' \
+            '$prs|map(select([{name:.name,sha:.sha}]|inside($deployments)|not))')
+          echo "Will install the following candidates, because they either aren't deployed or their deployment is out of date: $TO_INSTALL"
+          echo ::set-output name=list::$TO_INSTALL
+
+  upgrade-or-install-deployment:
+    name: Upgrade or install deployment
+    runs-on: ubuntu-latest
+    needs:
+      - select-env-to-deploy
+    if: fromJSON(needs.select-env-to-deploy.outputs.to-deploy)[0] != null
+    strategy:
+      fail-fast: false
+      matrix:
+        deployment: ${{ fromJSON(needs.select-env-to-deploy.outputs.to-deploy) }}
+    environment:
+      name: ${{ matrix.deployment.env }}
+    steps:
+
+      - name: Create a pending GitHub deployment
+        uses: bobheadxi/deployments@v1.3.0
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          env: ${{ matrix.deployment.name }}
+
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
+        with:
+          ref: ${{ matrix.deployment.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Build and push frontend docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          file: .docker-hub/frontend/Dockerfile
+          tags: ${{ ((matrix.deployment.name == 'alpha') && 'ecamp/ecamp3-frontend:alpha,' || '') }}ecamp/ecamp3-frontend:${{ matrix.deployment.sha }}
+          context: .
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max
+
+      - name: Build and push api docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          file: api/Dockerfile
+          tags: ${{ ((matrix.deployment.name == 'alpha') && 'ecamp/ecamp3-api:alpha,' || '') }}ecamp/ecamp3-api:${{ matrix.deployment.sha }}
+          context: './api'
+          target: api_platform_php
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,scope=api,mode=max
+
+      - name: Build and push caddy docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          file: api/Dockerfile
+          tags: ${{ ((matrix.deployment.name == 'alpha') && 'ecamp/ecamp3-caddy:alpha,' || '') }}ecamp/ecamp3-caddy:${{ matrix.deployment.sha }}
+          context: './api'
+          target: api_platform_caddy_prod
+          cache-from: type=gha,scope=caddy
+          cache-to: type=gha,scope=caddy,mode=max
+
+      - name: Build and push print docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          file: .docker-hub/print/Dockerfile
+          tags: ${{ ((matrix.deployment.name == 'alpha') && 'ecamp/ecamp3-print:alpha,' || '') }}ecamp/ecamp3-print:${{ matrix.deployment.sha }}
+          context: .
+          cache-from: type=gha,scope=print
+          cache-to: type=gha,scope=print,mode=max
+
+      - name: Upgrade or install helm release
+        run: |
+          # Setup authentication
+          mkdir ~/.kube && echo '${{ secrets.KUBECONFIG }}' > ~/.kube/config && chmod go-r ~/.kube/config
+          # Switch to the helm chart directory
+          cd .helm/ecamp3
+          # Install dependency charts
+          helm dependency update
+          # Set the appVersion, workaround from https://github.com/helm/helm/issues/8194 so that we can
+          # later find out which deployments need to be upgraded
+          sed -i 's/^appVersion:.*$/appVersion: "${{ matrix.deployment.sha }}"/' Chart.yaml
+          # Install or upgrade the release
+          helm upgrade --install ecamp3-${{ matrix.deployment.name }} . \
+            --set imageTag=${{ matrix.deployment.sha }} \
+            --set sharedCookieDomain=.ecamp3.ch \
+            --set api.domain=api-${{ matrix.deployment.name }}.ecamp3.ch \
+            --set frontend.domain=${{ matrix.deployment.name }}.ecamp3.ch \
+            --set print.domain=print-${{ matrix.deployment.name }}.ecamp3.ch \
+            --set mail.domain=mail-${{ matrix.deployment.name }}.ecamp3.ch \
+            --set postgresql.enabled=false \
+            --set postgresql.url='${{ secrets.POSTGRES_URL }}/ecamp3${{ matrix.deployment.name }}?sslmode=require' \
+            --set postgresql.adminUrl='${{ secrets.POSTGRES_ADMIN_URL }}/ecamp3${{ matrix.deployment.name }}?sslmode=require' \
+            --set postgresql.dropDBOnUninstall=false \
+            --set php.dataMigrationsDir='${{ secrets.DATA_MIGRATIONS_DIR }}' \
+            --set php.appSecret='${{ secrets.API_APP_SECRET }}' \
+            --set php.sentryDsn='${{ secrets.API_SENTRY_DSN }}' \
+            --set php.jwt.passphrase='${{ secrets.JWT_PASSPHRASE }}' \
+            --set php.jwt.publicKey='${{ secrets.JWT_PUBLIC_KEY }}' \
+            --set php.jwt.privateKey='${{ secrets.JWT_PRIVATE_KEY }}' \
+            --set frontend.sentryDsn='${{ secrets.FRONTEND_SENTRY_DSN }}' \
+            --set print.sentryDsn='${{ secrets.PRINT_SENTRY_DSN }}' \
+            --set print.browserWsEndpoint='${{ secrets.BROWSER_WS_ENDPOINT }}' \
+            --set deploymentTime="$(date -u +%s)" \
+            --set deployedVersion="$(git rev-parse --short '${{ matrix.deployment.sha }}')" \
+            --set recaptcha.siteKey='${{ secrets.RECAPTCHA_SITE_KEY }}' \
+            --set recaptcha.secret='${{ secrets.RECAPTCHA_SECRET }}'
+
+      - name: Finish the GitHub deployment
+        uses: bobheadxi/deployments@v1.3.0
+        if: always()
+        with:
+          step: finish
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: https://${{ matrix.deployment.name }}.ecamp3.ch
+          env: ${{ steps.deployment.outputs.env }}

--- a/.github/workflows/alpha-deployment.yml
+++ b/.github/workflows/alpha-deployment.yml
@@ -11,12 +11,12 @@ on:
         type: boolean
 
 jobs:
-  select-env-to-deploy:
-    name: Prepare metadata for the branch to deploy
+  upgrade-or-install-deployment:
+    name: Upgrade or install deployment
     if: ${{ (inputs.confirmDeployWithoutCI == true) || (github.event.client_payload.ref == 'refs/heads/alpha') }}
     runs-on: ubuntu-latest
-    outputs:
-      to-deploy: ${{ steps.to-deploy.outputs.list }}
+    environment:
+      name: alpha
     steps:
 
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
@@ -24,51 +24,11 @@ jobs:
           ref: alpha
 
       - name: Construct metadata for the alpha branch deployment
-        id: deployment-candidates
-        # create a list of JSON objects like:
-        # [
-        #  {"name": "alpha", "env": "alpha", "sha": "..."}
-        # ]
+        id: git-ref
         run: |
-          ALPHA=$(printf '[{"name":"alpha","env":"alpha","sha":"%s"}]' $(git rev-parse alpha))
-          echo "Deployment candidates: $ALPHA"
-          echo ::set-output name=list::$ALPHA
-
-      - name: Read the list of all currently active deployments
-        id: current-deployments
-        run: |
-          # Setup authentication
-          mkdir ~/.kube && echo '${{ secrets.KUBECONFIG }}' > ~/.kube/config && chmod go-r ~/.kube/config
-          # Read list of deployments using helm, and remove the leading ecamp3- from each of the names.
-          # Creates a list of objects like [{"name": "alpha", "sha": "..."}]
-          LIST=$(helm list -o json | jq 'map(.name|=sub("^ecamp3-";""))' | jq 'map({name:.name,sha:.app_version})')
-          echo "Currently active deployments: $LIST"
-          echo ::set-output name=list::$LIST
-
-      - name: Check if the alpha deployment is up to date with the branch status
-        id: to-deploy
-        env:
-          deployments: ${{ steps.current-deployments.outputs.list }}
-          prs: ${{ steps.deployment-candidates.outputs.list }}
-        run: |
-          TO_INSTALL=$(jq --null-input --argjson prs '${{ env.prs }}' --argjson deployments '${{ env.deployments }}' \
-            '$prs|map(select([{name:.name,sha:.sha}]|inside($deployments)|not))')
-          echo "Will install the following candidates, because they either aren't deployed or their deployment is out of date: $TO_INSTALL"
-          echo ::set-output name=list::$TO_INSTALL
-
-  upgrade-or-install-deployment:
-    name: Upgrade or install deployment
-    runs-on: ubuntu-latest
-    needs:
-      - select-env-to-deploy
-    if: fromJSON(needs.select-env-to-deploy.outputs.to-deploy)[0] != null
-    strategy:
-      fail-fast: false
-      matrix:
-        deployment: ${{ fromJSON(needs.select-env-to-deploy.outputs.to-deploy) }}
-    environment:
-      name: ${{ matrix.deployment.env }}
-    steps:
+          ALPHA=$(git rev-parse alpha)
+          echo "Git SHA: $ALPHA"
+          echo ::set-output name=sha::$ALPHA
 
       - name: Create a pending GitHub deployment
         uses: bobheadxi/deployments@v1.3.0
@@ -76,11 +36,11 @@ jobs:
         with:
           step: start
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
-          env: ${{ matrix.deployment.name }}
+          env: alpha
 
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
         with:
-          ref: ${{ matrix.deployment.sha }}
+          ref: ${{ steps.git-ref.outputs.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -96,7 +56,7 @@ jobs:
         with:
           push: true
           file: .docker-hub/frontend/Dockerfile
-          tags: ${{ ((matrix.deployment.name == 'alpha') && 'ecamp/ecamp3-frontend:alpha,' || '') }}ecamp/ecamp3-frontend:${{ matrix.deployment.sha }}
+          tags: ecamp/ecamp3-frontend:alpha,ecamp/ecamp3-frontend:${{ steps.git-ref.outputs.sha }}
           context: .
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max
@@ -106,7 +66,7 @@ jobs:
         with:
           push: true
           file: api/Dockerfile
-          tags: ${{ ((matrix.deployment.name == 'alpha') && 'ecamp/ecamp3-api:alpha,' || '') }}ecamp/ecamp3-api:${{ matrix.deployment.sha }}
+          tags: ecamp/ecamp3-api:alpha,ecamp/ecamp3-api:${{ steps.git-ref.outputs.sha }}
           context: './api'
           target: api_platform_php
           cache-from: type=gha,scope=api
@@ -117,7 +77,7 @@ jobs:
         with:
           push: true
           file: api/Dockerfile
-          tags: ${{ ((matrix.deployment.name == 'alpha') && 'ecamp/ecamp3-caddy:alpha,' || '') }}ecamp/ecamp3-caddy:${{ matrix.deployment.sha }}
+          tags: ecamp/ecamp3-caddy:alpha,ecamp/ecamp3-caddy:${{ steps.git-ref.outputs.sha }}
           context: './api'
           target: api_platform_caddy_prod
           cache-from: type=gha,scope=caddy
@@ -128,7 +88,7 @@ jobs:
         with:
           push: true
           file: .docker-hub/print/Dockerfile
-          tags: ${{ ((matrix.deployment.name == 'alpha') && 'ecamp/ecamp3-print:alpha,' || '') }}ecamp/ecamp3-print:${{ matrix.deployment.sha }}
+          tags: ecamp/ecamp3-print:alpha,ecamp/ecamp3-print:${{ steps.git-ref.outputs.sha }}
           context: .
           cache-from: type=gha,scope=print
           cache-to: type=gha,scope=print,mode=max
@@ -143,18 +103,18 @@ jobs:
           helm dependency update
           # Set the appVersion, workaround from https://github.com/helm/helm/issues/8194 so that we can
           # later find out which deployments need to be upgraded
-          sed -i 's/^appVersion:.*$/appVersion: "${{ matrix.deployment.sha }}"/' Chart.yaml
+          sed -i 's/^appVersion:.*$/appVersion: "${{ steps.git-ref.outputs.sha }}"/' Chart.yaml
           # Install or upgrade the release
-          helm upgrade --install ecamp3-${{ matrix.deployment.name }} . \
-            --set imageTag=${{ matrix.deployment.sha }} \
+          helm upgrade --install ecamp3-alpha . \
+            --set imageTag=${{ steps.git-ref.outputs.sha }} \
             --set sharedCookieDomain=.ecamp3.ch \
-            --set api.domain=api-${{ matrix.deployment.name }}.ecamp3.ch \
-            --set frontend.domain=${{ matrix.deployment.name }}.ecamp3.ch \
-            --set print.domain=print-${{ matrix.deployment.name }}.ecamp3.ch \
-            --set mail.domain=mail-${{ matrix.deployment.name }}.ecamp3.ch \
+            --set api.domain=api-alpha.ecamp3.ch \
+            --set frontend.domain=app-alpha.ecamp3.ch \
+            --set print.domain=print-alpha.ecamp3.ch \
+            --set mail.domain=mail-alpha.ecamp3.ch \
             --set postgresql.enabled=false \
-            --set postgresql.url='${{ secrets.POSTGRES_URL }}/ecamp3${{ matrix.deployment.name }}?sslmode=require' \
-            --set postgresql.adminUrl='${{ secrets.POSTGRES_ADMIN_URL }}/ecamp3${{ matrix.deployment.name }}?sslmode=require' \
+            --set postgresql.url='${{ secrets.POSTGRES_URL }}/ecamp3alpha?sslmode=require' \
+            --set postgresql.adminUrl='${{ secrets.POSTGRES_ADMIN_URL }}/ecamp3alpha?sslmode=require' \
             --set postgresql.dropDBOnUninstall=false \
             --set php.dataMigrationsDir='${{ secrets.DATA_MIGRATIONS_DIR }}' \
             --set php.appSecret='${{ secrets.API_APP_SECRET }}' \
@@ -166,7 +126,7 @@ jobs:
             --set print.sentryDsn='${{ secrets.PRINT_SENTRY_DSN }}' \
             --set print.browserWsEndpoint='${{ secrets.BROWSER_WS_ENDPOINT }}' \
             --set deploymentTime="$(date -u +%s)" \
-            --set deployedVersion="$(git rev-parse --short '${{ matrix.deployment.sha }}')" \
+            --set deployedVersion="$(git rev-parse --short '${{ steps.git-ref.outputs.sha }}')" \
             --set recaptcha.siteKey='${{ secrets.RECAPTCHA_SITE_KEY }}' \
             --set recaptcha.secret='${{ secrets.RECAPTCHA_SECRET }}'
 
@@ -178,5 +138,5 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: https://${{ matrix.deployment.name }}.ecamp3.ch
+          env_url: https://app-alpha.ecamp3.ch
           env: ${{ steps.deployment.outputs.env }}

--- a/.github/workflows/alpha-deployment.yml
+++ b/.github/workflows/alpha-deployment.yml
@@ -111,10 +111,9 @@ jobs:
             --set api.domain=api-alpha.ecamp3.ch \
             --set frontend.domain=app-alpha.ecamp3.ch \
             --set print.domain=print-alpha.ecamp3.ch \
-            --set mail.domain=mail-alpha.ecamp3.ch \
+            --set mail.dsn=${{ secrets.MAILER_DSN }} \
             --set postgresql.enabled=false \
             --set postgresql.url='${{ secrets.POSTGRES_URL }}/ecamp3alpha?sslmode=require' \
-            --set postgresql.adminUrl='${{ secrets.POSTGRES_ADMIN_URL }}/ecamp3alpha?sslmode=require' \
             --set postgresql.dropDBOnUninstall=false \
             --set php.dataMigrationsDir='${{ secrets.DATA_MIGRATIONS_DIR }}' \
             --set php.appSecret='${{ secrets.API_APP_SECRET }}' \
@@ -124,7 +123,6 @@ jobs:
             --set php.jwt.privateKey='${{ secrets.JWT_PRIVATE_KEY }}' \
             --set frontend.sentryDsn='${{ secrets.FRONTEND_SENTRY_DSN }}' \
             --set print.sentryDsn='${{ secrets.PRINT_SENTRY_DSN }}' \
-            --set print.browserWsEndpoint='${{ secrets.BROWSER_WS_ENDPOINT }}' \
             --set deploymentTime="$(date -u +%s)" \
             --set deployedVersion="$(git rev-parse --short '${{ steps.git-ref.outputs.sha }}')" \
             --set recaptcha.siteKey='${{ secrets.RECAPTCHA_SITE_KEY }}' \

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -233,5 +233,5 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: https://${{ matrix.deployment.name }}.ecamp3.ch
+          env_url: https://app-${{ matrix.deployment.name }}.ecamp3.ch
           env: ${{ steps.deployment.outputs.env }}


### PR DESCRIPTION
- [x] Needs #3043 first!

Copied and reduced / adapted from continuous-deployment.yml

Can be run manually, or will run automatically after the CI on the alpha branch succeeds (when the custom `ci-passed` event from the alpha branch arrives).

Example run in my fork, which only failed because of some missing secrets:
https://github.com/carlobeltrame/ecamp3/actions/runs/3211262214/jobs/5249311690

This can probably be tested on this repository using the workflow_dispatch trigger (manually triggering the workflow on the Actions tab), and selecting the `alpha` branch.