### PR TITLE
Deployment: only start browserless if needed

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -227,7 +227,8 @@ jobs:
             --set deployedVersion="$(git rev-parse --short '${{ matrix.deployment.sha }}')" \
             --set recaptcha.siteKey='${{ secrets.RECAPTCHA_SITE_KEY }}' \
             --set recaptcha.secret='${{ secrets.RECAPTCHA_SECRET }}' \
-            --set featureToggle.developer=true
+            --set featureToggle.developer=true \
+            --set scaleToZero.enabled=true
 
       - name: Finish the GitHub deployment
         uses: bobheadxi/deployments@v1.3.0

--- a/.helm/ecamp3/Chart.lock
+++ b/.helm/ecamp3/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami/
-  version: 10.16.2
-digest: sha256:ec24e84477cbbcb011ba7f5ab7bd598c960f76e3d7941930cd207a45ff4a8f23
-generated: "2022-02-27T21:02:04.646325727Z"

--- a/.helm/ecamp3/Chart.yaml
+++ b/.helm/ecamp3/Chart.yaml
@@ -23,9 +23,3 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 0.1.0
-
-dependencies:
-  - name: postgresql
-    version: ~10.16.0
-    repository: https://charts.bitnami.com/bitnami/
-    condition: postgresql.enabled

--- a/.helm/ecamp3/templates/browserless_deployment.yaml
+++ b/.helm/ecamp3/templates/browserless_deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     {{- include "browserless.selectorLabels" . | nindent 4 }}
     {{- include "app.commonLabels" . | nindent 4 }}
 spec:
-  replicas: 1
   selector:
     matchLabels:
       {{- include "browserless.selectorLabels" . | nindent 6 }}

--- a/.helm/ecamp3/templates/browserless_httpscaledobject.yaml
+++ b/.helm/ecamp3/templates/browserless_httpscaledobject.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.browserless.enabled .Values.scaleToZero.enabled }}
+kind: HTTPScaledObject
+apiVersion: http.keda.sh/v1alpha1
+metadata:
+  name: {{ include "browserless.name" . }}
+  labels:
+    {{- include "browserless.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
+spec:
+  host: {{ include "browserless.name" . }}
+  targetPendingRequests: 100
+  scaleTargetRef:
+    deployment: {{ include "browserless.name" . }}
+    service: {{ include "browserless.name" . }}
+    port: 3000
+  replicas:
+    min: 0
+    max: {{ .Values.autoscaling.maxReplicas }}
+{{- end }}

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -212,3 +212,6 @@ autoscaling:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+
+scaleToZero:
+  enabled: false


### PR DESCRIPTION
Tried to automatically scale down the browserless container with https://artifacthub.io/packages/helm/kedacore/keda-add-ons-http

The automatic scaling down worked, but the additional controllers and services needed too much resources, so i could not get an api running.
(Because the dev deployment is not working, we currently have only one node running.)
I could not get the node pool to scale up again. (maybe it could be achieved manually, but i did not do that.)
Used the instructions from https://www.linode.com/de/blog/kubernetes/scaling-kubernetes-to-zero-and-back/

That we have a http request to check if the container is used, i tried to send an http request to the /pressure endpoint of the browserless container.

I will close this PR for now.