### PR TITLE
Fix docker setup instructions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -389,7 +389,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      # build API (using cache; provide image to docker-compose)
+      # build API (using cache; provide image to docker compose)
       - name: Build docker image (API/PHP)
         uses: docker/build-push-action@v4
         with:
@@ -403,7 +403,7 @@ jobs:
           cache-from: type=gha,scope=api
           cache-to: type=gha,scope=api,mode=max
 
-      # build caddy (using cache; provide image to docker-compose)
+      # build caddy (using cache; provide image to docker compose)
       - name: Build docker image (Caddy)
         uses: docker/build-push-action@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,13 @@ git checkout -b my-new-feature-branch
 
 ### Code formatting
 
-We use cs-fixer for PHP and ESLint for Javascript to ensure a common code style. Make sure your code is auto-formatted before comitting and pushing to the repository.
+We use cs-fixer for PHP and ESLint and Prettier for Javascript to ensure a common code style. Make sure your code is auto-formatted before comitting and pushing to the repository.
 
 We recommend to [configure your IDE](https://github.com/ecamp/ecamp3/wiki/installation-development-windows#code-auto-formatting) such that your code is auto-formatted on save.
 
 Alternatively you can
 
-- run php-cs-fixer and ESLint manually before each commit:
+- run php-cs-fixer and ESLint / Prettier manually before each commit:
   ```bash
   docker compose run api composer cs-fix
   docker compose run frontend npm run lint
@@ -65,7 +65,7 @@ Alternatively you can
 ### Before submitting pull requests
 
 - [x] Did cs-fixer run on all changed or new PHP files?
-- [x] Did ESLint run on all changed or new JS / Vue files?
+- [x] Did ESLint / Prettier run on all changed or new JS / Vue files?
 - [x] Are all variables, classes, functions, comments etc. named or written in English?
 - [x] Did you write tests for any new functionality or adapt the existing tests for changed functionality?
 - [x] Are all passwords, credentials and local configuration removed from the code changes?
@@ -117,13 +117,13 @@ git checkout -b my-new-feature-branch
 
 ### Quellcode Formatierung
 
-Wir verwenden php-cs-fixer für PHP und ESLint für JS um einen gemeinsamen Code Style zu etablieren. Bitte stelle sicher, dass dein Code automatisch richtig formatiert wird, bevor du diesen ins Git repo committest.
+Wir verwenden php-cs-fixer für PHP und ESLint und Prettier für JS um einen gemeinsamen Code Style zu etablieren. Bitte stelle sicher, dass dein Code automatisch richtig formatiert wird, bevor du diesen ins Git repo committest.
 
 Wir empfehlen deine [IDE so zu konfigurieren](https://github.com/ecamp/ecamp3/wiki/installation-development-windows#code-auto-formatting), dass dein Code beim Speichern automatisch richtig formatiert wird.
 
 Alternativ kannst du
 
-- php-cs-fixer und ESLint vor jedem commit manuell laufen lassen:
+- php-cs-fixer und ESLint / Prettier vor jedem commit manuell laufen lassen:
   ```bash
   docker compose run api composer cs-fix
   docker compose run frontend npm run lint
@@ -134,7 +134,7 @@ Alternativ kannst du
 ### Vor dem Einreichen eines Pull Requests
 
 - [x] Wurden alle geänderten oder neuen PHP-Dateien von cs-fixer verarbeitet?
-- [x] Wurden alle geänderten oder neuen JS/Vue-Dateien von ESLint bereinigt?
+- [x] Wurden alle geänderten oder neuen JS/Vue-Dateien von ESLint / Prettier bereinigt?
 - [x] Sind alle Variabeln, Klassen, Funktionen, Kommentare, etc. auf englisch benannt?
 - [x] Hast du für neue Funktionalität Tests geschrieben und für geänderte Funktionalität die Tests angepasst?
 - [x] Wurden alle Passwörter, Zugangsdaten und lokale Konfiguration aus den Code-Änderungen entfernt?

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ eCamp v3 is made up of a backend based on the PHP framework API Platform (Symfon
 
 Thanks for helping! There are a few ways to get started.
 
-- Visit our test environment at https://app-dev.ecamp3.ch. If you discover a bug, [open an issue](https://github.com/ecamp/ecamp3/issues/new) for it.
+- Visit our test environment at https://dev.ecamp3.ch. If you discover a bug, [open an issue](https://github.com/ecamp/ecamp3/issues/new) for it.
 - To run the project on your computer for development, follow one of our installation guides:
-  - [Installation with Docker on Linux](https://github.com/ecamp/ecamp3/wiki/installation-development-linux) (German only)
-  - [Installation with Docker on Windows + WSL 2](https://github.com/ecamp/ecamp3/wiki/installation-development-windows)
-  - [Set up VS Code as your code editor](https://github.com/ecamp/ecamp3/wiki/installation-development-windows#setting-up-the-ide)
+  - [Installation on Linux](https://github.com/ecamp/ecamp3/wiki/Development-install-on-linux)
+  - [Installation on Windows + WSL 2](https://github.com/ecamp/ecamp3/wiki/Development-installation-on-Windows)
+  - [Set up VS Code as your code editor](https://github.com/ecamp/ecamp3/wiki/Development-installation-on-Windows#setting-up-the-ide)
 - If you run into problems during setup or need help, don't worry. Check the [discussions](https://github.com/ecamp/ecamp3/discussions) whether someone already had and solved your problem, and add a [new discussion](https://github.com/ecamp/ecamp3/discussions/new) otherwise.
 - Before you can start coding, read our [contributing guidelines](CONTRIBUTING.md)
 - Study the [documentation in the wiki](https://github.com/ecamp/ecamp3/wiki)
@@ -58,11 +58,11 @@ eCamp v3 besteht aus einem Backend basierend auf dem PHP-Framework API Platform 
 
 Danke dass du mithelfen möchtest! Es gibt ein paar verschiedene Arten wie du beginnen kannst.
 
-- Besuche unsere Testumgebung auf https://app-dev.ecamp3.ch. Wenn du einen Fehler entdeckst, [eröffne ein Issue dafür](https://github.com/ecamp/ecamp3/issues/new).
+- Besuche unsere Testumgebung auf https://dev.ecamp3.ch. Wenn du einen Fehler entdeckst, [eröffne ein Issue dafür](https://github.com/ecamp/ecamp3/issues/new).
 - Um das Projekt bei dir auf dem Computer laufen zu lassen, folge einer der Installationsanleitungen:
-  - [Installation mit Docker auf Linux](https://github.com/ecamp/ecamp3/wiki/installation-development-linux)
-  - [Installation mit Docker auf Windows + WSL2](https://github.com/ecamp/ecamp3/wiki/installation-development-windows) (nur englisch)
-  - [VS Code als Code-Editor einrichten](https://github.com/ecamp/ecamp3/wiki/installation-development-windows#setting-up-the-ide) (nur englisch)
+  - [Installation mit Docker auf Linux](https://github.com/ecamp/ecamp3/wiki/Development-install-on-linux#deutsch)
+  - [Installation mit Docker auf Windows + WSL2](https://github.com/ecamp/ecamp3/wiki/Development-installation-on-Windows) (nur englisch)
+  - [VS Code als Code-Editor einrichten](https://github.com/ecamp/ecamp3/wiki/Development-installation-on-Windows#setting-up-the-ide) (nur englisch)
 - Falls du Probleme beim Einrichten oder Verständnisfragen hast - keine Sorge, du bist nicht allein. Schau bei den [Discussions](https://github.com/ecamp/ecamp3/discussions) nach ob das Problem bekannt und gelöst ist. Falls nein, eröffne eine [neue Discussion](https://github.com/ecamp/ecamp3/discussions/new).
 - Bevor du mit programmieren loslegen kannst, lies unsere [contributing guidelines](CONTRIBUTING.md)
 - Studier die [Dokumentation im Wiki](https://github.com/ecamp/ecamp3/wiki)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.9'
 
 services:
   frontend:


### PR DESCRIPTION
On January 2nd, @manuelmeister renamed some pages in our wiki, leading to some dead links in the README and on other wiki pages.
In #3305, @pmattmann introduced a `profile` entry in docker-compose.yml, which is incompatible with the old way of using docker compose (using `docker-compose` instead of the new `docker compose` without dash).
In #3304, @usu partially migrated our instructions to use the new `docker compose` command.

This PR attempts to return to fully working and up-to-date docker setup instructions. I also updated several Wiki entries, and translated and completely overhauled the Docker Linux setup instructions, because the recommended way of installing Docker has changed. I tested by [completely uninstalling Docker](https://askubuntu.com/questions/935569/how-to-completely-uninstall-docker) from my system, then following the instructions.
I first tried with Docker Desktop for Linux, which is now the recommended way to install Docker on Linux. But I quickly ran into performance issues, permission issues and the Docker daemon crashed several times within the first hour of me using it. So instead, I changed the instructions to recommend Docker Engine (the headless version).