### PR TITLE
Deployment still isn't fixed

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -68,6 +68,7 @@ jobs:
           TO_UNINSTALL=$(jq --null-input --argjson prs '${{ env.prs }}' --argjson deployments '${{ env.deployments }}' --argjson never_uninstall '${{ env.never_uninstall }}' '$deployments-$prs-$never_uninstall')
           echo "Will uninstall: $TO_UNINSTALL"
           echo "list=$TO_UNINSTALL" | tr -d "\n" >> $GITHUB_OUTPUT
+          echo "\n" >> $GITHUB_OUTPUT
           echo "never_uninstall=$never_uninstall" | tr -d "\n" >> $GITHUB_OUTPUT
 
       - name: List PRs without up-to-date deployment


### PR DESCRIPTION
One day we may find a good (simple + realistic) way to test and debug GitHub Actions...
This specific step outputs two variables. But due to my previous removing of any newlines, the two outputs are no longer separated:
```
##[debug]Set output list = []never_uninstall=["dev", "stage", "staging", "prod", "alpha", "beta"]
```
https://github.com/ecamp/ecamp3/actions/runs/3316434413/jobs/5478387254

So, just insert a newline at the end if you plan to follow an output with some other outputs in the same step.