### PR TITLE
ci: use FAST_FORWARD_TOKEN to query api in fast-forward.yml

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/github-script@v6
         id: current_pr
         with:
+          github-token: ${{ secrets.FAST_FORWARD_TOKEN }}
           script: |
             return github.rest.pulls.get({
               pull_number: context.issue.number,


### PR DESCRIPTION
Without that it did not work on the test-org.
See https://github.com/bacluc-test-org/ecamp3/blob/64fa2aeec519ad9b6a9d62c218e68aa31a87383a/.github/workflows/fast-forward.yml#L35

Issue: #3135