### PR TITLE
renovate: add regex for docker images in helm values file

### DIFF
--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -115,6 +115,7 @@ browserless:
   image:
     repository: "docker.io/browserless/chrome"
     pullPolicy: IfNotPresent
+    # renovate: datasource=docker depName=browserless/chrome
     tag: "1.57.0-puppeteer-19.2.2"
   service:
     type: ClusterIP

--- a/renovate.json
+++ b/renovate.json
@@ -81,6 +81,7 @@
     },
     {
       "matchPackageNames": [
+        "browserless/chrome",
         "caddy",
         "krakjoe/apcu",
         "mailhog/mailhog",
@@ -94,6 +95,12 @@
         "after 10pm every sunday",
         "before 7am every monday"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "browserless/chrome"
+      ],
+      "versioning": "loose"
     },
     {
       "matchPackageNames": [
@@ -136,6 +143,14 @@
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ENV|ARG) .*?_VERSION=(?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "fileMatch": [
+        "^.helm/ecamp3/values.ya?ml$"
+      ],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)?\\s.*tag: \"(?<currentValue>.*)\"\\s"
+      ]
     },
     {
       "fileMatch": [


### PR DESCRIPTION
To update the browserless/chrome image.
Use loose because of the compatibility indicator puppeteer-18.0.5, else renovate does not find the appropriate docker tags.

closes #3120
closes #2720

Tested with https://github.com/BacLuc/ecamp3/pull/173/commits/a94514ccf5140667d929b2001d05ffef847bac8d
The pinning of caddy will go away with #3281 