### PR TITLE
DialogPeriodEdit add Mode

### DIFF
--- a/frontend/src/components/campAdmin/DialogPeriodEdit.vue
+++ b/frontend/src/components/campAdmin/DialogPeriodEdit.vue
@@ -11,13 +11,27 @@
     <template #activator="scope">
       <slot name="activator" v-bind="scope" />
     </template>
-    <dialog-period-form :period="entityData" />
+
+    <dialog-period-form
+      :period="entityData"
+      :start-disabled="startDisabled"
+      :end-disabled="endDisabled"
+    >
+      <template #beforeDates>
+        <e-select
+          v-model="mode"
+          :name="$tc('components.campAdmin.dialogPeriodEdit.mode')"
+          :items="modeItems"
+          class="mt-6"
+        />
+      </template>
+    </dialog-period-form>
 
     <e-checkbox
       v-model="entityData.moveScheduleEntries"
+      :disabled="moveScheduleEntriesDisabled"
       :name="$tc('components.campAdmin.dialogPeriodEdit.moveScheduleEntries')"
     />
-
     <svg
       viewBox="0 12 400 76"
       width="100%"
@@ -34,25 +48,14 @@
       <rect x="330" y="15" width="28" height="70" class="day-background" />
       <rect x="386" y="15" width="14" height="70" class="day-background" />
 
-      <g :class="{ 'annimation-all': entityData.moveScheduleEntries }">
-        <rect
-          x="70"
-          y="22"
-          width="260"
-          height="56"
-          ry="1"
-          class="period"
-          :class="{
-            'annimation-period': !entityData.moveScheduleEntries,
-            period: entityData.moveScheduleEntries,
-          }"
-        />
+      <g class="periodGrp" :class="cls">
+        <rect x="70" y="22" width="260" height="56" ry="2" class="period" :class="cls" />
 
-        <rect x="101" y="40" width="22" height="32" class="category1" />
-        <rect x="129" y="34" width="22" height="32" class="category2" />
+        <rect x="101" y="40" width="22" height="32" class="category c1" :class="cls" />
+        <rect x="129" y="34" width="22" height="32" class="category c2" :class="cls" />
 
-        <rect x="249" y="40" width="22" height="32" class="category1" />
-        <rect x="277" y="34" width="22" height="32" class="category2" />
+        <rect x="249" y="40" width="22" height="32" class="category c1" :class="cls" />
+        <rect x="277" y="34" width="22" height="32" class="category c2" :class="cls" />
       </g>
       <path
         style="stroke: rgb(0, 0, 0); fill: rgba(0, 0, 0, 0); stroke-width: 5px"
@@ -72,6 +75,11 @@ import DialogBase from '@/components/dialog/DialogBase.vue'
 import DialogForm from '@/components/dialog/DialogForm.vue'
 import DialogPeriodForm from './DialogPeriodForm.vue'
 
