### PR TITLE
Move e2e test script to a docker-compose profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,20 @@ services:
       - DISABLED_FEATURES=["downloadEndpoint","functionEndpoint","pdfEndpoint","screencastEndpoint","scrapeEndpoint","statsEndpoint","workspaces"]
       - FUNCTION_ENABLE_INCOGNITO_MODE=true
 
+  e2e:
+    image: cypress/included:12.7.0
+    profiles: [ "e2e" ]
+    container_name: 'ecamp3-e2e'
+    environment:
+      - DISPLAY
+      - APP_BASE_URL=http://localhost:3000
+      - CYPRESS_PROJECT=.
+    volumes:
+      - ./e2e:/e2e:delegated
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    network_mode: host
+    working_dir: /e2e
+
   translation:
     image: node:18.15.0
     profiles: [ "translation" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,6 @@ services:
     container_name: 'ecamp3-e2e'
     environment:
       - DISPLAY
-      - APP_BASE_URL=http://localhost:3000
       - CYPRESS_PROJECT=.
     volumes:
       - ./e2e:/e2e:delegated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,6 @@ services:
     container_name: 'ecamp3-e2e'
     environment:
       - DISPLAY
-      - CYPRESS_PROJECT=.
     volumes:
       - ./e2e:/e2e:delegated
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,10 +1,29 @@
-# end-to-end tests
+# End-to-end tests
+
+As a pre-requisite for running end-to-end tests, we assume you have the application fully up and running on your system.
+If not, please follow the documentation links in the README.md in the root of this repository.
 
 ## Option A: Run end-to-end tests in Docker container (headless)
-
 ```
-docker compose up -d
-docker run -v $PWD:/e2e -w /e2e --network host cypress/included:12.7.0
+docker compose --profile e2e run e2e
+```
+
+### Run tests using a specific browser
+```
+# Supported values: firefox, chrome, edge, electron (default)
+docker compose --profile e2e run e2e --browser firefox
+```
+
+### Open the cypress UI and visually see the tests run
+```
+# Only necessary on Mac OS: install xhost installieren. Restart your computer after this.
+brew cask install xquartz
+
+# Allow the container to open a window on the host (only required once per computer restart)
+xhost local:root
+
+# Open the cypress UI
+docker compose --profile e2e run --entrypoint "cypress open --project ." e2e
 ```
 
 ## Option B: Run end-to-end tests locally

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -5,13 +5,13 @@ If not, please follow the documentation links in the README.md in the root of th
 
 ## Option A: Run end-to-end tests in Docker container (headless)
 ```
-docker compose --profile e2e run e2e
+docker compose --profile e2e run --rm e2e
 ```
 
 ### Run tests using a specific browser
 ```
-# Supported values: firefox, chrome, edge, electron (default)
-docker compose --profile e2e run e2e --browser firefox
+# Supported values: chrome, edge, electron (default), firefox
+docker compose --profile e2e run --rm e2e --browser chrome
 ```
 
 ### Open the cypress UI and visually see the tests run

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -4,25 +4,35 @@ As a pre-requisite for running end-to-end tests, we assume you have the applicat
 If not, please follow the documentation links in the README.md in the root of this repository.
 
 ## Option A: Run end-to-end tests in Docker container (headless)
+
+### Preparation
+```
+# Only necessary on Mac OS: install xhost. Restart your Mac after this.
+brew cask install xquartz
+
+# Only necessary on Mac OS and Linux, and only once per computer restart:
+# Allow the Cypress Docker container to open a window on the host
+xhost local:root
+```
+
+### Run all e2e tests
 ```
 docker compose --profile e2e run --rm e2e
 ```
 
-### Run tests using a specific browser
+### Run a specific e2e test
 ```
-# Supported values: chrome, edge, electron (default), firefox
+docker compose --profile e2e run --rm e2e --spec specs/login.cy.js
+```
+
+### Run tests using a specific browser
+Supported browsers: `chrome`, `edge`, `electron` (default), `firefox`
+```
 docker compose --profile e2e run --rm e2e --browser chrome
 ```
 
 ### Open the cypress UI and visually see the tests run
 ```
-# Only necessary on Mac OS: install xhost installieren. Restart your computer after this.
-brew cask install xquartz
-
-# Allow the container to open a window on the host (only required once per computer restart)
-xhost local:root
-
-# Open the cypress UI
 docker compose --profile e2e run --entrypoint "cypress open --project ." e2e
 ```
 

--- a/e2e/cypress.config.js
+++ b/e2e/cypress.config.js
@@ -10,6 +10,7 @@ module.exports = defineConfig({
   screenshotsFolder: 'data/screenshots',
   videosFolder: 'data/videos',
   downloadsFolder: 'data/downloads',
+  trashAssetsBeforeRuns: false,
   e2e: {
     setupNodeEvents(on, config) {
       on('task', {
@@ -20,9 +21,11 @@ module.exports = defineConfig({
               console.log(err)
             } else {
               files.forEach((file) => {
-                fs.unlink(path.join(dirPath, file), () => {
-                  console.log('Removed ' + file)
-                })
+                if (file !== '.gitkeep') {
+                  fs.unlink(path.join(dirPath, file), () => {
+                    console.log('Removed ' + file)
+                  })
+                }
               })
             }
           })

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,7 +8,7 @@
       "name": "e2e",
       "version": "1.0.0",
       "devDependencies": {
-        "cypress": "^12.7.0",
+        "cypress": "12.7.0",
         "prettier": "2.8.4"
       }
     },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
     "lint": "prettier --write '**/*.js'"
   },
   "devDependencies": {
-    "cypress": "^12.7.0",
+    "cypress": "12.7.0",
     "prettier": "2.8.4"
   },
   "eslintConfig": {

--- a/renovate.json
+++ b/renovate.json
@@ -118,15 +118,6 @@
   "regexManagers": [
     {
       "fileMatch": [
-        "^docker-compose.yml$"
-      ],
-      "matchStrings": [
-        "(?<depName>cypress/included):(?<currentValue>[0-9.]+)\n"
-      ],
-      "datasourceTemplate": "docker"
-    },
-    {
-      "fileMatch": [
         "^api/phpunit.xml.dist$"
       ],
       "matchStrings": [

--- a/renovate.json
+++ b/renovate.json
@@ -118,7 +118,7 @@
   "regexManagers": [
     {
       "fileMatch": [
-        "^.github/workflows/continuous-integration.yml$"
+        "^docker-compose.yml$"
       ],
       "matchStrings": [
         "(?<depName>cypress/included):(?<currentValue>[0-9.]+)\n"


### PR DESCRIPTION
Addresses the following comment:

> Actually, since #3305, we have a docker compose profile in our docker-compose.yml. So we already have the translation service in docker-compose.yml for only running the translation script sometimes. I would propose we use the same mechanism for the e2e tests.
(Actually, right now our docker-compose.yml is invalid, because profiles are only supported starting with docker-compose.yml version 3.9. But I'm fixing this right now and updating the linux setup instructions, since the recommended way to install Docker on Linux has changed)

_Originally posted by @carlobeltrame in https://github.com/ecamp/ecamp3/pull/3309#discussion_r1125443328_
            
One advantage of this approach is that renovate will keep the cypress/included version in the command up to date.

Please help me test this on Windows and Mac OS.

- [ ] After merging this, we have to update https://github.com/ecamp/ecamp3/wiki/Testing-guide