### PR TITLE
Move services to subpath for development setup

### DIFF
--- a/.helm/ecamp3/templates/api_configmap.yaml
+++ b/.helm/ecamp3/templates/api_configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "api.selectorLabels" . | nindent 4 }}
     {{- include "app.commonLabels" . | nindent 4 }}
 data:
-  API_DOMAIN: {{ .Values.api.domain | quote }}
+  ADDITIONAL_TRUSTED_HOSTS: {{ .Values.api.domain | quote }}
   COOKIE_PREFIX: {{ include "api.cookiePrefix" . | quote }}
   SHARED_COOKIE_DOMAIN: {{ .Values.sharedCookieDomain | quote }}
   APP_ENV: {{ .Values.php.appEnv | quote }}

--- a/api/.env
+++ b/api/.env
@@ -15,7 +15,7 @@
 
 # API Platform distribution
 TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-API_DOMAIN=localhost
+ADDITIONAL_TRUSTED_HOSTS=localhost
 COOKIE_PREFIX=localhost_
 SHARED_COOKIE_DOMAIN=localhost
 MERCURE_SUBSCRIBE_URL=https://localhost/.well-known/mercure

--- a/api/.env.test
+++ b/api/.env.test
@@ -4,6 +4,6 @@ APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
-API_DOMAIN=example.com
+ADDITIONAL_TRUSTED_HOSTS=example.com
 COOKIE_PREFIX=example_com_
 TRANSLATE_ERRORS_TO_LOCALES="en,en_CH_scout,de,de_CH_scout,fr,fr_CH_scout,it,it_CH_scout"

--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -9,7 +9,9 @@ framework:
         - caddy
         - '%env(API_DOMAIN)%'
     # See https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers
-    trusted_headers: ['x-forwarded-for', 'x-forwarded-proto']
+    trusted_headers:
+        - 'x-forwarded-for'
+        - 'x-forwarded-proto'
 
     disallow_search_engine_index: true
 

--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -11,6 +11,7 @@ framework:
     # See https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers
     trusted_headers:
         - 'x-forwarded-for'
+        - 'x-forwarded-prefix'
         - 'x-forwarded-proto'
 
     disallow_search_engine_index: true

--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -7,7 +7,7 @@ framework:
     trusted_hosts:
         - localhost
         - caddy
-        - '%env(API_DOMAIN)%'
+        - '%env(ADDITIONAL_TRUSTED_HOSTS)%'
     # See https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers
     trusted_headers:
         - 'x-forwarded-for'

--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -1,50 +1,76 @@
 {
-    # Debug
-    {$DEBUG}
+	# Debug
+	{$DEBUG}
 
-    http_port 3001
-    https_port 3443
-    auto_https disable_redirects
+	auto_https disable_redirects
 }
 
