### PR TITLE
Fix missing language

### DIFF
--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -171,7 +171,7 @@ export default {
     termsOfServiceLink() {
       return (
         parseTemplate(window.environment.TERMS_OF_SERVICE_LINK_TEMPLATE || '').expand({
-          lang: this.language.substring(0, 2),
+          lang: (this.language || 'de').substring(0, 2),
         }) || false
       )
     },


### PR DESCRIPTION
Fixes https://ecamp.sentry.io/issues/3974908890/
For some reason, the language dropdown can yield an undefined value sometimes. Maybe a loading issue. Either way, this should fix this specific problem.