### PR TITLE
chore(print): improve browserless config + error handling

### DIFF
--- a/.github/workflows/alpha-deployment.yml
+++ b/.github/workflows/alpha-deployment.yml
@@ -129,6 +129,8 @@ jobs:
             --set php.oauth.cevidb.clientId='${{ secrets.OAUTH_CEVIDB_CLIENT_ID }}' \
             --set php.oauth.cevidb.clientSecret='${{ secrets.OAUTH_CEVIDB_CLIENT_SECRET }}' \
             --set php.oauth.cevidb.baseUrl='${{ secrets.OAUTH_CEVIDB_BASE_URL }}' \
+            --set browserless.maxConcurrentSessions=3 \
+            --set browserless.maxQueueLength=9 \
             --set frontend.sentryDsn='${{ secrets.FRONTEND_SENTRY_DSN }}' \
             --set print.sentryDsn='${{ secrets.PRINT_SENTRY_DSN }}' \
             --set deploymentTime="$(date -u +%s)" \

--- a/.helm/ecamp3/templates/browserless_configmap.yaml
+++ b/.helm/ecamp3/templates/browserless_configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "api.name" . }}-configmap
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+data:
+  MAX_CONCURRENT_SESSIONS: {{ .Values.browserless.maxConcurrentSessions | quote }}
+  CONNECTION_TIMEOUT: {{ .Values.browserless.connectionTimeout | quote }}
+  MAX_QUEUE_LENGTH: {{ .Values.browserless.maxQueueLength | quote }}

--- a/.helm/ecamp3/templates/browserless_configmap.yaml
+++ b/.helm/ecamp3/templates/browserless_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "api.name" . }}-configmap
+  name: {{ include "browserless.name" . }}-configmap
   labels:
     {{- include "app.labels" . | nindent 4 }}
 data:

--- a/.helm/ecamp3/templates/browserless_deployment.yaml
+++ b/.helm/ecamp3/templates/browserless_deployment.yaml
@@ -49,5 +49,19 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.browserless.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "browserless.name" . }}-configmap
+          env:
+            - name: PREBOOT_CHROME
+              value: "true"
+            - name: KEEP_ALIVE
+              value: "true"
+            - name: ENABLE_DEBUGGER
+              value: "false"
+            - name: FUNCTION_ENABLE_INCOGNITO_MODE
+              value: "true"
+            - name: DISABLED_FEATURES
+              value: '["downloadEndpoint","functionEndpoint","pdfEndpoint","screencastEndpoint","scrapeEndpoint","statsEndpoint","workspaces"]'
 {{- end }}

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -91,7 +91,7 @@ browserless:
   image:
     repository: "docker.io/browserless/chrome"
     pullPolicy: IfNotPresent
-    tag: "1.53-puppeteer-13.6.0"
+    tag: "1.56.0-puppeteer-18.0.5"
   service:
     type: ClusterIP
     port: 3000

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -95,6 +95,21 @@ browserless:
   service:
     type: ClusterIP
     port: 3000
+  maxConcurrentSessions: 1
+  connectionTimeout: 30000
+  maxQueueLength: 5
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
 
 mail:
   dummyEnabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
     restart: on-failure
 
   browserless:
-    image: browserless/chrome:1.50.0-puppeteer-12.0.1@sha256:ca9c1a56ff88ba91c3aac908713cfe92f4e308c941a64e408d00d26bf1de036a
+    image: browserless/chrome:1.56.0-puppeteer-18.0.5@sha256:83a0f24eb4341c30e0f5106a98f1d1e5a3981805fce2829403cda9ef2e0b965e
     container_name: 'ecamp3-browserless'
     ports:
       - '3010:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,15 @@ services:
     container_name: 'ecamp3-browserless'
     ports:
       - '3010:3000'
