### PR TITLE
fix(api): remove CleanHTML and add CleanText filter for non-HTML content

### DIFF
--- a/api/fixtures/activity1-slot1.yml
+++ b/api/fixtures/activity1-slot1.yml
@@ -26,7 +26,7 @@ App\Entity\ContentNode\SingleText:
     position: 2
     instanceName: 'singleText1'
     contentType: '@contentTypeNotes'
-    data: { text: <word()> }
+    data: { html: <word()> }
   safetyConcept1:
     root: '@columnLayout1'
     parent: '@columnLayout1'
@@ -34,4 +34,4 @@ App\Entity\ContentNode\SingleText:
     position: 3
     instanceName: 'safetyConcept1'
     contentType: '@contentTypeSafetyConcept'
-    data: { text: <sentence()> }
+    data: { html: <sentence()> }

--- a/api/fixtures/activity1-slot2-nested.yml
+++ b/api/fixtures/activity1-slot2-nested.yml
@@ -17,7 +17,7 @@ App\Entity\ContentNode\SingleText:
     position: 1
     instanceName: 'singleText2'
     contentType: '@contentTypeNotes'
-    data: { text: <word()> }
+    data: { html: <word()> }
 
 # nested column - slot2
 App\Entity\ContentNode\Storyboard:
@@ -35,7 +35,7 @@ App\Entity\ContentNode\Storyboard:
             'ea6f1e5d-0ef7-454f-8ae0-1d9b3bfd1177':
               {
                 column1: <word()>,
-                column2: <sentence()>,
+                column2Html: <sentence()>,
                 column3: <word()>,
                 position: 0,
               },

--- a/api/fixtures/activity1-slot2.yml
+++ b/api/fixtures/activity1-slot2.yml
@@ -14,14 +14,14 @@ App\Entity\ContentNode\Storyboard:
             'ab9740f6-61a4-4cae-b574-a73aeb7c5ea0':
               {
                 column1: <word()>,
-                column2: <sentence()>,
+                column2Html: <sentence()>,
                 column3: <word()>,
                 position: 0,
               },
             'cb26d76a-9e3b-43f0-a7c4-0f2ad0ea8029':
               {
                 column1: <word()>,
-                column2: <sentence()>,
+                column2Html: <sentence()>,
                 column3: <word()>,
                 position: 1,
               },

--- a/api/fixtures/singleTexts.yml
+++ b/api/fixtures/singleTexts.yml
@@ -6,4 +6,4 @@ App\Entity\ContentNode\SingleText:
     position: 1
     instanceName: <word()>
     contentType: '@contentTypeNotes'
-    data: { text: <word()> }
+    data: { html: <word()> }

--- a/api/fixtures/storyboards.yml
+++ b/api/fixtures/storyboards.yml
@@ -13,7 +13,7 @@ App\Entity\ContentNode\Storyboard:
             'cf13d4b5-3ccd-4d9a-ab40-ad6f7e287140':
               {
                 column1: <word()>,
-                column2: <sentence()>,
+                column2Html: <sentence()>,
                 column3: <word()>,
                 position: 0,
               },

--- a/api/migrations/schema/Version20221020194510.php
+++ b/api/migrations/schema/Version20221020194510.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221020194510 extends AbstractMigration {
+    public function getDescription(): string {
+        return 'Migrate SingleText text -> html and Storyboard column2 -> column2Html';
+    }
+
+    public function up(Schema $schema): void {
+        $this->addSql("UPDATE content_node cn SET data = (REPLACE(data::TEXT, '\"text\"', '\"html\"'))::JSONB WHERE cn.strategy='singletext'");
+        $this->addSql("UPDATE content_node cn SET data = (REPLACE(data::TEXT, '\"column2\"', '\"column2Html\"'))::JSONB WHERE cn.strategy='storyboard'");
+    }
+
+    public function down(Schema $schema): void {
+        $this->addSql("UPDATE content_node cn SET data = (REPLACE(data::TEXT, '\"html\"', '\"text\"'))::JSONB WHERE cn.strategy='singletext'");
+        $this->addSql("UPDATE content_node cn SET data = (REPLACE(data::TEXT, '\"column2Html\"', '\"column2\"'))::JSONB WHERE cn.strategy='storyboard'");
+    }
+}

