### PR TITLE
small fixes around LAThematicArea

### DIFF
--- a/frontend/src/components/print/print-react/components/scheduleEntry/contentNode/LAThematicArea.jsx
+++ b/frontend/src/components/print/print-react/components/scheduleEntry/contentNode/LAThematicArea.jsx
@@ -15,22 +15,24 @@ function LAThematicArea(props) {
   return (
     <View style={{ marginBottom: '6pt' }}>
       <InstanceName contentNode={laThematicArea} $tc={props.$tc} />
-      {optionsArray.map((option) => {
-        return (
-          <View
-            style={{ display: 'flex', flexDirection: 'row', alignItems: 'top' }}
-            key={option.translateKey}
-          >
-            <Checkmark size={8} />
-            <Text style={{ marginLeft: '2pt' }}>
-              {' '}
-              {props.$tc(
-                `contentNode.laThematicArea.entity.option.${option.translateKey}.name`
-              )}
-            </Text>
-          </View>
-        )
-      })}
+      {optionsArray
+        .filter((option) => option.checked)
+        .map((option) => {
+          return (
+            <View
+              style={{ display: 'flex', flexDirection: 'row', alignItems: 'top' }}
+              key={option.translateKey}
+            >
+              <Checkmark size={8} />
+              <Text style={{ marginLeft: '2pt' }}>
+                {' '}
+                {props.$tc(
+                  `contentNode.laThematicArea.entity.option.${option.translateKey}.name`
+                )}
+              </Text>
+            </View>
+          )
+        })}
     </View>
   )
 }

--- a/print/components/generic/CheckMark.vue
+++ b/print/components/generic/CheckMark.vue
@@ -9,7 +9,7 @@
     xml:space="preserve"
     width="8"
     height="8"
-    :style="{ transform: `scale(${scale})`, marginTop: '2px' }"
+    :style="{ transform: `scale(${scale})`, marginTop: '-0.15em', display: 'inline' }"
   >
     <metadata id="metadata13">
       <rdf:RDF>


### PR DESCRIPTION
# PDF print - react
Add filter for checked LAthematcArea

bevore:
![image](https://user-images.githubusercontent.com/470237/200115150-64adc167-49a3-414d-997d-59a5fc72a04d.png)

after:
![image](https://user-images.githubusercontent.com/470237/200115182-09386cdb-46c8-4a3c-ac6b-378b5d0577db.png)

# PDF print - nuxt
Display CheckMark inline with the text

bevore:
![image](https://user-images.githubusercontent.com/470237/200115254-11010afd-1ca7-481e-9d79-2110df74f6c1.png)

after:
![image](https://user-images.githubusercontent.com/470237/200115281-915a5764-5175-4c0e-877e-cace783d2fc1.png)
