### PR TITLE
.github: generalize deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,4 +1,4 @@
-name: Deploy alpha
+name: Deploy alpha, staging or prod
 
 on:
   repository_dispatch:
@@ -11,24 +11,63 @@ on:
         type: boolean
 
 jobs:
+  determine-environment:
+    name: Determine environment
+    if: ${{
+      (inputs.confirmDeployWithoutCI == true)
+      || (github.event.client_payload.ref == 'refs/heads/alpha')
+      || (github.event.client_payload.ref == 'refs/heads/staging')
+      || (github.event.client_payload.ref == 'refs/heads/prod')
+      }}
+    outputs:
+      environment: ${{ steps.get-branch-name.outputs.result }}
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/github-script@v6
+        id: get-branch-name
+        with:
+          result-encoding: string
+          script: |
+            return context.payload.ref.replace('refs/heads/', '')
+  
+
   upgrade-or-install-deployment:
     name: Upgrade or install deployment
-    if: ${{ (inputs.confirmDeployWithoutCI == true) || (github.event.client_payload.ref == 'refs/heads/alpha') }}
+    needs:
+      determine-environment
     runs-on: ubuntu-latest
-    environment:
-      name: alpha
+    environment: ${{ needs.determine-environment.outputs.environment }}
+    env:
+      environment: ${{ needs.determine-environment.outputs.environment }}
+      domain: ${{ vars.DOMAIN_SUFFIX }}.${{ vars.DOMAIN }}
     steps:
 
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
-        with:
-          ref: alpha
 
-      - name: Construct metadata for the alpha branch deployment
-        id: git-ref
+      - name: log environment
+        id: log-environment
         run: |
-          ALPHA=$(git rev-parse alpha)
-          echo "Git SHA: $ALPHA"
-          echo "sha=$ALPHA" | tr -d "\n" >> $GITHUB_OUTPUT
+          REF=$(git rev-parse HEAD)
+          echo "Git SHA: $REF"
+          echo "sha=$REF" | tr -d "\n" >> $GITHUB_OUTPUT
+
+          echo "github: ${{ toJSON(github) }}"
+          echo ""
+          echo "inputs: ${{ toJSON(inputs) }}"
+          echo ""
+          echo "job: ${{ toJSON(job) }}"
+          echo ""
+          echo "needs: ${{ toJSON(needs) }}"
+          echo ""
+          echo "env: ${{ toJSON(env) }}"
+          echo ""
+          echo "vars: ${{ toJSON(vars) }}"
+          echo ""
+          echo "secrets:"
+          cat <<-HEREDOC
+            ${{ toJSON(secrets) }}
+          HEREDOC
 
       - name: Create a pending GitHub deployment
         uses: bobheadxi/deployments@v1.4.0
