### PR TITLE
fix(deployment): fix failing startup probe when more than 2 deployments

### DIFF
--- a/.helm/ecamp3/templates/api_deployment.yaml
+++ b/.helm/ecamp3/templates/api_deployment.yaml
@@ -29,6 +29,7 @@ spec:
       serviceAccountName: {{ include "app.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      enableServiceLinks: false
       containers:
         - name: caddy
           securityContext:

--- a/.helm/ecamp3/templates/browserless_deployment.yaml
+++ b/.helm/ecamp3/templates/browserless_deployment.yaml
@@ -23,6 +23,7 @@ spec:
       serviceAccountName: {{ include "app.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      enableServiceLinks: false
       containers:
         - name: {{ .Chart.Name }}-browserless
           securityContext:

--- a/.helm/ecamp3/templates/frontend_deployment.yaml
+++ b/.helm/ecamp3/templates/frontend_deployment.yaml
@@ -24,6 +24,7 @@ spec:
       serviceAccountName: {{ include "app.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      enableServiceLinks: false
       containers:
         - name: {{ .Chart.Name }}-frontend
           securityContext:

--- a/.helm/ecamp3/templates/mail_deployment.yaml
+++ b/.helm/ecamp3/templates/mail_deployment.yaml
@@ -23,6 +23,7 @@ spec:
       serviceAccountName: {{ include "app.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      enableServiceLinks: false
       containers:
         - name: {{ .Chart.Name }}-mail
           securityContext:

--- a/.helm/ecamp3/templates/print_deployment.yaml
+++ b/.helm/ecamp3/templates/print_deployment.yaml
@@ -29,6 +29,7 @@ spec:
       serviceAccountName: {{ include "app.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      enableServiceLinks: false
       containers:
         - name: {{ .Chart.Name }}-print
           securityContext:

--- a/api/docker/php/docker-healthcheck.sh
+++ b/api/docker/php/docker-healthcheck.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
 set -e
 
-export SCRIPT_NAME=/ping
-export SCRIPT_FILENAME=/ping
-export REQUEST_METHOD=GET
-
-if cgi-fcgi -bind -connect /var/run/php/php-fpm.sock; then
+if env -i REQUEST_METHOD=GET SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping cgi-fcgi -bind -connect /var/run/php/php-fpm.sock; then
 	exit 0
 fi
 


### PR DESCRIPTION
### Root cause of the issue
_After lots of debugging by @BacLuc and @usu and after almost loosing our minds, on why the heck the deployments start to fail after the 3rd one, we finally found the root cause:_

- Kubernetes injects environment variables into each pod which can be used for service discovery as alternative to dns lookup (https://fabric8.io/guide/develop/serviceDiscovery.html#service-discovery-via-environment-variables)
- Injection is limited to services in the same namespace. However, as all our deployments live on the same default namespace, the number of environment variables scales up with each additional deployment.
- `mod_fcgid` has a bug/limitation, which [limits the number of passed environment variables to 64](https://bugzilla.redhat.com/show_bug.cgi?id=1876525)
- This leads to the fact that `docker-healthcheck` doesn't run properly, which relies on adding additional environment variables to run the `ping` command

### Short-term solution
- use `env -i` in docker-healthcheck in order to start with an empty environment (this was also corrected on the [api-platform application template](https://github.com/api-platform/api-platform/blame/main/api/docker/php/docker-healthcheck.sh))
- disable injecting service discovery environment variables (`enableServiceLinks: false`). We don't need them in our application.

### More sustainable solution
- use separate namespaces for the individual deployments. This would make the deployment also more secure by avoid leaking any environment data or secrets from one deployment to another.