+    environment:
+      - MAX_CONCURRENT_SESSIONS=1
+      - CONNECTION_TIMEOUT=40000
+      - MAX_QUEUE_LENGTH=10
+      - PREBOOT_CHROME=true
+      - KEEP_ALIVE=true
+      - ENABLE_DEBUGGER=false
+      - DISABLED_FEATURES=["downloadEndpoint","functionEndpoint","pdfEndpoint","screencastEndpoint","scrapeEndpoint","statsEndpoint","workspaces"]
+      - FUNCTION_ENABLE_INCOGNITO_MODE=true 
 
 volumes:
   db-data-postgres: null

--- a/frontend/src/components/print/print-nuxt/DownloadNuxtPdfButton.vue
+++ b/frontend/src/components/print/print-nuxt/DownloadNuxtPdfButton.vue
@@ -3,7 +3,7 @@
     <v-btn color="primary" :loading="loading" outlined @click="generatePdf">
       <v-icon>mdi-printer</v-icon>
       <div class="mx-1">
-        {{ $tc('components.print.printNuxt.label') }}
+        {{ $tc('components.print.printNuxt.downloadNuxtPdfButton.label') }}
       </div>
     </v-btn>
   </div>

--- a/frontend/src/components/print/print-nuxt/DownloadNuxtPdfButton.vue
+++ b/frontend/src/components/print/print-nuxt/DownloadNuxtPdfButton.vue
@@ -3,7 +3,7 @@
     <v-btn color="primary" :loading="loading" outlined @click="generatePdf">
       <v-icon>mdi-printer</v-icon>
       <div class="mx-1">
-        {{ $tc('components.print.printNuxt.downloadNuxtPdfListItem.label') }}
+        {{ $tc('components.print.printNuxt.label') }}
       </div>
     </v-btn>
   </div>

--- a/frontend/src/components/print/print-nuxt/DownloadNuxtPdfListItem.vue
+++ b/frontend/src/components/print/print-nuxt/DownloadNuxtPdfListItem.vue
@@ -5,7 +5,7 @@
       <v-icon v-else>mdi-printer</v-icon>
     </v-list-item-icon>
     <v-list-item-title>
-      {{ $tc('components.print.printNuxt.label') }}
+      {{ $tc('components.print.printNuxt.downloadNuxtPdfListItem.label') }}
     </v-list-item-title>
   </v-list-item>
 </template>

--- a/frontend/src/components/print/print-nuxt/DownloadNuxtPdfListItem.vue
+++ b/frontend/src/components/print/print-nuxt/DownloadNuxtPdfListItem.vue
@@ -5,7 +5,7 @@
       <v-icon v-else>mdi-printer</v-icon>
     </v-list-item-icon>
     <v-list-item-title>
-      {{ $tc('components.print.printNuxt.downloadNuxtPdfListItem.label') }}
+      {{ $tc('components.print.printNuxt.label') }}
     </v-list-item-title>
   </v-list-item>
 </template>

