### PR TITLE
.helm: remove possibility to run postgres in the cluster

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -251,7 +251,6 @@ jobs:
             --set termsOfServiceLinkTemplate='https://ecamp3.ch/{lang}/tos' \
             --set domain=${{ matrix.deployment.name }}.ecamp3.ch \
             --set mail.dummyEnabled=true \
-            --set postgresql.enabled=false \
             --set postgresql.url='${{ secrets.POSTGRES_URL }}/ecamp3${{ matrix.deployment.name }}?sslmode=require' \
             --set postgresql.adminUrl='${{ secrets.POSTGRES_ADMIN_URL }}/ecamp3${{ matrix.deployment.name }}?sslmode=require' \
             --set postgresql.dropDBOnUninstall=${{ contains(fromJson(env.never_uninstall), matrix.deployment.name) && 'false' || 'true' }} \

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -163,7 +163,6 @@ jobs:
             --set termsOfServiceLinkTemplate='https://ecamp3.ch/{lang}/tos' \
             --set domain=${{ env.domain }} \
             --set mail.dsn=${{ secrets.MAILER_DSN }} \
-            --set postgresql.enabled=false \
             --set postgresql.url='${{ secrets.POSTGRES_URL }}/${{ secrets.DB_NAME }}?sslmode=require' \
             --set postgresql.dropDBOnUninstall=false \
             --set php.dataMigrationsDir='${{ vars.DATA_MIGRATIONS_DIR }}' \

--- a/.helm/ecamp3/templates/api_secrets.yaml
+++ b/.helm/ecamp3/templates/api_secrets.yaml
@@ -1,3 +1,5 @@
+{{- $databaseUrl := .Values.postgresql.url | required ".Values.postgresql.url is required." -}}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,11 +9,7 @@ metadata:
     {{- include "app.commonLabels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.postgresql.enabled }}
-  database-url: {{ printf "pgsql://%s:%s@%s-postgresql/%s?serverVersion=15&charset=utf8" .Values.postgresql.postgresqlUsername .Values.postgresql.postgresqlPassword .Release.Name .Values.postgresql.postgresqlDatabase | b64enc | quote }}
-  {{- else }}
-  database-url: {{ .Values.postgresql.url | b64enc | quote }}
-  {{- end }}
+  database-url: {{ $databaseUrl | b64enc | quote }}
   php-app-secret: {{ .Values.php.appSecret | default (randAlphaNum 40) | b64enc | quote }}
   php-jwt-passphrase: {{ .Values.php.jwt.passphrase | default (randAlphaNum 40) | b64enc | quote }}
   jwt-public-key: {{ .Values.php.jwt.publicKey | default "" | b64enc | quote }}

--- a/.helm/ecamp3/templates/hook_db_create.yaml
+++ b/.helm/ecamp3/templates/hook_db_create.yaml
@@ -1,7 +1,7 @@
 #
 # Automatically creates the database in an external PostgreSQL when installing the chart for the first time.
 #
-{{- if and (not .Values.postgresql.enabled) (not (.Values.postgresql.adminUrl | empty)) }}
+{{- if not (.Values.postgresql.adminUrl | empty) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/.helm/ecamp3/templates/hook_db_drop.yaml
+++ b/.helm/ecamp3/templates/hook_db_drop.yaml
@@ -1,7 +1,7 @@
 #
 # Automatically drops the database in an external PostgreSQL when completely uninstalling the chart.
 #
-{{- if and (not .Values.postgresql.enabled) .Values.postgresql.dropDBOnUninstall (not (.Values.postgresql.adminUrl | empty)) }}
+{{- if and .Values.postgresql.dropDBOnUninstall (not (.Values.postgresql.adminUrl | empty)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/.helm/ecamp3/templates/hook_secrets.yaml
+++ b/.helm/ecamp3/templates/hook_secrets.yaml
@@ -1,7 +1,6 @@
 #
 # Provides the admin database credentials for the hooks that automatically create and drop the database.
 #
-{{- if not .Values.postgresql.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,4 +15,3 @@ metadata:
 type: Opaque
 data:
   admin-database-url: {{ .Values.postgresql.adminUrl | default .Values.postgresql.url | b64enc | quote }}
-{{- end }}

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -156,27 +156,11 @@ mercure:
 
 # Full configuration: https://github.com/bitnami/charts/tree/master/bitnami/postgresql
 postgresql:
-  enabled: true
-  # If bringing your own PostgreSQL, the full uri to use
-  url: postgresql://api-platform:!ChangeMe!@database:5432/api?serverVersion=15&charset=utf8
+  url:
   dropDBOnUninstall: false
-  # If bringing your own PostgreSQL, an uri with privileges to create and drop a database for the application
+  # An uri with privileges to create and drop a database for the application.
+  # Can be left empty if the required database specified in postgresql.url already exists.
   adminUrl:
-  postgresqlUsername: "example"
-  postgresqlPassword: "!ChangeMe!"
-  postgresqlDatabase: "api"
-  # Persistent Volume Storage configuration.
-  # ref: https://kubernetes.io/docs/user-guide/persistent-volumes
-  persistence:
-    enabled: false
-  pullPolicy: IfNotPresent
-  image:
-    repository: bitnami/postgresql
-    tag: 14
-  resources:
-    requests:
-      cpu: 10m
-      memory: 50Mi
 
 recaptcha:
   siteKey:


### PR DESCRIPTION
On the ecamp3 clusters we did not use this feature and did not update the chart. Now the used version is not supported anymore.

closes: #3228