### PR TITLE
prevent validationon empty autofocused e-text-field

### DIFF
--- a/frontend/src/components/form/base/ETextField.vue
+++ b/frontend/src/components/form/base/ETextField.vue
@@ -45,6 +45,11 @@ export default {
       default: 'text',
     },
   },
+  data() {
+    return {
+      preventValidationOnBlur: false,
+    }
+  },
   computed: {
     inputListeners: function () {
       const vm = this
@@ -56,15 +61,27 @@ export default {
         // override @input listener for correct handling of numeric values
         {
           input: function (value) {
+            vm.$data.preventValidationOnBlur = false
             if (vm.type === 'number') {
               vm.$emit('input', parseFloat(value))
             } else {
               vm.$emit('input', value)
             }
           },
+          blur: function () {
+            vm.$emit('blur')
+            if (vm.$data.preventValidationOnBlur && vm.$refs.textField.value == '') {
+              vm.$refs.validationProvider.reset()
+            }
+            vm.$data.preventValidationOnBlur = false
+          },
         }
       )
     },
+  },
+  mounted() {
+    this.preventValidationOnBlur =
+      'autofocus' in this.$attrs && 'required' in this.$refs.validationProvider.$attrs
   },
   methods: {
     focus() {

--- a/frontend/src/components/form/base/ETextField.vue
+++ b/frontend/src/components/form/base/ETextField.vue
@@ -70,7 +70,7 @@ export default {
           },
           blur: function () {
             vm.$emit('blur')
-            if (vm.$data.preventValidationOnBlur && vm.$refs.textField.value == '') {
+            if (vm.$data.preventValidationOnBlur) {
               vm.$refs.validationProvider.reset()
             }
             vm.$data.preventValidationOnBlur = false
@@ -81,7 +81,9 @@ export default {
   },
   mounted() {
     this.preventValidationOnBlur =
-      'autofocus' in this.$attrs && 'required' in this.$refs.validationProvider.$attrs
+      'autofocus' in this.$attrs &&
+      'required' in this.$refs.validationProvider.$attrs &&
+      this.$refs.textField.value == ''
   },
   methods: {
     focus() {


### PR DESCRIPTION
On the Login-Screen, Mail-Adress-Field is autofocesed.
If you tip on [Anmeldne mit Google] you might miss the Button, as Mail-Adress field is empty - and causes a validation-message

Solution:
An empty autofocused ETextFields never had an input, validation will be reset after first blur-event (only on the first one)
