### PR TITLE
api/Dockerfile: pin caddy plugin versions

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -131,10 +131,14 @@ RUN set -eux; \
 # depends on the "php" stage above
 FROM caddy:${CADDY_VERSION}-builder-alpine AS api_platform_caddy_builder
 
+# renovate: datasource=go depName=github.com/dunglas/mercure/caddy
+ARG MERCURE_CADDY_VERSION=v0.14.5
+# renovate: datasource=go depName=github.com/dunglas/vulcain/caddy
+ARG VULCAIN_CADDY_VERSION=v0.4.2
 # install Mercure and Vulcain modules
 RUN xcaddy build \
-	--with github.com/dunglas/mercure/caddy \
-	--with github.com/dunglas/vulcain/caddy
+	--with github.com/dunglas/mercure/caddy@$MERCURE_CADDY_VERSION \
+	--with github.com/dunglas/vulcain/caddy@$VULCAIN_CADDY_VERSION
 
 FROM caddy:${CADDY_VERSION} AS api_platform_caddy
 


### PR DESCRIPTION
closes #3272

Tested locally with the renovate docker image.
It detected the dependencies:
![image](https://user-images.githubusercontent.com/1506818/220118261-d89e3de5-4ffe-44e3-8421-23393a5177ac.png)
