### PR TITLE
Terms of service must be accepted when using OAuth to register

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -366,6 +366,7 @@
         "title": "Dein Account wird aktiviert"
       },
       "login": {
+        "acceptTermsOfUseOnOAuthLogin": "Beim Login via einen diese Services akzeptierst du die {termsOfServiceLink}.",
         "accountless": "Hast du noch keinen Account?",
         "email": "E-Mail",
         "infoText": {
@@ -385,7 +386,8 @@
           "jubladb": "JublaDB",
           "midata": "MiData"
         },
-        "registernow": "Jetzt registrieren"
+        "registernow": "Jetzt registrieren",
+        "termsOfServiceLink": "Nutzungsbedingungen"
       },
       "register": {
         "acceptTermsOfUse": "Akzeptieren Sie die Nutzungsbedingungen",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -366,7 +366,7 @@
         "title": "Dein Account wird aktiviert"
       },
       "login": {
-        "acceptTermsOfUseOnOAuthLogin": "Beim Login via einen diese Services akzeptierst du die {termsOfServiceLink}.",
+        "acceptTermsOfServiceOnOAuthLogin": "Beim Login via einen diese Services akzeptierst du die {termsOfServiceLink}.",
         "accountless": "Hast du noch keinen Account?",
         "email": "E-Mail",
         "infoText": {
@@ -390,8 +390,8 @@
         "termsOfServiceLink": "Nutzungsbedingungen"
       },
       "register": {
-        "acceptTermsOfUse": "Akzeptieren Sie die Nutzungsbedingungen",
-        "alreadyHaveAnAccount": "Haben Sie bereits ein Konto?",
+        "acceptTermsOfService": "Nutzungsbedingungen akzeptieren",
+        "alreadyHaveAnAccount": "Hast du bereits ein Konto?",
         "passwordConfirmation": "Passwort erneut eingeben",
         "register": "Registrieren",
         "requiredField": "Pflichtfelder",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -366,7 +366,7 @@
         "title": "Your account will be activated"
       },
       "login": {
-        "acceptTermsOfUseOnOAuthLogin": "By loggin in via one of these services, you accept the {termsOfServiceLink}.",
+        "acceptTermsOfUseOnOAuthLogin": "By logging in via one of these services, you accept the {termsOfServiceLink}.",
         "accountless": "Don't have an account yet?",
         "email": "Email",
         "infoText": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -390,7 +390,7 @@
         "termsOfServiceLink": "terms of service"
       },
       "register": {
-        "acceptTermsOfService": "Accept the terms of use",
+        "acceptTermsOfService": "Accept the terms of service",
         "alreadyHaveAnAccount": "Already have an account?",
         "passwordConfirmation": "Enter password again",
         "register": "Register",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -366,7 +366,7 @@
         "title": "Your account will be activated"
       },
       "login": {
-        "acceptTermsOfUseOnOAuthLogin": "By logging in via one of these services, you accept the {termsOfServiceLink}.",
+        "acceptTermsOfServiceOnOAuthLogin": "By logging in via one of these services, you accept the {termsOfServiceLink}.",
         "accountless": "Don't have an account yet?",
         "email": "Email",
         "infoText": {
@@ -390,7 +390,7 @@
         "termsOfServiceLink": "terms of service"
       },
       "register": {
-        "acceptTermsOfUse": "Accept the terms of use",
+        "acceptTermsOfService": "Accept the terms of use",
         "alreadyHaveAnAccount": "Already have an account?",
         "passwordConfirmation": "Enter password again",
         "register": "Register",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -366,6 +366,7 @@
         "title": "Your account will be activated"
       },
       "login": {
+        "acceptTermsOfUseOnOAuthLogin": "By loggin in via one of these services, you accept the {termsOfServiceLink}.",
         "accountless": "Don't have an account yet?",
         "email": "Email",
         "infoText": {
@@ -385,7 +386,8 @@
           "jubladb": "JublaDB",
           "midata": "MiData"
         },
-        "registernow": "Register now"
+        "registernow": "Register now",
+        "termsOfServiceLink": "terms of service"
       },
       "register": {
         "acceptTermsOfUse": "Accept the terms of use",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -358,6 +358,7 @@
         "title": "Ton compte sera activé"
       },
       "login": {
+        "acceptTermsOfUseOnOAuthLogin": "En te connectant via l'un de ces services, tu acceptes les {termsOfServiceLink}.",
         "accountless": "Vous n'avez pas encore de compte?",
         "email": "Courriel",
         "infoText": {
@@ -377,7 +378,8 @@
           "jubladb": "Jubla",
           "midata": "MiData"
         },
-        "registernow": "Inscrivez-vous maintenant"
+        "registernow": "Inscrivez-vous maintenant",
+        "termsOfServiceLink": "conditions d'utilisation"
       },
       "register": {
         "acceptTermsOfUse": "Accepter les conditions d'utilisation",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -358,7 +358,7 @@
         "title": "Ton compte sera activé"
       },
       "login": {
-        "acceptTermsOfUseOnOAuthLogin": "En te connectant via l'un de ces services, tu acceptes les {termsOfServiceLink}.",
+        "acceptTermsOfServiceOnOAuthLogin": "En te connectant via l'un de ces services, tu acceptes les {termsOfServiceLink}.",
         "accountless": "Vous n'avez pas encore de compte?",
         "email": "Courriel",
         "infoText": {
@@ -382,7 +382,7 @@
         "termsOfServiceLink": "conditions d'utilisation"
       },
       "register": {
-        "acceptTermsOfUse": "Accepter les conditions d'utilisation",
+        "acceptTermsOfService": "Accepter les conditions d'utilisation",
         "alreadyHaveAnAccount": "Vous avez déjà un compte ?",
         "passwordConfirmation": "Entrez à nouveau votre mot de passe",
         "register": "S'inscrire",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -358,7 +358,7 @@
         "title": "Il tuo account sarà attivato"
       },
       "login": {
-        "acceptTermsOfUseOnOAuthLogin": "Effettuando l'accesso tramite uno di questi servizi, si accettano i {termsOfServiceLink}.",
+        "acceptTermsOfServiceOnOAuthLogin": "Effettuando l'accesso tramite uno di questi servizi, si accettano i {termsOfServiceLink}.",
         "accountless": "Non hanno ancora un conto?",
         "email": "Indirizzo e-mail",
         "infoText": {
@@ -382,7 +382,7 @@
         "termsOfServiceLink": "condizioni di utilizzo"
       },
       "register": {
-        "acceptTermsOfUse": "Accettare le condizioni di utilizzo",
+        "acceptTermsOfService": "Accettare le condizioni di utilizzo",
         "alreadyHaveAnAccount": "Hai già un conto?",
         "passwordConfirmation": "Inserisci di nuovo la password",
         "register": "Registrati",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -358,6 +358,7 @@
         "title": "Il tuo account sarà attivato"
       },
       "login": {
+        "acceptTermsOfUseOnOAuthLogin": "Effettuando l'accesso tramite uno di questi servizi, si accettano i {termsOfServiceLink}.",
         "accountless": "Non hanno ancora un conto?",
         "email": "Indirizzo e-mail",
         "infoText": {
@@ -377,7 +378,8 @@
           "jubladb": "JublaDB",
           "midata": "MiData"
         },
-        "registernow": "Iscriviti ora"
+        "registernow": "Iscriviti ora",
+        "termsOfServiceLink": "condizioni di utilizzo"
       },
       "register": {
         "acceptTermsOfUse": "Accettare le condizioni di utilizzo",

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -118,6 +118,20 @@
           $tc('views.auth.login.provider.google')
         }}</span>
       </v-btn>
+      <small class="w-100">
+        <i18n
+          path="views.auth.login.acceptTermsOfUseOnOAuthLogin"
+          tag="p"
+          class="text--secondary text-center w-100 mt-2"
+          style="hyphens: auto"
+        >
+          <template #termsOfServiceLink>
+            <a :href="termsOfServiceLink" target="_blank" style="color: gray">{{
+              $tc('views.auth.login.termsOfServiceLink')
+            }}</a>
+          </template>
+        </i18n>
+      </small>
     </div>
     <p class="mt-8 mb-0 text--secondary text-center">
       {{ $tc('views.auth.login.accountless') }}<br />
@@ -134,6 +148,7 @@ import AuthContainer from '@/components/layout/AuthContainer.vue'
 import HorizontalRule from '@/components/layout/HorizontalRule.vue'
 import IconSpacer from '@/components/layout/IconSpacer.vue'
 import { serverErrorToString } from '@/helpers/serverError'
+import { parseTemplate } from 'url-template'
 
 const LOGIN_INFO_TEXT_KEY = window.environment.LOGIN_INFO_TEXT_KEY
 
@@ -163,6 +178,13 @@ export default {
   computed: {
     infoTextKey() {
       return `views.auth.login.infoText.${LOGIN_INFO_TEXT_KEY ?? 'dev'}`
+    },
+    termsOfServiceLink() {
+      return (
+        parseTemplate(window.environment.TERMS_OF_SERVICE_LINK_TEMPLATE || '').expand({
+          lang: this.$store.state.lang.language.substring(0, 2),
+        }) || false
+      )
     },
   },
   mounted() {

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -120,7 +120,7 @@
       </v-btn>
       <small class="w-100">
         <i18n
-          path="views.auth.login.acceptTermsOfUseOnOAuthLogin"
+          path="views.auth.login.acceptTermsOfServiceOnOAuthLogin"
           tag="p"
           class="text--secondary text-center w-100 mt-2"
           style="hyphens: auto"

--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -85,11 +85,11 @@
           v-model="tos"
           :vee-rules="{ required: { allowFalse: false } }"
           class="align-center"
-          :name="$tc('views.auth.register.acceptTermsOfUse')"
+          :name="$tc('views.auth.register.acceptTermsOfService')"
         >
           <template #label>
             <span style="hyphens: auto" :class="{ 'body-2': $vuetify.breakpoint.xsOnly }">
-              {{ $tc('views.auth.register.acceptTermsOfUse') }}
+              {{ $tc('views.auth.register.acceptTermsOfService') }}
             </span>
           </template>
           <template #append>


### PR DESCRIPTION
Fixes #3198

TOS pages in french and italian are not set up at the moment. To be decided: Do we set them up to redirect to english? Do we hardcode in ecamp3 which languages have no TOS translation?

Also to be decided: I have worded the notice such that it only applies to OAuth login. Do we want this to apply to "normal" logins as well? If so, is the checkbox on the register page necessary / useful at all? (I assume legally it's still better to keep the checkbox on the register page, but IANAL)
