### PR TITLE
renovate: disable pinning digest of docker images

### DIFF
--- a/.docker-hub/frontend/Dockerfile
+++ b/.docker-hub/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:lts-alpine@sha256:045b1a1c90bdfd8fcaad0769922aa16c401e31867d8bf5833365b0874884bbae AS build-stage
+FROM node:lts-alpine AS build-stage
 
 COPY common /common
 
@@ -12,7 +12,7 @@ COPY frontend .
 RUN npm run build
 
 # production stage
-FROM nginx:stable-alpine@sha256:cc61d734c3045fa64f3d50173e5025e35e0074a29e24559e5ce085b844f6287d as production-stage
+FROM nginx:stable-alpine as production-stage
 RUN mkdir /app
 WORKDIR /app
 COPY --from=build-stage /app/dist /app

--- a/.docker-hub/print/Dockerfile
+++ b/.docker-hub/print/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:18.14.1@sha256:671b86a524e12beac53f6679d791dc8b73bff3a46edf4878343e82503cb33938 AS build-stage
+FROM node:18.14.1 AS build-stage
 
 COPY common /common
 
@@ -13,7 +13,7 @@ ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN npm run build
 
 # production stage
-FROM node:18.14.1@sha256:671b86a524e12beac53f6679d791dc8b73bff3a46edf4878343e82503cb33938 AS production-stage
+FROM node:18.14.1 AS production-stage
 WORKDIR /app
 
 COPY --from=build-stage /app/node_modules ./node_modules

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -182,7 +182,7 @@ jobs:
 
     services:
       postgres:
-        image: 'postgres:13-alpine@sha256:df217beb4a3a8f25d337f601c77d824ce3d41178c2bdc3bf94166f7868de81e5'
+        image: 'postgres:13-alpine'
         env:
           POSTGRES_DB: 'ecamp3test'
           POSTGRES_PASSWORD: 'ecamp3'
@@ -255,7 +255,7 @@ jobs:
 
     services:
       postgres:
-        image: 'postgres:13-alpine@sha256:df217beb4a3a8f25d337f601c77d824ce3d41178c2bdc3bf94166f7868de81e5'
+        image: 'postgres:13-alpine'
         env:
           POSTGRES_DB: 'ecamp3test'
           POSTGRES_PASSWORD: 'ecamp3'

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -71,7 +71,7 @@ RUN set -eux; \
 ###> recipes ###
 ###< recipes ###
 
-COPY --from=composer:2.5@sha256:693e9e0b5dc8e8e7599ee9719334ee260498981f4cedb696c16927b0ea0eca98 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.5 /usr/bin/composer /usr/bin/composer
 
 # Copy development php.ini
 RUN cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   frontend:
-    image: node:18.14.1@sha256:671b86a524e12beac53f6679d791dc8b73bff3a46edf4878343e82503cb33938
+    image: node:18.14.1
     container_name: 'ecamp3-frontend'
     ports:
       - '3000:3000'
@@ -102,7 +102,7 @@ services:
       - ./api/public:/srv/api/public:ro
 
   print:
-    image: node:18.14.1@sha256:671b86a524e12beac53f6679d791dc8b73bff3a46edf4878343e82503cb33938
+    image: node:18.14.1
     container_name: 'ecamp3-print'
     ports:
       - '3003:3003'
@@ -125,7 +125,7 @@ services:
       - ./print/print.env
 
   database:
-    image: postgres:13-alpine@sha256:df217beb4a3a8f25d337f601c77d824ce3d41178c2bdc3bf94166f7868de81e5
+    image: postgres:13-alpine
     container_name: 'ecamp3-database'
     environment:
       - POSTGRES_DB=ecamp3dev
@@ -142,13 +142,13 @@ services:
         protocol: tcp
 
   mail:
-    image: mailhog/mailhog@sha256:8d76a3d4ffa32a3661311944007a415332c4bb855657f4f6c57996405c009bea
+    image: mailhog/mailhog
     container_name: 'ecamp3-mail'
     ports:
       - '3007:8025' # web UI
 
   docker-host:
-    image: qoomon/docker-host@sha256:74157ce8202abd91f4e21006f0f4e65a557ef167c40cd77a26be79528e6da85d
+    image: qoomon/docker-host
     container_name: 'ecamp3-docker-host-forwarder'
     cap_add: [ 'NET_ADMIN', 'NET_RAW' ]
     restart: on-failure

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "config:base",
-    "docker:pinDigests"
+    "config:base"
   ],
   "force": {
     "constraints": {
@@ -28,7 +27,6 @@
         "minor",
         "patch",
         "pin",
-        "digest",
         "lockFileMaintenance"
       ],
       "automerge": true


### PR DESCRIPTION
This makes the life of developers on apples silicon m1 arm chip easier. (And the pinning of docker images is good, but does not bring that much value.)

closes #2750