### PR TITLE
all category-chips dark

### DIFF
--- a/frontend/src/components/program/DialogActivityForm.vue
+++ b/frontend/src/components/program/DialogActivityForm.vue
@@ -17,7 +17,7 @@
       <template #item="{ item, on, attrs }">
         <v-list-item :key="item._meta.self" v-bind="attrs" v-on="on">
           <v-list-item-avatar>
-            <v-chip :color="item.color">{{ item.short }}</v-chip>
+            <v-chip dark :color="item.color">{{ item.short }}</v-chip>
           </v-list-item-avatar>
           <v-list-item-content>
             {{ item.name }}
@@ -29,7 +29,7 @@
           <span class="black--text">
             {{ item.name }}
           </span>
-          <v-chip x-small :color="item.color">{{ item.short }}</v-chip>
+          <v-chip x-small dark :color="item.color">{{ item.short }}</v-chip>
         </div>
       </template>
     </e-select>

--- a/frontend/src/views/activity/Activity.vue
+++ b/frontend/src/views/activity/Activity.vue
@@ -17,7 +17,7 @@ Displays a single activity
             :disabled="layoutMode || !isContributor"
           >
             <template #activator="{ on, attrs }">
-              <v-chip :color="category.color" dark v-bind="attrs" v-on="on">
+              <v-chip dark :color="category.color" v-bind="attrs" v-on="on">
                 {{ category.short }}
               </v-chip>
             </template>
@@ -28,7 +28,7 @@ Displays a single activity
                 @click="changeCategory(cat)"
               >
                 <v-list-item-title>
-                  <v-chip :color="cat.color">
+                  <v-chip dark :color="cat.color">
                     {{ cat.short }}
                   </v-chip>
                   {{ cat.name }}


### PR DESCRIPTION
Quick-Fix, dass alle gleich aussehen.
Besser wäre - überall CategoryChip - Component verwenden.
#3069


Before:
![image](https://user-images.githubusercontent.com/470237/194755032-1670e1ff-d791-4807-b7de-2f5023452643.png)

After:
![image](https://user-images.githubusercontent.com/470237/194755225-b636c129-419a-41af-adcb-d8fbc8b37ae9.png)
