### PR TITLE
fix(docker): avoid using production images in local dev environment

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -399,7 +399,7 @@ jobs:
           load: true
           target: api_platform_php_dev
           builder: ${{ steps.buildx.outputs.name }}
-          tags: ecamp/ecamp3-api-php
+          tags: ecamp/ecamp3-dev-api-php
           cache-from: type=gha,scope=api
           cache-to: type=gha,scope=api,mode=max
 
@@ -413,7 +413,7 @@ jobs:
           load: true
           target: api_platform_caddy
           builder: ${{ steps.buildx.outputs.name }}
-          tags: ecamp/ecamp3-api-caddy
+          tags: ecamp/ecamp3-dev-api-caddy
           cache-from: type=gha,scope=caddy
           cache-to: type=gha,scope=caddy,mode=max
       
@@ -426,7 +426,7 @@ jobs:
           push: false
           load: true
           builder: ${{ steps.buildx.outputs.name }}
-          tags: ecamp/ecamp3-frontend
+          tags: ecamp/ecamp3-dev-frontend
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max
 
@@ -439,7 +439,7 @@ jobs:
           push: false
           load: true
           builder: ${{ steps.buildx.outputs.name }}
-          tags: ecamp/ecamp3-print
+          tags: ecamp/ecamp3-dev-print
           cache-from: type=gha,scope=print
           cache-to: type=gha,scope=print,mode=max
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,11 @@ version: '3.9'
 
 services:
   frontend:
-    image: ecamp/ecamp3-frontend
+    image: ecamp/ecamp3-dev-frontend
     build:
       context: ./frontend
       cache_from:
-        - ecamp/ecamp3-frontend
+        - ecamp/ecamp3-dev-frontend
     container_name: 'ecamp3-frontend'
     ports:
       - '9229:9229' # jest debug
@@ -25,12 +25,12 @@ services:
       - CI=${CI}
 
   php:
-    image: ecamp/ecamp3-api-php
+    image: ecamp/ecamp3-dev-api-php
     build:
       context: ./api
       target: api_platform_php_dev
       cache_from:
-        - ecamp/ecamp3-api-php
+        - ecamp/ecamp3-dev-api-php
     container_name: 'ecamp3-api-php'
     depends_on:
       - database
@@ -66,12 +66,12 @@ services:
       - 'host.docker.internal:host-gateway'
 
   caddy:
-    image: ecamp/ecamp3-api-caddy
+    image: ecamp/ecamp3-dev-api-caddy
     build:
       context: ./api
       target: api_platform_caddy
       cache_from:
-        - ecamp/ecamp3-api-caddy
+        - ecamp/ecamp3-dev-api-caddy
     container_name: 'ecamp3-api-caddy'
     depends_on:
       - php
@@ -93,11 +93,11 @@ services:
       - ./api/public:/srv/api/public:ro
 
   print:
-    image: ecamp/ecamp3-print
+    image: ecamp/ecamp3-dev-print
     build:
       context: ./print
       cache_from:
-        - ecamp/ecamp3-print
+        - ecamp/ecamp3-dev-print
     container_name: 'ecamp3-print'
     user: ${USER_ID:-1000}
     volumes:


### PR DESCRIPTION
The usage of `cache_from` was introduced by me to accelerate building and startup during e2e-tests on CI (https://github.com/ecamp/ecamp3/commit/9021752ba1c65f3e453c96eb9eec7a4190741f74 and https://github.com/ecamp/ecamp3/commit/842b06a8f96af4f16822259a07a749f9b29db610). This is - however - a very bad idea, as this pulls the prod images from docker hub into local development environment.

With API (php/caddy) this was not super dramatic, as the difference between prod and dev is minor. But with print and frontend this fails.

The solution is to use different names for dev images. This triggers some warnings during startup, because these images don't exist on docker hub (and we don't really want to push them to docker hub). But things should still run. Please test.

An alternative would be to not specify any image names (remove `image` property and `cache_from` property in `docker-compose.yml`). This doesn't work 100% optimal with the caching in e2e-CI-tests, though.