### PR TITLE
Fix react printing when no picasso is selected

### DIFF
--- a/frontend/src/components/print/print-react/documents/campPrint/index.js
+++ b/frontend/src/components/print/print-react/documents/campPrint/index.js
@@ -1,8 +1,4 @@
 const picassoData = (config) => {
-  if (!config.contents.some((c) => c.type === 'Picasso')) {
-    return []
-  }
-
   const camp = config.apiGet(config.camp)
 
   return [


### PR DESCRIPTION
React printing of e.g. the story context was broken, because the loading logic only respected print configs which included the Picasso.
Printing would succeed when previously a something involving a picasso was printed, because then the store data is already loaded. But having to print the entire camp before printing the story context is not an acceptable workaround.