### PR TITLE
Improve activity header

### DIFF
--- a/common/helpers/__tests__/dateHelperUTCFormatted.spec.js
+++ b/common/helpers/__tests__/dateHelperUTCFormatted.spec.js
@@ -1,0 +1,84 @@
+import {
+  dateRange,
+  rangeLongEnd,
+  rangeShort,
+  timeDurationShort,
+} from '../dateHelperUTCFormatted.js'
+
+const tcMock = (string, _, obj = {}) => {
+  return Object.entries(obj).reduce((previous, [key, value]) => {
+    return previous.replace(`{${key}}`, value)
+  }, tcMockString(string))
+}
+
+const tcMockString = (string) => {
+  switch (string) {
+    case 'global.datetime.dateLong':
+      return 'dd L'
+    case 'global.datetime.dateShort':
+      return 'dd D.M.'
+    case 'global.datetime.dateTimeLong':
+      return 'dd L HH:mm'
+    case 'global.datetime.hourLong':
+      return 'HH:mm'
+    case 'global.datetime.hourShort':
+      return 'H:mm'
+    case 'global.datetime.duration.minutesOnly':
+      return '{minutes}min'
+    case 'global.datetime.duration.hoursOnly':
+      return '{hours}h'
+    case 'global.datetime.duration.hoursAndMinutes':
+      return '{hours}h {minutes}min'
+  }
+}
+
+describe('timeDurationShort', function () {
+  it.each([
+    ['only hour(s)', '1h', '2020-06-07T10:00:00.000Z', '2020-06-07T11:00:00.000Z'],
+    ['only minute(s)', '30min', '2020-06-07T10:00:00.000Z', '2020-06-07T10:30:00.000Z'],
+    ['both', '1h 30min', '2020-06-07T10:00:00.000Z', '2020-06-07T11:30:00.000Z'],
+    ['both', '8h', '2020-06-07T10:00:00.000Z', '2020-06-07T18:00:00.000Z'],
+    ['both', '25h 30min', '2020-06-07T10:00:00.000Z', '2020-06-08T11:30:00.000Z'],
+  ])('should print %s: %s', (_, duration, start, end) => {
+    expect(timeDurationShort(start, end, tcMock)).toEqual(duration)
+  })
+})
+
+describe('rangeShort', () => {
+  it('omits end date if it is the same as start date: Tu 1.1. 20:00 - 22:00', () => {
+    expect(
+      rangeShort('2019-01-01T20:00:00.000Z', '2019-01-01T22:00:00.000Z', tcMock)
+    ).toEqual('Tu 1.1. 20:00 - 22:00')
+  })
+  it('prints end date if it another date: Tu 1.1. 14:00 - We 2.1. 10:00', () => {
+    expect(
+      rangeShort('2019-01-01T14:00:00.000Z', '2019-01-02T10:00:00.000Z', tcMock)
+    ).toEqual('Tu 1.1. 14:00 - We 2.1. 10:00')
+  })
+})
+
+describe('rangeLongEnd', () => {
+  it('omits end date if it is the same as start date: 20:00 - 22:00', () => {
+    expect(
+      rangeLongEnd('2019-01-01T20:00:00.000Z', '2019-01-01T22:00:00.000Z', tcMock)
+    ).toEqual('20:00 - 22:00')
+  })
+  it('prints end date if it another date: 14:00 - We 2.1. 10:00', () => {
+    expect(
+      rangeLongEnd('2019-01-01T14:00:00.000Z', '2019-01-02T10:00:00.000Z', tcMock)
+    ).toEqual('14:00 - We 2.1. 10:00')
+  })
+})
+
+describe('dateRange', () => {
+  it('omits end date if it is the same as start date: Tu 01/01/2019', () => {
+    expect(
+      dateRange('2019-01-01T20:00:00.000Z', '2019-01-01T22:00:00.000Z', tcMock)
+    ).toEqual('Tu 01/01/2019')
+  })
+  it('prints end date if it another date: Tu 1.1. - We 01/02/2019', () => {
+    expect(
+      dateRange('2019-01-01T14:00:00.000Z', '2019-01-02T10:00:00.000Z', tcMock)
+    ).toEqual('Tu 1.1. - We 01/02/2019')
+  })
+})