+const MODE_FREE = 'free'
+const MODE_MOVE_PERIOD = 'move-period'
+const MODE_MOVE_START = 'move-start'
+const MODE_MOVE_END = 'move-end'
+
 export default {
   name: 'DialogPeriodEdit',
   components: { DialogForm, DialogPeriodForm },
@@ -82,20 +90,93 @@ export default {
   data() {
     return {
       entityProperties: ['description', 'start', 'end', 'moveScheduleEntries'],
+      modes: [MODE_FREE, MODE_MOVE_PERIOD, MODE_MOVE_START, MODE_MOVE_END],
+      mode: MODE_MOVE_PERIOD,
+      startDisabled: false,
+      endDisabled: true,
+      moveScheduleEntriesDisabled: true,
     }
+  },
+  computed: {
+    modeItems() {
+      return this.modes.map((item) => {
+        return {
+          text: this.$tc('components.campAdmin.dialogPeriodEdit.modes.' + item),
+          value: item,
+        }
+      })
+    },
+    cls() {
+      if (this.mode == MODE_FREE) {
+        return this.mode + (this.entityData.moveScheduleEntries ? '-move' : '-stay')
+      }
+      return this.mode
+    },
   },
   watch: {
     // copy data whenever dialog is opened
     showDialog: function (showDialog) {
       if (showDialog) {
         this.loadEntityData(this.period._meta.self)
+        this.mode = MODE_MOVE_PERIOD
+        this.startDisabled = false
+        this.endDisabled = true
+        this.moveScheduleEntriesDisabled = true
       }
     },
     loading: function (isLoading) {
       if (!isLoading) {
-        this.entityData.moveScheduleEntries = true
+        this.$set(this.entityData, 'moveScheduleEntries', true)
       }
     },
+    mode: function (mode) {
+      this.$set(this.entityData, 'start', this.period.start)
+      this.$set(this.entityData, 'end', this.period.end)
+      switch (mode) {
+        case MODE_FREE:
+          this.startDisabled = false
+          this.endDisabled = false
+          break
+
+        case MODE_MOVE_PERIOD:
+          this.$set(this.entityData, 'moveScheduleEntries', true)
+          this.startDisabled = false
+          this.endDisabled = true
+          break
+
+        case MODE_MOVE_START:
+          this.$set(this.entityData, 'moveScheduleEntries', false)
+          this.startDisabled = false
+          this.endDisabled = true
+          break
+
+        case MODE_MOVE_END:
+          this.$set(this.entityData, 'moveScheduleEntries', false)
+          this.startDisabled = true
+          this.endDisabled = false
+          break
+      }
+      this.moveScheduleEntriesDisabled = mode != MODE_FREE
+    },
+    entityData: {
+      handler(period) {
+        if (this.mode == MODE_MOVE_PERIOD) {
+          const newEnd = this.$date.unix(
+            this.$date.utc(period.start, 'YYYY-MM-DD').unix() -
+              this.$date.utc(this.period.start, 'YYYY-MM-DD').unix() +
+              this.$date.utc(this.period.end, 'YYYY-MM-DD').unix()
+          )
+          this.$set(period, 'end', newEnd.format('YYYY-MM-DD'))
+        }
+      },
+      deep: true,
+    },
+  },
+  mounted() {
+    this.mode = MODE_MOVE_PERIOD
+    this.startDisabled = false
+    this.endDisabled = true
+    this.moveScheduleEntriesDisabled = true
   },
 }
 </script>
@@ -108,39 +189,113 @@ rect.period {
   stroke: rgb(0, 0, 0);
   fill: rgba(30, 30, 255, 0.18);
 }
-rect.category1 {
+rect.category.c1 {
   fill: rgb(255, 137, 26);
 }
-rect.category2 {
+rect.category.c2 {
   fill: rgb(45, 172, 13);
 }
 
-/* Move Period + Events */
-g.annimation-all {
-  animation-name: move;
-  animation-duration: 5s;
-  animation-direction: normal;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
-}
-g.annimation-all rect.period {
-  animation-name: resize;
+/* Animations */
+g.periodGrp,
+rect.period,
+rect.category {
   animation-duration: 5s;
   animation-direction: normal;
   animation-timing-function: linear;
   animation-iteration-count: infinite;
 }
 
-/* Move Period */
-rect.annimation-period {
-  animation-name: move-and-resize;
-  animation-duration: 5s;
-  animation-direction: normal;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
+g.periodGrp.free-move {
+  animation-name: free-grp;
+}
+rect.period.free-move {
+  animation-name: free-move-period;
 }
 
-@keyframes move {
+rect.period.free-stay {
+  animation-name: free-stay-period;
+}
+
+rect.period.move-period,
+rect.category.move-period {
+  animation-name: move-period;
+}
+
+rect.period.move-start {
+  animation-name: period-move-start;
+}
+
+rect.period.move-end {
+  animation-name: period-move-end;
+}
+
+@keyframes free-grp {
+  0% {
+    transform: translate(0px, 0px);
+  }
+  3% {
+    transform: translate(-28px, 0px);
+  }
+  25% {
+    transform: translate(-28px, 0px);
+  }
+  28% {
+    transform: translate(0px, 0px);
+  }
+}
+
+@keyframes free-move-period {
+  50% {
+    width: 260px;
+  }
+  53% {
+    width: 288px;
+  }
+  75% {
+    width: 288px;
+  }
+  78% {
+    width: 260px;
+  }
+}
+
+@keyframes free-stay-period {
+  0% {
+    transform: translate(0px, 0px);
+    width: 260px;
+  }
+  3% {
+    transform: translate(0px, 0px);
+    width: 288px;
+  }
+  25% {
+    transform: translate(0px, 0px);
+    width: 288px;
+  }
+  28% {
+    transform: translate(0px, 0px);
+    width: 260px;
+  }
+  50% {
+    transform: translate(0px, 0px);
+    width: 260px;
+  }
+  53% {
+    transform: translate(-28px, 0px);
+    width: 288px;
+  }
+  75% {
+    transform: translate(-28px, 0px);
+    width: 288px;
+  }
+  78% {
+    transform: translate(0px, 0px);
+    width: 260px;
+  }
+}
+
+@keyframes move-period {
   0% {
     transform: translate(0px, 0px);
   }
@@ -167,64 +322,64 @@ rect.annimation-period {
   }
 }
 
-@keyframes resize {
+@keyframes period-move-start {
   0% {
+    transform: translate(0px, 0px);
     width: 260px;
   }
   3% {
-    width: 260px;
+    transform: translate(28px, 0px);
+    width: 232px;
   }
   25% {
-    width: 260px;
+    transform: translate(28px, 0px);
+    width: 232px;
   }
   28% {
+    transform: translate(0px, 0px);
     width: 260px;
   }
   50% {
+    transform: translate(0px, 0px);
     width: 260px;
   }
   53% {
+    transform: translate(-28px, 0px);
     width: 288px;
   }
   75% {
+    transform: translate(-28px, 0px);
     width: 288px;
   }
   78% {
+    transform: translate(0px, 0px);
     width: 260px;
   }
 }
 
-@keyframes move-and-resize {
+@keyframes period-move-end {
   0% {
-    transform: translate(0px, 0px);
     width: 260px;
   }
   3% {
-    transform: translate(28px, 0px);
-    width: 260px;
+    width: 232px;
   }
   25% {
-    transform: translate(28px, 0px);
-    width: 260px;
+    width: 232px;
   }
   28% {
-    transform: translate(0px, 0px);
     width: 260px;
   }
   50% {
-    transform: translate(0px, 0px);
     width: 260px;
   }
   53% {
-    transform: translate(-28px, 0px);
     width: 288px;
   }
   75% {
-    transform: translate(-28px, 0px);
     width: 288px;
   }
   78% {
-    transform: translate(0px, 0px);
     width: 260px;
   }
 }

--- a/frontend/src/components/campAdmin/DialogPeriodForm.vue
+++ b/frontend/src/components/campAdmin/DialogPeriodForm.vue
@@ -6,8 +6,10 @@
       vee-rules="required"
     />
 
+    <slot name="beforeDates" />
     <e-date-picker
       v-model="localPeriod.start"
+      :disabled="startDisabled"
       :name="$tc('entity.period.fields.start')"
       vee-id="start"
       vee-rules="required"
@@ -15,6 +17,7 @@
 
     <e-date-picker
       v-model="localPeriod.end"
+      :disabled="endDisabled"
       :name="$tc('entity.period.fields.end')"
       vee-rules="required|greaterThanOrEqual_date:@start"
     />
@@ -26,6 +29,8 @@ export default {
   name: 'DialogPeriodForm',
   props: {
     period: { type: Object, required: true },
+    startDisabled: { type: Boolean, required: false, default: false },
+    endDisabled: { type: Boolean, required: false, default: false },
   },
   data() {
     return {

--- a/frontend/src/components/dialog/DialogForm.vue
+++ b/frontend/src/components/dialog/DialogForm.vue
@@ -39,14 +39,15 @@
             <slot v-else />
           </div>
 
-          <v-card-text>
-            <!-- error message via slot -->
-            <v-alert v-if="$slots.error" text outlined color="warning" icon="mdi-alert">
+          <!-- error message via slot -->
+          <v-card-text v-if="$slots.error">
+            <v-alert text outlined color="warning" icon="mdi-alert">
               <slot name="error" />
             </v-alert>
-
+          </v-card-text>
+          <v-card-text v-else-if="error">
             <!-- error message via props -->
-            <server-error v-else :server-error="error" />
+            <server-error :server-error="error" />
           </v-card-text>
 
           <v-card-actions>

--- a/frontend/src/components/form/base/BasePicker.vue
+++ b/frontend/src/components/form/base/BasePicker.vue
@@ -23,14 +23,14 @@ Displays a field as a picker (can be used with v-model)
           :error-messages="combinedErrorMessages"
           :filled="filled"
           :disabled="disabled"
+          :readonly="readonly"
           @input="debouncedParseValue"
           @focus="textFieldIsActive = true"
           @blur="textFieldIsActive = false"
         >
           <template v-if="icon" #prepend>
-            <v-icon :color="iconColor" @click="on.click">
-              {{ icon }}
-            </v-icon>
+            <v-icon v-if="readonly || disabled" :color="iconColor">{{ icon }}</v-icon>
+            <v-icon v-else :color="iconColor" @click="on.click">{{ icon }}</v-icon>
           </template>
 
           <!-- passing the append slot through -->

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -77,7 +77,14 @@
         "title": "Lagerabschnitt erstellen"
       },
       "dialogPeriodEdit": {
-        "moveScheduleEntries": "Aktivitäten verschieben"
+        "moveScheduleEntries": "Aktivitäten verschieben",
+        "mode": "Modus",
+        "modes": {
+          "free": "Frei",
+          "move-period": "Lagerabschnitt verschieben",
+          "move-start": "Start-Datum anpassen",
+          "move-end": "End-Datum anpassen"
+        }
       }
     },
     "collaborator": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -74,7 +74,14 @@
         "title": "Create material list"
       },
       "dialogPeriodEdit": {
-        "moveScheduleEntries": "Move schedule entries"
+        "moveScheduleEntries": "Move schedule entries",
+        "mode": "Mode",
+        "modes": {
+          "free": "Free",
+          "move-period": "Move period",
+          "move-start": "Adjust start date",
+          "move-end": "Adjust end date"
+        }
       },
       "dialogPeriodCreate": {
         "title": "Create period"


### PR DESCRIPTION
[Idee #2437](https://github.com/ecamp/ecamp3/pull/2437#discussion_r800329667)

To support the user, i have added serveral modes to `DialogPeriodEdit`.

MovePeriod:  Start-Date editable;  Activities are moved as well
MoveStart: Start-Date editable;  Activities stay at there date
MoveEnd: End-Date editable  Activities stay at there date
Free: User is free


![image](https://user-images.githubusercontent.com/470237/198900400-e95bc18f-5176-4b2e-abc2-35274d0a0554.png)
![image](https://user-images.githubusercontent.com/470237/198900409-463ffe1b-79ed-4df2-9875-40ef731e9bc4.png)
