### PR TITLE
fix: allow fast-forward workflow for MEMBER

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -10,7 +10,7 @@ jobs:
     if: |
       (github.event.issue.pull_request != '') &&
       github.event.comment.body == '/fast-forward' &&
-      contains(github.event.comment.author_association, 'OWNER')
+      (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
     runs-on: ubuntu-latest
     steps:
       # To use this repository's private action, you must check out the repository


### PR DESCRIPTION
In an organization-repo, the property `author_association` equals to `MEMBER`.

`OWNER` is only for own/user repos.