--- a/frontend/src/components/print/print-nuxt/generatePdfMixin.js
+++ b/frontend/src/components/print/print-nuxt/generatePdfMixin.js
@@ -48,9 +48,11 @@ export const generatePdfMixin = {
         saveAs(new Blob([response.data]), config.documentName)
       } catch (error) {
         if (error?.response?.status === 503) {
-          this.$toast.error(this.$tc('components.print.printNuxt.queueFull'))
+          this.$toast.error(
+            this.$tc('components.print.printNuxt.generatePdfMixin.queueFull')
+          )
         } else {
-          this.$toast.error(this.$tc('components.print.printNuxt.error'))
+          this.$toast.error(this.$tc('components.print.printNuxt.generatePdfMixin.error'))
         }
       } finally {
         this.loading = false

--- a/frontend/src/components/print/print-nuxt/generatePdfMixin.js
+++ b/frontend/src/components/print/print-nuxt/generatePdfMixin.js
@@ -47,9 +47,11 @@ export const generatePdfMixin = {
 
         saveAs(new Blob([response.data]), config.documentName)
       } catch (error) {
-        this.$toast.error(
-          this.$tc('components.print.printNuxt.downloadNuxtPdfListItem.error')
-        )
+        if (error?.response?.status === 503) {
+          this.$toast.error(this.$tc('components.print.printNuxt.queueFull'))
+        } else {
+          this.$toast.error(this.$tc('components.print.printNuxt.error'))
+        }
       } finally {
         this.loading = false
       }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -190,9 +190,16 @@
         }
       },
       "printNuxt": {
-        "error": "Etwas hat nicht geklappt. Probiere es nochmals, oder lade die Seite neu.",
-        "label": "PDF herunterladen (Layout #1)",
-        "queueFull": "Alle unsere PDF-Drucker sind im Moment beschäftigt. Bitte versuche es später nochmals."
+        "downloadNuxtPdfButton": {
+          "label": "PDF herunterladen (Layout #1)"
+        },
+        "downloadNuxtPdfListItem": {
+          "label": "PDF herunterladen (Layout #1)"
+        },
+        "generatePdfMixin": {
+          "error": "Etwas hat nicht geklappt. Probiere es nochmals, oder lade die Seite neu.",
+          "queueFull": "Alle unsere PDF-Drucker sind im Moment beschäftigt. Bitte versuche es später nochmals."
+        }
       },
       "printPreviewNuxt": {
         "openPreview": "Vorschau in neuem Fenster öffnen"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -190,10 +190,9 @@
         }
       },
       "printNuxt": {
-        "downloadNuxtPdfListItem": {
-          "error": "Etwas hat nicht geklappt. Probiere es nochmals, oder lade die Seite neu.",
-          "label": "PDF herunterladen (Layout #1)"
-        }
+        "error": "Etwas hat nicht geklappt. Probiere es nochmals, oder lade die Seite neu.",
+        "label": "PDF herunterladen (Layout #1)",
+        "queueFull": "Alle unsere PDF-Drucker sind im Moment beschäftigt. Bitte versuche es später nochmals."
       },
       "printPreviewNuxt": {
         "openPreview": "Vorschau in neuem Fenster öffnen"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -190,9 +190,16 @@
         }
       },
       "printNuxt": {
-        "error": "Something did not work. Please try again, or try reloading the page.",
-        "label": "Download PDF (layout #1)",
-        "queueFull": "All our PDF printers are busy at the moment. Please try again later."
+        "downloadNuxtPdfButton": {
+          "label": "Download PDF (layout #1)"
+        },
+        "downloadNuxtPdfListItem": {
+          "label": "Download PDF (layout #1)"
+        },
+        "generatePdfMixin": {
+          "error": "Something did not work. Please try again, or try reloading the page.",
+          "queueFull": "All our PDF printers are busy at the moment. Please try again later."
+        }
       },
       "printPreviewNuxt": {
         "openPreview": "Open preview in new window"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -190,10 +190,9 @@
         }
       },
       "printNuxt": {
-        "downloadNuxtPdfListItem": {
-          "error": "Something did not work. Please try again, or try reloading the page.",
-          "label": "Download PDF (layout #1)"
-        }
+        "error": "Something did not work. Please try again, or try reloading the page.",
+        "label": "Download PDF (layout #1)",
+        "queueFull": "All our PDF printers are busy at the moment. Please try again later."
       },
       "printPreviewNuxt": {
         "openPreview": "Open preview in new window"

--- a/print/server-middleware/routes/pdfGeneratorNativeChrome.js
+++ b/print/server-middleware/routes/pdfGeneratorNativeChrome.js
@@ -125,19 +125,23 @@ router.use('/pdfChrome', async (req, res) => {
     }
 
     let errorMessage = null
+    let status = 500
     if (error.error) {
       // error is a WebScocket ErrorEvent Object which contains an error property
-      errorMessage = error.error.toString()
-      res.status(503)
+      errorMessage = error.error.message
+      if (errorMessage === 'Unexpected server response: 429') {
+        status = 503
+        errorMessage = 'Server responded with `429 Too Many Requests` (queue is full)'
+      }
     } else {
-      errorMessage = error.toString()
-      res.status(500)
+      errorMessage = error.message
     }
 
     console.error(error)
 
-    res.contentType('application/json')
-    res.send({ error: errorMessage })
+    res.status(status)
+    res.contentType('application/problem+json')
+    res.send({ status, title: errorMessage })
   }
 })
 

