### PR TITLE
feat(frontend): various small ux improvements around camp & camp overviews

### DIFF
--- a/api/fixtures/profiles.yml
+++ b/api/fixtures/profiles.yml
@@ -62,7 +62,7 @@ App\Entity\Profile:
     surname: Nistrator
     nickname: Administrator
     language: de
-    roles: [ 'ROLE_USER' ]
+    roles: [ 'ROLE_USER', 'ROLE_ADMIN' ]
   profileWithoutCampCollaborations:
     user: '@userWithoutCampCollaborations'
     email: <email()>

--- a/api/migrations/dev-data/Version202209110752PM_data.sql
+++ b/api/migrations/dev-data/Version202209110752PM_data.sql
@@ -5,7 +5,7 @@
 INSERT INTO public.profile (id, email, username, firstname, surname, nickname, language, roles, createtime, updatetime, googleid, pbsmidataid, cevidbid, untrustedemail, untrustedemailkeyhash) VALUES
 	('5e387cad273d', 'test@example.com', 'test-user', 'Robert', 'Baden-Powell', 'Bi-Pi', 'en', '["ROLE_USER"]', '2022-01-23 16:19:10', '2022-01-23 16:19:10', NULL, NULL, NULL, NULL, NULL),
 	('e5433660140b', 'joan.doyle@lynch.net', 'unrelated-user', 'Wanda', 'Koelpin', 'sit', 'en', '["ROLE_USER"]', '2022-01-23 16:19:10', '2022-01-23 16:19:10', NULL, NULL, NULL, NULL, NULL),
-	('711ad2e96f9f', 'admin@example.com', 'admin', 'Admi', 'Nistrator', 'Administrator', 'de', '["ROLE_USER"]', '2022-01-23 16:19:10', '2022-01-23 16:19:10', NULL, NULL, NULL, NULL, NULL),
+	('711ad2e96f9f', 'admin@example.com', 'admin', 'Admi', 'Nistrator', 'Administrator', 'de', '["ROLE_USER", "ROLE_ADMIN"]', '2022-01-23 16:19:10', '2022-01-23 16:19:10', NULL, NULL, NULL, NULL, NULL),
 	('d36197370d44', 'evonrueden@hotmail.com', 'fresh-user', 'Clifford', 'Beier', 'sed', 'en', '["ROLE_USER"]', '2022-01-23 16:19:10', '2022-01-23 16:19:10', NULL, NULL, NULL, NULL, NULL),
 	('f9f1a2f9af25', 'reichel.zetta@hotmail.com', 'member-user', 'Zora', 'Steuber', 'Baghira', 'en', '["ROLE_USER"]', '2022-01-23 16:19:10', '2022-02-04 19:18:01', NULL, NULL, NULL, NULL, NULL),
 	('0870635edda6', 'lane65@yahoo.com', 'guest-user', 'Tremaine', 'Kohler', 'Idefix', 'en', '["ROLE_USER"]', '2022-01-23 16:19:10', '2022-02-04 19:18:43', NULL, NULL, NULL, NULL, NULL),

--- a/api/migrations/prod-data/Version202210081114PM_data.sql
+++ b/api/migrations/prod-data/Version202210081114PM_data.sql
@@ -3,7 +3,7 @@
 
 
 INSERT INTO public.profile (id, email, firstname, surname, nickname, language, roles, createtime, updatetime, googleid, pbsmidataid, cevidbid, untrustedemail, untrustedemailkeyhash) VALUES
-	('f052d5a73a27', 'support@ecamp3.ch', 'Support', 'Support', 'Support', 'de', '["ROLE_USER"]', '2022-10-08 20:11:57', '2022-10-08 20:38:22', NULL, NULL, NULL, NULL, NULL);
+	('f052d5a73a27', 'support@ecamp3.ch', 'Support', 'Support', 'Support', 'de', '["ROLE_USER", "ROLE_ADMIN"]', '2022-10-08 20:11:57', '2022-10-08 20:38:22', NULL, NULL, NULL, NULL, NULL);
 
 
 

