### PR TITLE
ContentTypeNode Info-Box 

### DIFF
--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -9,8 +9,7 @@
       "name": "Spaltenlayout"
     },
     "laThematicArea": {
-      "info0": "Eine J+S Lageraktivität muss mindestens eines der aufgeführten Themen behandeln.",
-      "info1": "Erfasse, welche Themen in diesem Block behandelt werden.",
+      "info": "Eine J+S Lageraktivität muss mindestens eines der aufgeführten Themen behandeln.{br}Erfasse, welche Themen in diesem Block behandelt werden.",
       "entity": {
         "option": {
           "campsiteAndSurroundings": {
@@ -42,25 +41,19 @@
       "name": "LA Themenbereich"
     },
     "material": {
-      "info0": "Hier kannst du den Material-Bedarf für diesen Block erfassen.",
-      "info1": "Die Materiallisten kannst du im Menu 'Admin' verwalten.",
-      "info2": "Eine Zusammenstellung für den Einkauf findest du im Menu 'Material'.",
+      "info": "Hier kannst du den Material-Bedarf für diesen Block erfassen.{br}Die Materiallisten kannst du im Menu 'Admin' verwalten.{br}Eine Zusammenstellung für den Einkauf findest du im Menu 'Material'.",
       "name": "Material"
     },
     "notes": {
-      "info0": "Hier kannst du beliebige Notizen erfassen.",
-      "info1": "z.B. Ideen, Todo's, offene Fragen, Kontakte, ÖV-Verbindungen, usw.",
+      "info": "Hier kannst du beliebige Notizen erfassen.{br}z.B. Ideen, Todo's, offene Fragen, Kontakte, ÖV-Verbindungen, usw.",
       "name": "Notizen"
     },
     "safetyConcept": {
-      "info0": "Einige Blöcke erfordern, dass ihr euch Gedanken zu den Risiken macht. Hier könnt ihr diese Gedanken erfassen.",
-      "info1": "Haltet fest, welche Risiken ihr erkannt habt - und wie ihr diesen begegnen könnt.",
+      "info": "Einige Blöcke erfordern, dass ihr euch Gedanken zu den Risiken macht. Hier könnt ihr diese Gedanken erfassen.{br}Haltet fest, welche Risiken ihr erkannt habt - und wie ihr diesen begegnen könnt.",
       "name": "Sicherheitskonzept"
     },
     "storyboard": {
-      "info0": "Hier kannst du den Inhalt von diesem Block planen.",
-      "info1": "In der linken Spalte [Zeit] kannst du die Dauer der einzelnen Elemente erfassen.",
-      "info2": "In der rechten Spalte [Verantwortlich] kannst du Personen zuteilen.",
+      "info": "Hier kannst du den Inhalt von diesem Block planen.{br}In der linken Spalte [Zeit] kannst du die Dauer der einzelnen Elemente erfassen.{br}In der rechten Spalte [Verantwortlich] kannst du Personen zuteilen.",
       "entity": {
         "section": {
           "fields": {
@@ -74,9 +67,7 @@
       "name": "Programmabschnitt"
     },
     "storycontext": {
-      "info0": "Beschreibe, wie sich dieser Block in die Geschichte vom Lager einbetet.",
-      "info1": "Eine Zusammenstellung aller Geschichts-Elemente findest du im Menu 'Geschichte'.",
-      "info2": "Ihr könnt auch erst im Menu 'Geschichte' zuerst eine durchgänige Geschichte erarbeiten - so dass man den Block-Inhalt perfekt in die Geschichte einbeten kann.",
+      "info": "Beschreibe, wie sich dieser Block in die Geschichte vom Lager einbettet.{br}Eine Zusammenstellung aller Geschichts-Elemente findest du im Menu 'Geschichte'.{br}Ihr könnt auch erst im Menu 'Geschichte' zuerst eine durchgängige Geschichte erarbeiten - so dass man den Block-Inhalt perfekt in die Geschichte einbetten kann.",
       "name": "Geschichte"
     }
   },

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -40,6 +40,9 @@
       "name": "LA Themenbereich"
     },
     "material": {
+      "info0": "Hier kannst du den Material-Bedarf für diesen Block erfassen.",
+      "info1": "Die Materiallisten kannst du im Menu 'Admin' verwalten.",
+      "info2": "Eine Zusammenstellung für den Einkauf findest du im Menu 'Material'.",
       "name": "Material"
     },
     "notes": {
@@ -49,6 +52,9 @@
       "name": "Sicherheitskonzept"
     },
     "storyboard": {
+      "info0": "Hier kannst du den Inhalt von diesem Block planen.",
+      "info1": "In der linken Spalte [Zeit] kannst du die Dauer der einzelnen Elemente erfassen.",
+      "info2": "In der rechten Spalte [Verantwortlich] kannst du Personen zuteilen.",
       "entity": {
         "section": {
           "fields": {

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -9,6 +9,8 @@
       "name": "Spaltenlayout"
     },
     "laThematicArea": {
+      "info0": "Eine J+S Lageraktivität muss mindestens eines der aufgeführten Themen behandeln.",
+      "info1": "Erfasse, welche Themen in diesem Block behandelt werden.",
       "entity": {
         "option": {
           "campsiteAndSurroundings": {
@@ -46,9 +48,13 @@
       "name": "Material"
     },
     "notes": {
+      "info0": "Hier kannst du beliebige Notizen erfassen.",
+      "info1": "z.B. Ideen, Todo's, offene Fragen, Kontakte, ÖV-Verbindungen, usw.",
       "name": "Notizen"
     },
     "safetyConcept": {
+      "info0": "Einige Blöcke erfordern, dass ihr euch Gedanken zu den Risiken macht. Hier könnt ihr diese Gedanken erfassen.",
+      "info1": "Haltet fest, welche Risiken ihr erkannt habt - und wie ihr diesen begegnen könnt.",
       "name": "Sicherheitskonzept"
     },
     "storyboard": {
@@ -68,6 +74,9 @@
       "name": "Programmabschnitt"
     },
     "storycontext": {
+      "info0": "Beschreibe, wie sich dieser Block in die Geschichte vom Lager einbetet.",
+      "info1": "Eine Zusammenstellung aller Geschichts-Elemente findest du im Menu 'Geschichte'.",
+      "info2": "Ihr könnt auch erst im Menu 'Geschichte' zuerst eine durchgänige Geschichte erarbeiten - so dass man den Block-Inhalt perfekt in die Geschichte einbeten kann.",
       "name": "Geschichte"
     }
   },

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -10,6 +10,8 @@
       "name": "Column layout"
     },
     "laThematicArea": {
+      "info0": "A Y+S camp activity must address at least one of the listed topics.",
+      "info1": "Select what topics are covered in this block.",
       "entity": {
         "option": {
           "campsiteAndSurroundings": {
@@ -43,17 +45,27 @@
     },
     "material": {
       "icon": "mdi-package-variant",
+      "info0": "Here you can enter the material requirements for this block.",
+      "info1": "You can manage the material lists in the menu 'Admin'.",
+      "info2": "You can find a summary for the purchase in the menu 'Material'.",
       "name": "Material"
     },
     "notes": {
       "icon": "mdi-pen",
+      "info0": "Here you can enter any notes.",
+      "info1": "e.g. ideas, todo's, open questions, contacts, public transport connections, etc.",
       "name": "Notes"
     },
     "safetyConcept": {
       "icon": "mdi-security",
+      "info0": "Some blocks require to think about the risks. Here you can record these thoughts.",
+      "info1": "Record what risks you have identified - and how you can address them.",
       "name": "Safety concept"
     },
     "storyboard": {
+      "info0": "Here you can plan the content of this block.",
+      "info1": "In the left column [Time] you can record the duration of the individual elements.",
+      "info2": "In the right column [Responsible] you can assign persons.",
       "entity": {
         "section": {
           "fields": {
@@ -69,6 +81,9 @@
     },
     "storycontext": {
       "icon": "mdi-book-open-variant",
+      "info0": "Describe how this block fits into the story of the camp.",
+      "info1": "You can find a summary of all history elements in the menu 'History'.",
+      "info2": "You can also first work out a continuous story in the 'Story' menu - so that you can perfectly embed the block content into the story.",
       "name": "Story"
     }
   },

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -10,8 +10,7 @@
       "name": "Column layout"
     },
     "laThematicArea": {
-      "info0": "A Y+S camp activity must address at least one of the listed topics.",
-      "info1": "Select what topics are covered in this block.",
+      "info": "A Y+S camp activity must address at least one of the listed topics.{br}Select what topics are covered in this block.",
       "entity": {
         "option": {
           "campsiteAndSurroundings": {
@@ -45,27 +44,21 @@
     },
     "material": {
       "icon": "mdi-package-variant",
-      "info0": "Here you can enter the material requirements for this block.",
-      "info1": "You can manage the material lists in the menu 'Admin'.",
-      "info2": "You can find a summary for the purchase in the menu 'Material'.",
+      "info": "Here you can enter the material requirements for this block.{br}You can manage the material lists in the menu 'Admin'.{br}You can find a summary for the purchase in the menu 'Material'.",
       "name": "Material"
     },
     "notes": {
       "icon": "mdi-pen",
-      "info0": "Here you can enter any notes.",
-      "info1": "e.g. ideas, todo's, open questions, contacts, public transport connections, etc.",
+      "info": "Here you can enter any notes.{br}e.g. ideas, todo's, open questions, contacts, public transport connections, etc.",
       "name": "Notes"
     },
     "safetyConcept": {
       "icon": "mdi-security",
-      "info0": "Some blocks require to think about the risks. Here you can record these thoughts.",
-      "info1": "Record what risks you have identified - and how you can address them.",
+      "info": "Some blocks require to think about the risks. Here you can record these thoughts.{br}Record what risks you have identified - and how you can address them.",
       "name": "Safety concept"
     },
     "storyboard": {
-      "info0": "Here you can plan the content of this block.",
-      "info1": "In the left column [Time] you can record the duration of the individual elements.",
-      "info2": "In the right column [Responsible] you can assign persons.",
+      "info": "Here you can plan the content of this block.{br}In the left column [Time] you can record the duration of the individual elements.{br}In the right column [Responsible] you can assign persons.",
       "entity": {
         "section": {
           "fields": {
@@ -81,9 +74,7 @@
     },
     "storycontext": {
       "icon": "mdi-book-open-variant",
-      "info0": "Describe how this block fits into the story of the camp.",
-      "info1": "You can find a summary of all history elements in the menu 'History'.",
-      "info2": "You can also first work out a continuous story in the 'Story' menu - so that you can perfectly embed the block content into the story.",
+      "info": "Describe how this block fits into the story of the camp.{br}You can find a summary of all story elements in the menu 'Story'.{br}You can also first work out a continuous story in the 'Story' menu - so that you can perfectly embed the block content into the story.",
       "name": "Story"
     }
   },

--- a/frontend/src/components/activity/CardContentNode.vue
+++ b/frontend/src/components/activity/CardContentNode.vue
@@ -15,30 +15,56 @@
           />
         </div>
 
-        <v-toolbar-title v-else>
+        <v-toolbar-title v-if="!editInstanceName">
           {{ instanceOrContentTypeName }}
         </v-toolbar-title>
+        <v-spacer v-if="!editInstanceName" />
 
-        <v-spacer />
-
-        <v-menu v-if="!layoutMode && !disabled" bottom left offset-y>
-          <template #activator="{ on, attrs }">
-            <v-btn icon v-bind="attrs" v-on="on">
-              <v-icon>mdi-dots-vertical</v-icon>
+        <v-tooltip
+          v-if="infoRows.length > 0 && !editInstanceName && !layoutMode"
+          v-model="showInfoTooltip"
+          max-width="300px"
+          color="#333"
+          bottom
+        >
+          <template #activator="{ attrs }">
+            <v-btn
+              icon
+              class="visible-on-hover"
+              v-bind="attrs"
+              @click="
+                if ($vuetify.breakpoint.xsOnly) {
+                  showInfoTooltip = !showInfoTooltip
+                }
+              "
+              @mouseenter="
+                if (!$vuetify.breakpoint.xsOnly) {
+                  showInfoTooltip = true
+                }
+              "
+              @mouseleave="
+                if (!$vuetify.breakpoint.xsOnly) {
+                  showInfoTooltip = false
+                }
+              "
+            >
+              <v-icon>mdi-information-outline</v-icon>
             </v-btn>
           </template>
-          <v-list>
-            <v-list-item @click="toggleEditInstanceName">
-              <v-list-item-icon>
-                <v-icon>mdi-pencil</v-icon>
-              </v-list-item-icon>
-              <v-list-item-title>
-                {{ $tc('components.activity.contentNode.editName') }}
-              </v-list-item-title>
-            </v-list-item>
-          </v-list>
-        </v-menu>
-        <dialog-entity-delete v-else-if="!disabled" :entity="contentNode">
+          <p v-for="(row, idx) in infoRows" :key="idx">
+            {{ row }}
+          </p>
+        </v-tooltip>
+        <v-btn
+          v-if="!editInstanceName && !layoutMode"
+          icon
+          class="visible-on-hover"
+          @click="toggleEditInstanceName"
+        >
+          <v-icon>mdi-pencil</v-icon>
+        </v-btn>
+
+        <dialog-entity-delete v-if="layoutMode && !disabled" :entity="contentNode">
           <template #activator="{ on }">
             <v-btn icon small color="error" class="float-right" v-on="on">
               <v-icon>mdi-trash-can-outline</v-icon>
@@ -72,6 +98,7 @@ export default {
   },
   data() {
     return {
+      showInfoTooltip: false,
       editInstanceName: false,
     }
   },
@@ -85,6 +112,19 @@ export default {
     icon() {
       return this.$tc(`contentNode.${camelCase(this.contentNode.contentTypeName)}.icon`)
     },
+    infoRows() {
+      let rows = []
+      for (let i = 0; i < 10; i++) {
+        const key = `contentNode.${camelCase(this.contentNode.contentTypeName)}.info${i}`
+        const row = this.$tc(key)
+        if (row != key) {
+          rows.push(row)
+        } else {
+          break
+        }
+      }
+      return rows
+    },
   },
   methods: {
     toggleEditInstanceName() {
@@ -97,4 +137,22 @@ export default {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+.v-card >>> button {
+  width: 36px !important;
+  height: 36px !important;
+}
+
+.v-card:not(:hover) >>> button.visible-on-hover {
+  opacity: 0;
+  width: 0px !important;
+
+  transition: opacity 0.2s linear, width 0.3s steps(1, end);
+}
+.v-card:hover >>> button.visible-on-hover {
+  opacity: 1;
+  width: 36px !important;
+
+  transition: opacity 0.2s linear, width 0.3s steps(1, start);
+}
+</style>

--- a/frontend/src/components/activity/CardContentNode.vue
+++ b/frontend/src/components/activity/CardContentNode.vue
@@ -18,39 +18,13 @@
         <v-toolbar-title v-if="!editInstanceName">
           {{ instanceOrContentTypeName }}
         </v-toolbar-title>
-        <v-spacer v-if="!editInstanceName" />
 
-        <v-tooltip
-          v-if="infoRows.length > 0 && !editInstanceName && !layoutMode"
-          v-model="showInfoTooltip"
-          max-width="300px"
-          color="#333"
-          bottom
-        >
-          <template #activator="{ attrs }">
-            <v-btn
-              icon
-              class="visible-on-hover"
-              v-bind="attrs"
-              @click="
-                if ($vuetify.breakpoint.xsOnly) {
-                  showInfoTooltip = !showInfoTooltip
-                }
-              "
-              @mouseenter="
-                if (!$vuetify.breakpoint.xsOnly) {
-                  showInfoTooltip = true
-                }
-              "
-              @mouseleave="showInfoTooltip = false"
-            >
-              <v-icon>mdi-information-outline</v-icon>
-            </v-btn>
-          </template>
-          <p v-for="(row, idx) in infoRows" :key="idx">
-            {{ row }}
-          </p>
-        </v-tooltip>
+        <v-spacer v-if="!editInstanceName" />
+        <icon-with-tooltip
+          v-if="!editInstanceName && !layoutMode"
+          :tc-key="`contentNode.${camelCase(contentNode.contentTypeName)}.info`"
+        />
+
         <v-btn
           v-if="!editInstanceName && !layoutMode"
           icon
@@ -94,7 +68,6 @@ export default {
   },
   data() {
     return {
-      showInfoTooltip: false,
       editInstanceName: false,
     }
   },
@@ -108,21 +81,9 @@ export default {
     icon() {
       return this.$tc(`contentNode.${camelCase(this.contentNode.contentTypeName)}.icon`)
     },
-    infoRows() {
-      let rows = []
-      for (let i = 0; i < 10; i++) {
-        const key = `contentNode.${camelCase(this.contentNode.contentTypeName)}.info${i}`
-        const row = this.$tc(key)
-        if (row != key) {
-          rows.push(row)
-        } else {
-          break
-        }
-      }
-      return rows
-    },
   },
   methods: {
+    camelCase,
     toggleEditInstanceName() {
       if (this.disabled) {
         return
@@ -139,13 +100,15 @@ export default {
   height: 36px !important;
 }
 
-.v-card:not(:hover) >>> button.visible-on-hover {
+.v-card:not(:hover) >>> button.visible-on-hover,
+.v-card:not(:hover) >>> button.tooltip-activator {
   opacity: 0;
   width: 0px !important;
 
   transition: opacity 0.2s linear, width 0.3s steps(1, end);
 }
-.v-card:hover >>> button.visible-on-hover {
+.v-card:hover >>> button.visible-on-hover,
+.v-card:hover >>> button.tooltip-activator {
   opacity: 1;
   width: 36px !important;
 

--- a/frontend/src/components/activity/CardContentNode.vue
+++ b/frontend/src/components/activity/CardContentNode.vue
@@ -42,11 +42,7 @@
                   showInfoTooltip = true
                 }
               "
-              @mouseleave="
-                if (!$vuetify.breakpoint.xsOnly) {
-                  showInfoTooltip = false
-                }
-              "
+              @mouseleave="showInfoTooltip = false"
             >
               <v-icon>mdi-information-outline</v-icon>
             </v-btn>

--- a/frontend/src/components/generic/IconWithTooltip.vue
+++ b/frontend/src/components/generic/IconWithTooltip.vue
@@ -1,0 +1,68 @@
+<template>
+  <v-tooltip v-if="showIcon" v-model="showTooltip" max-width="300px" color="#333" bottom>
+    <template #activator="dat">
+      <v-btn
+        icon
+        v-bind="dat.attrs"
+        class="tooltip-activator"
+        @click="click"
+        @mouseenter="mouseenter"
+        @mouseleave="mouseleave"
+      >
+        <v-icon>{{ icon }}</v-icon>
+      </v-btn>
+    </template>
+    <slot>
+      {{ text }}
+      <i18n v-if="tcKey" :path="tcKey">
+        <template #br><br class="linebreak" /></template>
+      </i18n>
+    </slot>
+  </v-tooltip>
+</template>
+
+<script>
+export default {
+  name: 'IconWithTooltip',
+  components: {},
+  inheritAttrs: false,
+  props: {
+    icon: { type: String, required: false, default: 'mdi-information-outline' },
+    text: { type: String, required: false, default: undefined },
+    tcKey: { type: String, required: false, default: undefined },
+  },
+  data() {
+    return {
+      showTooltip: false,
+    }
+  },
+  computed: {
+    showIcon() {
+      return this.text || 'default' in this.$slots || this.$tc(this.tcKey) != this.tcKey
+    },
+  },
+  methods: {
+    click() {
+      if (this.$vuetify.breakpoint.xsOnly) {
+        this.showTooltip = !this.showTooltip
+      }
+    },
+    mouseenter() {
+      if (!this.$vuetify.breakpoint.xsOnly) {
+        this.showTooltip = true
+      }
+    },
+    mouseleave() {
+      this.showTooltip = false
+    },
+  },
+}
+</script>
+
+<style scoped>
+br.linebreak {
+  display: block;
+  content: '';
+  margin-top: 8px;
+}
+</style>


### PR DESCRIPTION
Ich glaube es wäre hilfreich, wenn wir zu den einzelnen ContentTypen erklärende Zusatz-Info anzeigen könnten.
Hier ein möglicher draft.

Die Eckpunkte:
- Damit das Bild möglichst ruhig ist, wird das Info-i und der Edit-Pen nur angezeigt, wenn man mit der Maus auf dem ContentNode ist. Die anderen sind dadurch nun 'clean'.
- Hover auf das Info-i zeigt erklärenden Text (übersetzt natürlich)
- Auf Mobile muss man klicken (da hover kein Sinn macht)
- Info-i ist nur vorhanden, wenn eine erklärender Text erfasst wurde - sonst fehlt es.

Ideen:
- Materialliste
  - Listen werden unter 'Admin' verwaltet
  - Menu 'Material' zeigt Zusammenstellung für Einkauf
- Roter Faden
  - Blöcke mit einem Roten Faden erscheinen in der Zusammenstellung
  - Zusammenstellung soll einen guten überblick geben.
  - evtl. schreibt man sogar zuerst den Roten Faden als Überblick - und plant die Blöcke danach
- usw.

![image](https://user-images.githubusercontent.com/470237/196054817-5c89b5fb-8221-415c-80bd-ce1ed03da4be.png)

Ich bin gespannt auf eure Inputs.