--- a/print/server-middleware/routes/pdfGeneratorNativeChrome.js
+++ b/print/server-middleware/routes/pdfGeneratorNativeChrome.js
@@ -127,7 +127,7 @@ router.use('/pdfChrome', async (req, res) => {
     let errorMessage = null
     let status = 500
     if (error.error) {
-      // error is a WebScocket ErrorEvent Object which contains an error property
+      // error is a WebSocket ErrorEvent Object which contains an error property
       errorMessage = error.error.message
       if (errorMessage === 'Unexpected server response: 429') {
         status = 503


### PR DESCRIPTION
Various improvements around browserless. Detailed description below.

### Concurrency and queue length
**MAX_CONCURRENT_SESSIONS** determines the number of parallel running chrome browsers within the browserless image. For local development and in the default helm charts I have set this to 1. For local development and feature branches, anything above seems unnecessary resource usage. The default value before was 10, which is way to high (eating the available RAM/CPU on our Kubernetes nodes pretty fast).

It's configurable via helm, so it can be fine tuned for each deployment.

**MAX_QUEUE_LENGTH** determines the number of requests that are queued. If the queue is full, an error is immediately returned to the request.

Also configurable via helm. In production I guess we want to fine-tune a number, which still makes users to wait for the PDF, even if the queue is almost full. My gut feeling is it should be around 2* to max. 3* MAX_CONCURRENT_SESSIONS, which means in worst case users wait for 2-3 times the shortest print duration (3 * 7s = approx. 21s).

### KEEP_ALIVE and PREBOOT_CHROME
Both set to true, which preboots chrome and avoids closing them after usage (=faster printing as no need to wait for chrome startup).

Usage of the websocket is now slightly different, as after printing chrome is not closed but just disconnected from (`browser.disconnect()`). To avoid any risk of leakage of cookies between requests, all sessions are using a new incognito context (`browser.createIncognitoBrowserContext()`).

### Error handling
The error handling was not done correctly previously. An error on nodejs returned a 200 response that was interpreted by the frontend as an (invalid) PDF. This also resulted in an infinite loading spinner, even if printing failed.
Now errors are properly returned as `application/problem+json` to the frontend. When the queue is full, a _503 Service Unavailable_ is returned immediately, in order to display a proper message to the user.

### Kubernetes resource definition
The resource requests and limits can now be configured for the browserless image. At one point, we probably want to implement this also for the other services. This ensures, pods are scheduled on nodes with appropriate free CPU and memory capacity. At the moment, proper scheduling is a bit difficult, because a lot of our node's CPU/memory is already reserved by all the various supporting agents/services other than our ecamp services.

### Example helm configuration
Values can be configured as below. Tested it with below values on my own cluster.
Memory usage was more or less stable at 360MB and CPU peaked around 30%.
```
helm upgrade --install ecamp3 . \
  --set browserless.maxConcurrentSessions=3 \
  --set browserless.maxQueueLength=9 \
  --set browserless.resources.requests.cpu=500m \
  --set browserless.resources.requests.memory=500Mi \
  ...
```

### Other improvements and ideas
Will create separate issues if we agree to implement.
- Validate JWT cookie at the beginning of pdfGeneratorNativeChrome.js to validate the user is authenticated (avoiding DDOS)
- Consider reverting to page.setContent #3122