--- a/frontend/src/components/navigation/UserMeta.vue
+++ b/frontend/src/components/navigation/UserMeta.vue
@@ -27,9 +27,7 @@
       </v-list-item>
       <v-list-item block tag="li" exact :to="{ name: 'camps' }" @click="open = false">
         <v-icon left>mdi-format-list-bulleted-triangle</v-icon>
-        <span>{{
-          $tc('components.navigation.userMeta.myCamps', api.get().camps().items.length)
-        }}</span>
+        <span>{{ $tc('components.navigation.userMeta.myCamps') }}</span>
       </v-list-item>
       <v-list-item block tag="li" @click="logout">
         <v-progress-circular

--- a/frontend/src/components/print/config/ActivityConfig.vue
+++ b/frontend/src/components/print/config/ActivityConfig.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
-    <e-select v-model="optionsScheduleEntry" :items="scheduleEntries" />
+    <e-select v-if="!loading" v-model="optionsScheduleEntry" :items="scheduleEntries" />
+    <v-skeleton-loader v-else type="image" height="56" />
   </div>
 </template>
 
@@ -10,9 +11,6 @@ export default {
   props: {
     value: { type: Object, required: true },
     camp: { type: Object, required: true },
-  },
-  data() {
-    return {}
   },
   computed: {
     options: {
@@ -47,6 +45,12 @@ export default {
       })
 
       return scheduleEntries
+    },
+    loading() {
+      return [
+        this.camp.activities(),
+        ...this.camp.periods().items.map((period) => period.scheduleEntries()),
+      ].some((entity) => entity._meta.loading)
     },
   },
   defaultOptions() {

--- a/frontend/src/components/program/ScheduleEntries.vue
+++ b/frontend/src/components/program/ScheduleEntries.vue
@@ -1,10 +1,6 @@
 <template>
   <div>
-    <slot
-      :schedule-entries="scheduleEntries"
-      :loading="scheduleEntries._meta.loading"
-      :on="eventHandlers"
-    />
+    <slot :schedule-entries="scheduleEntries" :loading="loading" :on="eventHandlers" />
     <dialog-activity-create
       ref="dialogActivityCreate"
       :period="period"
@@ -58,6 +54,13 @@ export default {
     scheduleEntries() {
       // TODO for SideBar, add filtering for the current day, now that the API supports it
       return this.period().scheduleEntries()
+    },
+    loading() {
+      return (
+        this.scheduleEntries._meta.loading ||
+        this.period().camp().activities()._meta.loading ||
+        this.period().camp().categories()._meta.loading
+      )
     },
   },
   mounted() {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -133,7 +133,7 @@
     "navigation": {
       "userMeta": {
         "logOut": "Ausloggen",
-        "myCamps": "Mein Lager | Meine Lager",
+        "myCamps": "Meine Lager",
         "profile": "Profil"
       }
     },
@@ -477,7 +477,7 @@
       "create": "Lager erstellen",
       "pastCamps": "Alte Lager",
       "prototypeCamps": "Vorlagen",
-      "title": "Mein Lager | Meine Lager"
+      "title": "Meine Lager"
     },
     "profile": {
       "changeEmail": "Ändern",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -133,7 +133,7 @@
     "navigation": {
       "userMeta": {
         "logOut": "Log out",
-        "myCamps": "My camp | My camps",
+        "myCamps": "My camps",
         "profile": "Profile"
       }
     },
@@ -474,7 +474,7 @@
       "create": "Create a camp",
       "pastCamps": "Past camps",
       "prototypeCamps": "Prototypes",
-      "title": "My Camp | My Camps"
+      "title": "My Camps"
     },
     "profile": {
       "changeEmail": "Change",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -46,7 +46,7 @@
     "navigation": {
       "userMeta": {
         "logOut": "Se déconnecter",
-        "myCamps": "Mon camp | Mes camps",
+        "myCamps": "Mes camps",
         "profile": "Profil"
       }
     },
@@ -199,7 +199,7 @@
     },
     "camps": {
       "create": "Créer un camp",
-      "title": "Mon camp | Mes camps"
+      "title": "Mes camps"
     },
     "profile": {
       "profile": "Profil"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -46,7 +46,7 @@
     "navigation": {
       "userMeta": {
         "logOut": "Disconnettiti",
-        "myCamps": "Il mio campo | I miei campi",
+        "myCamps": "I miei campi",
         "profile": "Profilo"
       }
     },
@@ -199,7 +199,7 @@
     },
     "camps": {
       "create": "Creare il campo",
-      "title": "Il mio campo | I miei campi"
+      "title": "I miei campi"
     },
     "profile": {
       "profile": "Profilo"

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -46,6 +46,14 @@ export function isLoggedIn() {
   return isLoggedIn
 }
 
+export function isAdmin() {
+  if (!isLoggedIn()) {
+    return false
+  }
+
+  return parseJWTPayload(getJWTPayloadFromCookie()).roles.includes('ROLE_ADMIN')
+}
+
 async function login(email, password) {
   const url = await apiStore.href(apiStore.get(), 'login')
   return apiStore.post(url, { identifier: email, password: password }).then(() => {
@@ -143,6 +151,7 @@ function cookiePrefix() {
 
 export const auth = {
   isLoggedIn,
+  isAdmin,
   login,
   register,
   loginGoogle,

--- a/frontend/src/views/CampCreate.vue
+++ b/frontend/src/views/CampCreate.vue
@@ -41,8 +41,8 @@
           </v-card-text>
           <v-divider />
           <v-card-text class="text-right">
-            <button-cancel @click="$router.go(-1)" />
-            <button-add type="submit">
+            <button-cancel :disabled="isSaving" @click="$router.go(-1)" />
+            <button-add type="submit" :loading="isSaving">
               {{ $tc('views.campCreate.create') }}
             </button-add>
           </v-card-text>
@@ -88,6 +88,7 @@ export default {
         ],
       },
       serverError: null,
+      isSaving: false,
     }
   },
   computed: {
@@ -110,16 +111,18 @@ export default {
   },
   created() {},
   methods: {
-    createCamp: function () {
-      this.api.post(this.campsUrl, this.camp).then(
-        (c) => {
-          this.$router.push(campRoute(c, 'admin'))
-          this.api.reload(this.campsUrl)
-        },
-        (error) => {
-          this.serverError = error
-        }
-      )
+    createCamp: async function () {
+      this.isSaving = true
+
+      try {
+        const camp = await this.api.post(this.campsUrl, this.camp)
+        await this.$router.push(campRoute(camp, 'admin'))
+        this.api.reload(this.campsUrl)
+      } catch (error) {
+        this.serverError = error
+      }
+
+      this.isSaving = false
     },
     addPeriod: function () {
       this.camp.periods.push({

--- a/frontend/src/views/Camps.vue
+++ b/frontend/src/views/Camps.vue
@@ -39,7 +39,9 @@
         </v-list-item>
       </v-list>
       <v-expansion-panels
-        v-if="(isAdmin() && prototypeCamps.length > 0) || pastCamps.length > 0"
+        v-if="
+          !loading && ((isAdmin() && prototypeCamps.length > 0) || pastCamps.length > 0)
+        "
         multiple
         flat
         accordion

--- a/frontend/src/views/Camps.vue
+++ b/frontend/src/views/Camps.vue
@@ -1,10 +1,6 @@
 <template>
   <v-container fluid>
-    <content-card
-      :title="$tc('views.camps.title', camps.items.length)"
-      max-width="800"
-      toolbar
-    >
+    <content-card :title="$tc('views.camps.title')" max-width="800" toolbar>
       <template #title-actions>
         <v-btn
           class="d-sm-none"
@@ -15,12 +11,13 @@
         </v-btn>
       </template>
       <v-list class="py-0">
-        <template v-if="camps._meta.loading">
+        <template v-if="loading">
           <v-skeleton-loader type="list-item-two-line" height="64" />
           <v-skeleton-loader type="list-item-two-line" height="64" />
         </template>
         <v-list-item
           v-for="camp in upcomingCamps"
+          v-else
           :key="camp._meta.self"
           two-line
           :to="campRoute(camp)"
@@ -42,12 +39,12 @@
         </v-list-item>
       </v-list>
       <v-expansion-panels
-        v-if="prototypeCamps.length > 0 || pastCamps.length > 0"
+        v-if="(isAdmin() && prototypeCamps.length > 0) || pastCamps.length > 0"
         multiple
         flat
         accordion
       >
-        <v-expansion-panel v-if="prototypeCamps.length > 0">
+        <v-expansion-panel v-if="isAdmin() && prototypeCamps.length > 0">
           <v-expansion-panel-header>
             <h3>
               {{ $tc('views.camps.prototypeCamps') }}
@@ -71,7 +68,7 @@
             </v-list>
           </v-expansion-panel-content>
         </v-expansion-panel>
-        <v-expansion-panel v-if="pastCamps.length > 0">
+        <v-expansion-panel v-if="!loading && pastCamps.length > 0">
           <v-expansion-panel-header>
             <h3>
               {{ $tc('views.camps.pastCamps') }}
@@ -102,6 +99,7 @@
 
 <script>
 import { campRoute } from '@/router.js'
+import { isAdmin } from '@/plugins/auth'
 import ContentCard from '@/components/layout/ContentCard.vue'
 import ButtonAdd from '@/components/buttons/ButtonAdd.vue'
 import UserAvatar from '@/components/user/UserAvatar.vue'
@@ -113,6 +111,11 @@ export default {
     ContentCard,
     ButtonAdd,
   },
+  data: function () {
+    return {
+      loading: true,
+    }
+  },
   computed: {
     camps() {
       return this.api.get().camps()
@@ -120,28 +123,45 @@ export default {
     prototypeCamps() {
       return this.camps.items.filter((c) => c.isPrototype)
     },
+    nonPrototypeCamps() {
+      return this.camps.items.filter((c) => !c.isPrototype)
+    },
     upcomingCamps() {
-      return this.camps.items
-        .filter((c) => !c.isPrototype)
-        .filter((c) => c.periods().items.some((p) => new Date(p.end) > new Date()))
+      return this.nonPrototypeCamps.filter((c) =>
+        c.periods().items.some((p) => new Date(p.end) > new Date())
+      )
     },
     pastCamps() {
-      return this.camps.items
-        .filter((c) => !c.isPrototype)
-        .filter((c) => !c.periods().items.some((p) => new Date(p.end) > new Date()))
+      return this.nonPrototypeCamps.filter(
+        (c) => !c.periods().items.some((p) => new Date(p.end) > new Date())
+      )
     },
     user() {
       return this.$store.state.auth.user
     },
   },
-  mounted() {
-    // Only reload camps if they were loaded before, to avoid console error
-    if (this.camps._meta.self !== null) {
-      this.api.reload(this.camps)
-    }
+  async mounted() {
+    this.loadCamps()
   },
   methods: {
     campRoute,
+    isAdmin,
+    async loadCamps() {
+      // Only reload camps if they were loaded before, to avoid console error
+      if (this.camps._meta.self !== null) {
+        this.api.reload(this.camps)
+      }
+
+      await this.camps._meta.load
+
+      await Promise.all(
+        this.nonPrototypeCamps.map((camp) => {
+          camp.periods()._meta.load
+        })
+      )
+
+      this.loading = false
+    },
   },
 }
 </script>

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -300,6 +300,8 @@ export default {
     },
   },
   async mounted() {
+    this.api.reload(this.camp())
+
     const [loggedInUser] = await Promise.all([
       this.$auth.loadUser(),
       this.camp().periods()._meta.load,


### PR DESCRIPTION
**/camps**
- improved loading spinner (waiting for periods to load)
- show prototypes only to admins
- avoid singular title "my camp" (the page and all the sections are mentally a bucket for all my camps, irrespectful whether I have 0,1 or more camps)

**/camps/create**
- loading spinner while saving

**/camp/*/dashboard**
- add a camp reload (which comes with many embedded data) to avoid n+1 network requests

**picasso**
- wait not only for scheduleEntries but also for activities and categories to avoid n+1 network requests #3015