### PR TITLE
Api entity validations for profile and user

### DIFF
--- a/api/src/Entity/Profile.php
+++ b/api/src/Entity/Profile.php
@@ -107,6 +107,7 @@ class Profile extends BaseEntity {
      */
     #[InputFilter\Trim]
     #[InputFilter\CleanText]
+    #[Assert\Length(max: 64)]
     #[ApiProperty(example: self::EXAMPLE_FIRSTNAME)]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]
@@ -117,6 +118,7 @@ class Profile extends BaseEntity {
      */
     #[InputFilter\Trim]
     #[InputFilter\CleanText]
+    #[Assert\Length(max: 64)]
     #[ApiProperty(example: self::EXAMPLE_SURNAME)]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]
@@ -127,6 +129,7 @@ class Profile extends BaseEntity {
      */
     #[InputFilter\Trim]
     #[InputFilter\CleanText]
+    #[Assert\Length(max: 32)]
     #[ApiProperty(example: self::EXAMPLE_NICKNAME)]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -8,6 +8,7 @@ use App\Repository\UserRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -43,6 +44,10 @@ use Symfony\Component\Validator\Constraints as Assert;
     ],
     denormalizationContext: ['groups' => ['write']],
     normalizationContext: ['groups' => ['read']],
+)]
+#[UniqueEntity(
+    fields: ['profile'],
+    message: 'Only one User can reference a Profile.',
 )]
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: '`user`')]

--- a/api/tests/Api/Profiles/UpdateProfileTest.php
+++ b/api/tests/Api/Profiles/UpdateProfileTest.php
@@ -239,4 +239,36 @@ class UpdateProfileTest extends ECampApiTestCase {
             'detail' => 'Extra attributes are not allowed ("user" is unknown).',
         ]);
     }
+
+    /**
+     * @dataProvider notWriteableProfileProperties
+     */
+    public function testNotWriteableProperties(string $property) {
+        $user = static::$fixtures['profile1manager'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/profiles/'.$user->getId(),
+            [
+                'json' => [
+                    $property => 'something',
+                ],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'title' => 'An error occurred',
+            'detail' => "Extra attributes are not allowed (\"{$property}\" is unknown).",
+        ]);
+    }
+
+    public static function notWriteableProfileProperties(): array {
+        return [
+            'untrustedEmailKeyHash' => ['untrustedEmailKeyHash'],
+            'googleId' => ['googleId'],
+            'pbsmidataId' => ['pbsmidataId'],
+            'roles' => ['roles'],
+            'user' => ['user'],
+        ];
+    }
 }

--- a/api/tests/Api/Profiles/UpdateProfileTest.php
+++ b/api/tests/Api/Profiles/UpdateProfileTest.php
@@ -112,6 +112,18 @@ class UpdateProfileTest extends ECampApiTestCase {
         ]);
     }
 
+    public function testPatchProfileValidatesFirstnameMaxLength() {
+        /** @var Profile $profile */
+        $profile = static::$fixtures['profile1manager'];
+        static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
+            'firstname' => str_repeat('a', 65),
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'detail' => 'firstname: This value is too long. It should have 64 characters or less.',
+        ]);
+    }
+
     public function testPatchProfileTrimsSurname() {
         $profile = static::$fixtures['profile1manager'];
         static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
@@ -134,6 +146,18 @@ class UpdateProfileTest extends ECampApiTestCase {
         ]);
     }
 
+    public function testPatchProfileValidatesSurnameMaxLength() {
+        /** @var Profile $profile */
+        $profile = static::$fixtures['profile1manager'];
+        static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
+            'surname' => str_repeat('a', 65),
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'detail' => 'surname: This value is too long. It should have 64 characters or less.',
+        ]);
+    }
+
     public function testPatchProfileTrimsNickname() {
         $profile = static::$fixtures['profile1manager'];
         static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
@@ -153,6 +177,18 @@ class UpdateProfileTest extends ECampApiTestCase {
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             'nickname' => 'Hello',
+        ]);
+    }
+
+    public function testPatchProfileValidatesNicknameMaxLength() {
+        /** @var Profile $profile */
+        $profile = static::$fixtures['profile1manager'];
+        static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
+            'nickname' => str_repeat('a', 33),
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'detail' => 'nickname: This value is too long. It should have 32 characters or less.',
         ]);
     }
 

--- a/api/tests/Api/Users/CreateUserTest.php
+++ b/api/tests/Api/Users/CreateUserTest.php
@@ -720,6 +720,72 @@ class CreateUserTest extends ECampApiTestCase {
         ]);
     }
 
