### PR TITLE
route camp/material use ContentLayout wide

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -379,8 +379,8 @@ function getContentLayout(route) {
     case 'camp/period/program':
       return 'full'
     case 'camp/admin':
-      return 'wide'
     case 'camp/print':
+    case 'camp/material':
       return 'wide'
     default:
       return 'normal'


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/470237/194750249-b36cd910-13fe-4f55-ab32-681cbe1c1aca.png)


After:
![image](https://user-images.githubusercontent.com/470237/194750268-ee880ffd-5ff2-4ee2-8b66-e737838b2357.png)