--- a/api/src/DataPersister/ContentNode/SingleTextDataPersister.php
+++ b/api/src/DataPersister/ContentNode/SingleTextDataPersister.php
@@ -26,7 +26,7 @@ class SingleTextDataPersister extends ContentNodeAbstractDataPersister {
     public function beforeCreate($data): SingleText {
         $data = parent::beforeCreate($data);
 
-        $data->data = $this->cleanHTMLFilter->applyTo($data->data, 'text');
+        $data->data = $this->cleanHTMLFilter->applyTo($data->data, 'html');
 
         return $data;
     }
@@ -37,7 +37,7 @@ class SingleTextDataPersister extends ContentNodeAbstractDataPersister {
     public function beforeUpdate($data): SingleText {
         $data = parent::beforeUpdate($data);
 
-        $data->data = $this->cleanHTMLFilter->applyTo($data->data, 'text');
+        $data->data = $this->cleanHTMLFilter->applyTo($data->data, 'html');
 
         return $data;
     }

--- a/api/src/DataPersister/ContentNode/StoryboardDataPersister.php
+++ b/api/src/DataPersister/ContentNode/StoryboardDataPersister.php
@@ -33,7 +33,7 @@ class StoryboardDataPersister extends ContentNodeAbstractDataPersister {
             $data->data = ['sections' => [
                 Uuid::uuid4()->toString() => [
                     'column1' => '',
-                    'column2' => '',
+                    'column2Html' => '',
                     'column3' => '',
                     'position' => 0,
                 ],
@@ -55,7 +55,7 @@ class StoryboardDataPersister extends ContentNodeAbstractDataPersister {
     private function sanitizeData($data) {
         foreach ($data->data['sections'] as &$section) {
             $section = $this->cleanTextFilter->applyTo($section, 'column1');
-            $section = $this->cleanHTMLFilter->applyTo($section, 'column2');
+            $section = $this->cleanHTMLFilter->applyTo($section, 'column2Html');
             $section = $this->cleanTextFilter->applyTo($section, 'column3');
         }
 

--- a/api/src/DataPersister/ContentNode/StoryboardDataPersister.php
+++ b/api/src/DataPersister/ContentNode/StoryboardDataPersister.php
@@ -5,6 +5,7 @@ namespace App\DataPersister\ContentNode;
 use App\DataPersister\Util\DataPersisterObservable;
 use App\Entity\ContentNode\Storyboard;
 use App\InputFilter\CleanHTMLFilter;
+use App\InputFilter\CleanTextFilter;
 use Ramsey\Uuid\Uuid;
 
 class StoryboardDataPersister extends ContentNodeAbstractDataPersister {
@@ -13,7 +14,8 @@ class StoryboardDataPersister extends ContentNodeAbstractDataPersister {
      */
     public function __construct(
         DataPersisterObservable $dataPersisterObservable,
-        private CleanHTMLFilter $cleanHTMLFilter
+        private CleanHTMLFilter $cleanHTMLFilter,
+        private CleanTextFilter $cleanTextFilter
     ) {
         parent::__construct(
             Storyboard::class,
@@ -52,9 +54,9 @@ class StoryboardDataPersister extends ContentNodeAbstractDataPersister {
 
     private function sanitizeData($data) {
         foreach ($data->data['sections'] as &$section) {
-            $section = $this->cleanHTMLFilter->applyTo($section, 'column1');
+            $section = $this->cleanTextFilter->applyTo($section, 'column1');
             $section = $this->cleanHTMLFilter->applyTo($section, 'column2');
-            $section = $this->cleanHTMLFilter->applyTo($section, 'column3');
+            $section = $this->cleanTextFilter->applyTo($section, 'column3');
         }
 
         return $data;

--- a/api/src/Entity/Activity.php
+++ b/api/src/Entity/Activity.php
@@ -107,7 +107,7 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
      * The title of this activity that is shown in the picasso.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[Assert\NotBlank]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Sportolympiade')]
@@ -119,7 +119,7 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
      * The physical location where this activity's programme will be carried out.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: 'Spielwiese')]
     #[Groups(['read', 'write'])]

--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -135,7 +135,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      * A short name for the camp.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[Assert\NotBlank]
     #[ApiProperty(example: 'SoLa 2022')]
     #[Groups(['read', 'write'])]
@@ -146,7 +146,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      * The full title of the camp.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[Assert\NotBlank]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Abteilungs-Sommerlager 2022')]
@@ -158,7 +158,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      * The thematic topic (if any) of the camp's programme and storyline.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[Assert\Length(max: 128)]
     #[ApiProperty(example: 'Piraten')]
     #[Groups(['read', 'write'])]
@@ -169,7 +169,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      * A textual description of the location of the camp.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[Assert\Length(max: 128)]
     #[ApiProperty(example: 'Wiese hinter der alten Mühle')]
     #[Groups(['read', 'write'])]
@@ -180,7 +180,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      * The street name and number (if any) of the location of the camp.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[Assert\Length(max: 128)]
     #[ApiProperty(example: 'Schönriedweg 23')]
     #[Groups(['read', 'write'])]
@@ -191,7 +191,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      * The zipcode of the location of the camp.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[Assert\Length(max: 128)]
     #[ApiProperty(example: '1234')]
     #[Groups(['read', 'write'])]
@@ -202,7 +202,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      * The name of the town where the camp will take place.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[Assert\Length(max: 128)]
     #[ApiProperty(example: 'Hintertüpfingen')]
     #[Groups(['read', 'write'])]

--- a/api/src/Entity/Category.php
+++ b/api/src/Entity/Category.php
@@ -109,6 +109,7 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
      * schedule entry number, e.g. LS 3.a, where LS is the category's short name.
      */
     #[InputFilter\Trim]
+    #[InputFilter\CleanText]
     #[Assert\NotBlank]
     #[Assert\Length(max: 16)]
     #[ApiProperty(example: 'LS')]
@@ -120,6 +121,7 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
      * The full name of the category.
      */
     #[InputFilter\Trim]
+    #[InputFilter\CleanText]
     #[Assert\NotBlank]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Lagersport')]

--- a/api/src/Entity/ContentNode.php
+++ b/api/src/Entity/ContentNode.php
@@ -9,6 +9,7 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Core\Util\ClassInfoTrait;
 use App\Doctrine\Filter\ContentNodePeriodFilter;
 use App\Entity\ContentNode\ColumnLayout;
+use App\InputFilter;
 use App\Repository\ContentNodeRepository;
 use App\Util\EntityMap;
 use App\Util\JsonMergePatch;
@@ -98,6 +99,9 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
      * The name of the slot in the parent in which this content node resides. The valid slot names
      * are defined by the content type of the parent.
      */
+    #[InputFilter\Trim]
+    #[InputFilter\CleanText]
+    #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'footer')]
     #[Gedmo\SortableGroup]
     #[Groups(['read', 'write'])]
@@ -118,6 +122,9 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
      * An optional name for this content node. This is useful when planning e.g. an alternative
      * version of the programme suited for bad weather, in addition to the normal version.
      */
+    #[InputFilter\Trim]
+    #[InputFilter\CleanText]
+    #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Schlechtwetterprogramm')]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]

--- a/api/src/Entity/ContentNode/SingleText.php
+++ b/api/src/Entity/ContentNode/SingleText.php
@@ -40,9 +40,9 @@ class SingleText extends ContentNode {
     public const JSON_SCHEMA = [
         'type' => 'object',
         'additionalProperties' => false,
-        'required' => ['text'],
+        'required' => ['html'],
         'properties' => [
-            'text' => [
+            'html' => [
                 'type' => 'string',
             ],
         ],
@@ -52,10 +52,10 @@ class SingleText extends ContentNode {
      * Holds the actual data of the content node
      * (overridden from abstract class in order to add specific validation).
      */
-    #[ApiProperty(example: ['text' => 'my example text'])]
+    #[ApiProperty(example: ['html' => 'my example text'])]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'json', nullable: true, options: ['jsonb' => true])]
     #[AssertJsonSchema(schema: self::JSON_SCHEMA)]
     #[Assert\NotNull]
-    public ?array $data = ['text' => ''];
+    public ?array $data = ['html' => ''];
 }

--- a/api/src/Entity/ContentNode/Storyboard.php
+++ b/api/src/Entity/ContentNode/Storyboard.php
@@ -58,12 +58,12 @@ class Storyboard extends ContentNode {
             'section' => [
                 'type' => 'object',
                 'additionalProperties' => false,
-                'required' => ['column1', 'column2', 'column3', 'position'],
+                'required' => ['column1', 'column2Html', 'column3', 'position'],
                 'properties' => [
                     'column1' => [
                         'type' => 'string',
                     ],
-                    'column2' => [
+                    'column2Html' => [
                         'type' => 'string',
                     ],
                     'column3' => [
@@ -85,7 +85,7 @@ class Storyboard extends ContentNode {
     #[ApiProperty(example: ['sections' => [
         '186b7ff2-7470-4de4-8783-082c2c189fcd' => [
             'column1' => '',
-            'column2' => '',
+            'column2Html' => '',
             'column3' => '',
             'position' => 0, ], ]])]
     #[Groups(['read', 'write'])]

--- a/api/src/Entity/MaterialList.php
+++ b/api/src/Entity/MaterialList.php
@@ -85,6 +85,7 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface, CopyFro
     #[ApiProperty(example: 'Lebensmittel')]
     #[Groups(['write'])]
     #[InputFilter\Trim]
+    #[InputFilter\CleanText]
     #[Assert\NotBlank]
     #[Assert\Length(max: 32)]
     #[ORM\Column(type: 'text', nullable: true)]

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -99,7 +99,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
      *
      * TODO: Make non-nullable in the DB
      */
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[InputFilter\Trim]
     #[Assert\NotBlank]
     #[Assert\Length(max: 32)]

--- a/api/src/Entity/Profile.php
+++ b/api/src/Entity/Profile.php
@@ -106,7 +106,7 @@ class Profile extends BaseEntity {
      * The user's (optional) first name.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[ApiProperty(example: self::EXAMPLE_FIRSTNAME)]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]
@@ -116,7 +116,7 @@ class Profile extends BaseEntity {
      * The user's (optional) last name.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[ApiProperty(example: self::EXAMPLE_SURNAME)]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]
@@ -126,7 +126,7 @@ class Profile extends BaseEntity {
      * The user's (optional) nickname or scout name.
      */
     #[InputFilter\Trim]
-    #[InputFilter\CleanHTML]
+    #[InputFilter\CleanText]
     #[ApiProperty(example: self::EXAMPLE_NICKNAME)]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]

--- a/api/src/InputFilter/CleanText.php
+++ b/api/src/InputFilter/CleanText.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\InputFilter;
+
+/**
+ * Removes unsafe character from text.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+class CleanText extends FilterAttribute {
+    public function __construct(array $options = [], int $priority = 10) {
+        parent::__construct($options, $priority);
+    }
+}

--- a/api/src/InputFilter/CleanTextFilter.php
+++ b/api/src/InputFilter/CleanTextFilter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\InputFilter;
+
+class CleanTextFilter extends InputFilter {
+    /**
+     * {@inheritdoc}
+     */
+    public function applyTo(array $data, string $propertyName): array {
+        if (!array_key_exists($propertyName, $data)) {
+            return $data;
+        }
+
+        $value = $data[$propertyName];
+
+        if (null === $value) {
+            return $data;
+        }
+
+        if (!is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedValueException('Cannot convert value to string for trimming.');
+        }
+
+        $value = (string) $value;
+
+        // remove all unicode control caracters
+        $value = preg_replace('/[\p{C}]/u', '', $value);
+
+        // Alternative: preserve whitespace characters like \t or \n
+        // $value = preg_replace('/[^\PC\s]/u', '', $value);
+
+        $data[$propertyName] = $value;
+
+        return $data;
+    }
+}

--- a/api/tests/Api/Activities/CreateActivityTest.php
+++ b/api/tests/Api/Activities/CreateActivityTest.php
@@ -202,7 +202,7 @@ class CreateActivityTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testCreateActivityCleansHtmlFromTitle() {
+    public function testCreateActivityCleansForbiddenCharactersFromTitle() {
         static::createClientWithCredentials(['email' => static::$fixtures['user2member']->getEmail()])
             ->request(
                 'POST',
@@ -210,7 +210,7 @@ class CreateActivityTest extends ECampApiTestCase {
                 [
                     'json' => $this->getExampleWritePayload(
                         [
-                            'title' => 'Dschungel<script>alert(1)</script>buch',
+                            'title' => "this\n\t\u{202E} is 'a' <sample> text😀 \\",
                         ]
                     ),
                 ]
@@ -219,7 +219,7 @@ class CreateActivityTest extends ECampApiTestCase {
 
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains($this->getExampleReadPayload([
-            'title' => 'Dschungelbuch',
+            'title' => "this is 'a' <sample> text😀 \\",
         ]));
     }
 
@@ -299,7 +299,7 @@ class CreateActivityTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testCreateActivityCleansHtmlFromLocation() {
+    public function testCreateActivityCleansForbiddenCharactersFromLocation() {
         static::createClientWithCredentials(['email' => static::$fixtures['user2member']->getEmail()])
             ->request(
                 'POST',
@@ -307,7 +307,7 @@ class CreateActivityTest extends ECampApiTestCase {
                 [
                     'json' => $this->getExampleWritePayload(
                         [
-                            'location' => 'Dschungel<script>alert(1)</script>buch',
+                            'location' => "this\n\t\u{202E} is 'a' <sample> text😀 \\",
                         ]
                     ),
                 ]
@@ -316,7 +316,7 @@ class CreateActivityTest extends ECampApiTestCase {
 
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains($this->getExampleReadPayload([
-            'location' => 'Dschungelbuch',
+            'location' => "this is 'a' <sample> text😀 \\",
         ]));
     }
 

--- a/api/tests/Api/Activities/UpdateActivityTest.php
+++ b/api/tests/Api/Activities/UpdateActivityTest.php
@@ -190,17 +190,17 @@ class UpdateActivityTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchActivityCleansHtmlFromTitle() {
+    public function testPatchActivityCleansForbiddenCharactersFromTitle() {
         $activity = static::$fixtures['activity1'];
         static::createClientWithCredentials(['email' => static::$fixtures['user2member']->getEmail()])
             ->request('PATCH', '/activities/'.$activity->getId(), ['json' => [
-                'title' => 'Dschungel<script>alert(1)</script>buch',
+                'title' => "this\n\t\u{202E} is 'a' <sample> text😀 \\",
             ], 'headers' => ['Content-Type' => 'application/merge-patch+json']])
         ;
 
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'title' => 'Dschungelbuch',
+            'title' => "this is 'a' <sample> text😀 \\",
         ]);
     }
 
@@ -266,17 +266,17 @@ class UpdateActivityTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchActivityCleansHtmlFromLocation() {
+    public function testPatchActivityCleansForbiddenCharactersFromLocation() {
         $activity = static::$fixtures['activity1'];
         static::createClientWithCredentials(['email' => static::$fixtures['user2member']->getEmail()])
             ->request('PATCH', '/activities/'.$activity->getId(), ['json' => [
-                'location' => 'Dschungel<script>alert(1)</script>buch',
+                'location' => "this\n\t\u{202E} is 'a' <sample> text😀 \\",
             ], 'headers' => ['Content-Type' => 'application/merge-patch+json']])
         ;
 
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'location' => 'Dschungelbuch',
+            'location' => "this is 'a' <sample> text😀 \\",
         ]);
     }
 

--- a/api/tests/Api/Camps/CreateCampTest.php
+++ b/api/tests/Api/Camps/CreateCampTest.php
@@ -151,9 +151,9 @@ class CreateCampTest extends ECampApiTestCase {
         ]));
     }
 
-    public function testCreateCampCleansHTMLFromName() {
+    public function testCreateCampCleansForbiddenCharactersFromName() {
         static::createClientWithCredentials()->request('POST', '/camps', ['json' => $this->getExampleWritePayload([
-            'name' => 'So-<script>alert(1)</script>La',
+            'name' => "So-\n\tLa",
         ])]);
 
         $this->assertResponseStatusCodeSame(201);
@@ -219,9 +219,9 @@ class CreateCampTest extends ECampApiTestCase {
         ]));
     }
 
-    public function testCreateCampCleansHTMLFromTitle() {
+    public function testCreateCampCleansForbiddenCharactersFromTitle() {
         static::createClientWithCredentials()->request('POST', '/camps', ['json' => $this->getExampleWritePayload([
-            'title' => 'Sommer<script>alert(1)</script>lager',
+            'title' => "Sommer\n\tlager",
         ])]);
 
         $this->assertResponseStatusCodeSame(201);
@@ -287,14 +287,14 @@ class CreateCampTest extends ECampApiTestCase {
         ]));
     }
 
-    public function testCreateCampCleansHTMLFromMotto() {
+    public function testCreateCampCleansForbiddenCharactersFromMotto() {
         static::createClientWithCredentials()->request('POST', '/camps', ['json' => $this->getExampleWritePayload([
-            'motto' => 'Dschungel<script>alert(1)</script>buch',
+            'motto' => "this\n\t\u{202E} is 'a' <sample> text😀 \\",
         ])]);
 
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains($this->getExampleReadPayload([
-            'motto' => 'Dschungelbuch',
+            'motto' => "this is 'a' <sample> text😀 \\",
         ]));
     }
 
@@ -356,9 +356,9 @@ class CreateCampTest extends ECampApiTestCase {
         ]));
     }
 
-    public function testCreateCampCleansHTMLFromAddressName() {
+    public function testCreateCampCleansForbiddenCharactersFromAddressName() {
         static::createClientWithCredentials()->request('POST', '/camps', ['json' => $this->getExampleWritePayload([
-            'addressName' => 'Auf dem Hügel<script>alert(1)</script>',
+            'addressName' => "Auf dem Hügel\n\t",
         ])]);
 
         $this->assertResponseStatusCodeSame(201);
@@ -425,9 +425,9 @@ class CreateCampTest extends ECampApiTestCase {
         ]));
     }
 
-    public function testCreateCampCleansHTMLFromAddressStreet() {
+    public function testCreateCampCleansForbiddenCharactersFromAddressStreet() {
         static::createClientWithCredentials()->request('POST', '/camps', ['json' => $this->getExampleWritePayload([
-            'addressStreet' => 'Suppenstrasse <script>alert(1)</script>123a',
+            'addressStreet' => "Suppenstrasse \n\t123a",
         ])]);
 
         $this->assertResponseStatusCodeSame(201);
@@ -494,9 +494,9 @@ class CreateCampTest extends ECampApiTestCase {
         ]));
     }
 
-    public function testCreateCampCleansHTMLFromAddressZipcode() {
+    public function testCreateCampCleansForbiddenCharactersFromAddressZipcode() {
         static::createClientWithCredentials()->request('POST', '/camps', ['json' => $this->getExampleWritePayload([
-            'addressZipcode' => '800<script>alert(1)</script>0',
+            'addressZipcode' => "800\n\t0",
         ])]);
 
         $this->assertResponseStatusCodeSame(201);
@@ -563,9 +563,9 @@ class CreateCampTest extends ECampApiTestCase {
         ]));
     }
 
-    public function testCreateCampCleansHTMLFromAddressCity() {
+    public function testCreateCampCleansForbiddenCharactersFromAddressCity() {
         static::createClientWithCredentials()->request('POST', '/camps', ['json' => $this->getExampleWritePayload([
-            'addressCity' => 'Unter<script>alert(1)</script>berg',
+            'addressCity' => "Unter\n\tberg",
         ])]);
 
         $this->assertResponseStatusCodeSame(201);

--- a/api/tests/Api/Camps/UpdateCampTest.php
+++ b/api/tests/Api/Camps/UpdateCampTest.php
@@ -123,10 +123,10 @@ class UpdateCampTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchCampCleansHTMLFromName() {
+    public function testPatchCampCleansForbiddenCharactersFromName() {
         $camp = static::$fixtures['camp1'];
         static::createClientWithCredentials()->request('PATCH', '/camps/'.$camp->getId(), ['json' => [
-            'name' => 'So-<script>alert(1)</script>La',
+            'name' => "So-\n\tLa",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
 
         $this->assertResponseStatusCodeSame(200);
@@ -181,10 +181,10 @@ class UpdateCampTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchCampCleansHTMLFromTitle() {
+    public function testPatchCampCleansForbiddenCharactersFromTitle() {
         $camp = static::$fixtures['camp1'];
         static::createClientWithCredentials()->request('PATCH', '/camps/'.$camp->getId(), ['json' => [
-            'title' => 'Sommer<script>alert(1)</script>lager',
+            'title' => "Sommer\n\tlager",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
 
         $this->assertResponseStatusCodeSame(200);
@@ -239,15 +239,15 @@ class UpdateCampTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchCampCleansHTMLFromMotto() {
+    public function testPatchCampCleansForbiddenCharactersFromMotto() {
         $camp = static::$fixtures['camp1'];
         static::createClientWithCredentials()->request('PATCH', '/camps/'.$camp->getId(), ['json' => [
-            'motto' => 'Dschungel<script>alert(1)</script>buch',
+            'motto' => "this\n\t\u{202E} is 'a' <sample> text😀 \\",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
 
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'motto' => 'Dschungelbuch',
+            'motto' => "this is 'a' <sample> text😀 \\",
         ]);
     }
 
@@ -304,10 +304,10 @@ class UpdateCampTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchCampCleansHTMLFromAddressName() {
+    public function testPatchCampCleansForbiddenCharactersFromAddressName() {
         $camp = static::$fixtures['camp1'];
         static::createClientWithCredentials()->request('PATCH', '/camps/'.$camp->getId(), ['json' => [
-            'addressName' => 'Auf dem Hügel<script>alert(1)</script>',
+            'addressName' => "Auf dem Hügel\n\t",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
 
         $this->assertResponseStatusCodeSame(200);
@@ -369,10 +369,10 @@ class UpdateCampTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchCampCleansHTMLFromAddressStreet() {
+    public function testPatchCampCleansForbiddenCharactersFromAddressStreet() {
         $camp = static::$fixtures['camp1'];
         static::createClientWithCredentials()->request('PATCH', '/camps/'.$camp->getId(), ['json' => [
-            'addressStreet' => 'Suppenstrasse <script>alert(1)</script>123a',
+            'addressStreet' => "Suppenstrasse \n\t123a",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
 
         $this->assertResponseStatusCodeSame(200);
@@ -434,10 +434,10 @@ class UpdateCampTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchCampCleansHTMLFromAddressZipcode() {
+    public function testPatchCampCleansForbiddenCharactersFromAddressZipcode() {
         $camp = static::$fixtures['camp1'];
         static::createClientWithCredentials()->request('PATCH', '/camps/'.$camp->getId(), ['json' => [
-            'addressZipcode' => '800<script>alert(1)</script>0',
+            'addressZipcode' => "800\n\t0",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
 
         $this->assertResponseStatusCodeSame(200);
@@ -499,10 +499,10 @@ class UpdateCampTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchCampCleansHTMLFromAddressCity() {
+    public function testPatchCampCleansForbiddenCharactersFromAddressCity() {
         $camp = static::$fixtures['camp1'];
         static::createClientWithCredentials()->request('PATCH', '/camps/'.$camp->getId(), ['json' => [
-            'addressCity' => 'Unter<script>alert(1)</script>berg',
+            'addressCity' => "Unter\n\tberg",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
 
         $this->assertResponseStatusCodeSame(200);

--- a/api/tests/Api/Categories/CreateCategoryTest.php
+++ b/api/tests/Api/Categories/CreateCategoryTest.php
@@ -206,14 +206,14 @@ class CreateCategoryTest extends ECampApiTestCase {
         ));
     }
 
-    public function testCreateCategoryDoesNotCleanHtmlForShort() {
+    public function testCreateCategoryCleansForbiddenCharactersFromShort() {
         static::createClientWithCredentials()->request(
             'POST',
             '/categories',
             [
                 'json' => $this->getExampleWritePayload(
                     [
-                        'short' => 'L<b>S</b><a>',
+                        'short' => "L<b>S</b>\n\t<a>",
                     ]
                 ),
             ]
@@ -310,14 +310,14 @@ class CreateCategoryTest extends ECampApiTestCase {
         ));
     }
 
-    public function testCreateCategoryDoesNotCleanHtmlForName() {
+    public function testCreateCategoryCleansForbiddenCharactersFromName() {
         static::createClientWithCredentials()->request(
             'POST',
             '/categories',
             [
                 'json' => $this->getExampleWritePayload(
                     [
-                        'name' => '<script>Lager</script><b>sport',
+                        'name' => "\n\t<b>sport",
                     ]
                 ),
             ]
@@ -326,7 +326,7 @@ class CreateCategoryTest extends ECampApiTestCase {
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains($this->getExampleReadPayload(
             [
-                'name' => '<script>Lager</script><b>sport',
+                'name' => '<b>sport',
             ]
         ));
     }

--- a/api/tests/Api/Categories/UpdateCategoryTest.php
+++ b/api/tests/Api/Categories/UpdateCategoryTest.php
@@ -289,14 +289,14 @@ class UpdateCategoryTest extends ECampApiTestCase {
         );
     }
 
-    public function testPatchCategoryDoesNotCleanHtmlForShort() {
+    public function testPatchCategoryCleansForbiddenCharactersFromShort() {
         $category = static::$fixtures['category1'];
         static::createClientWithCredentials()->request(
             'PATCH',
             '/categories/'.$category->getId(),
             [
                 'json' => [
-                    'short' => 'L<b>S</b><a>',
+                    'short' => "L<b>S</b>\n\t<a>",
                 ],
                 'headers' => ['Content-Type' => 'application/merge-patch+json'], ]
         );
@@ -395,7 +395,7 @@ class UpdateCategoryTest extends ECampApiTestCase {
         );
     }
 
-    public function testPatchCategoryDoesNotCleanHtmlForName() {
+    public function testPatchCategoryCleansForbiddenCharactersFromName() {
         $category = static::$fixtures['category1'];
         $client = static::createClientWithCredentials();
         $client->disableReboot();
@@ -404,7 +404,7 @@ class UpdateCategoryTest extends ECampApiTestCase {
             '/categories/'.$category->getId(),
             [
                 'json' => [
-                    'name' => '<b>Lager</b>sport<a>',
+                    'name' => "<b>Lager</b>sport\n\t<a>",
                 ],
                 'headers' => ['Content-Type' => 'application/merge-patch+json'], ]
         );

--- a/api/tests/Api/ContentNodes/SingleText/CreateSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/CreateSingleTextTest.php
@@ -22,11 +22,11 @@ class CreateSingleTextTest extends CreateContentNodeTestCase {
         $text = 'TestText';
 
         // when
-        $this->create($this->getExampleWritePayload(['data' => ['text' => $text]]));
+        $this->create($this->getExampleWritePayload(['data' => ['html' => $text]]));
 
         // then
         $this->assertResponseStatusCodeSame(201);
-        $this->assertJsonContains(['data' => ['text' => $text]]);
+        $this->assertJsonContains(['data' => ['html' => $text]]);
     }
 
     public function testCreateSingleTextAcceptsEmptyJson() {
@@ -35,7 +35,7 @@ class CreateSingleTextTest extends CreateContentNodeTestCase {
 
         // then
         $this->assertResponseStatusCodeSame(201);
-        $this->assertJsonContains(['data' => ['text' => '']]);
+        $this->assertJsonContains(['data' => ['html' => '']]);
     }
 
     public function testCreateSingleTextAcceptsNonExistingJson() {
@@ -43,7 +43,7 @@ class CreateSingleTextTest extends CreateContentNodeTestCase {
 
         $this->assertResponseStatusCodeSame(201);
 
-        $this->assertJsonContains(['data' => ['text' => '']]);
+        $this->assertJsonContains(['data' => ['html' => '']]);
     }
 
     public function testCreateSingleTextCleansHTMLFromText() {
@@ -51,12 +51,12 @@ class CreateSingleTextTest extends CreateContentNodeTestCase {
         $text = ' testText<script>alert(1)</script>';
 
         // when
-        $this->create($this->getExampleWritePayload(['data' => ['text' => $text]]));
+        $this->create($this->getExampleWritePayload(['data' => ['html' => $text]]));
 
         // then
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains(['data' => [
-            'text' => ' testText',
+            'html' => ' testText',
         ]]);
     }
 }

--- a/api/tests/Api/ContentNodes/SingleText/UpdateSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/UpdateSingleTextTest.php
@@ -17,23 +17,23 @@ class UpdateSingleTextTest extends UpdateContentNodeTestCase {
 
     public function testPatchText() {
         // when
-        $this->patch($this->defaultEntity, ['data' => ['text' => 'testText']]);
+        $this->patch($this->defaultEntity, ['data' => ['html' => 'testText']]);
 
         // then
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains(['data' => [
-            'text' => 'testText',
+            'html' => 'testText',
         ]]);
     }
 
     public function testPatchCleansHTMLFromText() {
         // when
-        $this->patch($this->defaultEntity, ['data' => ['text' => ' testText<script>alert(1)</script>']]);
+        $this->patch($this->defaultEntity, ['data' => ['html' => ' testText<script>alert(1)</script>']]);
 
         // then
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains(['data' => [
-            'text' => ' testText',
+            'html' => ' testText',
         ]]);
     }
 }

--- a/api/tests/Api/ContentNodes/Storyboard/CreateStoryboardTest.php
+++ b/api/tests/Api/ContentNodes/Storyboard/CreateStoryboardTest.php
@@ -21,9 +21,9 @@ class CreateStoryboardTest extends CreateContentNodeTestCase {
         $response = $this->create($this->getExampleWritePayload(['data' => [
             'sections' => [
                 'f5ee1e2a-af0a-4fa5-8f3f-b869ed184c5c' => [
-                    'column1' => 'A',
-                    'column2' => 'B',
-                    'column3' => ' testText<script>alert(1)</script>',
+                    'column1' => " testText\n\t",
+                    'column2' => ' <b>testText</b><script>alert(1)</script>',
+                    'column3' => " testText\n\t",
                     'position' => 99,
                 ],
             ],
@@ -34,8 +34,8 @@ class CreateStoryboardTest extends CreateContentNodeTestCase {
         $this->assertJsonContains(['data' => [
             'sections' => [
                 'f5ee1e2a-af0a-4fa5-8f3f-b869ed184c5c' => [
-                    'column1' => 'A',
-                    'column2' => 'B',
+                    'column1' => ' testText',
+                    'column2' => ' <b>testText</b>',
                     'column3' => ' testText',
                     'position' => 99,
                 ],

--- a/api/tests/Api/ContentNodes/Storyboard/CreateStoryboardTest.php
+++ b/api/tests/Api/ContentNodes/Storyboard/CreateStoryboardTest.php
@@ -22,7 +22,7 @@ class CreateStoryboardTest extends CreateContentNodeTestCase {
             'sections' => [
                 'f5ee1e2a-af0a-4fa5-8f3f-b869ed184c5c' => [
                     'column1' => " testText\n\t",
-                    'column2' => ' <b>testText</b><script>alert(1)</script>',
+                    'column2Html' => ' <b>testText</b><script>alert(1)</script>',
                     'column3' => " testText\n\t",
                     'position' => 99,
                 ],
@@ -35,7 +35,7 @@ class CreateStoryboardTest extends CreateContentNodeTestCase {
             'sections' => [
                 'f5ee1e2a-af0a-4fa5-8f3f-b869ed184c5c' => [
                     'column1' => ' testText',
-                    'column2' => ' <b>testText</b>',
+                    'column2Html' => ' <b>testText</b>',
                     'column3' => ' testText',
                     'position' => 99,
                 ],

--- a/api/tests/Api/ContentNodes/Storyboard/UpdateStoryboardTest.php
+++ b/api/tests/Api/ContentNodes/Storyboard/UpdateStoryboardTest.php
@@ -19,9 +19,9 @@ class UpdateStoryboardTest extends UpdateContentNodeTestCase {
         $response = $this->patch($this->defaultEntity, ['data' => [
             'sections' => [
                 'f5ee1e2a-af0a-4fa5-8f3f-b869ed184c5c' => [
-                    'column1' => 'A',
-                    'column2' => 'B',
-                    'column3' => 'C',
+                    'column1' => " testText\n\t",
+                    'column2' => ' <b>testText</b><script>alert(1)</script>',
+                    'column3' => " testText\n\t",
                     'position' => 99,
                 ],
             ],
@@ -35,9 +35,9 @@ class UpdateStoryboardTest extends UpdateContentNodeTestCase {
         $this->assertArrayHasKey('f5ee1e2a-af0a-4fa5-8f3f-b869ed184c5c', $responseArray['data']['sections']);
 
         $this->assertEquals([
-            'column1' => 'A',
-            'column2' => 'B',
-            'column3' => 'C',
+            'column1' => ' testText',
+            'column2' => ' <b>testText</b>',
+            'column3' => ' testText',
             'position' => 99,
         ], $responseArray['data']['sections']['f5ee1e2a-af0a-4fa5-8f3f-b869ed184c5c']);
     }
@@ -46,7 +46,7 @@ class UpdateStoryboardTest extends UpdateContentNodeTestCase {
         $response = $this->patch($this->defaultEntity, ['data' => [
             'sections' => [
                 'ab9740f6-61a4-4cae-b574-a73aeb7c5ea0' => [
-                    'column1' => ' testText<script>alert(1)</script>',
+                    'column1' => " testText\n\t",
                     'position' => 50,
                 ],
             ],

--- a/api/tests/Api/ContentNodes/Storyboard/UpdateStoryboardTest.php
+++ b/api/tests/Api/ContentNodes/Storyboard/UpdateStoryboardTest.php
@@ -20,7 +20,7 @@ class UpdateStoryboardTest extends UpdateContentNodeTestCase {
             'sections' => [
                 'f5ee1e2a-af0a-4fa5-8f3f-b869ed184c5c' => [
                     'column1' => " testText\n\t",
-                    'column2' => ' <b>testText</b><script>alert(1)</script>',
+                    'column2Html' => ' <b>testText</b><script>alert(1)</script>',
                     'column3' => " testText\n\t",
                     'position' => 99,
                 ],
@@ -36,7 +36,7 @@ class UpdateStoryboardTest extends UpdateContentNodeTestCase {
 
         $this->assertEquals([
             'column1' => ' testText',
-            'column2' => ' <b>testText</b>',
+            'column2Html' => ' <b>testText</b>',
             'column3' => ' testText',
             'position' => 99,
         ], $responseArray['data']['sections']['f5ee1e2a-af0a-4fa5-8f3f-b869ed184c5c']);
@@ -60,7 +60,7 @@ class UpdateStoryboardTest extends UpdateContentNodeTestCase {
 
         $this->assertEquals([
             'column1' => ' testText',
-            'column2' => $this->defaultEntity->data['sections']['ab9740f6-61a4-4cae-b574-a73aeb7c5ea0']['column2'],
+            'column2Html' => $this->defaultEntity->data['sections']['ab9740f6-61a4-4cae-b574-a73aeb7c5ea0']['column2Html'],
             'column3' => $this->defaultEntity->data['sections']['ab9740f6-61a4-4cae-b574-a73aeb7c5ea0']['column3'],
             'position' => 50,
         ], $responseArray['data']['sections']['ab9740f6-61a4-4cae-b574-a73aeb7c5ea0']);

--- a/api/tests/Api/MaterialLists/CreateMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/CreateMaterialListTest.php
@@ -172,14 +172,14 @@ class CreateMaterialListTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testCreateMaterialListDoesNotCleanHtmlOfName() {
+    public function testCreateMaterialListCleansForbiddenCharactersFromName() {
         static::createClientWithCredentials()
             ->request(
                 'POST',
                 '/material_lists',
                 [
                     'json' => $this->getExampleWritePayload([
-                        'name' => ' <script>alert(1)</script><b>t</b ',
+                        'name' => " \n\t<b>t</b ",
                     ]),
                 ]
             )
@@ -187,7 +187,7 @@ class CreateMaterialListTest extends ECampApiTestCase {
 
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains([
-            'name' => '<script>alert(1)</script><b>t</b',
+            'name' => '<b>t</b',
         ]);
     }
 

--- a/api/tests/Api/MaterialLists/UpdateMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/UpdateMaterialListTest.php
@@ -193,16 +193,16 @@ class UpdateMaterialListTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchMaterialListDoesNotCleanHtmlOfName() {
+    public function testPatchMaterialListCleansForbiddenCharactersFromName() {
         $materialList = static::$fixtures['materialList1'];
         static::createClientWithCredentials(['email' => static::$fixtures['user2member']->getEmail()])
             ->request('PATCH', '/material_lists/'.$materialList->getId(), ['json' => [
-                'name' => ' <script>alert(1)</script><b>t</b ',
+                'name' => " \n\t<b>t</b ",
             ], 'headers' => ['Content-Type' => 'application/merge-patch+json']])
         ;
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'name' => '<script>alert(1)</script><b>t</b',
+            'name' => '<b>t</b',
         ]);
     }
 }

--- a/api/tests/Api/Periods/CreatePeriodTest.php
+++ b/api/tests/Api/Periods/CreatePeriodTest.php
@@ -173,14 +173,14 @@ class CreatePeriodTest extends ECampApiTestCase {
         ));
     }
 
-    public function testCreatePeriodCleansHtmlForDescription() {
+    public function testCreatePeriodCleansForbiddenCharactersForDescription() {
         static::createClientWithCredentials()->request(
             'POST',
             '/periods',
             [
                 'json' => $this->getExampleWritePayload(
                     [
-                        'description' => 'Vorl<script>alert(1)</script>ager',
+                        'description' => "Vorl\n\tager",
                     ]
                 ),
             ]

--- a/api/tests/Api/Periods/UpdatePeriodTest.php
+++ b/api/tests/Api/Periods/UpdatePeriodTest.php
@@ -198,10 +198,10 @@ class UpdatePeriodTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchPeriodCleansHtmlForDescription() {
+    public function testPatchPeriodCleansForbiddenCharactersForDescription() {
         $period = static::$fixtures['period1'];
         static::createClientWithCredentials()->request('PATCH', '/periods/'.$period->getId(), ['json' => [
-            'description' => 'Vorwe<script>alert(1)</script>ekend',
+            'description' => "Vorwe\n\tekend",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([

--- a/api/tests/Api/Profiles/UpdateProfileTest.php
+++ b/api/tests/Api/Profiles/UpdateProfileTest.php
@@ -101,10 +101,10 @@ class UpdateProfileTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchProfileCleansHTMLFromFirstname() {
+    public function testPatchProfileCleansForbiddenCharactersFromFirstname() {
         $profile = static::$fixtures['profile1manager'];
         static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
-            'firstname' => '<script>alert(1)</script>Hello',
+            'firstname' => "\n\tHello",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
@@ -123,10 +123,10 @@ class UpdateProfileTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchProfileCleansHTMLFromSurname() {
+    public function testPatchProfileCleansForbiddenCharactersFromSurname() {
         $profile = static::$fixtures['profile1manager'];
         static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
-            'surname' => '<script>alert(1)</script>Hello',
+            'surname' => "\n\tHello",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
@@ -145,10 +145,10 @@ class UpdateProfileTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchProfileCleansHTMLFromNickname() {
+    public function testPatchProfileCleansForbiddenCharactersFromNickname() {
         $profile = static::$fixtures['profile1manager'];
         static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
-            'nickname' => '<script>alert(1)</script>Hello',
+            'nickname' => "\n\tHello",
         ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([

--- a/api/tests/Api/Users/CreateUserTest.php
+++ b/api/tests/Api/Users/CreateUserTest.php
@@ -353,7 +353,7 @@ class CreateUserTest extends ECampApiTestCase {
         ));
     }
 
-    public function testCreateUserCleansHTMLFromFirstname() {
+    public function testCreateUserCleansForbiddenCharactersFromFirstname() {
         static::createBasicClient()->request(
             'POST',
             '/users',
@@ -361,7 +361,7 @@ class CreateUserTest extends ECampApiTestCase {
                 'json' => $this->getExampleWritePayload(
                     mergeEmbeddedAttributes: [
                         'profile' => [
-                            'firstname' => 'Robert<script>alert(1)</script>',
+                            'firstname' => "Robert\n\t",
                         ],
                     ]
                 ),
@@ -409,7 +409,7 @@ class CreateUserTest extends ECampApiTestCase {
         ));
     }
 
-    public function testCreateUserCleansHTMLFromSurname() {
+    public function testCreateUserCleansForbiddenCharactersFromSurname() {
         static::createBasicClient()->request(
             'POST',
             '/users',
@@ -417,7 +417,7 @@ class CreateUserTest extends ECampApiTestCase {
                 'json' => $this->getExampleWritePayload(
                     mergeEmbeddedAttributes: [
                         'profile' => [
-                            'surname' => 'Baden-Powell<script>alert(1)</script>',
+                            'surname' => "Baden-Powell\n\t",
                         ],
                     ]
                 ),
@@ -465,7 +465,7 @@ class CreateUserTest extends ECampApiTestCase {
         ));
     }
 
-    public function testCreateUserCleansHTMLFromNickname() {
+    public function testCreateUserCleansForbiddenCharactersFromNickname() {
         static::createBasicClient()->request(
             'POST',
             '/users',
@@ -473,7 +473,7 @@ class CreateUserTest extends ECampApiTestCase {
                 'json' => $this->getExampleWritePayload(
                     mergeEmbeddedAttributes: [
                         'profile' => [
-                            'nickname' => 'Bi-Pi<script>alert(1)</script>',
+                            'nickname' => "Bi-Pi\n\t",
                         ],
                     ]
                 ),

--- a/api/tests/DataPersister/ContentNodes/StoryboardDataPersisterTest.php
+++ b/api/tests/DataPersister/ContentNodes/StoryboardDataPersisterTest.php
@@ -7,6 +7,7 @@ use App\DataPersister\Util\DataPersisterObservable;
 use App\Entity\ContentNode\ColumnLayout;
 use App\Entity\ContentNode\Storyboard;
 use App\InputFilter\CleanHTMLFilter;
+use App\InputFilter\CleanTextFilter;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -17,16 +18,29 @@ class StoryboardDataPersisterTest extends TestCase {
     private StoryboardDataPersister $dataPersister;
     private MockObject|DataPersisterObservable $dataPersisterObservable;
     private MockObject|CleanHTMLFilter $cleanHTMLFilter;
+    private MockObject|CleanTextFilter $cleanTextFilter;
     private ColumnLayout $root;
     private Storyboard $contentNode;
 
     protected function setUp(): void {
         $this->dataPersisterObservable = $this->createMock(DataPersisterObservable::class);
+
         $this->cleanHTMLFilter = $this->createMock(CleanHTMLFilter::class);
         $this->cleanHTMLFilter->method('applyTo')->will(
             $this->returnCallback(
                 function ($object, $property) {
-                    $object[$property] = '***sanitzed***';
+                    $object[$property] = '***sanitizedHTML***';
+
+                    return $object;
+                }
+            )
+        );
+
+        $this->cleanTextFilter = $this->createMock(CleanTextFilter::class);
+        $this->cleanTextFilter->method('applyTo')->will(
+            $this->returnCallback(
+                function ($object, $property) {
+                    $object[$property] = '***sanitizedText***';
 
                     return $object;
                 }
@@ -37,13 +51,13 @@ class StoryboardDataPersisterTest extends TestCase {
         $this->contentNode->data = ['sections' => [
             '37bbd7b8-441e-403e-b227-70ea52170b9b' => [
                 'column1' => "test1\n\t",
-                'column2' => "test2\n\t",
+                'column2Html' => "test2\n\t",
                 'column3' => "test3\n\t",
                 'position' => 0,
             ],
             '2c5534d3-d077-4ccd-8c9e-b961b451f6e3' => [
                 'column1' => "test1\n\t",
-                'column2' => "test2\n\t",
+                'column2Html' => "test2\n\t",
                 'column3' => "test3\n\t",
                 'position' => 1,
             ],
@@ -53,7 +67,7 @@ class StoryboardDataPersisterTest extends TestCase {
         $this->contentNode->parent = new ColumnLayout();
         $this->contentNode->parent->root = $this->root;
 
-        $this->dataPersister = new StoryboardDataPersister($this->dataPersisterObservable, $this->cleanHTMLFilter);
+        $this->dataPersister = new StoryboardDataPersister($this->dataPersisterObservable, $this->cleanHTMLFilter, $this->cleanTextFilter);
     }
 
     public function testDoesNotSupportNonStoryboard() {
@@ -91,15 +105,15 @@ class StoryboardDataPersisterTest extends TestCase {
         // then
         $this->assertEquals(['sections' => [
             '37bbd7b8-441e-403e-b227-70ea52170b9b' => [
-                'column1' => '***sanitzed***',
-                'column2' => '***sanitzed***',
-                'column3' => '***sanitzed***',
+                'column1' => '***sanitizedText***',
+                'column2Html' => '***sanitizedHTML***',
+                'column3' => '***sanitizedText***',
                 'position' => 0,
             ],
             '2c5534d3-d077-4ccd-8c9e-b961b451f6e3' => [
-                'column1' => '***sanitzed***',
-                'column2' => '***sanitzed***',
-                'column3' => '***sanitzed***',
+                'column1' => '***sanitizedText***',
+                'column2Html' => '***sanitizedHTML***',
+                'column3' => '***sanitizedText***',
                 'position' => 1,
             ],
         ]], $data->data);
@@ -114,15 +128,15 @@ class StoryboardDataPersisterTest extends TestCase {
         // then
         $this->assertEquals(['sections' => [
             '37bbd7b8-441e-403e-b227-70ea52170b9b' => [
-                'column1' => '***sanitzed***',
-                'column2' => '***sanitzed***',
-                'column3' => '***sanitzed***',
+                'column1' => '***sanitizedText***',
+                'column2Html' => '***sanitizedHTML***',
+                'column3' => '***sanitizedText***',
                 'position' => 0,
             ],
             '2c5534d3-d077-4ccd-8c9e-b961b451f6e3' => [
-                'column1' => '***sanitzed***',
-                'column2' => '***sanitzed***',
-                'column3' => '***sanitzed***',
+                'column1' => '***sanitizedText***',
+                'column2Html' => '***sanitizedHTML***',
+                'column3' => '***sanitizedText***',
                 'position' => 1,
             ],
         ]], $data->data);

--- a/api/tests/DataPersister/ContentNodes/StoryboardDataPersisterTest.php
+++ b/api/tests/DataPersister/ContentNodes/StoryboardDataPersisterTest.php
@@ -36,15 +36,15 @@ class StoryboardDataPersisterTest extends TestCase {
         $this->contentNode = new Storyboard();
         $this->contentNode->data = ['sections' => [
             '37bbd7b8-441e-403e-b227-70ea52170b9b' => [
-                'column1' => 'test1<script>alert(1)</script>',
-                'column2' => 'test2<script>alert(2)</script>',
-                'column3' => 'test3<script>alert(3)</script>',
+                'column1' => "test1\n\t",
+                'column2' => "test2\n\t",
+                'column3' => "test3\n\t",
                 'position' => 0,
             ],
             '2c5534d3-d077-4ccd-8c9e-b961b451f6e3' => [
-                'column1' => 'test1<script>alert(1)</script>',
-                'column2' => 'test2<script>alert(2)</script>',
-                'column3' => 'test3<script>alert(3)</script>',
+                'column1' => "test1\n\t",
+                'column2' => "test2\n\t",
+                'column3' => "test3\n\t",
                 'position' => 1,
             ],
         ]];

--- a/api/tests/InputFilter/CleanTextFilterTest.php
+++ b/api/tests/InputFilter/CleanTextFilterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Tests\InputFilter;
+
+use App\InputFilter\CleanTextFilter;
+use App\InputFilter\InputFilter;
+use App\InputFilter\UnexpectedValueException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @internal
+ */
+class CleanTextFilterTest extends KernelTestCase {
+    private ?InputFilter $inputFilter = null;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->inputFilter = new CleanTextFilter();
+    }
+
+    /**
+     * @dataProvider getExamples
+     */
+    public function testInputFiltering($input, $output) {
+        // given
+        $data = ['key' => $input];
+        $outputData = ['key' => $output];
+
+        // when
+        $result = $this->inputFilter->applyTo($data, 'key');
+
+        // then
+        $this->assertEquals($outputData, $result);
+    }
+
+    public function getExamples() {
+        return [
+            ['', ''],
+            ['abc', 'abc'],
+            ['<tag>', '<tag>'],
+            ['😀', '😀'],
+            ['keeps \backslash\ and "double quotes"', 'keeps \backslash\ and "double quotes"'],
+            ["keeps 'single quotes'", "keeps 'single quotes'"],
+            ["removes newlines\n, tabs\t, vertical tabs\v and form-feed\f", 'removes newlines, tabs, vertical tabs and form-feed'],
+            ["removes unicode\u{000A} control\u{0007} caracters", 'removes unicode control caracters'],
+            ["removes ASCII\x0A control\x07 caracters", 'removes ASCII control caracters'],
+            ["removes ANSI escape \e[32m sequences", 'removes ANSI escape [32m sequences'],
+            ["removes bidirectional\u{202E} text control", 'removes bidirectional text control'],
+            ['removes non-escaped bidirectional‮ text control', 'removes non-escaped bidirectional text control'],
+        ];
+    }
+
+    public function testDoesNothingWhenKeyIsMissing() {
+        // given
+        $data = ['otherkey' => 'something'];
+
+        // when
+        $result = $this->inputFilter->applyTo($data, 'key');
+
+        // then
+        $this->assertEquals($data, $result);
+    }
+
+    public function testDoesNothingWhenValueIsNull() {
+        // given
+        $data = ['key' => null];
+
+        // when
+        $result = $this->inputFilter->applyTo($data, 'key');
+
+        // then
+        $this->assertEquals($data, $result);
+    }
+
+    public function testThrowsWhenValueIsNotStringable() {
+        // given
+        $data = ['key' => new \stdClass()];
+
+        // then
+        $this->expectException(UnexpectedValueException::class);
+
+        // when
+        $result = $this->inputFilter->applyTo($data, 'key');
+    }
+}

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -53,7 +53,7 @@
         "section": {
           "fields": {
             "column1": "Zeit",
-            "column2": "Programm",
+            "column2Html": "Programm",
             "column3": "Verantwortlich"
           },
           "name": "Programmpunkt | Programmpunkte"

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -58,7 +58,7 @@
         "section": {
           "fields": {
             "column1": "Time",
-            "column2": "Program",
+            "column2Html": "Program",
             "column3": "Responsible"
           },
           "name": "Storyboard | Storyboards"

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -42,7 +42,7 @@
         "section": {
           "fields": {
             "column1": "Heure",
-            "column2": "Programme",
+            "column2Html": "Programme",
             "column3": "Responsable"
           },
           "name": "Section du programme | Sections du programme"

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -42,7 +42,7 @@
         "section": {
           "fields": {
             "column1": "Tempo",
-            "column2": "Programma",
+            "column2Html": "Programma",
             "column3": "Responsabile"
           },
           "name": "Sezione del programma | Sezioni del programma"

--- a/frontend/src/components/activity/content/Notes.vue
+++ b/frontend/src/components/activity/content/Notes.vue
@@ -3,7 +3,7 @@
     <div class="mb-3">
       <api-form :entity="contentNode">
         <api-richtext
-          fieldname="data.text"
+          fieldname="data.html"
           :label="$tc('contentNode.notes.name')"
           rows="4"
           auto-grow

--- a/frontend/src/components/activity/content/SafetyConcept.vue
+++ b/frontend/src/components/activity/content/SafetyConcept.vue
@@ -3,7 +3,7 @@
     <div class="mb-3">
       <api-form :entity="contentNode">
         <api-richtext
-          fieldname="data.text"
+          fieldname="data.html"
           :placeholder="$tc('contentNode.safetyConcept.name')"
           rows="2"
           :disabled="layoutMode || disabled"

--- a/frontend/src/components/activity/content/Storyboard.vue
+++ b/frontend/src/components/activity/content/Storyboard.vue
@@ -6,7 +6,7 @@
           {{ $tc('contentNode.storyboard.entity.section.fields.column1') }}
         </v-col>
         <v-col cols="7">
-          {{ $tc('contentNode.storyboard.entity.section.fields.column2') }}
+          {{ $tc('contentNode.storyboard.entity.section.fields.column2Html') }}
         </v-col>
         <v-col cols="2">
           {{ $tc('contentNode.storyboard.entity.section.fields.column3') }}
@@ -31,7 +31,7 @@
             </v-col>
             <v-col cols="7">
               <api-richtext
-                :fieldname="`data.sections[${sortable.itemKey}].column2`"
+                :fieldname="`data.sections[${sortable.itemKey}].column2Html`"
                 rows="4"
                 :disabled="layoutMode || disabled"
                 :filled="layoutMode"
@@ -178,7 +178,7 @@ export default {
             sections: {
               [sectionId]: {
                 column1: '',
-                column2: '',
+                column2Html: '',
                 column3: '',
                 position: Object.keys(this.sections).length + 1,
               },

--- a/frontend/src/components/activity/content/Storycontext.vue
+++ b/frontend/src/components/activity/content/Storycontext.vue
@@ -3,7 +3,7 @@
     <div class="mb-3">
       <api-form :entity="contentNode">
         <api-richtext
-          fieldname="data.text"
+          fieldname="data.html"
           :placeholder="$tc('contentNode.storycontext.name')"
           rows="2"
           auto-grow

--- a/frontend/src/components/print/print-react/components/scheduleEntry/contentNode/Notes.jsx
+++ b/frontend/src/components/print/print-react/components/scheduleEntry/contentNode/Notes.jsx
@@ -9,7 +9,7 @@ function Notes(props) {
   return (
     <View style={{ marginBottom: '6pt' }}>
       <InstanceName contentNode={notes} $tc={props.$tc} />
-      <RichText richText={notes.data.text} />
+      <RichText richText={notes.data.html} />
     </View>
   )
 }

--- a/frontend/src/components/print/print-react/components/scheduleEntry/contentNode/SafetyConcept.jsx
+++ b/frontend/src/components/print/print-react/components/scheduleEntry/contentNode/SafetyConcept.jsx
@@ -10,7 +10,7 @@ function SafetyConcept(props) {
   return (
     <View style={{ marginBottom: '6pt' }}>
       <InstanceName contentNode={safetyConcept} $tc={props.$tc} />
-      <RichText richText={safetyConcept.data.text} />
+      <RichText richText={safetyConcept.data.html} />
     </View>
   )
 }

--- a/frontend/src/components/print/print-react/components/scheduleEntry/contentNode/Storyboard.jsx
+++ b/frontend/src/components/print/print-react/components/scheduleEntry/contentNode/Storyboard.jsx
@@ -43,7 +43,7 @@ function Storyboard(props) {
   const sectionsArray = Object.keys(sections).map((key) => ({
     key,
     column1: sections[key].column1,
-    column2: sections[key].column2,
+    column2Html: sections[key].column2Html,
     column3: sections[key].column3,
     position: sections[key].position,
   }))
@@ -61,7 +61,9 @@ function Storyboard(props) {
           <Text>{props.$tc('contentNode.storyboard.entity.section.fields.column1')}</Text>
         </View>
         <View style={{ ...column2Styles, paddingBottom: 0 }}>
-          <Text>{props.$tc('contentNode.storyboard.entity.section.fields.column2')}</Text>
+          <Text>
+            {props.$tc('contentNode.storyboard.entity.section.fields.column2Html')}
+          </Text>
         </View>
         <View style={{ ...column3Styles, paddingBottom: 0 }}>
           <Text>{props.$tc('contentNode.storyboard.entity.section.fields.column3')}</Text>
@@ -76,7 +78,7 @@ function Storyboard(props) {
                 <Text>{section.column1}</Text>
               </View>
               <View style={column2Styles}>
-                <RichText richText={section.column2} />
+                <RichText richText={section.column2Html} />
               </View>
               <View style={column3Styles}>
                 <Text>{section.column3}</Text>

--- a/frontend/src/components/print/print-react/components/scheduleEntry/contentNode/Storycontext.jsx
+++ b/frontend/src/components/print/print-react/components/scheduleEntry/contentNode/Storycontext.jsx
@@ -9,7 +9,7 @@ function Storycontext(props) {
   return (
     <View style={{ marginBottom: '6pt' }}>
       <InstanceName contentNode={storycontext} $tc={props.$tc} />
-      <RichText richText={storycontext.data.text} />
+      <RichText richText={storycontext.data.html} />
     </View>
   )
 }

--- a/frontend/src/components/print/print-react/components/story/StoryDay.jsx
+++ b/frontend/src/components/print/print-react/components/story/StoryDay.jsx
@@ -34,7 +34,7 @@ function StoryDay(props) {
           contentNode.contentTypeName === 'Storycontext' &&
           contentNode.root()._meta.self ===
             scheduleEntry.activity().rootContentNode()._meta.self &&
-          !isEmptyHtml(contentNode.data.text)
+          !isEmptyHtml(contentNode.data.html)
       ),
   }))
   const entriesWithStory = entries.filter(({ storyChapters }) => storyChapters.length)
@@ -72,7 +72,7 @@ function StoryDay(props) {
                     <CategoryLabel activity={scheduleEntry.activity()} />
                     <Text> {chapterTitle}</Text>
                   </View>
-                  <RichText richText={chapter.data.text} />
+                  <RichText richText={chapter.data.html} />
                 </React.Fragment>
               )
             })}

--- a/frontend/src/components/story/StoryDay.vue
+++ b/frontend/src/components/story/StoryDay.vue
@@ -43,7 +43,7 @@
                 auto-grow
                 dense
                 :readonly="!editing"
-                fieldname="data.text"
+                fieldname="data.html"
                 aria-label="Erfassen"
                 label=""
               />

--- a/print/components/scheduleEntry/contentNode/Notes.vue
+++ b/print/components/scheduleEntry/contentNode/Notes.vue
@@ -1,6 +1,6 @@
 <template>
   <content-node-content :content-node="contentNode" :icon-path="mdiPen">
-    <rich-text :rich-text="contentNode.data.text" />
+    <rich-text :rich-text="contentNode.data.html" />
   </content-node-content>
 </template>
 

--- a/print/components/scheduleEntry/contentNode/SafetyConcept.vue
+++ b/print/components/scheduleEntry/contentNode/SafetyConcept.vue
@@ -1,6 +1,6 @@
 <template>
   <content-node-content :content-node="contentNode" :icon-path="mdiSecurity">
-    <rich-text :rich-text="contentNode.data.text" />
+    <rich-text :rich-text="contentNode.data.html" />
   </content-node-content>
 </template>
 

--- a/print/components/scheduleEntry/contentNode/Storyboard.vue
+++ b/print/components/scheduleEntry/contentNode/Storyboard.vue
@@ -6,7 +6,7 @@
           {{ $tc('contentNode.storyboard.entity.section.fields.column1') }}
         </th>
         <th class="column column2 header tw-w-10/12">
-          {{ $tc('contentNode.storyboard.entity.section.fields.column2') }}
+          {{ $tc('contentNode.storyboard.entity.section.fields.column2Html') }}
         </th>
         <th class="column column3 header tw-w-1/12">
           {{ $tc('contentNode.storyboard.entity.section.fields.column3') }}
@@ -17,7 +17,7 @@
           {{ section.column1 }}
         </td>
         <td class="column column2">
-          <rich-text :rich-text="section.column2" />
+          <rich-text :rich-text="section.column2Html" />
         </td>
         <td class="column column3">
           {{ section.column3 }}

--- a/print/components/scheduleEntry/contentNode/Storycontext.vue
+++ b/print/components/scheduleEntry/contentNode/Storycontext.vue
@@ -1,6 +1,6 @@
 <template>
   <content-node-content :content-node="contentNode" :icon-path="mdiBookOpenVariant">
-    <rich-text :rich-text="contentNode.data.text" />
+    <rich-text :rich-text="contentNode.data.html" />
   </content-node-content>
 </template>
 

--- a/print/components/story/StoryDay.vue
+++ b/print/components/story/StoryDay.vue
@@ -22,7 +22,7 @@
             </template>
           </h4>
 
-          <rich-text :rich-text="chapter.data.text" />
+          <rich-text :rich-text="chapter.data.html" />
         </div>
       </template>
     </template>
@@ -75,7 +75,7 @@ export default {
           (contentNode) =>
             contentNode.root()._meta.self ===
               scheduleEntry.activity().rootContentNode()._meta.self &&
-            !isEmptyHtml(contentNode.data.text)
+            !isEmptyHtml(contentNode.data.html)
         ),
       }))
     },


### PR DESCRIPTION
Fixes #2987 

Instead of removing filters completely, I chose to introduce a separate CleanText filter. 

**Why?** There are some characters, we really don't want to allow
- Any non-printable control caracters
- Any control caracters that messes with
- For the moment probably also newline (all our multiline text fields are richtext/html fields). We could do this more granulary later, if we want to allow linebreaks for specific properties

### Todo
- [x] write and fix tests
- [x] add "Html" postfix to all properties that are HTML-safe

### more info
https://github.com/symfony/symfony/issues/44144#issuecomment-974129220
https://stackoverflow.com/a/23066553

### Just some fun pictures from right-to-left control character injection 😄 
<img width="779" alt="image" src="https://user-images.githubusercontent.com/449555/197048157-b9b1647f-dc1f-4cb5-8ccc-685d711f26f4.png">

<img width="609" alt="image" src="https://user-images.githubusercontent.com/449555/197046667-8306717c-d75d-4e1e-8ed8-8280c4cf2ba7.png">

<img width="514" alt="image" src="https://user-images.githubusercontent.com/449555/197046917-86bd85e1-b96f-43db-89cd-3bd78e40b533.png">

<img width="421" alt="image" src="https://user-images.githubusercontent.com/449555/197047783-305f9efc-2889-4409-b9cc-de4a458cfce3.png">
