### PR TITLE
bugfix/Camp: allow to edit camp when it was created with a coupon

### DIFF
--- a/api/fixtures/camps.yml
+++ b/api/fixtures/camps.yml
@@ -11,6 +11,7 @@ App\Entity\Camp:
     creator: '@user2member'
     isPrototype: false
     campPrototypeId: null
+    couponKey: 'l593-8qps'
   camp2:
     name: Camp2
     title: <word()>

--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -50,7 +50,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Post(
             processor: CampCreateProcessor::class,
             security: 'is_authenticated()',
-            validationContext: ['groups' => ['Default', 'create']],
+            validationContext: ['groups' => ['Default', 'create', 'Camp:create']],
             denormalizationContext: ['groups' => ['write', 'create']],
             normalizationContext: self::ITEM_NORMALIZATION_CONTEXT,
         ),
@@ -247,7 +247,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      * If a COUPON_SECRET is configured, a valid Coupon is required.
      */
     #[InputFilter\Trim]
-    #[AssertValidCouponKey()]
+    #[AssertValidCouponKey(groups: ['Camp:create'])]
     #[ApiProperty(readable: false)]
     #[Groups(['create'])]
     #[ORM\Column(type: 'text', length: 128, nullable: true)]

--- a/api/src/Service/CampCouponService.php
+++ b/api/src/Service/CampCouponService.php
@@ -6,6 +6,8 @@ use App\Entity\Camp;
 use Doctrine\ORM\EntityManagerInterface;
 
 class CampCouponService {
+    public const NO_COUPON_KEY_REQUIRED_MESSAGE = 'No Coupon-Key required';
+
     public function __construct(
         private string $secret,
         private EntityManagerInterface $em
@@ -13,8 +15,8 @@ class CampCouponService {
     }
 
     public function createCoupon() {
-        if ('' == $this->secret) {
-            return 'No Coupon-Key required';
+        if (!$this->isActive()) {
+            return self::NO_COUPON_KEY_REQUIRED_MESSAGE;
         }
         $secret = intval($this->secret);
         $min = intval(ceil(78364164096 / $secret));
@@ -30,7 +32,7 @@ class CampCouponService {
         // since we want to have short coupon keys, we implement our own algorithm here.
         // In the long run the CampCouponService will be deleted again.
 
-        if ('' == $this->secret) {
+        if (!$this->isActive()) {
             return true;
         }
 
@@ -56,5 +58,9 @@ class CampCouponService {
         $cnt = $q->getQuery()->getSingleScalarResult();
 
         return 0 == $cnt;
+    }
+
+    public function isActive(): bool {
+        return '' != $this->secret;
     }
 }

--- a/api/src/State/CampCreateProcessor.php
+++ b/api/src/State/CampCreateProcessor.php
@@ -9,6 +9,7 @@ use App\Entity\Camp;
 use App\Entity\CampCollaboration;
 use App\Entity\MaterialList;
 use App\Entity\User;
+use App\Service\CampCouponService;
 use App\State\Util\AbstractPersistProcessor;
 use App\Util\EntityMap;
 use Doctrine\ORM\EntityManagerInterface;
@@ -19,6 +20,7 @@ class CampCreateProcessor extends AbstractPersistProcessor {
         ProcessorInterface $decorated,
         private Security $security,
         private EntityManagerInterface $em,
+        private readonly CampCouponService $campCouponService
     ) {
         parent::__construct($decorated);
     }
@@ -27,6 +29,10 @@ class CampCreateProcessor extends AbstractPersistProcessor {
      * @param Camp $data
      */
     public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []): BaseEntity {
+        if (!$this->campCouponService->isActive()) {
+            $data->couponKey = null;
+        }
+
         /** @var User $user */
         $user = $this->security->getUser();
         $data->creator = $user;

--- a/api/tests/Integration/Service/CampCouponServiceTest.php
+++ b/api/tests/Integration/Service/CampCouponServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Tests\Integration\Service;
+
+use App\Service\CampCouponService;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+use function PHPUnit\Framework\assertThat;
+use function PHPUnit\Framework\equalTo;
+use function PHPUnit\Framework\isFalse;
+use function PHPUnit\Framework\isTrue;
+use function PHPUnit\Framework\logicalNot;
+
+/**
+ * @internal
+ */
+class CampCouponServiceTest extends KernelTestCase {
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void {
+        self::bootKernel();
+        parent::setUp();
+
+        /** @var EntityManagerInterface $obj */
+        $obj = self::getContainer()->get('doctrine.orm.default_entity_manager');
+        $this->entityManager = $obj;
+    }
+
+    public function testCreatesNoTokensWhenSecretIsEmpty() {
+        $campCouponService = $this->createService('');
+
+        $coupon = $campCouponService->createCoupon();
+
+        assertThat($coupon, equalTo(CampCouponService::NO_COUPON_KEY_REQUIRED_MESSAGE));
+    }
+
+    public function testCreateToken() {
+        $campCouponService = $this->createService('10000');
+
+        $coupon = $campCouponService->createCoupon();
+
+        assertThat(strlen($coupon), equalTo(9));
+        assertThat($coupon, logicalNot(equalTo(CampCouponService::NO_COUPON_KEY_REQUIRED_MESSAGE)));
+    }
+
+    public function testCreateDifferentTokensForEachCall() {
+        $campCouponService = $this->createService('1000000');
+
+        $coupon = $campCouponService->createCoupon();
+        $coupon2 = $campCouponService->createCoupon();
+
+        assertThat($coupon, logicalNot(equalTo($coupon2)));
+    }
+
+    /**
+     * @dataProvider someRandomTokens()
+     */
+    public function testReturnsTrueForAllTokensWhenSecretIsEmpty(string $token) {
+        $campCouponService = $this->createService('');
+
+        assertThat($campCouponService->verifyCoupon($token), isTrue());
+    }
+
+    /**
+     * @dataProvider someRandomTokens()
+     */
+    public function testReturnsFalseForRandomTokensIfSecretIsNotEmpty(string $token) {
+        $campCouponService = $this->createService('45983');
+
+        assertThat($campCouponService->verifyCoupon($token), isFalse());
+    }
+
+    /**
+     * @dataProvider someRandomSecrets()
+     */
+    public function testReturnsTrueForValidTokens(string $secret) {
+        $campCouponService = $this->createService($secret);
+
+        $coupon = $campCouponService->createCoupon();
+
+        assertThat($campCouponService->verifyCoupon($coupon), isTrue());
+    }
+
+    public static function someRandomTokens(): array {
+        $emptyString = '';
+        // created with secret 1000000
+        $token1 = 'l593-8qps';
+        // created with secret 1000000
+        $token2 = '84jq-m35s';
+        $uuid = Uuid::uuid4()->toString();
+
+        return [
+            $emptyString => [$emptyString],
+            $token1 => [$token1],
+            $token2 => [$token2],
+            $uuid => [$uuid],
+        ];
+    }
+
+    public static function someRandomSecrets(): array {
+        $parameters = [];
+        for ($__ = 0; $__ < 10; ++$__) {
+            $secret = rand(1000, 1000000);
+            for ($i = 0; $i < 10; ++$i) {
+                $parameters["{$secret} {$i}"] = ["{$secret}"];
+            }
+        }
+
+        return $parameters;
+    }
+
+    private function createService(string $secret): CampCouponService {
+        return new CampCouponService($secret, $this->entityManager);
+    }
+}


### PR DESCRIPTION
Bug was detected because no CampCollaboration could be created for a camp with a couponKey.
- Add a camp with couponkey to camps.yml that we detect if a similar bug happens
- Only run the validator on Camp:create
- Remove the couponKey from the data when creating a Camp if the feature is deactivated, because there is a unique constraint.
(null does not match with the = operator)