### PR TITLE
fix: end2tests + print + iri

### DIFF
--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -16,9 +16,13 @@ module.exports = defineConfig({
         deleteDownloads() {
           const dirPath = config.downloadsFolder
           fs.readdir(dirPath, (err, files) => {
-            for (const file of files) {
-              fs.unlink(path.join(dirPath, file), () => {
-                console.log('Removed ' + file)
+            if (err) {
+              console.log(err)
+            } else {
+              files.forEach((file) => {
+                fs.unlink(path.join(dirPath, file), () => {
+                  console.log('Removed ' + file)
+                })
               })
             }
           })

--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -1,5 +1,8 @@
 const { defineConfig } = require('cypress')
 
+const fs = require('fs')
+const path = require('path')
+
 module.exports = defineConfig({
   video: false,
   pageLoadTimeout: 120000,
@@ -9,7 +12,19 @@ module.exports = defineConfig({
   videosFolder: 'data/e2e/videos',
   e2e: {
     setupNodeEvents(on, config) {
-      return config
+      on('task', {
+        deleteDownloads() {
+          const dirPath = config.downloadsFolder
+          fs.readdir(dirPath, (err, files) => {
+            for (const file of files) {
+              fs.unlink(path.join(dirPath, file), () => {
+                console.log('Removed ' + file)
+              })
+            }
+          })
+          return null
+        },
+      })
     },
     specPattern: 'tests/e2e/specs/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: 'tests/e2e/support/index.js',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,7 +42,7 @@
         "dayjs": "1.11.7",
         "deepmerge": "4.3.0",
         "file-saver": "2.0.5",
-        "hal-json-vuex": "2.0.0-alpha.15",
+        "hal-json-vuex": "2.0.0-alpha.16",
         "html-to-react": "1.5.0",
         "inter-ui": "3.19.3",
         "js-cookie": "3.0.1",
@@ -11946,9 +11946,9 @@
       }
     },
     "node_modules/hal-json-normalizer": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/hal-json-normalizer/-/hal-json-normalizer-4.1.2.tgz",
-      "integrity": "sha512-PuIobGpKeXHBLeXWj5gXtisoxRdywJ9IxlYCo9ck4rlG9UrFkQyzNMF+v7jprwLqsAPfTzM1I9QyiN99weoZQg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hal-json-normalizer/-/hal-json-normalizer-4.2.0.tgz",
+      "integrity": "sha512-TnlN4OzP/RPTCRC/+Zy9qjt9mefSHEjQrI2RQPERahBsOh5gPnUnpuH2DfIM3NiMdlCNQaTQuyhU1oJ0L4vNEg==",
       "dependencies": {
         "lodash": "^4.17.15"
       },
@@ -11957,12 +11957,12 @@
       }
     },
     "node_modules/hal-json-vuex": {
-      "version": "2.0.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/hal-json-vuex/-/hal-json-vuex-2.0.0-alpha.15.tgz",
-      "integrity": "sha512-Smq9UHXSp28HCZVjlhihkZ2Tm5eLWqwgTrTQYadaqRhft5nYT5SB9971PlMcAdZZ8/IPxJ8+gJ5cV4Mf9EOIqw==",
+      "version": "2.0.0-alpha.16",
+      "resolved": "https://registry.npmjs.org/hal-json-vuex/-/hal-json-vuex-2.0.0-alpha.16.tgz",
+      "integrity": "sha512-7OtQtJLr9Od4giw27ryINOYlM/6dvNZlcQiiseINq8qKrpc5dV9hLo4QOvKy8YGgnQOXYnCMSJ55/7XM+qiPGg==",
       "dependencies": {
-        "hal-json-normalizer": "4.1.2",
-        "url-template": "2.0.8"
+        "hal-json-normalizer": "^4.2.0",
+        "url-template": "^2.0.8"
       },
       "engines": {
         "node": ">=14.0.0 <19.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
     "dayjs": "1.11.7",
     "deepmerge": "4.3.0",
     "file-saver": "2.0.5",
-    "hal-json-vuex": "2.0.0-alpha.15",
+    "hal-json-vuex": "2.0.0-alpha.16",
     "html-to-react": "1.5.0",
     "inter-ui": "3.19.3",
     "js-cookie": "3.0.1",

--- a/frontend/tests/e2e/specs/nuxtPrint.cy.js
+++ b/frontend/tests/e2e/specs/nuxtPrint.cy.js
@@ -35,6 +35,7 @@ describe('Nuxt print test', () => {
   })
 
   it('downloads PDF', () => {
+    cy.task('deleteDownloads')
     cy.login('test@example.com')
 
     cy.visit('/camps')

--- a/frontend/tests/e2e/specs/reactPrint.cy.js
+++ b/frontend/tests/e2e/specs/reactPrint.cy.js
@@ -4,6 +4,7 @@ const path = require('path')
 
 describe('React print test', () => {
   it('downloads PDF', () => {
+    cy.task('deleteDownloads')
     cy.login('test@example.com')
 
     cy.visit('/camps')

--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -19,7 +19,7 @@
         "dayjs": "1.11.7",
         "deepmerge": "4.3.0",
         "express": "4.18.2",
-        "hal-json-vuex": "2.0.0-alpha.15",
+        "hal-json-vuex": "2.0.0-alpha.16",
         "isomorphic-dompurify": "1.0.0",
         "lodash": "4.17.21",
         "nuxt": "2.16.1",
@@ -10808,9 +10808,9 @@
       "integrity": "sha512-7+G0/2/COR8pwteYFqHIVYfQpuEiO2HXwJrhCBJVgrNrl9O5eaUoJVDGXUJX+0RpGncNVTuestexjk1afj01wQ=="
     },
     "node_modules/hal-json-normalizer": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/hal-json-normalizer/-/hal-json-normalizer-4.1.2.tgz",
-      "integrity": "sha512-PuIobGpKeXHBLeXWj5gXtisoxRdywJ9IxlYCo9ck4rlG9UrFkQyzNMF+v7jprwLqsAPfTzM1I9QyiN99weoZQg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hal-json-normalizer/-/hal-json-normalizer-4.2.0.tgz",
+      "integrity": "sha512-TnlN4OzP/RPTCRC/+Zy9qjt9mefSHEjQrI2RQPERahBsOh5gPnUnpuH2DfIM3NiMdlCNQaTQuyhU1oJ0L4vNEg==",
       "dependencies": {
         "lodash": "^4.17.15"
       },
@@ -10819,12 +10819,12 @@
       }
     },
     "node_modules/hal-json-vuex": {
-      "version": "2.0.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/hal-json-vuex/-/hal-json-vuex-2.0.0-alpha.15.tgz",
-      "integrity": "sha512-Smq9UHXSp28HCZVjlhihkZ2Tm5eLWqwgTrTQYadaqRhft5nYT5SB9971PlMcAdZZ8/IPxJ8+gJ5cV4Mf9EOIqw==",
+      "version": "2.0.0-alpha.16",
+      "resolved": "https://registry.npmjs.org/hal-json-vuex/-/hal-json-vuex-2.0.0-alpha.16.tgz",
+      "integrity": "sha512-7OtQtJLr9Od4giw27ryINOYlM/6dvNZlcQiiseINq8qKrpc5dV9hLo4QOvKy8YGgnQOXYnCMSJ55/7XM+qiPGg==",
       "dependencies": {
-        "hal-json-normalizer": "4.1.2",
-        "url-template": "2.0.8"
+        "hal-json-normalizer": "^4.2.0",
+        "url-template": "^2.0.8"
       },
       "engines": {
         "node": ">=14.0.0 <19.0.0"

--- a/print/package.json
+++ b/print/package.json
@@ -29,7 +29,7 @@
     "dayjs": "1.11.7",
     "deepmerge": "4.3.0",
     "express": "4.18.2",
-    "hal-json-vuex": "2.0.0-alpha.15",
+    "hal-json-vuex": "2.0.0-alpha.16",
     "isomorphic-dompurify": "1.0.0",
     "lodash": "4.17.21",
     "nuxt": "2.16.1",


### PR DESCRIPTION
This avoid false-positive for the print end-to-end test.

My hope is this runs through, once https://github.com/carlobeltrame/hal-json-normalizer/pull/87 is integrated.

Also blocked by https://github.com/ecamp/hal-json-vuex/pull/281/files