### PR TITLE
.helm: convert coupon-secret to string in api_secrets.yaml

### DIFF
--- a/.helm/ecamp3/templates/api_secrets.yaml
+++ b/.helm/ecamp3/templates/api_secrets.yaml
@@ -42,4 +42,8 @@ data:
   mailer-dsn: {{ .Values.mail.dsn | b64enc | quote }}
   {{- end }}
   recaptcha-secret: {{ .Values.recaptcha.secret | default "" | b64enc | quote }}
-  coupon-secret: {{ .Values.coupon.secret | default "" | b64enc | quote }}
+  {{- if .Values.coupon.secret }}
+  coupon-secret: {{ .Values.coupon.secret | printf "%d" | b64enc | quote }}
+  {{- else }}
+  coupon-secret: {{ "" | b64enc | quote }}
+  {{- end }}


### PR DESCRIPTION
Helm seems to be very strict when in comes to types:
with string: prinf "%d" "" -> %!d(string=)
with int:    prinf "%s" 123 -> %!d(string=)
but b64enc only accepts strings.