@@ -36,11 +75,7 @@ jobs:
         with:
           step: start
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
-          env: alpha
-
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
-        with:
-          ref: ${{ steps.git-ref.outputs.sha }}
+          env: ${{ env.environment }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -56,7 +91,7 @@ jobs:
         with:
           push: true
           file: .docker-hub/frontend/Dockerfile
-          tags: ecamp/ecamp3-frontend:alpha,ecamp/ecamp3-frontend:${{ steps.git-ref.outputs.sha }}
+          tags: ecamp/ecamp3-frontend:${{ env.environment }},ecamp/ecamp3-frontend:${{ steps.log-environment.outputs.sha }}
           context: .
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max
@@ -66,7 +101,7 @@ jobs:
         with:
           push: true
           file: api/Dockerfile
-          tags: ecamp/ecamp3-api:alpha,ecamp/ecamp3-api:${{ steps.git-ref.outputs.sha }}
+          tags: ecamp/ecamp3-api:${{ env.environment }},ecamp/ecamp3-api:${{ steps.log-environment.outputs.sha }}
           context: './api'
           target: api_platform_php
           cache-from: type=gha,scope=api
@@ -77,7 +112,7 @@ jobs:
         with:
           push: true
           file: api/Dockerfile
-          tags: ecamp/ecamp3-caddy:alpha,ecamp/ecamp3-caddy:${{ steps.git-ref.outputs.sha }}
+          tags: ecamp/ecamp3-caddy:${{ env.environment }},ecamp/ecamp3-caddy:${{ steps.log-environment.outputs.sha }}
           context: './api'
           target: api_platform_caddy_prod
           cache-from: type=gha,scope=caddy
@@ -88,7 +123,7 @@ jobs:
         with:
           push: true
           file: .docker-hub/print/Dockerfile
-          tags: ecamp/ecamp3-print:alpha,ecamp/ecamp3-print:${{ steps.git-ref.outputs.sha }}
+          tags: ecamp/ecamp3-print:${{ env.environment }},ecamp/ecamp3-print:${{ steps.log-environment.outputs.sha }}
           context: .
           cache-from: type=gha,scope=print
           cache-to: type=gha,scope=print,mode=max
@@ -105,18 +140,18 @@ jobs:
           # later find out which deployments need to be upgraded
           sed -i 's/^appVersion:.*$/appVersion: "${{ steps.git-ref.outputs.sha }}"/' Chart.yaml
           # Install or upgrade the release
-          helm upgrade --install ecamp3-alpha . \
-            --set imageTag=${{ steps.git-ref.outputs.sha }} \
-            --set sharedCookieDomain=.ecamp3.ch \
+          helm upgrade --install ecamp3-${{ env.environment }} . \
+            --set imageTag=${{ steps.log-environment.outputs.sha }} \
+            --set sharedCookieDomain=.${{ vars.DOMAIN }} \
             --set termsOfServiceLinkTemplate='https://ecamp3.ch/{lang}/tos' \
-            --set api.domain=api-alpha.ecamp3.ch \
-            --set frontend.domain=app-alpha.ecamp3.ch \
-            --set print.domain=print-alpha.ecamp3.ch \
+            --set api.domain=api${{ env.domain }} \
+            --set frontend.domain=app${{ env.domain }} \
+            --set print.domain=print${{ env.domain }} \
             --set mail.dsn=${{ secrets.MAILER_DSN }} \
             --set postgresql.enabled=false \
-            --set postgresql.url='${{ secrets.POSTGRES_URL }}/ecamp3alpha?sslmode=require' \
+            --set postgresql.url='${{ secrets.POSTGRES_URL }}/${{ secrets.DB_NAME }}?sslmode=require' \
             --set postgresql.dropDBOnUninstall=false \
-            --set php.dataMigrationsDir='${{ secrets.DATA_MIGRATIONS_DIR }}' \
+            --set php.dataMigrationsDir='${{ vars.DATA_MIGRATIONS_DIR }}' \
             --set php.appSecret='${{ secrets.API_APP_SECRET }}' \
             --set php.sentryDsn='${{ secrets.API_SENTRY_DSN }}' \
             --set php.jwt.passphrase='${{ secrets.JWT_PASSPHRASE }}' \
@@ -142,7 +177,7 @@ jobs:
             --set recaptcha.siteKey='${{ secrets.RECAPTCHA_SITE_KEY }}' \
             --set recaptcha.secret='${{ secrets.RECAPTCHA_SECRET }}' \
             --set coupon.secret='${{ secrets.COUPON_SECRET }}' \
-            --set frontend.loginInfoTextKey=alpha
+            --set frontend.loginInfoTextKey=${{ vars.LOGIN_INFO_TEXT_KEY }}
 
       - name: Finish the GitHub deployment
         uses: bobheadxi/deployments@v1.4.0
@@ -152,5 +187,5 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: https://app-alpha.ecamp3.ch
+          env_url: https://app${{ env.domain }}
           env: ${{ steps.deployment.outputs.env }}


### PR DESCRIPTION
That it can be used for the "beta" or prod deployment, for the alpha deployment and for the staging deployment.

We can remove the alpha deployment as soon as we replaced it with the production deployment, and added a staging deployment.