### PR TITLE
fix(frontend): prevent console errors during logout

### DIFF
--- a/frontend/src/components/collaborator/CollaboratorListItem.vue
+++ b/frontend/src/components/collaborator/CollaboratorListItem.vue
@@ -114,7 +114,7 @@ export default {
       if (!(typeof this.collaborator.user === 'function')) {
         return false
       }
-      return this.$store.state.auth.user.id === this.collaborator.user().id
+      return this.$store.state.auth.user?.id === this.collaborator.user().id
     },
   },
   methods: {

--- a/frontend/src/components/collaborator/CollaboratorListItemDeactivate.vue
+++ b/frontend/src/components/collaborator/CollaboratorListItemDeactivate.vue
@@ -50,7 +50,7 @@ export default {
       if (!(typeof this.entity.user === 'function')) {
         return false
       }
-      return this.$store.state.auth.user.id === this.entity.user().id
+      return this.$store.state.auth.user?.id === this.entity.user().id
     },
     displayName() {
       return campCollaborationDisplayName(this.entity, this.$tc.bind(this))

--- a/frontend/src/mixins/campRoleMixin.js
+++ b/frontend/src/mixins/campRoleMixin.js
@@ -13,7 +13,7 @@ export const campRoleMixin = {
       return this.role === 'member'
     },
     role() {
-      const currentUserLink = this.$store.state.auth.user._meta.self
+      const currentUserLink = this.$store.state.auth.user?._meta.self
       const result = this._campCollaborations
         .filter((coll) => typeof coll.user === 'function')
         .find((coll) => coll.user()._meta.self === currentUserLink)

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -1,6 +1,7 @@
 <template>
   <v-container fluid>
     <content-card
+      v-if="user"
       max-width="800"
       :title="
         $tc('views.profile.profile') + ': ' + (user._meta.loading ? '' : user.displayName)
@@ -97,7 +98,7 @@ export default {
       return this.$store.state.auth.user
     },
     profile() {
-      return this.user.profile()
+      return this.user?.profile()
     },
     availableLocales() {
       return VueI18n.availableLocales.map((l) => ({
@@ -108,13 +109,15 @@ export default {
   },
   watch: {
     profile() {
-      if (VueI18n.availableLocales.includes(this.profile.language)) {
-        this.$store.commit('setLanguage', this.profile.language)
+      if (VueI18n.availableLocales.includes(this.profile?.language)) {
+        this.$store.commit('setLanguage', this.profile?.language)
       }
     },
   },
   mounted() {
-    this.api.reload(this.user).then((user) => this.api.reload(user.profile()))
+    if (this.user) {
+      this.api.reload(this.user).then((user) => this.api.reload(user.profile()))
+    }
   },
 }
 </script>


### PR DESCRIPTION
The errors are harmless but clutter console & sentry.

These errors are thrown during logout when `this.$store.state.auth.user` is already null. Several pieces in our code don't expect this to be null.