### PR TITLE
Fix deprecation warnings in GitHub actions

### DIFF
--- a/.github/workflows/alpha-deployment.yml
+++ b/.github/workflows/alpha-deployment.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           ALPHA=$(git rev-parse alpha)
           echo "Git SHA: $ALPHA"
-          echo ::set-output name=sha::$ALPHA
+          echo "sha=$ALPHA" >> $GITHUB_OUTPUT
 
       - name: Create a pending GitHub deployment
         uses: bobheadxi/deployments@v1.3.0

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       to-uninstall: ${{ steps.to-uninstall.outputs.list }}
       to-deploy: ${{ steps.to-deploy.outputs.list }}
-      never-uninstall: ${{ steps.to-uninstall.outputs.never-uninstall }}
+      never-uninstall: ${{ steps.to-uninstall.outputs.never_uninstall }}
     steps:
 
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
@@ -26,7 +26,7 @@ jobs:
               -d "{\"query\": \"query { repository(owner: \\\"ecamp\\\", name: \\\"ecamp3\\\") { ref(qualifiedName: \\\"devel\\\") { target { ... on Commit { statusCheckRollup { state } } } } } }\"}" \
             | jq '.data.repository.ref.target.statusCheckRollup.state=="SUCCESS"')
           echo "Devel CI has passed (within the last 100 CI workflow runs across all forks): $DEVEL_GREEN"
-          echo ::set-output name=passed::$DEVEL_GREEN
+          echo "passed=$DEVEL_GREEN" >> $GITHUB_OUTPUT
 
       - name: Find all open PRs that have a "deploy!" label, plus devel
         id: deployment-candidates
@@ -45,7 +45,7 @@ jobs:
             | jq 'map({"name":("pr"+(.node.number|tostring)),env:"feature-branch",sha:.node.headRefOid})' \
             | jq ".+[$DEVEL]")
           echo "Deployment candidates: $LIST"
-          echo ::set-output name=list::$LIST
+          echo "list=$LIST" >> $GITHUB_OUTPUT
 
       - name: Read the list of all currently active deployments
         id: current-deployments
@@ -56,19 +56,19 @@ jobs:
           # Creates a list of objects like [{"name": "pr1234", "sha": "... commit sha ..."}, {"name": "dev", "sha": "..."}]
           LIST=$(helm list -o json | jq 'map(.name|=sub("^ecamp3-";""))' | jq 'map({name:.name,sha:.app_version})')
           echo "Currently active deployments: $LIST"
-          echo ::set-output name=list::$LIST
+          echo "list=$LIST" >> $GITHUB_OUTPUT
 
       - name: List deployments without PR
         id: to-uninstall
         env:
           deployments: ${{ toJSON(fromJSON(steps.current-deployments.outputs.list).*.name) }}
           prs: ${{ toJSON(fromJSON(steps.deployment-candidates.outputs.list).*.name) }}
-          never_uninstall: '["dev", "stage", "staging", "prod"]'
+          never_uninstall: '["dev", "stage", "staging", "prod", "alpha", "beta"]'
         run: |
           TO_UNINSTALL=$(jq --null-input --argjson prs '${{ env.prs }}' --argjson deployments '${{ env.deployments }}' --argjson never_uninstall '${{ env.never_uninstall }}' '$deployments-$prs-$never_uninstall')
           echo "Will uninstall: $TO_UNINSTALL"
-          echo ::set-output name=list::$TO_UNINSTALL
-          echo ::set-output name=never-uninstall::$never_uninstall
+          echo "list=$TO_UNINSTALL" >> $GITHUB_OUTPUT
+          echo "never_uninstall=$never_uninstall" >> $GITHUB_OUTPUT
 
       - name: List PRs without up-to-date deployment
         id: to-deploy
@@ -81,7 +81,7 @@ jobs:
             '$prs|map(select([{name:.name,sha:.sha}]|inside($deployments)|not))' \
             | jq --argjson allow_dev "${{ env.allow_dev }}" 'map(select((.name!="dev")or($allow_dev==true)))')
           echo "Will install the following candidates, because they either aren't deployed or their deployment is out of date: $TO_INSTALL"
-          echo ::set-output name=list::$TO_INSTALL
+          echo "list=$TO_INSTALL" >> $GITHUB_OUTPUT
 
   uninstall-old-deployment:
     name: Uninstall old deployment

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: 'echo "::set-output name=dir::$(composer config cache-files-dir)"'
+        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
         working-directory: api
 
       - uses: actions/cache@1c73980b09e7aea7201f325a7aa3ad00beddcdda # tag=v3
@@ -70,7 +70,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: 'echo "::set-output name=dir::$(composer config cache-files-dir)"'
+        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
         working-directory: api
 
       - uses: actions/cache@1c73980b09e7aea7201f325a7aa3ad00beddcdda # tag=v3
@@ -100,7 +100,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: 'echo "::set-output name=dir::$(composer config cache-files-dir)"'
+        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
         working-directory: api
 
       - uses: actions/cache@1c73980b09e7aea7201f325a7aa3ad00beddcdda # tag=v3
@@ -206,7 +206,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: 'echo "::set-output name=dir::$(composer config cache-files-dir)"'
+        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
         working-directory: api
 
       - uses: actions/cache@1c73980b09e7aea7201f325a7aa3ad00beddcdda # tag=v3
@@ -279,7 +279,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: 'echo "::set-output name=dir::$(composer config cache-files-dir)"'
+        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
         working-directory: api
 
       - uses: actions/cache@1c73980b09e7aea7201f325a7aa3ad00beddcdda # tag=v3


### PR DESCRIPTION
`::set-output` is deprecated:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Example deprecation warnings in a workflow: https://github.com/ecamp/ecamp3/actions/runs/3295277711