### PR TITLE
Run e2e tests in multiple browsers

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -468,6 +468,15 @@ jobs:
           wait-on: 'http://localhost:3000, http://localhost:3000/api'
           wait-on-timeout: 300
 
+      # store screenshots and videos on GitHub as artifacts, for downloading and debugging in case of problems
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: cypress-output
+          path: |
+            ./cypress/screenshots
+            ./cypress/videos
+
       # print docker container logs (good for debugging; can be disabled again later on)
       - run: docker compose logs --tail="all"
         if: always()

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -380,6 +380,12 @@ jobs:
     name: 'Tests: End-to-end'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        browser:
+          - chrome
+          - firefox
+          - edge
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
 
@@ -457,7 +463,7 @@ jobs:
       - uses: cypress-io/github-action@v5
         with:
           working-directory: e2e
-          browser: chrome
+          browser: ${{ matrix.browser }}
           wait-on: 'http://localhost:3000, http://localhost:3000/api'
           wait-on-timeout: 300
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -407,8 +407,8 @@ jobs:
           target: api_platform_php_dev
           builder: ${{ steps.buildx.outputs.name }}
           tags: ecamp/ecamp3-dev-api-php
-          cache-from: type=gha,scope=api
-          cache-to: type=gha,scope=api,mode=max
+          cache-from: type=gha,scope=${{ matrix.browser }}-api
+          cache-to: type=gha,scope=${{ matrix.browser }}-api,mode=max
 
       # build caddy (using cache; provide image to docker compose)
       - name: Build docker image (Caddy)
@@ -421,8 +421,8 @@ jobs:
           target: api_platform_caddy
           builder: ${{ steps.buildx.outputs.name }}
           tags: ecamp/ecamp3-dev-api-caddy
-          cache-from: type=gha,scope=caddy
-          cache-to: type=gha,scope=caddy,mode=max
+          cache-from: type=gha,scope=${{ matrix.browser }}-caddy
+          cache-to: type=gha,scope=${{ matrix.browser }}-caddy,mode=max
       
       # build frontend (using cache; provide image to docker compose)
       - name: Build docker image (Frontend)
@@ -434,8 +434,8 @@ jobs:
           load: true
           builder: ${{ steps.buildx.outputs.name }}
           tags: ecamp/ecamp3-dev-frontend
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,scope=frontend,mode=max
+          cache-from: type=gha,scope=${{ matrix.browser }}-frontend
+          cache-to: type=gha,scope=${{ matrix.browser }}-frontend,mode=max
 
       # build print (using cache; provide image to docker compose)
       - name: Build docker image (Print)
@@ -447,14 +447,14 @@ jobs:
           load: true
           builder: ${{ steps.buildx.outputs.name }}
           tags: ecamp/ecamp3-dev-print
-          cache-from: type=gha,scope=print
-          cache-to: type=gha,scope=print,mode=max
+          cache-from: type=gha,scope=${{ matrix.browser }}-print
+          cache-to: type=gha,scope=${{ matrix.browser }}-print,mode=max
 
       - name: Restore cache volumes (npm, composer)
         uses: actions/cache@940f3d7cf195ba83374c77632d1e2cbb2f24ae68 # v3
         with:
           path: .cache
-          key: docker-compose-${{ hashFiles('frontend/package-lock.json', 'print/package-lock.json', 'api/composer.lock') }}
+          key: docker-compose-${{ hashFiles('frontend/package-lock.json', 'print/package-lock.json', 'api/composer.lock') }}-${{ matrix.browser }}
           restore-keys: |
             docker-compose-
 
@@ -468,7 +468,7 @@ jobs:
           wait-on: 'http://localhost:3000, http://localhost:3000/api'
           wait-on-timeout: 300
 
-      # print docker container logs (good for debugging; can be disabled again lateron)
+      # print docker container logs (good for debugging; can be disabled again later on)
       - run: docker compose logs --tail="all"
         if: always()
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -383,6 +383,7 @@ jobs:
     strategy:
       matrix:
         browser:
+          - electron
           - chrome
           - firefox
           - edge


### PR DESCRIPTION
Fixes #3320

Matrix builds run in parallel, so the workflow in total shouldn't be slower: https://github.com/ecamp/ecamp3/actions/runs/4338242912/jobs/7574801743