### PR TITLE
fix(renovate): pin php-version for renovate to 8.1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
   ],
   "force": {
     "constraints": {
-      "node": "18.12.1"
+      "node": "18.12.1",
+      "php": "~8.1.13"
     }
   },
   "automergeType": "branch",
@@ -18,7 +19,9 @@
   "vulnerabilityAlerts": {
     "automerge": true
   },
-  "labels": ["renovate"],
+  "labels": [
+    "renovate"
+  ],
   "packageRules": [
     {
       "updateTypes": [


### PR DESCRIPTION
Some packages are not yet compatible with php 8.2
Renovate currently runs with php 8.2 though and fails. This PR ensures renovate runs composer with php < 8.2.

See for example the following PRs:
https://github.com/ecamp/ecamp3/pull/3207#issuecomment-1347588052
https://github.com/ecamp/ecamp3/pull/3208#issuecomment-1348990830