### PR TITLE
Update colorjs and remove temporary workaround

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "frontend",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@intlify/core": "9.2.2",
         "@mdi/font": "7.0.96",
@@ -38,7 +37,7 @@
         "@zxcvbn-ts/language-it": "2.1.0",
         "assert": "2.0.0",
         "axios": "1.1.3",
-        "colorjs.io": "^0.4.1-patch.1",
+        "colorjs.io": "0.4.2",
         "comlink": "4.3.1",
         "dayjs": "1.11.6",
         "deepmerge": "4.2.2",
@@ -7355,9 +7354,9 @@
       "dev": true
     },
     "node_modules/colorjs.io": {
-      "version": "0.4.1-patch.1",
-      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.4.1-patch.1.tgz",
-      "integrity": "sha512-7UWunVDvnUtWRvGD0hEuGyxIvZvw4QbV8/Hz5fhePZdzyvZ8/Ze3mVGxa/8B084jZGBKJDX0ZwHPL/FDn7PZZA=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.4.2.tgz",
+      "integrity": "sha512-vtpiH+BTzZtzs4Yno0GyoC05Z20fTeLwNJ7lQzjxi8GJJb1SZO2o5yUBAUXzgvrO2JNuyIqur4gb1Z6HBjpd9A=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -28401,9 +28400,9 @@
       "dev": true
     },
     "colorjs.io": {
-      "version": "0.4.1-patch.1",
-      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.4.1-patch.1.tgz",
-      "integrity": "sha512-7UWunVDvnUtWRvGD0hEuGyxIvZvw4QbV8/Hz5fhePZdzyvZ8/Ze3mVGxa/8B084jZGBKJDX0ZwHPL/FDn7PZZA=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.4.2.tgz",
+      "integrity": "sha512-vtpiH+BTzZtzs4Yno0GyoC05Z20fTeLwNJ7lQzjxi8GJJb1SZO2o5yUBAUXzgvrO2JNuyIqur4gb1Z6HBjpd9A=="
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,8 +19,7 @@
     "test:e2e": "vue-cli-service test:e2e",
     "test:e2e:ci": "vue-cli-service test:e2e --headless",
     "test:unit:debug": "node --inspect-brk=0.0.0.0:9229 ./node_modules/@vue/cli-service/bin/vue-cli-service.js test:unit --no-cache --runInBand",
-    "test:unit:watch": "vue-cli-service test:unit --watch",
-    "postinstall": "sed 's/Color.extend(contrast);/Color.extend({contrast});/g' node_modules/colorjs.io/dist/color.js > node_modules/colorjs.io/dist/color.js.tmpfix; cat node_modules/colorjs.io/dist/color.js.tmpfix > node_modules/colorjs.io/dist/color.js; rm node_modules/colorjs.io/dist/color.js.tmpfix"
+    "test:unit:watch": "vue-cli-service test:unit --watch"
   },
   "dependencies": {
     "@intlify/core": "9.2.2",
@@ -52,7 +51,7 @@
     "@zxcvbn-ts/language-it": "2.1.0",
     "assert": "2.0.0",
     "axios": "1.1.3",
-    "colorjs.io": "^0.4.1-patch.1",
+    "colorjs.io": "0.4.2",
     "comlink": "4.3.1",
     "dayjs": "1.11.6",
     "deepmerge": "4.2.2",

--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -11,7 +11,7 @@
         "@mdi/js": "7.0.96",
         "@nuxtjs/axios": "5.13.6",
         "@nuxtjs/sentry": "6.0.1",
-        "colorjs.io": "^0.4.1-patch.1",
+        "colorjs.io": "0.4.2",
         "cookie-parser": "1.4.6",
         "cors": "2.8.5",
         "cssesc": "3.0.0",
@@ -6801,9 +6801,9 @@
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
     "node_modules/colorjs.io": {
-      "version": "0.4.1-patch.1",
-      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.4.1-patch.1.tgz",
-      "integrity": "sha512-7UWunVDvnUtWRvGD0hEuGyxIvZvw4QbV8/Hz5fhePZdzyvZ8/Ze3mVGxa/8B084jZGBKJDX0ZwHPL/FDn7PZZA=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.4.2.tgz",
+      "integrity": "sha512-vtpiH+BTzZtzs4Yno0GyoC05Z20fTeLwNJ7lQzjxi8GJJb1SZO2o5yUBAUXzgvrO2JNuyIqur4gb1Z6HBjpd9A=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -28801,9 +28801,9 @@
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
     "colorjs.io": {
-      "version": "0.4.1-patch.1",
-      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.4.1-patch.1.tgz",
-      "integrity": "sha512-7UWunVDvnUtWRvGD0hEuGyxIvZvw4QbV8/Hz5fhePZdzyvZ8/Ze3mVGxa/8B084jZGBKJDX0ZwHPL/FDn7PZZA=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.4.2.tgz",
+      "integrity": "sha512-vtpiH+BTzZtzs4Yno0GyoC05Z20fTeLwNJ7lQzjxi8GJJb1SZO2o5yUBAUXzgvrO2JNuyIqur4gb1Z6HBjpd9A=="
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/print/package.json
+++ b/print/package.json
@@ -21,7 +21,7 @@
     "@mdi/js": "7.0.96",
     "@nuxtjs/axios": "5.13.6",
     "@nuxtjs/sentry": "6.0.1",
-    "colorjs.io": "^0.4.1-patch.1",
+    "colorjs.io": "0.4.2",
     "cookie-parser": "1.4.6",
     "cors": "2.8.5",
     "cssesc": "3.0.0",


### PR DESCRIPTION
https://github.com/LeaVerou/color.js/pull/239 was released as 0.4.2 in the meantime.

I updated and pinned the dependency version, and removed the temporary workaround from #3154. On my machine it works, and I also tested it locally using a production build of the frontend as described [here](https://github.com/ecamp/ecamp3/wiki/debugging-locally-reproducing-production-error).

I tried to predict the renovate branch name, so that renovate won't conflict with this. Let's see how that works out.