### PR TITLE
fix(api): fix and refactor PeriodPersistProcessor

### DIFF
--- a/api/fixtures/dayResponsibles.yml
+++ b/api/fixtures/dayResponsibles.yml
@@ -5,6 +5,18 @@ App\Entity\DayResponsible:
   dayResponsible1day2period1:
     campCollaboration: '@campCollaboration1manager'
     day: '@day2period1'
+  dayResponsible1day1period2:
+    campCollaboration: '@campCollaboration1manager'
+    day: '@day1period2'
+  dayResponsible1day2period2:
+    campCollaboration: '@campCollaboration1manager'
+    day: '@day2period2'
+  dayResponsible1day3period2:
+    campCollaboration: '@campCollaboration1manager'
+    day: '@day3period2'
+  dayResponsible2day3period2:
+    campCollaboration: '@campCollaboration2member'
+    day: '@day3period2'
   dayResponsible1day1period1campUnrelated:
     campCollaboration: '@campCollaboration1campUnrelated'
     day: '@day1period1campUnrelated'

--- a/api/fixtures/days.yml
+++ b/api/fixtures/days.yml
@@ -11,6 +11,12 @@ App\Entity\Day:
   day1period2:
     period: '@period2'
     dayOffset: 0
+  day2period2:
+    period: '@period2'
+    dayOffset: 1
+  day3period2:
+    period: '@period2'
+    dayOffset: 2
   day1period1camp2:
     period: '@period1camp2'
     dayOffset: 0

--- a/api/fixtures/periods.yml
+++ b/api/fixtures/periods.yml
@@ -8,7 +8,7 @@ App\Entity\Period:
     camp: '@camp1'
     description: Vorabend
     start: '<(new DateTime("2023-04-15"))>'
-    end: '<(new DateTime("2023-04-15"))>'
+    end: '<(new DateTime("2023-04-17"))>'
   period1camp2:
     camp: '@camp2'
     description: Vorweekend

--- a/api/migrations/schema/Version20230204135941.php
+++ b/api/migrations/schema/Version20230204135941.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230204135941 extends AbstractMigration {
+    public function getDescription(): string {
+        return 'Make unique constraint offset_period_idx a deferred constraint';
+    }
+
+    public function up(Schema $schema): void {
+        $this->addSql('DROP INDEX offset_period_idx');
+        $this->addSql(
+            <<<'EOF'
+                        alter table day 
+                            add constraint offset_period_idx 
+                                unique (periodId, dayOffset)
+                                    deferrable initially deferred
+                        EOF
+        );
+    }
+
+    public function down(Schema $schema): void {
+        $this->addSql(
+            <<<'EOF'
+                        alter table day 
+                            drop constraint offset_period_idx
+                        EOF
+        );
+        $this->addSql('CREATE UNIQUE INDEX offset_period_idx ON day (periodId, dayOffset)');
+    }
+}

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -194,6 +194,13 @@ class Period extends BaseEntity implements BelongsToCampInterface {
         return $this->days->getValues();
     }
 
