### PR TITLE
frontend: pin messageResolver to resolveValue in i18n.js of print-react

### DIFF
--- a/frontend/src/components/print/print-react/i18n.js
+++ b/frontend/src/components/print/print-react/i18n.js
@@ -2,6 +2,7 @@ import {
   compileToFunction,
   createCoreContext,
   registerMessageCompiler,
+  resolveValue,
   translate,
 } from '@intlify/core'
 
@@ -14,6 +15,7 @@ const createI18n = (translationData, language) => {
     messages: translationData,
     missingWarn: false,
     fallbackWarn: false,
+    messageResolver: resolveValue,
   })
 
   return {


### PR DESCRIPTION
Else the resolver used is not the same in dev and prod build.

If you print the pdf when running the frontend in npm run dev, it uses @intlify/core::resolveValue.
(https://github.com/intlify/vue-i18n-next/blob/bb2e1770a0344b7d6993e03759cf8ba96d7a6396/packages/core-base/src/resolver.ts#L322)
If you print the pdf when running the frontend in npm run preview, it uses @intlify/core::resolveWithKeyValue, which only supports flattened messages with the jsonpath as key.
(https://github.com/intlify/vue-i18n-next/blob/bb2e1770a0344b7d6993e03759cf8ba96d7a6396/packages/core-base/src/resolver.ts#L305)

Fortunately the resolveValue function is exported and we can set the messageResolver when creating the context.

resolveFunction should be registered as MessageResolver when core.esm-browser.js is included, but this does not happen somehow.
(https://github.com/intlify/vue-i18n-next/blob/bb2e1770a0344b7d6993e03759cf8ba96d7a6396/packages/core/src/index.ts) This happens in the worker thread and when rendering the pdf in the main thread.

closes #3068