### PR TITLE
contenttypes displayed in consistent order

### DIFF
--- a/api/src/Entity/Category.php
+++ b/api/src/Entity/Category.php
@@ -80,6 +80,7 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
     #[ORM\JoinTable(name: 'category_contenttype')]
     #[ORM\JoinColumn(name: 'category_id', referencedColumnName: 'id')]
     #[ORM\InverseJoinColumn(name: 'contenttype_id', referencedColumnName: 'id')]
+    #[ORM\OrderBy(['name' => 'ASC'])]
     public Collection $preferredContentTypes;
 
     /**

--- a/api/src/Entity/ContentType.php
+++ b/api/src/Entity/ContentType.php
@@ -20,6 +20,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
     collectionOperations: ['get'],
     itemOperations: ['get'],
     normalizationContext: ['groups' => ['read']],
+    order: ['name' => 'ASC']
 )]
 #[ApiFilter(SearchFilter::class, properties: ['categories'])]
 #[ORM\Entity]

--- a/frontend/src/components/activity/ButtonNestedContentNodeAdd.vue
+++ b/frontend/src/components/activity/ButtonNestedContentNodeAdd.vue
@@ -60,9 +60,15 @@ export default {
   },
   computed: {
     preferredContentTypesItems() {
-      return this.preferredContentTypes().items
+      if (this.contentTypesLoading) {
+        return []
+      }
+      return this.preferredContentTypes().items.sort(this.sortContentTypeByTranslatedName)
     },
     nonpreferredContentTypesItems() {
+      if (this.contentTypesLoading) {
+        return []
+      }
       return this.api
         .get()
         .contentTypes()
@@ -72,6 +78,10 @@ export default {
               .items.map((ct) => ct.id)
               .includes(ct.id)
         ) // remove contentTypes already included in preferredContentTypes
+        .sort(this.sortContentTypeByTranslatedName)
+    },
+    contentTypesLoading() {
+      return this.api.get().contentTypes()._meta.loading
     },
   },
   methods: {
@@ -80,6 +90,11 @@ export default {
     },
     contentTypeIconKey(contentType) {
       return 'contentNode.' + camelCase(contentType.name) + '.icon'
+    },
+    sortContentTypeByTranslatedName(ct1, ct2) {
+      const ct1name = this.$i18n.tc(this.contentTypeNameKey(ct1))
+      const ct2name = this.$i18n.tc(this.contentTypeNameKey(ct2))
+      return ct1name.localeCompare(ct2name)
     },
     async addContentNode(contentType) {
       this.isAdding = true

--- a/frontend/src/components/campAdmin/DialogCategoryForm.vue
+++ b/frontend/src/components/campAdmin/DialogCategoryForm.vue
@@ -61,6 +61,9 @@ export default {
       }))
     },
     contentTypes() {
+      if (this.contentTypesLoading) {
+        return []
+      }
       return this.api
         .get()
         .contentTypes()
@@ -68,6 +71,9 @@ export default {
           value: ct._meta.self,
           text: this.$tc('contentNode.' + camelCase(ct.name) + '.name'),
         }))
+        .sort(function (a, b) {
+          return a.text.localeCompare(b.text)
+        })
     },
     contentTypesLoading() {
       return this.api.get().contentTypes()._meta.loading


### PR DESCRIPTION
sorted by translated name