### PR TITLE
Fix colorjs

### DIFF
--- a/common/helpers/colors.js
+++ b/common/helpers/colors.js
@@ -8,8 +8,8 @@ function contrastColor(color) {
   const input = new Color(color)
   const black = new Color('#000')
   const white = new Color('#fff')
-  const blackContrast = input.contrast(black, 'APCA')
-  const whiteContrast = input.contrast(white, 'APCA')
+  const blackContrast = Math.abs(input.contrast(black, 'APCA'))
+  const whiteContrast = Math.abs(input.contrast(white, 'APCA'))
   return blackContrast > whiteContrast
     ? black.toString({ format: 'hex' })
     : white.toString({ format: 'hex' })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "test:e2e": "vue-cli-service test:e2e",
     "test:e2e:ci": "vue-cli-service test:e2e --headless",
     "test:unit:debug": "node --inspect-brk=0.0.0.0:9229 ./node_modules/@vue/cli-service/bin/vue-cli-service.js test:unit --no-cache --runInBand",
-    "test:unit:watch": "vue-cli-service test:unit --watch"
+    "test:unit:watch": "vue-cli-service test:unit --watch",
+    "postinstall": "sed -i 's/Color.extend(contrast);/Color.extend({contrast});/g' node_modules/colorjs.io/dist/color.js"
   },
   "dependencies": {
     "@intlify/core": "9.2.2",


### PR DESCRIPTION
colorjs.io is currently incompatible with bundlers. See https://github.com/LeaVerou/color.js/pull/239
We can remove the postinstall script once we upgrade to a version which includes that PR.

(also, the contrast function can return negative values if the first color is lighter than the second)