-{$SERVER_NAME}
+:3000 {
+	log {
+		level DEBUG
+	}
 
-log
+	handle_path /api* {
+		# rewriting the uri used for php-fcgi did not work
+		# so we make a hop more to localhost:3001 with the rewritten url where the fcgi happens
+		# this may slow down the request
 
-# Matches requests for HTML documents, for static files,
-# except for known API paths and paths with extensions handled by API Platform
-@pwa expression `(
-        {header.Accept}.matches("\\btext/html\\b")
-        && !{path}.matches("(?i)(?:^/docs|^/graphql|^/bundles/|^/_profiler|^/_wdt|\\.(?:json|html$|csv$|ya?ml$|xml$))")
-    )
-    || {path} == "/favicon.ico"
-    || {path} == "/manifest.json"
-    || {path} == "/robots.txt"
-    || {path}.startsWith("/sitemap")`
+		reverse_proxy localhost:3001 {
+			header_up X-Forwarded-Prefix "/api"
+		}
+	}
 
-route {
-    root * /srv/api/public
-    mercure {
-        # Transport to use (default to Bolt)
-        transport_url {$MERCURE_TRANSPORT_URL:bolt:///data/mercure.db}
-        # Publisher JWT key
-        publisher_jwt {env.MERCURE_PUBLISHER_JWT_KEY} {env.MERCURE_PUBLISHER_JWT_ALG}
-        # Subscriber JWT key
-        subscriber_jwt {env.MERCURE_SUBSCRIBER_JWT_KEY} {env.MERCURE_SUBSCRIBER_JWT_ALG}
-        # Allow anonymous subscribers (double-check that it's what you want)
-        anonymous
-        # Enable the subscription API (double-check that it's what you want)
-        subscriptions
-        # Extra directives
-        {$MERCURE_EXTRA_DIRECTIVES}
-    }
-    vulcain
-    push
+	handle_path /print* {
+		reverse_proxy print:3003
+	}
 
-    # Add links to the API docs and to the Mercure Hub if not set explicitly (e.g. the PWA)
-    header ?Link `</docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation", </.well-known/mercure>; rel="mercure"`
+	handle /mail* {
+		reverse_proxy mail:8025
+	}
 
-    php_fastcgi unix//var/run/php/php-fpm.sock
-    encode zstd gzip
-    file_server
+	handle {
+		reverse_proxy frontend:3000
+	}
+}
+
+:3001 {
+	# Matches requests for HTML documents, for static files,
+	# except for known API paths and paths with extensions handled by API Platform
+	@pwa expression `( 
+	{header.Accept}.matches("\\btext/html\\b")
+	&& !{path}.matches("(?i)(?:^/docs|^/graphql|^/bundles/|^/_profiler|^/_wdt|\\.(?:json|html$|csv$|ya?ml$|xml$))")
+	)
+	|| {path} == "/favicon.ico"
+	|| {path} == "/manifest.json"
+	|| {path} == "/robots.txt"
+	|| {path}.startsWith("/sitemap")`
+
+	route {
+		root * /srv/api/public
+		mercure {
+			# Transport to use (default to Bolt)
+			transport_url {$MERCURE_TRANSPORT_URL:bolt:///data/mercure.db}
+			# Publisher JWT key
+			publisher_jwt {env.MERCURE_PUBLISHER_JWT_KEY} {env.MERCURE_PUBLISHER_JWT_ALG}
+			# Subscriber JWT key
+			subscriber_jwt {env.MERCURE_SUBSCRIBER_JWT_KEY} {env.MERCURE_SUBSCRIBER_JWT_ALG}
+			# Allow anonymous subscribers (double-check that it's what you want)
+			anonymous
+			# Enable the subscription API (double-check that it's what you want)
+			subscriptions
+			# Extra directives
+			{$MERCURE_EXTRA_DIRECTIVES}
+		}
+		vulcain
+		push
+
+		# Add links to the API docs and to the Mercure Hub if not set explicitly (e.g. the PWA)
+		header ?Link `</docs.jsonld>; rel="www.w3.org/ns/hydra/core#apiDocumentation", </.well-known/mercure>; rel="mercure"`
+
+		php_fastcgi unix//var/run/php/php-fpm.sock {
+			env HTTP_X_FORWARDED_PREFIX {header.X-Forwarded-Prefix}
+		}
+		encode zstd gzip
+		file_server
+	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: node:18.14.1
     container_name: 'ecamp3-frontend'
     ports:
-      - '3000:3000'
       - '9229:9229' # jest debug
     stdin_open: true
     tty: true
@@ -57,6 +56,8 @@ services:
       # This should correspond to the server declared in PHPStorm `Preferences | Languages & Frameworks | PHP | Servers`
       # Then PHPStorm will use the corresponding path mappings
       PHP_IDE_CONFIG: serverName=localhost
+      API_DOMAIN: ".*"
+      SHARED_COOKIE_DOMAIN: ""
     healthcheck:
       interval: 10s
       timeout: 3s
@@ -80,18 +81,9 @@ services:
       MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_SUBSCRIBER_JWT_KEY:-!ChangeMe!}
       MERCURE_EXTRA_DIRECTIVES: demo
     ports:
-      # HTTP
-      - target: 3001
-        published: 3001
+      - target: 3000
+        published: 3000
         protocol: tcp
-      # HTTPS
-      - target: 3443
-        published: 3443
-        protocol: tcp
-      # HTTP/3
-      - target: 3443
-        published: 3443
-        protocol: udp
     restart: unless-stopped
     user: ${USER_ID:-1000}
     volumes:
@@ -104,8 +96,6 @@ services:
   print:
     image: node:18.14.1
     container_name: 'ecamp3-print'
-    ports:
-      - '3003:3003'
     volumes:
       - ./.prettierrc:/.prettierrc
       - ./print:/app:delegated
@@ -144,8 +134,8 @@ services:
   mail:
     image: mailhog/mailhog
     container_name: 'ecamp3-mail'
-    ports:
-      - '3007:8025' # web UI
+    environment:
+      - MH_UI_WEB_PATH=/mail
 
   docker-host:
     image: qoomon/docker-host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       # This should correspond to the server declared in PHPStorm `Preferences | Languages & Frameworks | PHP | Servers`
       # Then PHPStorm will use the corresponding path mappings
       PHP_IDE_CONFIG: serverName=localhost
-      API_DOMAIN: ".*"
+      ADDITIONAL_TRUSTED_HOSTS: ".*"
       SHARED_COOKIE_DOMAIN: ""
     healthcheck:
       interval: 10s

--- a/frontend/.jest/environment.js
+++ b/frontend/.jest/environment.js
@@ -1,7 +1,7 @@
 window.environment = {
-  API_ROOT_URL: 'http://localhost',
+  API_ROOT_URL: '/api',
   COOKIE_PREFIX: 'localhost_',
-  PRINT_URL: 'http://localhost:3003',
+  PRINT_URL: '/print',
   SENTRY_FRONTEND_DSN: null,
   SENTRY_ENVIRONMENT: "http://localhost:3000",
   SHARED_COOKIE_DOMAIN: 'localhost',

--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -16,7 +16,7 @@ module.exports = defineConfig({
     baseUrl: 'http://localhost:3000',
   },
   env: {
-    PRINT_URL: 'http://localhost:3003',
-    API_ROOT_URL: 'http://localhost:3001',
+    PRINT_URL: 'http://localhost:3000/print',
+    API_ROOT_URL: 'http://localhost:3000/api',
   },
 })

--- a/frontend/public/environment.dist
+++ b/frontend/public/environment.dist
@@ -1,7 +1,7 @@
 window.environment = {
-  API_ROOT_URL: 'http://localhost:3001',
+  API_ROOT_URL: '/api',
   COOKIE_PREFIX: 'localhost_',
-  PRINT_URL: 'http://localhost:3003',
+  PRINT_URL: '/print',
   SENTRY_FRONTEND_DSN: null,
   SENTRY_ENVIRONMENT: "http://localhost:3000",
   SHARED_COOKIE_DOMAIN: 'localhost',

--- a/frontend/public/environment.docker.dist
+++ b/frontend/public/environment.docker.dist
@@ -1,7 +1,7 @@
 window.environment = {
-  API_ROOT_URL: 'http://localhost:3001',
+  API_ROOT_URL: '/api',
   COOKIE_PREFIX: 'localhost_',
-  PRINT_URL: 'http://localhost:3003',
+  PRINT_URL: '/print',
   SENTRY_FRONTEND_DSN: null,
   SENTRY_ENVIRONMENT: "http://localhost:3000",
   SHARED_COOKIE_DOMAIN: 'localhost',

--- a/frontend/src/components/print/print-nuxt/generatePdfMixin.js
+++ b/frontend/src/components/print/print-nuxt/generatePdfMixin.js
@@ -32,6 +32,7 @@ export const generatePdfMixin = {
 
       try {
         const response = await axios({
+          baseURL: null,
           method: 'get',
           url: `${PRINT_URL}/server/pdfChrome?config=${encodeURIComponent(
             JSON.stringify(this.config)

--- a/frontend/src/plugins/__tests__/auth.spec.js
+++ b/frontend/src/plugins/__tests__/auth.spec.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import { auth } from '@/plugins/auth'
 import storeLoader, { store, apiStore } from '@/plugins/store'
 import Cookies from 'js-cookie'
+import cloneDeep from 'lodash/cloneDeep'
 
 Vue.use(storeLoader)
 
@@ -31,6 +32,8 @@ const validJWTPayload =
 //   "user": "/users/1a2b3c4d"
 // }
 
+const envBackup = cloneDeep(window.environment)
+
 expect.extend({
   haveUri(actual, expectedUri) {
     return {
@@ -44,6 +47,7 @@ describe('authentication logic', () => {
   afterEach(() => {
     jest.restoreAllMocks()
     Cookies.remove('localhost_jwt_hp')
+    window.environment = cloneDeep(envBackup)
   })
 
   describe('isLoggedIn()', () => {
@@ -215,13 +219,24 @@ describe('authentication logic', () => {
       window.location = location
     })
 
-    it('forwards to google authentication endpoint', async () => {
+    it('forwards to google authentication endpoint in dev setup', async () => {
       // when
       await auth.loginGoogle()
 
       // then
       expect(window.location.href).toBe(
-        'http://localhost/auth/google?callback=http%3A%2F%2Flocalhost%2FloginCallback'
+        '/auth/google?callback=http%3A%2F%2Flocalhost%2FloginCallback'
+      )
+    })
+
+    it('forwards to google authentication endpoint in kubernetes deployment', async () => {
+      window.environment.API_ROOT_URL = 'https://api-dev.ecamp3.ch'
+      // when
+      await auth.loginGoogle()
+
+      // then
+      expect(window.location.href).toBe(
+        'https://api-dev.ecamp3.ch/auth/google?callback=http%3A%2F%2Flocalhost%2FloginCallback'
       )
     })
   })
@@ -240,13 +255,24 @@ describe('authentication logic', () => {
       window.location = location
     })
 
-    it('forwards to pbsmidata authentication endpoint', async () => {
+    it('forwards to pbsmidata authentication endpoint in dev setup', async () => {
       // when
       await auth.loginPbsMiData()
 
       // then
       expect(window.location.href).toBe(
-        'http://localhost/auth/pbsmidata?callback=http%3A%2F%2Flocalhost%2FloginCallback'
+        '/auth/pbsmidata?callback=http%3A%2F%2Flocalhost%2FloginCallback'
+      )
+    })
+
+    it('forwards to pbsmidata authentication endpoint in kubernetes deployment', async () => {
+      window.environment.API_ROOT_URL = 'https://api-dev.ecamp3.ch'
+      // when
+      await auth.loginPbsMiData()
+
+      // then
+      expect(window.location.href).toBe(
+        'https://api-dev.ecamp3.ch/auth/pbsmidata?callback=http%3A%2F%2Flocalhost%2FloginCallback'
       )
     })
   })
@@ -265,13 +291,24 @@ describe('authentication logic', () => {
       window.location = location
     })
 
-    it('forwards to cevidb authentication endpoint', async () => {
+    it('forwards to cevidb authentication endpoint in dev setup', async () => {
       // when
       await auth.loginCeviDB()
 
       // then
       expect(window.location.href).toBe(
-        'http://localhost/auth/cevidb?callback=http%3A%2F%2Flocalhost%2FloginCallback'
+        '/auth/cevidb?callback=http%3A%2F%2Flocalhost%2FloginCallback'
+      )
+    })
+
+    it('forwards to cevidb authentication endpoint in kubernetes deployment', async () => {
+      window.environment.API_ROOT_URL = 'https://api-dev.ecamp3.ch'
+      // when
+      await auth.loginCeviDB()
+
+      // then
+      expect(window.location.href).toBe(
+        'https://api-dev.ecamp3.ch/auth/cevidb?callback=http%3A%2F%2Flocalhost%2FloginCallback'
       )
     })
   })
@@ -290,13 +327,24 @@ describe('authentication logic', () => {
       window.location = location
     })
 
-    it('forwards to jubladb authentication endpoint', async () => {
+    it('forwards to jubladb authentication endpoint in dev setup', async () => {
       // when
       await auth.loginJublaDB()
 
       // then
       expect(window.location.href).toBe(
-        'http://localhost/auth/jubladb?callback=http%3A%2F%2Flocalhost%2FloginCallback'
+        '/auth/jubladb?callback=http%3A%2F%2Flocalhost%2FloginCallback'
+      )
+    })
+
+    it('forwards to jubladb authentication endpoint in kubernetes setup', async () => {
+      window.environment.API_ROOT_URL = 'https://api-dev.ecamp3.ch'
+      // when
+      await auth.loginJublaDB()
+
+      // then
+      expect(window.location.href).toBe(
+        'https://api-dev.ecamp3.ch/auth/jubladb?callback=http%3A%2F%2Flocalhost%2FloginCallback'
       )
     })
   })

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -113,8 +113,18 @@ async function redirectToOAuthLogin(provider) {
   return apiStore
     .href(apiStore.get(), provider, { callback: encodeURI(returnUrl) })
     .then((url) => {
-      window.location.href = window.environment.API_ROOT_URL + url
+      const apiRootUrl = window.environment.API_ROOT_URL
+      window.location.href = (hasHost(apiRootUrl) ? apiRootUrl : '') + url
     })
+}
+
+function hasHost(rootUrl) {
+  try {
+    const url = new URL(rootUrl)
+    return url.host.length > 0
+  } catch (_) {
+    return false
+  }
 }
 
 async function loginGoogle() {

--- a/print/nuxt.config.js
+++ b/print/nuxt.config.js
@@ -89,7 +89,7 @@ export default {
    ** See https://axios.nuxtjs.org/options
    */
   axios: {
-    baseURL: process.env.INTERNAL_API_ROOT_URL || 'http://caddy:3001/',
+    baseURL: process.env.INTERNAL_API_ROOT_URL || 'http://caddy:3000/api',
     credentials: true,
   },
   /*

--- a/print/print.env
+++ b/print/print.env
@@ -1,4 +1,4 @@
-INTERNAL_API_ROOT_URL=http://caddy:3001
+INTERNAL_API_ROOT_URL=http://caddy:3000/api
 FRONTEND_URL=http://localhost:3000
 SENTRY_PRINT_DSN=
 SENTRY_ENVIRONMENT=http://localhost:3000

--- a/wait-for-container-startup.sh
+++ b/wait-for-container-startup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Waiting for API container to start up and migrate DB..."
-until curl --output /dev/null --silent --fail http://localhost:3001
+until curl --output /dev/null --silent --fail http://localhost:3000/api
 do
   sleep 2
 done


### PR DESCRIPTION
Like this its possible to access the local instance from the mobile phone if you are in the same network, or to use
github codespaces to run ecamp.

Needs https://github.com/ecamp/hal-json-vuex/pull/280

- [x] test with github codespace and mobile
- [x] access local instance from mobile phone in the same network
- [x] Fix react print, some uri's still have the baseUrl and are "not preloaded" (print react worked fine without errors, don't know what happened here. the error did not reappier)
- [x] Add new callback urls
  - [x] add http://localhost:3000/api/auth/pbsmidata/callback to pbs.puzzle.ch
  - [x] add http://localhost:3000/api/auth/cevidb/callback to cevi.puzzle.ch (login is not really public, so I just changed it without adding to keepass)
  - [x] add http://localhost:3000/api/auth/jubladb/callback to jubla.puzzle.ch (login is not really public, so I just changed it without adding to keepass)
  - [x] to google oauth (i did not find the oauth2 config in the shared google account)