+    public function getDaysSorted(): array {
+        $days = $this->getDays();
+        usort($days, fn (Day $a, Day $b) => $a->dayOffset <=> $b->dayOffset);
+
+        return $days;
+    }
+
     public function addDay(Day $day): self {
         if (!$this->days->contains($day)) {
             $this->days[] = $day;

--- a/api/src/State/CampCreateProcessor.php
+++ b/api/src/State/CampCreateProcessor.php
@@ -39,7 +39,7 @@ class CampCreateProcessor extends AbstractPersistProcessor {
         }
 
         foreach ($data->periods as $period) {
-            PeriodPersistProcessor::updateDaysAndScheduleEntries($period);
+            PeriodPersistProcessor::addMissingDays($period);
         }
 
         return $data;

--- a/api/src/State/PeriodPersistProcessor.php
+++ b/api/src/State/PeriodPersistProcessor.php
@@ -5,7 +5,6 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Day;
-use App\Entity\DayResponsible;
 use App\Entity\Period;
 use App\State\Util\AbstractPersistProcessor;
 use App\Util\DateTimeUtil;
@@ -21,68 +20,65 @@ class PeriodPersistProcessor extends AbstractPersistProcessor {
      * @param Period $data
      */
     public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []): Period {
-        static::updateDaysAndScheduleEntries($data, $context['previous_data'] ?? null);
+        self::moveDaysAndScheduleEntries($data, $context['previous_data'] ?? null);
+        self::removeExtraDays($data);
+        self::addMissingDays($data);
 
         return $data;
     }
 
-    public static function updateDaysAndScheduleEntries(Period $period, Period $orig = null) {
-        $length = $period->getPeriodLength();
-        $days = $period->getDays();
-        $daysCount = count($days);
-
-        // Add new days
-        for ($i = $daysCount; $i < $length; ++$i) {
-            $day = new Day();
-            $day->dayOffset = $i;
-            $period->addDay($day);
-        }
-
-        // if Period was newly created, no more actions needed
-        if (0 == $daysCount) {
+    public static function moveDaysAndScheduleEntries(Period $period, Period $originalPeriod = null) {
+        if (!$originalPeriod) {
             return;
         }
 
-        // moveScheduleEntries === true: scheduleEntries move relative to the start date (no change of offset needed)
+        // moveScheduleEntries === true: scheduleEntries move relative to the start date (no change of offset needed -> return)
         // moveScheduleEntries === false: scheduleEntries stay absolutely on the scheduled calendar date (change of offset needed)
-        $deltaMinutes = DateTimeUtil::differenceInMinutes($period->start, $orig->start);
-        if (!$period->moveScheduleEntries && 0 != $deltaMinutes) {
-            $deltaDays = floor($deltaMinutes / 60 / 24);
-
-            // Move ScheduleEntries
-            foreach ($period->scheduleEntries as $scheduleEntry) {
-                $scheduleEntry->startOffset += $deltaMinutes;
-                $scheduleEntry->endOffset += $deltaMinutes;
-            }
-
-            // Move DayResponsibles
-            $days = $period->days->getValues();
-            usort($days, fn ($a, $b) => $a->dayOffset <=> $b->dayOffset);
-
-            // UniqueIndex day_campCollaboration_unique forces correct order of Update
-            if ($deltaDays > 0) {
-                $days = array_reverse($days);
-            }
-
-            foreach ($days as $day) {
-                /** @var Day $day */
-                $newDay = $period->days->filter(fn ($d) => $d->dayOffset == $day->dayOffset + $deltaDays)->first();
-
-                /** @var DayResponsible $dayResp */
-                foreach ($day->dayResponsibles as $dayResp) {
-                    if (null != $newDay) {
-                        $dayResp->day = $newDay;
-                    } else {
-                        $day->removeDayResponsible($dayResp);
-                    }
-                }
-            }
+        if ($period->moveScheduleEntries) {
+            return;
         }
 
-        // Remove extra days
-        for ($i = $daysCount - 1; $i >= $length; --$i) {
-            $day = $days[$i];
-            $period->removeDay($day);
+        $deltaMinutes = DateTimeUtil::differenceInMinutes($originalPeriod->start, $period->start);
+        if (0 === $deltaMinutes) {
+            return;
+        }
+
+        // Move ScheduleEntries
+        // --> existing scheduleEntries outside the new period boundary are not possible (validation should have already failed)
+        foreach ($period->scheduleEntries as $scheduleEntry) {
+            $scheduleEntry->startOffset -= $deltaMinutes;
+            $scheduleEntry->endOffset -= $deltaMinutes;
+        }
+
+        // Move days (incl. related DayResponsibles)
+        // --> existing days outside the new period boundary will be removed in `removeExtraDays`
+        $deltaDays = intval(floor($deltaMinutes / 60 / 24));
+        foreach ($period->getDays() as $day) {
+            $day->dayOffset -= $deltaDays;
+        }
+    }
+
+    public static function removeExtraDays(Period $period) {
+        $length = $period->getPeriodLength();
+        $days = $period->getDays();
+
+        foreach ($days as $day) {
+            if ($day->dayOffset < 0 or $day->dayOffset >= $length) {
+                $period->removeDay($day);
+            }
+        }
+    }
+
+    public static function addMissingDays(Period $period) {
+        $length = $period->getPeriodLength();
+
+        for ($i = 0; $i < $length; ++$i) {
+            $dayAlreadyExists = $period->days->exists(fn ($key, Day $day) => $day->dayOffset === $i);
+            if (!$dayAlreadyExists) {
+                $day = new Day();
+                $day->dayOffset = $i;
+                $period->addDay($day);
+            }
         }
     }
 }

--- a/api/src/State/PeriodPersistProcessor.php
+++ b/api/src/State/PeriodPersistProcessor.php
@@ -44,19 +44,19 @@ class PeriodPersistProcessor extends AbstractPersistProcessor {
                 // Add Days at end
                 for ($i = $daysCount; $i < $length; ++$i) {
                     $day = new Day();
-                    $day->dayOffset = $i++;
+                    $day->dayOffset = $i;
                     $period->addDay($day);
                 }
                 // Remove Days at end
-                for ($i = $daysCount; $i > $length; --$i) {
-                    $day = $days[$i - 1];
+                for ($i = $daysCount - 1; $i >= $length; --$i) {
+                    $day = $days[$i];
                     $period->removeDay($day);
                 }
             } else {
                 $deltaMinutes = DateTimeUtil::differenceInMinutes($period->start, $orig->start);
                 $deltaDaysAtStart = floor($deltaMinutes / 60 / 24);
 
-                // Tage erstellen
+                // Add days
                 for ($i = $daysCount; $i < $length; ++$i) {
                     $day = new Day();
                     $day->dayOffset = $i;
@@ -93,8 +93,8 @@ class PeriodPersistProcessor extends AbstractPersistProcessor {
                 }
 
                 // Remove Days at end
-                for ($i = $daysCount; $i > $length; --$i) {
-                    $day = $days[$i - 1];
+                for ($i = $daysCount - 1; $i >= $length; --$i) {
+                    $day = $days[$i];
                     $period->removeDay($day);
                 }
             }

--- a/api/tests/Api/DayResponsibles/ListDayResponsiblesTest.php
+++ b/api/tests/Api/DayResponsibles/ListDayResponsiblesTest.php
@@ -23,7 +23,7 @@ class ListDayResponsiblesTest extends ECampApiTestCase {
 
         $response = static::createClientWithCredentials()->request('GET', '/day_responsibles');
         $this->assertJsonContains([
-            'totalItems' => 3,
+            'totalItems' => 7,
             '_links' => [
                 'items' => [],
             ],
@@ -34,6 +34,10 @@ class ListDayResponsiblesTest extends ECampApiTestCase {
         $this->assertEqualsCanonicalizing([
             ['href' => $this->getIriFor('dayResponsible1')],
             ['href' => $this->getIriFor('dayResponsible1day2period1')],
+            ['href' => $this->getIriFor('dayResponsible1day1period2')],
+            ['href' => $this->getIriFor('dayResponsible1day2period2')],
+            ['href' => $this->getIriFor('dayResponsible1day3period2')],
+            ['href' => $this->getIriFor('dayResponsible2day3period2')],
             ['href' => $this->getIriFor('dayResponsible1day1period1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }

--- a/api/tests/Api/Days/ListDaysTest.php
+++ b/api/tests/Api/Days/ListDaysTest.php
@@ -24,7 +24,7 @@ class ListDaysTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()->request('GET', '/days');
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'totalItems' => 7,
+            'totalItems' => 9,
             '_links' => [
                 'items' => [],
             ],
@@ -37,6 +37,8 @@ class ListDaysTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('day2period1')],
             ['href' => $this->getIriFor('day3period1')],
             ['href' => $this->getIriFor('day1period2')],
+            ['href' => $this->getIriFor('day2period2')],
+            ['href' => $this->getIriFor('day3period2')],
             ['href' => $this->getIriFor('day1period1camp2')],
             ['href' => $this->getIriFor('day2period1camp2')],
             ['href' => $this->getIriFor('day1period1campPrototype')],
@@ -95,6 +97,8 @@ class ListDaysTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('day1period1camp2')],
             ['href' => $this->getIriFor('day2period1camp2')],
             ['href' => $this->getIriFor('day1period2')],
+            ['href' => $this->getIriFor('day2period2')],
+            ['href' => $this->getIriFor('day3period2')],
             ['href' => $this->getIriFor('day1period1')],
             ['href' => $this->getIriFor('day2period1')],
             ['href' => $this->getIriFor('day3period1')],

--- a/api/tests/Api/Days/ReadDayTest.php
+++ b/api/tests/Api/Days/ReadDayTest.php
@@ -58,7 +58,7 @@ class ReadDayTest extends ECampApiTestCase {
         $this->assertJsonContains([
             'id' => $day->getId(),
             'dayOffset' => $day->dayOffset,
-            'number' => 2,
+            'number' => 4,
             '_links' => [
                 'period' => ['href' => $this->getIriFor('period1')],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$day->period->getId().'&start%5Bstrictly_before%5D='.urlencode($end).'&end%5Bafter%5D='.urlencode($start)],
@@ -79,7 +79,7 @@ class ReadDayTest extends ECampApiTestCase {
         $this->assertJsonContains([
             'id' => $day->getId(),
             'dayOffset' => $day->dayOffset,
-            'number' => 2,
+            'number' => 4,
             '_links' => [
                 'period' => ['href' => $this->getIriFor('period1')],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$day->period->getId().'&start%5Bstrictly_before%5D='.urlencode($end).'&end%5Bafter%5D='.urlencode($start)],
@@ -98,7 +98,7 @@ class ReadDayTest extends ECampApiTestCase {
         $this->assertJsonContains([
             'id' => $day->getId(),
             'dayOffset' => $day->dayOffset,
-            'number' => 2,
+            'number' => 4,
             '_links' => [
                 'period' => ['href' => $this->getIriFor('period1')],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$day->period->getId().'&start%5Bstrictly_before%5D='.urlencode($end).'&end%5Bafter%5D='.urlencode($start)],

--- a/api/tests/Api/Periods/UpdatePeriodTest.php
+++ b/api/tests/Api/Periods/UpdatePeriodTest.php
@@ -418,9 +418,9 @@ at position 10: Trailing data',
         $day1_resp = $this->getEntityManager()->getRepository(DayResponsible::class)->find($day1_resp->getId());
         $day2_resp = $this->getEntityManager()->getRepository(DayResponsible::class)->find($day2_resp->getId());
 
-        // CampCollaboration is now responsible for Day2 and Day3
-        $this->assertEquals($day2, $day1_resp->day);
-        $this->assertEquals($day3, $day2_resp->day);
+        // CampCollaboration is now responsible for Day2 (offset=1) and Day3 (offset=2)
+        $this->assertEquals(1, $day1_resp->day->dayOffset);
+        $this->assertEquals(2, $day2_resp->day->dayOffset);
     }
 
     public function testPatchPeriodMovesScheduleEntries() {

--- a/api/tests/Api/ScheduleEntries/ReadScheduleEntryTest.php
+++ b/api/tests/Api/ScheduleEntries/ReadScheduleEntryTest.php
@@ -60,9 +60,9 @@ class ReadScheduleEntryTest extends ECampApiTestCase {
 
             'left' => 0,
             'width' => 1,
-            'dayNumber' => 2,
+            'dayNumber' => 4,
             'scheduleEntryNumber' => 1,
-            'number' => '2.1',
+            'number' => '4.1',
             'start' => '2023-05-01T08:00:00+00:00',
             'end' => '2023-05-01T09:00:00+00:00',
             '_links' => [
@@ -85,9 +85,9 @@ class ReadScheduleEntryTest extends ECampApiTestCase {
             'id' => $scheduleEntry->getId(),
             'left' => 0,
             'width' => 1,
-            'dayNumber' => 2,
+            'dayNumber' => 4,
             'scheduleEntryNumber' => 1,
-            'number' => '2.1',
+            'number' => '4.1',
             'start' => '2023-05-01T08:00:00+00:00',
             'end' => '2023-05-01T09:00:00+00:00',
             '_links' => [
@@ -108,9 +108,9 @@ class ReadScheduleEntryTest extends ECampApiTestCase {
             'id' => $scheduleEntry->getId(),
             'left' => 0,
             'width' => 1,
-            'dayNumber' => 2,
+            'dayNumber' => 4,
             'scheduleEntryNumber' => 1,
-            'number' => '2.1',
+            'number' => '4.1',
             'start' => '2023-05-01T08:00:00+00:00',
             'end' => '2023-05-01T09:00:00+00:00',
             '_links' => [

--- a/api/tests/State/PeriodPersistProcessorTest.php
+++ b/api/tests/State/PeriodPersistProcessorTest.php
@@ -83,6 +83,12 @@ class PeriodPersistProcessorTest extends TestCase {
         // then
         $this->assertEquals(1440 + 600, $this->scheduleEntry->startOffset);
         $this->assertEquals(1, $this->dayResponsible->day->dayOffset);
+
+        $this->assertCount(4, $this->period->days);
+        $this->assertEquals(0, $this->period->days[0]->dayOffset);
+        $this->assertEquals(1, $this->period->days[1]->dayOffset);
+        $this->assertEquals(2, $this->period->days[2]->dayOffset);
+        $this->assertEquals(3, $this->period->days[3]->dayOffset);
     }
 
     public function testAddDayAtStartNoMoveData() {
@@ -97,6 +103,12 @@ class PeriodPersistProcessorTest extends TestCase {
         // then
         $this->assertEquals(1440 + 1440 + 600, $this->scheduleEntry->startOffset);
         $this->assertEquals(2, $this->dayResponsible->day->dayOffset);
+
+        $this->assertCount(4, $this->period->days);
+        $this->assertEquals(0, $this->period->days[0]->dayOffset);
+        $this->assertEquals(1, $this->period->days[1]->dayOffset);
+        $this->assertEquals(2, $this->period->days[2]->dayOffset);
+        $this->assertEquals(3, $this->period->days[3]->dayOffset);
     }
 
     public function testRemoveDayAtStartMoveData() {
@@ -111,6 +123,10 @@ class PeriodPersistProcessorTest extends TestCase {
         // then
         $this->assertEquals(1440 + 600, $this->scheduleEntry->startOffset);
         $this->assertEquals(1, $this->dayResponsible->day->dayOffset);
+
+        $this->assertCount(2, $this->period->days);
+        $this->assertEquals(0, $this->period->days[0]->dayOffset);
+        $this->assertEquals(1, $this->period->days[1]->dayOffset);
     }
 
     public function testRemoveDayAtStartNoMoveData() {
@@ -125,5 +141,58 @@ class PeriodPersistProcessorTest extends TestCase {
         // then
         $this->assertEquals(600, $this->scheduleEntry->startOffset);
         $this->assertEquals(0, $this->dayResponsible->day->dayOffset);
+
+        $this->assertCount(2, $this->period->days);
+        $this->assertEquals(0, $this->period->days[0]->dayOffset);
+        $this->assertEquals(1, $this->period->days[1]->dayOffset);
+    }
+
+    public function testAddDayAtEndMoveData() {
+        // given
+        $patchData = clone $this->period;
+        $patchData->moveScheduleEntries = true;
+        $patchData->end = new \DateTime('2000-01-14');
+
+        // when
+        $this->processor->onBefore($patchData, new Patch(), [], ['previous_data' => $this->period]);
+
+        // then
+        $this->assertCount(5, $this->period->days);
+        $this->assertEquals(0, $this->period->days[0]->dayOffset);
+        $this->assertEquals(1, $this->period->days[1]->dayOffset);
+        $this->assertEquals(2, $this->period->days[2]->dayOffset);
+        $this->assertEquals(3, $this->period->days[3]->dayOffset);
+        $this->assertEquals(4, $this->period->days[4]->dayOffset);
+    }
+
+    public function testAddDayAtEndNoMoveData() {
+        // given
+        $patchData = clone $this->period;
+        $patchData->moveScheduleEntries = false;
+        $patchData->end = new \DateTime('2000-01-14');
+
+        // when
+        $this->processor->onBefore($patchData, new Patch(), [], ['previous_data' => $this->period]);
+
+        // then
+        $this->assertCount(5, $this->period->days);
+        $this->assertEquals(0, $this->period->days[0]->dayOffset);
+        $this->assertEquals(1, $this->period->days[1]->dayOffset);
+        $this->assertEquals(2, $this->period->days[2]->dayOffset);
+        $this->assertEquals(3, $this->period->days[3]->dayOffset);
+        $this->assertEquals(4, $this->period->days[4]->dayOffset);
+    }
+
+    public function testRemoveAllDaysButOne() {
+        // given
+        $patchData = clone $this->period;
+        $patchData->moveScheduleEntries = true;
+        $patchData->end = new \DateTime('2000-01-10');
+
+        // when
+        $this->processor->onBefore($patchData, new Patch(), [], ['previous_data' => $this->period]);
+
+        $this->assertCount(1, $this->period->days);
+        $this->assertEquals(0, $this->period->days[0]->dayOffset);
     }
 }

--- a/api/tests/State/PeriodPersistProcessorTest.php
+++ b/api/tests/State/PeriodPersistProcessorTest.php
@@ -84,11 +84,12 @@ class PeriodPersistProcessorTest extends TestCase {
         $this->assertEquals(1440 + 600, $this->scheduleEntry->startOffset);
         $this->assertEquals(1, $this->dayResponsible->day->dayOffset);
 
-        $this->assertCount(4, $this->period->days);
-        $this->assertEquals(0, $this->period->days[0]->dayOffset);
-        $this->assertEquals(1, $this->period->days[1]->dayOffset);
-        $this->assertEquals(2, $this->period->days[2]->dayOffset);
-        $this->assertEquals(3, $this->period->days[3]->dayOffset);
+        $days = $this->period->getDaysSorted();
+        $this->assertCount(4, $days);
+        $this->assertEquals(0, $days[0]->dayOffset);
+        $this->assertEquals(1, $days[1]->dayOffset);
+        $this->assertEquals(2, $days[2]->dayOffset);
+        $this->assertEquals(3, $days[3]->dayOffset);
     }
 
     public function testAddDayAtStartNoMoveData() {
@@ -104,11 +105,12 @@ class PeriodPersistProcessorTest extends TestCase {
         $this->assertEquals(1440 + 1440 + 600, $this->scheduleEntry->startOffset);
         $this->assertEquals(2, $this->dayResponsible->day->dayOffset);
 
-        $this->assertCount(4, $this->period->days);
-        $this->assertEquals(0, $this->period->days[0]->dayOffset);
-        $this->assertEquals(1, $this->period->days[1]->dayOffset);
-        $this->assertEquals(2, $this->period->days[2]->dayOffset);
-        $this->assertEquals(3, $this->period->days[3]->dayOffset);
+        $days = $this->period->getDaysSorted();
+        $this->assertCount(4, $days);
+        $this->assertEquals(0, $days[0]->dayOffset);
+        $this->assertEquals(1, $days[1]->dayOffset);
+        $this->assertEquals(2, $days[2]->dayOffset);
+        $this->assertEquals(3, $days[3]->dayOffset);
     }
 
     public function testRemoveDayAtStartMoveData() {
@@ -124,9 +126,10 @@ class PeriodPersistProcessorTest extends TestCase {
         $this->assertEquals(1440 + 600, $this->scheduleEntry->startOffset);
         $this->assertEquals(1, $this->dayResponsible->day->dayOffset);
 
-        $this->assertCount(2, $this->period->days);
-        $this->assertEquals(0, $this->period->days[0]->dayOffset);
-        $this->assertEquals(1, $this->period->days[1]->dayOffset);
+        $days = $this->period->getDaysSorted();
+        $this->assertCount(2, $days);
+        $this->assertEquals(0, $days[0]->dayOffset);
+        $this->assertEquals(1, $days[1]->dayOffset);
     }
 
     public function testRemoveDayAtStartNoMoveData() {
@@ -142,9 +145,10 @@ class PeriodPersistProcessorTest extends TestCase {
         $this->assertEquals(600, $this->scheduleEntry->startOffset);
         $this->assertEquals(0, $this->dayResponsible->day->dayOffset);
 
-        $this->assertCount(2, $this->period->days);
-        $this->assertEquals(0, $this->period->days[0]->dayOffset);
-        $this->assertEquals(1, $this->period->days[1]->dayOffset);
+        $days = $this->period->getDaysSorted();
+        $this->assertCount(2, $days);
+        $this->assertEquals(0, $days[0]->dayOffset);
+        $this->assertEquals(1, $days[1]->dayOffset);
     }
 
     public function testAddDayAtEndMoveData() {


### PR DESCRIPTION
Noticed some bugs in the business logic of moving days and scheduleEntries when changing the period start date. The PR can be reviewed complete as-is or also via single commits (I tried to keep the commit history as clean & logical as possible).

The main issue is with moveScheduleEntries=false, which triggers an update of the offsets.

Previously, dayResponsible entities were detached from the old day entities and added to the new entities. This is very flaky and doesn't go well with orphanRemoval=true.

After refactoring, dayResponsibles are kept attached to the day object, but the dayOffset is adjusted (similar as for scheduleEntries). I think this is also more future-proof, in case we want to add more information to the Day entity in the future.