### PR TITLE
fix: prevent browserPreferredLocale from being undefined

### DIFF
--- a/frontend/src/components/print/print-nuxt/generatePdfMixin.js
+++ b/frontend/src/components/print/print-nuxt/generatePdfMixin.js
@@ -25,7 +25,7 @@ export const generatePdfMixin = {
 
       const config = cloneDeep(this.config)
       config.documentName = slugify(config.documentName, {
-        locale: this.$store.state.lang.language.substr(0, 2),
+        locale: this.$store.state.lang.language.substring(0, 2),
       })
 
       this.loading = true

--- a/frontend/src/components/print/print-react/generatePdfMixin.js
+++ b/frontend/src/components/print/print-react/generatePdfMixin.js
@@ -42,7 +42,7 @@ export const generatePdfMixin = {
       saveAs(
         blob,
         slugify(this.config.documentName, {
-          locale: this.$store.state.lang.language.substr(0, 2),
+          locale: this.$store.state.lang.language.substring(0, 2),
         })
       )
 

--- a/frontend/src/mixins/passwordStrengthMixin.js
+++ b/frontend/src/mixins/passwordStrengthMixin.js
@@ -6,7 +6,7 @@ export const passwordStrengthMixin = {
     passwordStrengthColor: 'green',
   }),
   methods: {
-    async strength(password, lang = this.$store.state.lang.language.substr(0, 2)) {
+    async strength(password, lang = this.$store.state.lang.language.substring(0, 2)) {
       if (password.length === 0) {
         this.passwordStrength = 0
       } else {

--- a/frontend/src/plugins/i18n/index.js
+++ b/frontend/src/plugins/i18n/index.js
@@ -109,7 +109,7 @@ Object.defineProperty(i18n, 'browserPreferredLocale', {
         return languageFallback
       }
     }
-    return 'en'
+    return fallbackLocale
   },
 })
 

--- a/frontend/src/plugins/i18n/index.js
+++ b/frontend/src/plugins/i18n/index.js
@@ -103,8 +103,13 @@ Object.defineProperty(i18n, 'browserPreferredLocale', {
       if (this.availableLocales.includes(language)) {
         return language
       }
+
+      const languageFallback = language.substring(0, 2)
+      if (this.availableLocales.includes(languageFallback)) {
+        return languageFallback
+      }
     }
-    return undefined
+    return 'en'
   },
 })
 

--- a/frontend/src/plugins/store/lang.js
+++ b/frontend/src/plugins/store/lang.js
@@ -16,6 +16,10 @@ export const mutations = {
    * @param lang Language string
    */
   setLanguage(state, lang) {
+    if (!lang) {
+      return
+    }
+
     state.language = lang
     VueI18n.locale = lang
     Vue.dayjs.locale(lang)

--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -171,7 +171,7 @@ export default {
     termsOfServiceLink() {
       return (
         parseTemplate(window.environment.TERMS_OF_SERVICE_LINK_TEMPLATE || '').expand({
-          lang: (this.language || 'de').substring(0, 2),
+          lang: this.language.substring(0, 2),
         }) || false
       )
     },


### PR DESCRIPTION
The root cause of https://github.com/ecamp/ecamp3/pull/3318 was that browserPreferredLocale could return `undefined` (for example `de-DE` wouldn't match any our our defined locales; neither would any locale outside de,en,it,fr).

This led to errors at multiple places (see sentry).

This PR should improve detecting the language + fall back to "en" if no language is detected.