### PR TITLE
.helm: move services to subpaths

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -248,13 +248,9 @@ jobs:
           # Install or upgrade the release
           helm upgrade --install ecamp3-${{ matrix.deployment.name }} . \
             --set imageTag=${{ matrix.deployment.sha }} \
-            --set sharedCookieDomain=.ecamp3.ch \
             --set termsOfServiceLinkTemplate='https://ecamp3.ch/{lang}/tos' \
-            --set api.domain=api-${{ matrix.deployment.name }}.ecamp3.ch \
-            --set frontend.domain=app-${{ matrix.deployment.name }}.ecamp3.ch \
-            --set print.domain=print-${{ matrix.deployment.name }}.ecamp3.ch \
+            --set domain=${{ matrix.deployment.name }}.ecamp3.ch \
             --set mail.dummyEnabled=true \
-            --set mail.domain=mail-${{ matrix.deployment.name }}.ecamp3.ch \
             --set postgresql.enabled=false \
             --set postgresql.url='${{ secrets.POSTGRES_URL }}/ecamp3${{ matrix.deployment.name }}?sslmode=require' \
             --set postgresql.adminUrl='${{ secrets.POSTGRES_ADMIN_URL }}/ecamp3${{ matrix.deployment.name }}?sslmode=require' \

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -142,11 +142,8 @@ jobs:
           # Install or upgrade the release
           helm upgrade --install ecamp3-${{ env.environment }} . \
             --set imageTag=${{ steps.log-environment.outputs.sha }} \
-            --set sharedCookieDomain=.${{ vars.DOMAIN }} \
             --set termsOfServiceLinkTemplate='https://ecamp3.ch/{lang}/tos' \
-            --set api.domain=api${{ env.domain }} \
-            --set frontend.domain=app${{ env.domain }} \
-            --set print.domain=print${{ env.domain }} \
+            --set domain=${{ env.domain }} \
             --set mail.dsn=${{ secrets.MAILER_DSN }} \
             --set postgresql.enabled=false \
             --set postgresql.url='${{ secrets.POSTGRES_URL }}/${{ secrets.DB_NAME }}?sslmode=require' \
@@ -187,5 +184,5 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: https://app${{ env.domain }}
+          env_url: https://${{ env.domain }}
           env: ${{ steps.deployment.outputs.env }}

--- a/.helm/deploy-to-cluster.sh
+++ b/.helm/deploy-to-cluster.sh
@@ -34,13 +34,9 @@ app_jwt_private_key=$(echo -n "$app_jwt_passphrase" | openssl pkey -in "$SCRIPT_
 #use 1 2 instead of "1" to deploy multiple deployments
 for i in 1; do
   values="$values --set imageTag=${version}"
-  values="$values --set sharedCookieDomain=.$domain"
   values="$values --set termsOfServiceLinkTemplate=https://ecamp3.ch/{lang}/tos"
-  values="$values --set api.domain=api-$instance_name-"$i".$domain"
-  values="$values --set frontend.domain=app-$instance_name-"$i".$domain"
-  values="$values --set print.domain=print-$instance_name-"$i".$domain"
+  values="$values --set domain=$instance_name-"$i".$domain"
   values="$values --set mail.dummyEnabled=true"
-  values="$values --set mail.domain=mail-$instance_name-"$i".$domain"
   values="$values --set postgresql.enabled=false"
   values="$values --set postgresql.url=$POSTGRES_URL/ecamp3$instance_name-"$i"?sslmode=require"
   values="$values --set postgresql.adminUrl=$POSTGRES_ADMIN_URL/ecamp3$instance_name-"$i"?sslmode=require"

--- a/.helm/ecamp3/templates/NOTES.txt
+++ b/.helm/ecamp3/templates/NOTES.txt
@@ -2,7 +2,7 @@
 Access the application at one of these URLs:
   Frontend: {{ include "frontend.url" . }}
   API docs: {{ include "api.url" . }}
-  {{- if and .Values.mail.dummyEnabled .Values.mail.domain (not .Values.mail.dsn) }}
+  {{- if and .Values.mail.dummyEnabled .Values.mail.subpath (not .Values.mail.dsn) }}
   View all mails sent out by eCamp: {{ include "mail.url" . }}
   {{- end }}
 {{- else if contains "NodePort" .Values.api.service.type }}

--- a/.helm/ecamp3/templates/_helpers.tpl
+++ b/.helm/ecamp3/templates/_helpers.tpl
@@ -93,35 +93,35 @@ Create chart name and version as used by the chart label.
 The full URL where the API root will be available.
 */}}
 {{- define "api.url" -}}