+    /**
+     * @dataProvider notWriteableUserProperties
+     */
+    public function testNotWriteableUserProperties(string $property) {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/users',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        $property => 'something',
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'title' => 'An error occurred',
+            'detail' => "Extra attributes are not allowed (\"{$property}\" is unknown).",
+        ]);
+    }
+
+    public static function notWriteableUserProperties(): array {
+        return [
+            'activationKeyHash' => ['activationKeyHash'],
+            'passwordResetKeyHash' => ['passwordResetKeyHash'],
+        ];
+    }
+
+    /**
+     * @dataProvider notWriteableProfileProperties
+     */
+    public function testNotWriteableProfileProperties(string $property) {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/users',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        'profile' => [
+                            $property => 'something',
+                        ],
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'title' => 'An error occurred',
+            'detail' => "Extra attributes are not allowed (\"{$property}\" is unknown).",
+        ]);
+    }
+
+    public static function notWriteableProfileProperties(): array {
+        return [
+            'untrustedEmailKey' => ['untrustedEmailKey'],
+            'untrustedEmailKeyHash' => ['untrustedEmailKeyHash'],
+            'googleId' => ['googleId'],
+            'pbsmidataId' => ['pbsmidataId'],
+            'roles' => ['roles'],
+            'user' => ['user'],
+        ];
+    }
+
     public function getExampleWritePayload($attributes = [], $except = [], $mergeEmbeddedAttributes = []) {
         $examplePayload = $this->getExamplePayload(
             User::class,

--- a/api/tests/Api/Users/CreateUserTest.php
+++ b/api/tests/Api/Users/CreateUserTest.php
@@ -147,6 +147,28 @@ class CreateUserTest extends ECampApiTestCase {
         );
     }
 
+    public function testCreateUserDoesNotAllowToUseAnotherProfile() {
+        static::createClientWithCredentials()->request(
+            'POST',
+            '/users',
+            [
+                'json' => $this->getExampleWritePayload([
+                    'profile' => $this->getIriFor('profile1manager'),
+                ]),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'profile',
+                    'message' => 'Only one User can reference a Profile.',
+                ],
+            ],
+        ]);
+    }
+
     public function testCreateUserTrimsEmail() {
         static::createBasicClient()->request(
             'POST',
@@ -381,6 +403,33 @@ class CreateUserTest extends ECampApiTestCase {
         ));
     }
 
+    public function testCreateUserValidatesFirstnameMaxLength() {
+        $client = static::createClientWithCredentials();
+        $client->request(
+            'POST',
+            '/users',
+            [
+                'json' => $this->getExampleWritePayload(
+                    mergeEmbeddedAttributes: [
+                        'profile' => [
+                            'firstname' => str_repeat('a', 65),
+                        ],
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'profile.firstname',
+                    'message' => 'This value is too long. It should have 64 characters or less.',
+                ],
+            ],
+        ]);
+    }
+
     public function testCreateUserTrimsSurname() {
         static::createBasicClient()->request(
             'POST',
@@ -437,6 +486,33 @@ class CreateUserTest extends ECampApiTestCase {
         ));
     }
 
+    public function testCreateUserValidatesSurnameMaxLength() {
+        $client = static::createClientWithCredentials();
+        $client->request(
+            'POST',
+            '/users',
+            [
+                'json' => $this->getExampleWritePayload(
+                    mergeEmbeddedAttributes: [
+                        'profile' => [
+                            'surname' => str_repeat('a', 65),
+                        ],
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'profile.surname',
+                    'message' => 'This value is too long. It should have 64 characters or less.',
+                ],
+            ],
+        ]);
+    }
+
     public function testCreateUserTrimsNickname() {
         static::createBasicClient()->request(
             'POST',
@@ -491,6 +567,33 @@ class CreateUserTest extends ECampApiTestCase {
             ],
             ['password']
         ));
+    }
+
+    public function testCreateUserValidatesNicknameMaxLength() {
+        $client = static::createClientWithCredentials();
+        $client->request(
+            'POST',
+            '/users',
+            [
+                'json' => $this->getExampleWritePayload(
+                    mergeEmbeddedAttributes: [
+                        'profile' => [
+                            'nickname' => str_repeat('a', 33),
+                        ],
+                    ]
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'profile.nickname',
+                    'message' => 'This value is too long. It should have 32 characters or less.',
+                ],
+            ],
+        ]);
     }
 
     public function testCreateUserTrimsLanguage() {

--- a/api/tests/Api/Users/UpdateUserTest.php
+++ b/api/tests/Api/Users/UpdateUserTest.php
@@ -79,4 +79,33 @@ class UpdateUserTest extends ECampApiTestCase {
             'detail' => 'Extra attributes are not allowed ("profile" is unknown).',
         ]);
     }
+
+    /**
+     * @dataProvider notWriteableUserProperties
+     */
+    public function testNotWriteableProperties(string $property) {
+        $user = static::$fixtures['user1manager'];
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/users/'.$user->getId(),
+            [
+                'json' => [
+                    $property => 'something',
+                ],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains([
+            'title' => 'An error occurred',
+            'detail' => "Extra attributes are not allowed (\"{$property}\" is unknown).",
+        ]);
+    }
+
+    public static function notWriteableUserProperties(): array {
+        return [
+            'activationKeyHash' => ['activationKeyHash'],
+            'passwordResetKeyHash' => ['passwordResetKeyHash'],
+        ];
+    }
 }


### PR DESCRIPTION
### Profile.php
- [x] firstname
  - [x] length <= 64
- [x] surname
  - [x] length <= 64
- [x] nickname
  - [x] length <= 32

### User.php
- [x] activationKeyHash
  - [x] Is not writeable
- [x] passwordResetKeyHash
  - [x] Is not writeable
- [x] profile
  - [x] not null
  - [x] another profile cannot be referenced, a new profile must be created when creating a user
  - [x] you cannot link to another profile
  - [x] embedded patch is not allowed
  - [x] unique (assured by oneToOne)

Issue: #2553 