--- a/common/helpers/dateHelperUTCFormatted.js
+++ b/common/helpers/dateHelperUTCFormatted.js
@@ -12,6 +12,10 @@ function hourShort(dateTimeString, tc) {
   return dayjs.utc(dateTimeString).format(tc('global.datetime.hourShort'))
 }
 
+function hourLong(dateTimeString, tc) {
+  return dayjs.utc(dateTimeString).format(tc('global.datetime.hourLong'))
+}
+
 function timeDurationShort(start, end, tc) {
   const startTime = dayjs.utc(start)
   const endTime = dayjs.utc(end)
@@ -54,6 +58,25 @@ function rangeShort(start, end, tc) {
   return result
 }
 
+// long end part of dateTime range format
+// doesn't repeat end date if on the same day
+function rangeLongEnd(start, end, tc) {
+  let result = ''
+
+  result += hourLong(start, tc)
+
+  result += ' - '
+
+  if (dateShort(start, tc) !== dateShort(end, tc)) {
+    result += dateShort(end, tc)
+    result += ' '
+  }
+
+  result += hourLong(end, tc)
+
+  return result
+}
+
 // format of date range
 function dateRange(start, end, tc) {
   if (dateLong(start, tc) === dateLong(end, tc)) {
@@ -62,4 +85,13 @@ function dateRange(start, end, tc) {
   return `${dateShort(start, tc)} - ${dateLong(end, tc)}`
 }
 
-export { dateShort, dateLong, timeDurationShort, hourShort, dateRange, rangeShort }
+export {
+  dateShort,
+  dateLong,
+  timeDurationShort,
+  hourShort,
+  hourLong,
+  dateRange,
+  rangeShort,
+  rangeLongEnd,
+}

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -153,8 +153,8 @@
     },
     "scheduleEntry": {
       "fields": {
-        "length": "Dauer in Minuten",
-        "nr": "Nr",
+        "duration": "Dauer",
+        "nr": "Nr.",
         "time": "Zeitpunkt"
       },
       "name": "Zeitplaneintrag"

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -160,8 +160,8 @@
     },
     "scheduleEntry": {
       "fields": {
-        "length": "Length in Minutes",
-        "nr": "Nr",
+        "duration": "Duration",
+        "nr": "No.",
         "time": "Time"
       },
       "name": "Activity scheduled"

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -109,9 +109,9 @@
     },
     "scheduleEntry": {
       "fields": {
-        "length": "Durée en minutes",
-        "nr": "Numéro",
-        "time": "Heure"
+        "duration": "Durée",
+        "nr": "No.",
+        "time": "Moment"
       },
       "name": "Inscription au calendrier"
     }

--- a/common/locales/it.json
+++ b/common/locales/it.json
@@ -109,8 +109,8 @@
     },
     "scheduleEntry": {
       "fields": {
-        "length": "Lunghezza in minuti",
-        "nr": "Numero",
+        "duration": "Durata",
+        "nr": "N.",
         "time": "Tempo"
       },
       "name": "Inserimento nel programma"

--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -139,27 +139,45 @@ Displays a single scheduleEntry
       <template v-else>
         <!-- Header -->
         <v-row dense class="activity-header">
-          <v-col class="col col-sm-6 col-12">
-            <v-row v-if="$vuetify.breakpoint.smAndUp" dense>
-              <v-col cols="2">
-                {{ $tc('entity.scheduleEntry.fields.nr') }}
-              </v-col>
-              <v-col cols="10">
-                {{ $tc('entity.scheduleEntry.fields.time') }}
-              </v-col>
-            </v-row>
-            <v-row
-              v-for="scheduleEntryItem in scheduleEntries"
-              :key="scheduleEntryItem._meta.self"
-              dense
-            >
-              <v-col cols="2"> ({{ scheduleEntryItem.number }}) </v-col>
-              <v-col cols="10">
-                {{ rangeShort(scheduleEntryItem.start, scheduleEntryItem.end) }}
-              </v-col>
-            </v-row>
+          <v-col class="col col-sm-6 col-12 px-0 pt-0">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col" class="text-right pb-2 pr-4">
+                    {{ $tc('entity.scheduleEntry.fields.nr') }}
+                  </th>
+                  <th scope="col" class="text-left pb-2 pr-4">
+                    {{ $tc('entity.scheduleEntry.fields.duration') }}
+                  </th>
+                  <th scope="col" class="text-left pb-2" colspan="2">
+                    {{ $tc('entity.scheduleEntry.fields.time') }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="scheduleEntryItem in scheduleEntries"
+                  :key="scheduleEntryItem._meta.self"
+                >
+                  <th class="text-right tabular-nums pb-2 pr-4">
+                    {{ scheduleEntryItem.number }}
+                  </th>
+                  <td class="text-left tabular-nums pb-2 pr-4">
+                    {{
+                      timeDurationShort(scheduleEntryItem.start, scheduleEntryItem.end)
+                    }}
+                  </td>
+                  <td class="text-right tabular-nums pb-2 pr-1">
+                    {{ dateShort(scheduleEntryItem.start) }}
+                  </td>
+                  <td class="text-left tabular-nums pb-2 pr-0">
+                    {{ rangeLongEnd(scheduleEntryItem.start, scheduleEntryItem.end) }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </v-col>
-          <v-col class="col col-sm-6 col-12">
+          <v-col class="col col-sm-6 col-12 px-0">
             <v-row dense>
               <v-col>
                 <api-text-field

--- a/frontend/src/mixins/dateHelperUTCFormatted.js
+++ b/frontend/src/mixins/dateHelperUTCFormatted.js
@@ -2,8 +2,10 @@ import {
   dateShort,
   dateLong,
   hourShort,
+  hourLong,
   timeDurationShort,
   rangeShort,
+  rangeLongEnd,
   dateRange,
 } from '@/common/helpers/dateHelperUTCFormatted.js'
 
@@ -18,11 +20,17 @@ export const dateHelperUTCFormatted = {
     hourShort(dateTimeString) {
       return hourShort(dateTimeString, this.$tc.bind(this))
     },
+    hourLong(dateTimeString) {
+      return hourLong(dateTimeString, this.$tc.bind(this))
+    },
     timeDurationShort(start, end) {
       return timeDurationShort(start, end, this.$tc.bind(this))
     },
     rangeShort(start, end) {
       return rangeShort(start, end, this.$tc.bind(this))
+    },
+    rangeLongEnd(start, end) {
+      return rangeLongEnd(start, end, this.$tc.bind(this))
     },
     dateRange(start, end) {
       return dateRange(start, end, this.$tc.bind(this))


### PR DESCRIPTION
I tried to make the schedule entry list more useful. It now shows duration and tabular times.

| before | after |
| - | - |
| ![Bildschirmfoto 2023-01-02 um 20 44 32](https://user-images.githubusercontent.com/3001985/210272951-3513b7d1-39ed-4058-92c1-675669f527db.png) | ![Bildschirmfoto 2023-01-02 um 20 44 42](https://user-images.githubusercontent.com/3001985/210272961-6ec06562-c510-4277-b6eb-d1bb71b6297d.png) |
| ![Bildschirmfoto 2023-01-02 um 20 47 02](https://user-images.githubusercontent.com/3001985/210273121-7b71cc24-7cad-43c8-9a9c-43f8b3cdad3f.png) | ![Bildschirmfoto 2023-01-02 um 20 47 38](https://user-images.githubusercontent.com/3001985/210273152-832124e0-0881-4e48-8f7c-78aeefd816a6.png) |
