### PR TITLE
chore(deploy): performance + autoscalers

### DIFF
--- a/.helm/ecamp3/templates/_helpers.tpl
+++ b/.helm/ecamp3/templates/_helpers.tpl
@@ -127,9 +127,8 @@ The full URL where the dummy mail catcher service will be available.
 {{/*
 Common labels
 */}}
-{{- define "app.labels" -}}
+{{- define "app.commonLabels" -}}
 helm.sh/chart: {{ include "chart.fullname" . }}
-{{ include "app.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -137,12 +136,51 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Common selector labels
 */}}
-{{- define "app.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "chart.name" . }}
+{{- define "app.commonSelectorLabels" -}}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/part-of: {{ include "chart.name" . }}
+{{- end }}
+
+{{/*
+Selector labels for API
+*/}}
+{{- define "api.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}-api
+{{ include "app.commonSelectorLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels for Frontend
+*/}}
+{{- define "frontend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}-frontend
+{{ include "app.commonSelectorLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels for Print
+*/}}
+{{- define "print.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}-print
+{{ include "app.commonSelectorLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels for Mail
+*/}}
+{{- define "mail.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}-mail
+{{ include "app.commonSelectorLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels for Browserless
+*/}}
+{{- define "browserless.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}-browserless
+{{ include "app.commonSelectorLabels" . }}
 {{- end }}
 
 {{/*

--- a/.helm/ecamp3/templates/api_configmap.yaml
+++ b/.helm/ecamp3/templates/api_configmap.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ include "api.name" . }}-configmap
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 data:
   API_DOMAIN: {{ .Values.api.domain | quote }}
   COOKIE_PREFIX: {{ include "api.cookiePrefix" . | quote }}

--- a/.helm/ecamp3/templates/api_deployment.yaml
+++ b/.helm/ecamp3/templates/api_deployment.yaml
@@ -172,10 +172,10 @@ spec:
             preStop:
               exec:
                 command: ["/bin/sh", "-c", "/bin/sleep 1; kill -QUIT 1"]
-          resources:
-            {{- toYaml .Values.php.resources | nindent 12 }}
           {{- end }}
           {{- template "api.phpContainer" . }}
+          resources:
+            {{- toYaml .Values.php.resources | nindent 12 }}
           readinessProbe:
             exec:
               command:

--- a/.helm/ecamp3/templates/api_deployment.yaml
+++ b/.helm/ecamp3/templates/api_deployment.yaml
@@ -3,18 +3,19 @@ kind: Deployment
 metadata:
   name: {{ include "api.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.api.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "app.selectorLabels" . | nindent 6 }}
+      {{- include "api.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
+        {{- include "api.selectorLabels" . | nindent 8 }}
       annotations:
         # This deployment should be restarted whenever either the configmap or the secrets change
         # because the containers depend on environment variables from these places during startup

--- a/.helm/ecamp3/templates/api_deployment.yaml
+++ b/.helm/ecamp3/templates/api_deployment.yaml
@@ -62,14 +62,16 @@ spec:
             tcpSocket:
               port: 3001
             initialDelaySeconds: 3
-            periodSeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             tcpSocket:
               port: 3001
             initialDelaySeconds: 3
-            periodSeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.caddy.resources | nindent 12 }}
         - name: php
           {{/* Define the php container as a template, so it can be reused in other places */}}
           {{- define "api.phpContainer" }}
@@ -171,7 +173,7 @@ spec:
               exec:
                 command: ["/bin/sh", "-c", "/bin/sleep 1; kill -QUIT 1"]
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.php.resources | nindent 12 }}
           {{- end }}
           {{- template "api.phpContainer" . }}
           readinessProbe:
@@ -179,12 +181,14 @@ spec:
               command:
                 - docker-healthcheck
             initialDelaySeconds: 3
-            periodSeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             exec:
               command:
                 - docker-healthcheck
-            periodSeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
           startupProbe:
             exec:
               command:

--- a/.helm/ecamp3/templates/api_hpa.yaml
+++ b/.helm/ecamp3/templates/api_hpa.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "api.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -17,12 +18,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/.helm/ecamp3/templates/api_ingress.yaml
+++ b/.helm/ecamp3/templates/api_ingress.yaml
@@ -4,7 +4,8 @@ kind: Ingress
 metadata:
   name: {{ include "api.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/.helm/ecamp3/templates/api_secrets.yaml
+++ b/.helm/ecamp3/templates/api_secrets.yaml
@@ -3,7 +3,8 @@ kind: Secret
 metadata:
   name: {{ include "api.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.postgresql.enabled }}

--- a/.helm/ecamp3/templates/api_service.yaml
+++ b/.helm/ecamp3/templates/api_service.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: {{ include "api.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.api.service.type }}
   ports:
@@ -12,4 +13,4 @@ spec:
       protocol: TCP
       name: api-http
   selector:
-    {{- include "app.selectorLabels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}

--- a/.helm/ecamp3/templates/browserless_configmap.yaml
+++ b/.helm/ecamp3/templates/browserless_configmap.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ include "browserless.name" . }}-configmap
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "browserless.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 data:
   MAX_CONCURRENT_SESSIONS: {{ .Values.browserless.maxConcurrentSessions | quote }}
   CONNECTION_TIMEOUT: {{ .Values.browserless.connectionTimeout | quote }}

--- a/.helm/ecamp3/templates/browserless_deployment.yaml
+++ b/.helm/ecamp3/templates/browserless_deployment.yaml
@@ -4,16 +4,17 @@ kind: Deployment
 metadata:
   name: {{ include "browserless.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "browserless.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "app.selectorLabels" . | nindent 6 }}
+      {{- include "browserless.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
+        {{- include "browserless.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/.helm/ecamp3/templates/browserless_service.yaml
+++ b/.helm/ecamp3/templates/browserless_service.yaml
@@ -4,7 +4,8 @@ kind: Service
 metadata:
   name: {{ include "browserless.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "browserless.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.browserless.service.type }}
   ports:
@@ -13,5 +14,5 @@ spec:
       protocol: TCP
       name: browserless-ws
   selector:
-    {{- include "app.selectorLabels" . | nindent 4 }}
+    {{- include "browserless.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/.helm/ecamp3/templates/frontend_configmap.yaml
+++ b/.helm/ecamp3/templates/frontend_configmap.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ include "frontend.name" . }}-configmap
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "frontend.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 data:
   environment.js: |
     window.environment = {
@@ -27,4 +28,4 @@ data:
     {{- end }}
       FEATURE_DEVELOPER: {{ .Values.featureToggle.developer | default false }},
     }
-  deployedVersion: {{ .Values.deployedVersion }}
+  deployedVersion: {{ .Values.deployedVersion | quote }}

--- a/.helm/ecamp3/templates/frontend_deployment.yaml
+++ b/.helm/ecamp3/templates/frontend_deployment.yaml
@@ -3,18 +3,19 @@ kind: Deployment
 metadata:
   name: {{ include "frontend.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "frontend.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.frontend.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "app.selectorLabels" . | nindent 6 }}
+      {{- include "frontend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
+        {{- include "frontend.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/.helm/ecamp3/templates/frontend_deployment.yaml
+++ b/.helm/ecamp3/templates/frontend_deployment.yaml
@@ -50,7 +50,7 @@ spec:
           # https://developers.redhat.com/blog/2020/11/10/you-probably-need-liveness-and-readiness-probes
           # livenessProbe:
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /app/environment.js
               name: environment-js

--- a/.helm/ecamp3/templates/frontend_hpa.yaml
+++ b/.helm/ecamp3/templates/frontend_hpa.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "frontend.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "frontend.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -17,12 +18,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/.helm/ecamp3/templates/frontend_ingress.yaml
+++ b/.helm/ecamp3/templates/frontend_ingress.yaml
@@ -4,7 +4,8 @@ kind: Ingress
 metadata:
   name: {{ include "frontend.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "frontend.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/.helm/ecamp3/templates/frontend_service.yaml
+++ b/.helm/ecamp3/templates/frontend_service.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: {{ include "frontend.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "frontend.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.frontend.service.type }}
   ports:
@@ -12,4 +13,4 @@ spec:
       protocol: TCP
       name: frontend-http
   selector:
-    {{- include "app.selectorLabels" . | nindent 4 }}
+    {{- include "frontend.selectorLabels" . | nindent 4 }}

--- a/.helm/ecamp3/templates/hook_db_create.yaml
+++ b/.helm/ecamp3/templates/hook_db_create.yaml
@@ -7,7 +7,8 @@ kind: Job
 metadata:
   name: "{{ include "app.name" . }}-db-create"
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -17,7 +18,7 @@ spec:
     metadata:
       name: "{{ include "app.name" . }}-pre-install"
       labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
+        {{- include "api.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       containers:

--- a/.helm/ecamp3/templates/hook_db_drop.yaml
+++ b/.helm/ecamp3/templates/hook_db_drop.yaml
@@ -7,7 +7,8 @@ kind: Job
 metadata:
   name: "{{ include "app.name" . }}-db-drop"
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-5"
@@ -17,7 +18,7 @@ spec:
     metadata:
       name: "{{ include "app.name" . }}-post-delete"
       labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
+        {{- include "api.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       containers:

--- a/.helm/ecamp3/templates/hook_db_migrate.yaml
+++ b/.helm/ecamp3/templates/hook_db_migrate.yaml
@@ -6,7 +6,8 @@ kind: Job
 metadata:
   name: "{{ include "app.name" . }}-db-migrate"
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -15,7 +16,7 @@ spec:
     metadata:
       name: "{{ include "app.name" . }}-pre-install"
       labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
+        {{- include "api.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       containers:

--- a/.helm/ecamp3/templates/hook_secrets.yaml
+++ b/.helm/ecamp3/templates/hook_secrets.yaml
@@ -7,7 +7,8 @@ kind: Secret
 metadata:
   name: "{{ include "app.name" . }}-hooks"
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,post-delete
     "helm.sh/hook-weight": "-6"

--- a/.helm/ecamp3/templates/mail_deployment.yaml
+++ b/.helm/ecamp3/templates/mail_deployment.yaml
@@ -4,16 +4,17 @@ kind: Deployment
 metadata:
   name: {{ include "mail.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "mail.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "app.selectorLabels" . | nindent 6 }}
+      {{- include "mail.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
+        {{- include "mail.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -43,5 +44,5 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 5
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.mail.resources | nindent 12 }}
 {{- end }}

--- a/.helm/ecamp3/templates/mail_ingress.yaml
+++ b/.helm/ecamp3/templates/mail_ingress.yaml
@@ -5,7 +5,8 @@ kind: Ingress
 metadata:
   name: {{ include "mail.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "mail.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/.helm/ecamp3/templates/mail_service.yaml
+++ b/.helm/ecamp3/templates/mail_service.yaml
@@ -4,7 +4,8 @@ kind: Service
 metadata:
   name: {{ include "mail.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "mail.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.mail.service.type }}
   ports:
@@ -17,5 +18,5 @@ spec:
       protocol: TCP
       name: mail-smtp
   selector:
-    {{- include "app.selectorLabels" . | nindent 4 }}
+    {{- include "mail.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/.helm/ecamp3/templates/print_configmap.yaml
+++ b/.helm/ecamp3/templates/print_configmap.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ include "print.name" . }}-configmap
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "print.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 data:
   INTERNAL_API_ROOT_URL: {{ include "api.url" . | quote }}
   FRONTEND_URL: {{ include "frontend.url" . | quote }}

--- a/.helm/ecamp3/templates/print_deployment.yaml
+++ b/.helm/ecamp3/templates/print_deployment.yaml
@@ -55,7 +55,7 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 10
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.print.resources | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "print.name" . }}-configmap

--- a/.helm/ecamp3/templates/print_deployment.yaml
+++ b/.helm/ecamp3/templates/print_deployment.yaml
@@ -3,18 +3,19 @@ kind: Deployment
 metadata:
   name: {{ include "print.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "print.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.print.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "app.selectorLabels" . | nindent 6 }}
+      {{- include "print.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
+        {{- include "print.selectorLabels" . | nindent 8 }}
       annotations:
         # This deployment should be restarted whenever either the configmap or the secrets change
         # because the container depends on environment variables from these places during startup

--- a/.helm/ecamp3/templates/print_hpa.yaml
+++ b/.helm/ecamp3/templates/print_hpa.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "print.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "print.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -17,12 +18,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/.helm/ecamp3/templates/print_ingress.yaml
+++ b/.helm/ecamp3/templates/print_ingress.yaml
@@ -4,7 +4,8 @@ kind: Ingress
 metadata:
   name: {{ include "print.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "print.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/.helm/ecamp3/templates/print_secrets.yaml
+++ b/.helm/ecamp3/templates/print_secrets.yaml
@@ -3,7 +3,8 @@ kind: Secret
 metadata:
   name: {{ include "print.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "print.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.print.sentryDsn }}

--- a/.helm/ecamp3/templates/print_service.yaml
+++ b/.helm/ecamp3/templates/print_service.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: {{ include "print.name" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "print.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.print.service.type }}
   ports:
@@ -12,4 +13,4 @@ spec:
       protocol: TCP
       name: print-http
   selector:
-    {{- include "app.selectorLabels" . | nindent 4 }}
+    {{- include "print.selectorLabels" . | nindent 4 }}

--- a/.helm/ecamp3/templates/serviceaccount.yaml
+++ b/.helm/ecamp3/templates/serviceaccount.yaml
@@ -4,7 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ include "app.serviceAccountName" . }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/.helm/ecamp3/templates/tests/test-connection.yaml
+++ b/.helm/ecamp3/templates/tests/test-connection.yaml
@@ -3,7 +3,8 @@ kind: Pod
 metadata:
   name: "{{ include "api.name" . }}-test-connection"
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
 spec:

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -53,7 +53,10 @@ php:
       clientId: 'raT1QFf6TOQzpn3yVH-My6YLrmsvOrfMhYypxzjPMWk'
       clientSecret: 'fTxMrzjBn3gPGg3eB0bNMmjRqg4ccs3_su7CaTXtljE'
       baseUrl: 'https://cevi.puzzle.ch'
-  resources: {}
+  resources:
+    requests:
+      cpu: 10m
+      memory: 120Mi
 
 caddy:
   image:
@@ -61,7 +64,10 @@ caddy:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose shared default is .Values.imageTag
     tag:
-  resources: {}
+  resources:
+    requests:
+      cpu: 10m
+      memory: 20Mi
 
 frontend:
   domain:
@@ -75,7 +81,10 @@ frontend:
     type: ClusterIP
     port: 3000
   replicaCount: 1
-  resources: {}
+  resources:
+    requests:
+      cpu: 10m
+      memory: 10Mi
 
 print:
   domain:
@@ -90,7 +99,10 @@ print:
     type: ClusterIP
     port: 3003
   replicaCount: 1
-  resources: {}
+  resources:
+    requests:
+      cpu: 10m
+      memory: 150Mi
 
 browserless:
   enabled: true
@@ -105,18 +117,10 @@ browserless:
   maxConcurrentSessions: 1
   connectionTimeout: 30000
   maxQueueLength: 5
-  resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
+  resources:
+    requests:
+      cpu: 10m
+      memory: 200Mi
 
 mail:
   dummyEnabled: true
@@ -135,7 +139,7 @@ mail:
   resources:
     requests:
       cpu: 10m
-      memory: 15Mi
+      memory: 10Mi
 
 
 # You may prefer using the managed version in production: https://mercure.rocks
@@ -164,6 +168,10 @@ postgresql:
   image:
     repository: bitnami/postgresql
     tag: 14
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi
 
 recaptcha:
   siteKey:

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -53,6 +53,7 @@ php:
       clientId: 'raT1QFf6TOQzpn3yVH-My6YLrmsvOrfMhYypxzjPMWk'
       clientSecret: 'fTxMrzjBn3gPGg3eB0bNMmjRqg4ccs3_su7CaTXtljE'
       baseUrl: 'https://cevi.puzzle.ch'
+  resources: {}
 
 caddy:
   image:
@@ -60,6 +61,7 @@ caddy:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose shared default is .Values.imageTag
     tag:
+  resources: {}
 
 frontend:
   domain:
@@ -73,6 +75,7 @@ frontend:
     type: ClusterIP
     port: 3000
   replicaCount: 1
+  resources: {}
 
 print:
   domain:
@@ -87,6 +90,7 @@ print:
     type: ClusterIP
     port: 3003
   replicaCount: 1
+  resources: {}
 
 browserless:
   enabled: true

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -132,6 +132,11 @@ mail:
   service:
     type: ClusterIP
     port: 8025
+  resources:
+    requests:
+      cpu: 10m
+      memory: 15Mi
+
 
 # You may prefer using the managed version in production: https://mercure.rocks
 mercure:
@@ -191,17 +196,6 @@ ingress:
   className: nginx
   tls:
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 autoscaling:
   enabled: false

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -75,6 +75,7 @@ RUN cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 COPY docker/php/conf.d/api-platform.prod.ini $PHP_INI_DIR/conf.d/api-platform.ini
 
 COPY docker/php/php-fpm.d/zz-docker.conf /usr/local/etc/php-fpm.d/zz-docker.conf
+COPY docker/php/php-fpm.d/www.conf /usr/local/etc/php-fpm.d/www.conf
 
 VOLUME /var/run/php
 

--- a/api/docker/php/php-fpm.d/www.conf
+++ b/api/docker/php/php-fpm.d/www.conf
@@ -113,7 +113,7 @@ pm = static
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 4
+pm.max_children = 6
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'

--- a/api/docker/php/php-fpm.d/www.conf
+++ b/api/docker/php/php-fpm.d/www.conf
@@ -1,0 +1,463 @@
+; Start a new pool named 'www'.
+; the variable $pool can be used in any directive and will be replaced by the
+; pool name ('www' here)
+[www]
+
+; Per pool prefix
+; It only applies on the following directives:
+; - 'access.log'
+; - 'slowlog'
+; - 'listen' (unixsocket)
+; - 'chroot'
+; - 'chdir'
+; - 'php_values'
+; - 'php_admin_values'
+; When not set, the global prefix (or NONE) applies instead.
+; Note: This directive can also be relative to the global prefix.
+; Default Value: none
+;prefix = /path/to/pools/$pool
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+user = www-data
+group = www-data
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
+;                            a specific port;
+;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses
+;                            (IPv6 and IPv4-mapped) on a specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
+listen = 127.0.0.1:9000
+
+; Set listen(2) backlog.
+; Default Value: 511 (-1 on FreeBSD and OpenBSD)
+;listen.backlog = 511
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server. Many
+; BSD-derived systems allow connections regardless of permissions. The owner
+; and group can be specified either by name or by their numeric IDs.
+; Default Values: user and group are set as the running user
+;                 mode is set to 0660
+;listen.owner = www-data
+;listen.group = www-data
+;listen.mode = 0660
+; When POSIX Access Control Lists are supported you can set them using
+; these options, value is a comma separated list of user/group names.
+; When set, listen.owner and listen.group are ignored
+;listen.acl_users =
+;listen.acl_groups =
+
+; List of addresses (IPv4/IPv6) of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+;listen.allowed_clients = 127.0.0.1
+
+; Specify the nice(2) priority to apply to the pool processes (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool processes will inherit the master process priority
+;         unless it specified otherwise
+; Default Value: no set
+; process.priority = -19
+
+; Set the process dumpable flag (PR_SET_DUMPABLE prctl) even if the process user
+; or group is different than the master process user. It allows to create process
+; core dump and ptrace the process for the pool user.
+; Default Value: no
+; process.dumpable = yes
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;             pm.max_spawn_rate    - the maximum number of rate to spawn child
+;                                    processes at once.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = static
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 4
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: (min_spare_servers + max_spare_servers) / 2
+;pm.start_servers = 2
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+;pm.min_spare_servers = 1
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+;pm.max_spare_servers = 3
+
+; The number of rate to spawn child processes at once.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+; Default Value: 32
+;pm.max_spawn_rate = 32
+
+; The number of seconds after which an idle process will be killed.
+; Note: Used only when pm is set to 'ondemand'
+; Default Value: 10s
+;pm.process_idle_timeout = 10s;
+
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+pm.max_requests = 1000
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. It shows the following information:
+;   pool                 - the name of the pool;
+;   process manager      - static, dynamic or ondemand;
+;   start time           - the date and time FPM has started;
+;   start since          - number of seconds since FPM has started;
+;   accepted conn        - the number of request accepted by the pool;
+;   listen queue         - the number of request in the queue of pending
+;                          connections (see backlog in listen(2));
+;   max listen queue     - the maximum number of requests in the queue
+;                          of pending connections since FPM has started;
+;   listen queue len     - the size of the socket queue of pending connections;
+;   idle processes       - the number of idle processes;
+;   active processes     - the number of active processes;
+;   total processes      - the number of idle + active processes;
+;   max active processes - the maximum number of active processes since FPM
+;                          has started;
+;   max children reached - number of times, the process limit has been reached,
+;                          when pm tries to start more children (works only for
+;                          pm 'dynamic' and 'ondemand');
+; Value are updated in real time.
+; Example output:
+;   pool:                 www
+;   process manager:      static
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          62636
+;   accepted conn:        190460
+;   listen queue:         0
+;   max listen queue:     1
+;   listen queue len:     42
+;   idle processes:       4
+;   active processes:     11
+;   total processes:      15
+;   max active processes: 12
+;   max children reached: 0
+;
+; By default the status page output is formatted as text/plain. Passing either
+; 'html', 'xml' or 'json' in the query string will return the corresponding
+; output syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+;   http://www.foo.bar/status?xml
+;
+; By default the status page only outputs short status. Passing 'full' in the
+; query string will also return status for each pool process.
+; Example:
+;   http://www.foo.bar/status?full
+;   http://www.foo.bar/status?json&full
+;   http://www.foo.bar/status?html&full
+;   http://www.foo.bar/status?xml&full
+; The Full status returns for each process:
+;   pid                  - the PID of the process;
+;   state                - the state of the process (Idle, Running, ...);
+;   start time           - the date and time the process has started;
+;   start since          - the number of seconds since the process has started;
+;   requests             - the number of requests the process has served;
+;   request duration     - the duration in µs of the requests;
+;   request method       - the request method (GET, POST, ...);
+;   request URI          - the request URI with the query string;
+;   content length       - the content length of the request (only with POST);
+;   user                 - the user (PHP_AUTH_USER) (or '-' if not set);
+;   script               - the main script called (or '-' if not set);
+;   last request cpu     - the %cpu the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because CPU calculation is done when the request
+;                          processing has terminated;
+;   last request memory  - the max amount of memory the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because memory calculation is done when the request
+;                          processing has terminated;
+; If the process is in Idle state, then informations are related to the
+; last request the process has served. Otherwise informations are related to
+; the current request being served.
+; Example output:
+;   ************************
+;   pid:                  31330
+;   state:                Running
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          63087
+;   requests:             12808
+;   request duration:     1250261
+;   request method:       GET
+;   request URI:          /test_mem.php?N=10000
+;   content length:       0
+;   user:                 -
+;   script:               /home/fat/web/docs/php/test_mem.php
+;   last request cpu:     0.00
+;   last request memory:  0
+;
+; Note: There is a real-time FPM status monitoring sample web page available
+;       It's available in: /usr/local/share/php/fpm/status.html
+;
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;pm.status_path = /status
+
+; The address on which to accept FastCGI status request. This creates a new
+; invisible pool that can handle requests independently. This is useful
+; if the main pool is busy with long running requests because it is still possible
+; to get the status before finishing the long running requests.
+;
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
+;                            a specific port;
+;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses
+;                            (IPv6 and IPv4-mapped) on a specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Default Value: value of the listen option
+;pm.status_listen = 127.0.0.1:9001
+
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong
+
+; The access log file
+; Default: not set
+;access.log = log/$pool.access.log
+
+; The access log format.
+; The following syntax is allowed
+;  %%: the '%' character
+;  %C: %CPU used by the request
+;      it can accept the following format:
+;      - %{user}C for user CPU only
+;      - %{system}C for system CPU only
+;      - %{total}C  for user + system CPU (default)
+;  %d: time taken to serve the request
+;      it can accept the following format:
+;      - %{seconds}d (default)
+;      - %{milliseconds}d
+;      - %{milli}d
+;      - %{microseconds}d
+;      - %{micro}d
+;  %e: an environment variable (same as $_ENV or $_SERVER)
+;      it must be associated with embraces to specify the name of the env
+;      variable. Some examples:
+;      - server specifics like: %{REQUEST_METHOD}e or %{SERVER_PROTOCOL}e
+;      - HTTP headers like: %{HTTP_HOST}e or %{HTTP_USER_AGENT}e
+;  %f: script filename
+;  %l: content-length of the request (for POST request only)
+;  %m: request method
+;  %M: peak of memory allocated by PHP
+;      it can accept the following format:
+;      - %{bytes}M (default)
+;      - %{kilobytes}M
+;      - %{kilo}M
+;      - %{megabytes}M
+;      - %{mega}M
+;  %n: pool name
+;  %o: output header
+;      it must be associated with embraces to specify the name of the header:
+;      - %{Content-Type}o
+;      - %{X-Powered-By}o
+;      - %{Transfert-Encoding}o
+;      - ....
+;  %p: PID of the child that serviced the request
+;  %P: PID of the parent of the child that serviced the request
+;  %q: the query string
+;  %Q: the '?' character if query string exists
+;  %r: the request URI (without the query string, see %q and %Q)
+;  %R: remote IP address
+;  %s: status (response code)
+;  %t: server time the request was received
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsulated in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %T: time the log has been written (the request has finished)
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsulated in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %u: remote user
+;
+; Default: "%R - %u %t \"%m %r\" %s"
+;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{milli}d %{kilo}M %C%%"
+
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
+;slowlog = log/$pool.log.slow
+
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_slowlog_timeout = 0
+
+; Depth of slow log stack trace.
+; Default Value: 20
+;request_slowlog_trace_depth = 20
+
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_terminate_timeout = 0
+
+; The timeout set by 'request_terminate_timeout' ini option is not engaged after
+; application calls 'fastcgi_finish_request' or when application has finished and
+; shutdown functions are being called (registered via register_shutdown_function).
+; This option will enable timeout limit to be applied unconditionally
+; even in such cases.
+; Default Value: no
+;request_terminate_timeout_track_finished = no
+
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+;rlimit_files = 1024
+
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: you can prefix with '$prefix' to chroot to the pool prefix or one
+; of its subdirectories. If the pool prefix is not set, the global prefix
+; will be used instead.
+; Note: chrooting is a great security feature and should be used whenever
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+;chroot =
+
+; Chdir to this directory at the start.
+; Note: relative path can be used.
+; Default Value: current directory or / when chroot
+;chdir = /var/www
+
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environment, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+;catch_workers_output = yes
+
+; Decorate worker output with prefix and suffix containing information about
+; the child that writes to the log and if stdout or stderr is used as well as
+; log level and time. This options is used only if catch_workers_output is yes.
+; Settings to "no" will output data as written to the stdout or stderr.
+; Default value: yes
+;decorate_workers_output = no
+
+; Clear environment in FPM workers
+; Prevents arbitrary environment variables from reaching FPM worker processes
+; by clearing the environment in workers before env vars specified in this
+; pool configuration are added.
+; Setting to "no" will make all environment variables available to PHP code
+; via getenv(), $_ENV and $_SERVER.
+; Default Value: yes
+;clear_env = no
+
+; Limits the extensions of the main script FPM will allow to parse. This can
+; prevent configuration mistakes on the web server side. You should only limit
+; FPM to .php extensions to prevent malicious users to use other extensions to
+; execute php code.
+; Note: set an empty value to allow all extensions.
+; Default Value: .php
+;security.limit_extensions = .php .php3 .php4 .php5 .php7
+
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'.
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Note: path INI options can be relative and will be expanded with the prefix
+; (pool, global or /usr/local)
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_flag[display_errors] = off
+;php_admin_value[error_log] = /var/log/fpm-php.www.log
+;php_admin_flag[log_errors] = on
+;php_admin_value[memory_limit] = 32M


### PR DESCRIPTION
I was doing a bit of load testing for our API with Apache JMeter. A JMeter test plan and some screenshots are uploaded to Dropbox, if anyone wants to play around.

**Some key parameters of the load test:**
- GET requests on /index.jsonhal directly to Kubernetes server (not via Cloudflare)
- Ramp-up from 0 to 30 concurrent thread over 1min (1 additional thread every 2 seconds) - see screenshot below
- Stable load (30 threads) for another 2 min
- Each thread continuously sends requests, whenever the previous request has finished (infinite loop)
- Postgres running in Kubernetes (not as managed DB). It didn't seem that the DB was any bottleneck in the test, nevertheless, this could improve results slightly when having DB as a managed/separate workload.

For the helm deployment I used the following params:
```
  --set browserless.resources.requests.cpu=500m \
  --set browserless.resources.requests.memory=800Mi \
  --set caddy.resources.requests.cpu=50m \
  --set caddy.resources.limits.cpu=500m \
  --set php.resources.requests.cpu=1000m \
  --set php.resources.requests.memory=500Mi \
  --set php.resources.limits.cpu=1900m \
  --set frontend.resources.requests.cpu=50m \
  --set print.resources.requests.cpu=300m \
  --set print.resources.requests.memory=150Mi \
  --set autoscaling.enabled=true \
  --set autoscaling.targetCPUUtilizationPercentage=90 \
````

![image](https://user-images.githubusercontent.com/449555/204149753-03d77e0b-9916-4751-bd1f-afccbc4f25f0.png)

**Some results:** 
- On our dev environment, the API maxes out at approx. 12 transactions/second
- The small type of droplets we have on dev environment is not very optimal. The various services form Kubernetes + DNS + Ingress + Prometheus already reserve a lot of resources and don't leave much for our own services.
- For my tests, I set up a cluster based on slightly larger droplets "Basic - 2vCPU 4 GB RAM"
- With this setup, I achieved a throughput of approx. 30 transaction per API-pod (see below an example with 3 running API-pods)
- Autoscaling takes quite some time (barely within the 3min of tests), so it's less suitable for quick spikes but more for a granular increase in load

![image](https://user-images.githubusercontent.com/449555/204149976-293a25d7-6c17-41cb-8983-798d3c313720.png)

**Some improvements in this PR based on my findings:**
- Configurable resources for each deployment
- Static FPM workers
- More lax probes to avoid pods being shut down when under fire
- Fix Autoscaler: There was an issue with the usage of labels, which led to the autoscaler using metrics of all pods across the application. This is now fixed and the autoscaler only measure the metrics of the pods of the concerning deployment/service.
- Added some sensible minimum defaults for memory requests to avoid pods being scheduled on memory-depleted nodes. The default memory requests are very minimal and suitable for dev-environment where the pods are mostly idle. Higher requests are needed for real/prod deployments.

**Some further idea for improvements:**
- make HPA parameters configurable for each service (e.g. different maximum number of replicas for API than for frontend)
- user other parameters than CPU for efficient scaling, e.g. the number of busy fpm workers (https://blog.wyrihaximus.net/2021/01/scaling-php-fpm-based-on-utilization-demand-on-kubernetes/)
- debug prometheus memory requirements: prometheus using quite some memory (>500M) but having very small memory requests. Unless this memory requirement is adjusting automatically (maybe?), this will create issues when memory is near the limit.