### PR TITLE
Improve compatibility with password managers

### DIFF
--- a/e2e/specs/login.cy.js
+++ b/e2e/specs/login.cy.js
@@ -11,7 +11,7 @@ describe('Login test', () => {
   it('can login with default user', () => {
     cy.visit('/')
 
-    cy.get('[type="text"]').type('test@example.com')
+    cy.get('[type="email"]').type('test@example.com')
     cy.get('[type="password"]').type('test')
     cy.get('[type="submit').click()
 

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -26,7 +26,8 @@
         name="email"
         append-icon="mdi-account-outline"
         :dense="$vuetify.breakpoint.xsOnly"
-        type="text"
+        type="email"
+        autocomplete="username"
       />
 
       <e-text-field
@@ -38,6 +39,7 @@
         append-icon="mdi-lock-outline"
         :dense="$vuetify.breakpoint.xsOnly"
         type="password"
+        autocomplete="current-password"
       />
       <small class="ml-2">
         <router-link

--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -10,6 +10,7 @@
           append-icon="mdi-account-outline"
           dense
           type="text"
+          autocomplete="given-name"
         />
 
         <e-text-field
@@ -19,6 +20,7 @@
           append-icon="mdi-account-outline"
           dense
           type="text"
+          autocomplete="family-name"
         />
 
         <e-text-field
@@ -27,7 +29,8 @@
           vee-rules="email|required"
           append-icon="mdi-at"
           dense
-          type="text"
+          type="email"
+          autocomplete="username"
         />
 
         <e-text-field
@@ -39,6 +42,10 @@
           append-icon="mdi-lock-outline"
           dense
           type="password"
+          autocomplete="new-password"
+          minlength="12"
+          maxlength="128"
+          passwordrules="minlength: 12; maxlength: 128;"
           loading
           @input="debouncedPasswordStrengthCheck"
         >
@@ -60,6 +67,10 @@
           dense
           append-icon="mdi-lock-outline"
           type="password"
+          autocomplete="new-password"
+          minlength="12"
+          maxlength="128"
+          passwordrules="minlength: 12; maxlength: 128;"
         />
 
         <e-select

--- a/frontend/src/views/auth/ResetPassword.vue
+++ b/frontend/src/views/auth/ResetPassword.vue
@@ -31,7 +31,8 @@
           name="email"
           append-icon="mdi-at"
           :dense="$vuetify.breakpoint.xsOnly"
-          type="text"
+          type="email"
+          autocomplete="username"
           readonly
         />
 
@@ -44,6 +45,10 @@
           append-icon="mdi-lock-outline"
           :dense="$vuetify.breakpoint.xsOnly"
           type="password"
+          autocomplete="new-password"
+          minlength="12"
+          maxlength="128"
+          passwordrules="minlength: 12; maxlength: 128;"
           loading
           autofocus
           @input="debouncedPasswordStrengthCheck"
@@ -66,6 +71,10 @@
           :dense="$vuetify.breakpoint.xsOnly"
           append-icon="mdi-lock-outline"
           type="password"
+          autocomplete="new-password"
+          minlength="12"
+          maxlength="128"
+          passwordrules="minlength: 12; maxlength: 128;"
         />
 
         <v-btn

--- a/frontend/src/views/auth/ResetPasswordRequest.vue
+++ b/frontend/src/views/auth/ResetPasswordRequest.vue
@@ -23,7 +23,8 @@
         vee-rules="email"
         append-icon="mdi-at"
         :dense="$vuetify.breakpoint.xsOnly"
-        type="text"
+        type="email"
+        autocomplete="username"
         autofocus
       />
       <v-btn


### PR DESCRIPTION
Following the recommendations from:
https://hidde.blog/making-password-managers-play-ball-with-your-login-form/
https://developer.1password.com/docs/web/compatible-website-design/
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill

and some manual testing using 1password on desktop.

I will deploy this and check it on the phone, because that's where I had more issues previously (with 1password for Android).
It'd be great if you could help out by testing with your own password managers on all your devices :)