-{{- printf "https://%s" .Values.api.domain }}
+{{- printf "https://%s%s" .Values.domain .Values.api.subpath }}
 {{- end }}
 
 {{/*
 The prefix used by API for setting cookie names
 */}}
 {{- define "api.cookiePrefix" -}}
-{{- printf "%s_" (.Values.api.domain | replace "." "_") }}
+{{- printf "%s_" (.Values.domain | replace "." "_") }}
 {{- end }}
 
 {{/*
 The full URL where the frontend will be available.
 */}}
 {{- define "frontend.url" -}}
-{{- printf "https://%s" .Values.frontend.domain }}
+{{- printf "https://%s" .Values.domain }}
 {{- end }}
 
 {{/*
 The full URL where the print service will be available.
 */}}
 {{- define "print.url" -}}
-{{- printf "https://%s" .Values.print.domain }}
+{{- printf "https://%s%s" .Values.domain .Values.print.subpath }}
 {{- end }}
 
 {{/*
 The full URL where the dummy mail catcher service will be available.
 */}}
 {{- define "mail.url" -}}
-{{- printf "https://%s" .Values.mail.domain }}
+{{- printf "https://%s%s" .Values.domain .Values.mail.subpath }}
 {{- end }}
 
 {{/*

--- a/.helm/ecamp3/templates/api_configmap.yaml
+++ b/.helm/ecamp3/templates/api_configmap.yaml
@@ -6,9 +6,8 @@ metadata:
     {{- include "api.selectorLabels" . | nindent 4 }}
     {{- include "app.commonLabels" . | nindent 4 }}
 data:
-  ADDITIONAL_TRUSTED_HOSTS: {{ .Values.api.domain | quote }}
+  ADDITIONAL_TRUSTED_HOSTS: {{ .Values.domain | quote }}
   COOKIE_PREFIX: {{ include "api.cookiePrefix" . | quote }}
-  SHARED_COOKIE_DOMAIN: {{ .Values.sharedCookieDomain | quote }}
   APP_ENV: {{ .Values.php.appEnv | quote }}
   APP_DEBUG: {{ .Values.php.appDebug | quote }}
   {{- if .Values.php.dataMigrationsDir }}
@@ -20,7 +19,7 @@ data:
   MERCURE_PUBLIC_URL: {{ .Values.mercure.publicUrl | default "http://127.0.0.1/.well-known/mercure" | quote }}
   {{- if .Values.php.sentryDsn }}
   SENTRY_API_DSN: {{ .Values.php.sentryDsn | quote }}
-  SENTRY_ENVIRONMENT: {{ .Values.frontend.domain | quote }}
+  SENTRY_ENVIRONMENT: {{ .Values.domain | quote }}
   {{- else }}
   SENTRY_API_DSN: {{ "" | quote }}
   {{- end }}

--- a/.helm/ecamp3/templates/api_ingress.yaml
+++ b/.helm/ecamp3/templates/api_ingress.yaml
@@ -6,23 +6,25 @@ metadata:
   labels:
     {{- include "api.selectorLabels" . | nindent 4 }}
     {{- include "app.commonLabels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/x-forwarded-prefix: {{ .Values.api.subpath }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}
   tls:
     - hosts:
-        - {{ $.Values.api.domain | quote }}
+        - {{ $.Values.domain | quote }}
       secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
-    - host: {{ .Values.api.domain | quote }}
+    - host: {{ .Values.domain | quote }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.api.subpath }}(/|$)(.*)
             pathType: Prefix
             backend:
               service:

--- a/.helm/ecamp3/templates/frontend_configmap.yaml
+++ b/.helm/ecamp3/templates/frontend_configmap.yaml
@@ -13,11 +13,10 @@ data:
       PRINT_URL: '{{ include "print.url" . }}',
     {{- if .Values.frontend.sentryDsn }}
       SENTRY_FRONTEND_DSN: '{{ .Values.frontend.sentryDsn }}',
-      SENTRY_ENVIRONMENT: '{{ .Values.frontend.domain }}',
+      SENTRY_ENVIRONMENT: '{{ .Values.domain }}',
     {{- else }}
       SENTRY_FRONTEND_DSN: null,
     {{- end }}
-      SHARED_COOKIE_DOMAIN: '{{ .Values.sharedCookieDomain }}',
       DEPLOYMENT_TIME: '{{ .Values.deploymentTime }}',
       VERSION: '{{ .Values.deployedVersion }}',
       VERSION_LINK_TEMPLATE: '{{ .Values.versionLinkTemplate }}',

--- a/.helm/ecamp3/templates/frontend_ingress.yaml
+++ b/.helm/ecamp3/templates/frontend_ingress.yaml
@@ -15,11 +15,11 @@ spec:
   {{- if .Values.ingress.tls }}
   tls:
     - hosts:
-        - {{ $.Values.frontend.domain | quote }}
+        - {{ $.Values.domain | quote }}
       secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
-    - host: {{ .Values.frontend.domain | quote }}
+    - host: {{ .Values.domain | quote }}
       http:
         paths:
           - path: /

--- a/.helm/ecamp3/templates/mail_deployment.yaml
+++ b/.helm/ecamp3/templates/mail_deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mail.dummyEnabled .Values.mail.domain (not .Values.mail.dsn) }}
+{{- if and .Values.mail.dummyEnabled .Values.mail.subpath (not .Values.mail.dsn) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,10 +37,13 @@ spec:
             - name: mail-smtp
               containerPort: 1025
               protocol: TCP
+          env:
+            - name: MH_UI_WEB_PATH
+              value: {{ .Values.mail.subpath }}
           readinessProbe:
             httpGet:
               scheme: HTTP
-              path: /
+              path: {{ .Values.mail.subpath }}
               port: 8025
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/.helm/ecamp3/templates/mail_ingress.yaml
+++ b/.helm/ecamp3/templates/mail_ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mail.dummyEnabled .Values.mail.domain (not .Values.mail.dsn) }}
+{{- if and .Values.mail.dummyEnabled .Values.mail.subpath (not .Values.mail.dsn) }}
 {{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -7,23 +7,23 @@ metadata:
   labels:
     {{- include "mail.selectorLabels" . | nindent 4 }}
     {{- include "app.commonLabels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}
   tls:
     - hosts:
-        - {{ $.Values.mail.domain | quote }}
+        - {{ $.Values.mail.subpath | quote }}
       secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
-    - host: {{ .Values.mail.domain | quote }}
+    - host: {{ .Values.domain | quote }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.mail.subpath }}
             pathType: Prefix
             backend:
               service:

--- a/.helm/ecamp3/templates/mail_service.yaml
+++ b/.helm/ecamp3/templates/mail_service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mail.dummyEnabled .Values.mail.domain (not .Values.mail.dsn) }}
+{{- if and .Values.mail.dummyEnabled .Values.mail.subpath (not .Values.mail.dsn) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/.helm/ecamp3/templates/print_configmap.yaml
+++ b/.helm/ecamp3/templates/print_configmap.yaml
@@ -10,4 +10,4 @@ data:
   FRONTEND_URL: {{ include "frontend.url" . | quote }}
   PRINT_URL: {{ include "print.url" . | quote }}
   COOKIE_PREFIX: {{ include "api.cookiePrefix" . | quote }}
-  SENTRY_ENVIRONMENT: {{ .Values.frontend.domain | quote }}
+  SENTRY_ENVIRONMENT: {{ .Values.domain | quote }}

--- a/.helm/ecamp3/templates/print_ingress.yaml
+++ b/.helm/ecamp3/templates/print_ingress.yaml
@@ -6,23 +6,25 @@ metadata:
   labels:
     {{- include "print.selectorLabels" . | nindent 4 }}
     {{- include "app.commonLabels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/x-forwarded-prefix: {{ .Values.print.subpath }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}
   tls:
     - hosts:
-        - {{ $.Values.print.domain | quote }}
+        - {{ $.Values.domain | quote }}
       secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
-    - host: {{ .Values.print.domain | quote }}
+    - host: {{ .Values.domain | quote }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.print.subpath }}(/|$)(.*)
             pathType: Prefix
             backend:
               service:

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -5,17 +5,17 @@ chartNameOverride: ""
 imageTag: "latest"
 imagePullSecrets: []
 deploymentTime: ""
+domain:
 deployedVersion: "devel"
 versionLinkTemplate: 'https://github.com/ecamp/ecamp3/commit/{version}'
 termsOfServiceLinkTemplate: # 'https://ecamp3.ch/{lang}/tos'
-sharedCookieDomain:
 
 # enable/disable feature across the complete deployment
 featureToggle:
   developer: false # enables various tools/features foreseen for development deployments (language switcher, form controls view, performance measurement view, etc.)
 
 api:
-  domain:
+  subpath: "/api"
   service:
     type: ClusterIP
     port: 3001
@@ -75,7 +75,6 @@ caddy:
       memory: 20Mi
 
 frontend:
-  domain:
   image:
     repository: "docker.io/ecamp/ecamp3-frontend"
     pullPolicy: IfNotPresent
@@ -93,7 +92,7 @@ frontend:
   loginInfoTextKey: 'dev'
 
 print:
-  domain:
+  subpath: "/print"
   image:
     repository: "docker.io/ecamp/ecamp3-print"
     pullPolicy: IfNotPresent
@@ -133,7 +132,7 @@ mail:
   # If using a real mail server, the connection uri to send emails to
   dsn: # smtp://myuser:mypass@mymailserver:1025
   # If the dummy mail server is enabled, the domain where the web interface is available
-  domain:
+  subpath: "/mail"
   image:
     repository: "docker.io/mailhog/mailhog"
     pullPolicy: IfNotPresent

--- a/api/.env
+++ b/api/.env
@@ -17,7 +17,6 @@
 TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 ADDITIONAL_TRUSTED_HOSTS=localhost
 COOKIE_PREFIX=localhost_
-SHARED_COOKIE_DOMAIN=localhost
 MERCURE_SUBSCRIBE_URL=https://localhost/.well-known/mercure
 
 ###> symfony/framework-bundle ###

--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,6 @@
 # eCamp v3 API
 
-After starting the project using `docker compose up -d`, you can visit the API documentation in the browser at http://localhost:3001
+After starting the project using `docker compose up -d`, you can visit the API documentation in the browser at http://localhost:3000/api
 
 To use the API, you will need to log in. You can use the "Login" endpoint offered in the Swagger UI for this. The example credentials should work fine in development.
 

--- a/api/config/packages/lexik_jwt_authentication.yaml
+++ b/api/config/packages/lexik_jwt_authentication.yaml
@@ -25,18 +25,16 @@ lexik_jwt_authentication:
     set_cookies:
         '%env(COOKIE_PREFIX)%jwt_hp':
             lifetime: null
-            samesite: lax
+            samesite: strict
             path: /
-            domain: '%env(resolve:SHARED_COOKIE_DOMAIN)%'
             httpOnly: false
             split:
                 - header
                 - payload
         '%env(COOKIE_PREFIX)%jwt_s':
             lifetime: null
-            samesite: lax
+            samesite: strict
             path: /
-            domain: '%env(resolve:SHARED_COOKIE_DOMAIN)%'
             httpOnly: true
             split:
                 - signature

--- a/api/docker/caddy/Caddyfile.prod
+++ b/api/docker/caddy/Caddyfile.prod
@@ -44,7 +44,9 @@ route {
     # Add links to the API docs and to the Mercure Hub if not set explicitly (e.g. the PWA)
     header ?Link `</docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation", </.well-known/mercure>; rel="mercure"`
 
-    php_fastcgi unix//var/run/php/php-fpm.sock
+    php_fastcgi unix//var/run/php/php-fpm.sock {
+        env HTTP_X_FORWARDED_PREFIX {header.X-Forwarded-Prefix}
+    }
     encode zstd gzip
     file_server
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,6 @@ services:
     depends_on:
       - php
     environment:
-      SERVER_NAME: ${SERVER_NAME:-localhost:3001, localhost:3443, caddy:3001}
       MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_PUBLISHER_JWT_KEY:-!ChangeMe!}
       MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_SUBSCRIBER_JWT_KEY:-!ChangeMe!}
       MERCURE_EXTRA_DIRECTIVES: demo

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -144,9 +144,7 @@ async function loginJublaDB() {
 }
 
 export async function logout() {
-  Cookies.remove(headerAndPayloadCookieName(), {
-    domain: window.environment.SHARED_COOKIE_DOMAIN,
-  })
+  Cookies.remove(headerAndPayloadCookieName())
   store.commit('logout')
   return router
     .push({ name: 'login' })


### PR DESCRIPTION
This removes the need for a shared cookie domain and makes the setup a little simpler. Now the setup in production is more like the development setup after #3222.

Needs #3222 to work