### PR TITLE
api/Dockerfile: pin caddy plugin versions

### DIFF
--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -116,6 +116,7 @@ browserless:
   image:
     repository: "docker.io/browserless/chrome"
     pullPolicy: IfNotPresent
+    # renovate: datasource=docker depName=browserless/chrome
     tag: "1.56.0-puppeteer-18.0.5"
   service:
     type: ClusterIP

--- a/renovate.json
+++ b/renovate.json
@@ -83,6 +83,7 @@
     },
     {
       "matchPackageNames": [
+        "browserless/chrome",
         "caddy",
         "krakjoe/apcu",
         "mailhog/mailhog",
@@ -96,6 +97,12 @@
         "after 10pm every sunday",
         "before 7am every monday"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "browserless/chrome"
+      ],
+      "versioning": "regex:(?\\d+\\.\\d+.\\d+)-(puppeteer-)(?\\d+)\\.(?\\d+)\\.(?\\d+)$"
     },
     {
       "matchPackageNames": [
@@ -136,6 +143,15 @@
       ],
       "matchStrings": [
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ENV|ARG) .*?_VERSION=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "fileMatch": [
+        "^.helm/ecamp3/values.yml$"
+      ],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\stag: \"(?<currentValue>.*)\"\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "force": {
     "constraints": {
       "node": "18.14.1",
-      "php": "~8.1.13"
+      "php": "8.1.13"
     }
   },
   "automergeType": "branch",
@@ -172,6 +172,19 @@
       ],
       "matchStrings": [
         "php-version: '(?<currentValue>[0-9.]+)'"
+      ],
+      "depNameTemplate": "php",
+      "lookupNameTemplate": "php/php-src",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>\\w+)?$",
+      "extractVersionTemplate": "^php-(?<version>.*)$"
+    },
+    {
+      "fileMatch": [
+        "^renovate.json$"
+      ],
+      "matchStrings": [
+        "\"php\": \"(?<currentValue>[^\"]+).*\".*"
       ],
       "depNameTemplate": "php",
       "lookupNameTemplate": "php/php-src",

--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,16 @@
       "dependencyDashboardApproval": true
     },
     {
+      "matchDatasources": [
+        "docker"
+      ],
+      "updateTypes": [
+        "digest",
+        "pin"
+      ],
+      "enabled": false
+    },
+    {
       "matchPackageNames": [
         "sass"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -48,7 +48,8 @@
       ],
       "updateTypes": [
         "digest",
-        "pin"
+        "pin",
+        "pinDigest"
       ],
       "enabled": false
     },

--- a/renovate.json
+++ b/renovate.json
@@ -112,7 +112,7 @@
       "matchPackageNames": [
         "browserless/chrome"
       ],
-      "versioning": "regex:(?\\d+\\.\\d+.\\d+)-(puppeteer-)(?\\d+)\\.(?\\d+)\\.(?\\d+)$"
+      "versioning": "regex:(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(puppeteer-)(?<compatibility>.*)$"
     },
     {
       "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "config:base",
-    "docker:pinDigests"
+    "config:base"
   ],
   "force": {
     "constraints": {
@@ -41,17 +40,6 @@
         "major"
       ],
       "dependencyDashboardApproval": true
-    },
-    {
-      "matchDatasources": [
-        "docker"
-      ],
-      "updateTypes": [
-        "digest",
-        "pin",
-        "pinDigest"
-      ],
-      "enabled": false
     },
     {
       "matchPackageNames": [
@@ -94,6 +82,7 @@
     },
     {
       "matchPackageNames": [
+        "browserless/chrome",
         "caddy",
         "krakjoe/apcu",
         "mailhog/mailhog",

--- a/renovate.json
+++ b/renovate.json
@@ -82,7 +82,6 @@
     },
     {
       "matchPackageNames": [
-        "browserless/chrome",
         "caddy",
         "krakjoe/apcu",
         "mailhog/mailhog",
@@ -97,7 +96,8 @@
       "matchPackageNames": [
         "browserless/chrome"
       ],
-      "versioning": "regex:(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(puppeteer-)(?<compatibility>.*)$"
+      "versioning": "loose",
+      "automerge": false
     },
     {
       "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -143,12 +143,11 @@
     },
     {
       "fileMatch": [
-        "^.helm/ecamp3/values.yml$"
+        "^.helm/ecamp3/values.ya?ml$"
       ],
       "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\stag: \"(?<currentValue>.*)\"\\s"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)?\\stag: \"(?<currentValue>.*)\"\\s"
+      ]
     },
     {
       "fileMatch": [

--- a/renovate.json
+++ b/renovate.json
@@ -94,7 +94,6 @@
     },
     {
       "matchPackageNames": [
-        "browserless/chrome",
         "caddy",
         "krakjoe/apcu",
         "mailhog/mailhog",
@@ -103,11 +102,7 @@
         "python",
         "qoomon/docker-host"
       ],
-      "groupName": "docker-images",
-      "schedule": [
-        "after 10pm every sunday",
-        "before 7am every monday"
-      ]
+      "groupName": "docker-images"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
closes #3272

Tested locally with the renovate docker image.
It detected the dependencies:
![image](https://user-images.githubusercontent.com/1506818/220118261-d89e3de5-4ffe-44e3-8421-23393a5177ac.png)
