### PR TITLE
fix(renovate): use version regex to detect correct browserless version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -100,7 +100,7 @@
       "matchPackageNames": [
         "browserless/chrome"
       ],
-      "versioning": "loose"
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<compatibility>\\w+)-(?<build>\\d+)\\.(\\d+)\\.(\\d+)?$"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
Our current browserless version is: 1.57.0-puppeteer-19.2.2

Renovate wants to upgrade to: 1.58.0-puppeteer-9.1.1

However the correct version would be: 1.58.0-puppeteer-19.7.5

This regex uses the puppeteer major version (i.e. 19) as 4th <build> version property. This should ensure we always upgrade to the version with the highest puppeteer major version. The puppeteer minor & patch are ignored (there's always only 1 docker image with the same major version for the same browserless semver).

For documentation check these:
https://docs.renovatebot.com/modules/versioning/#using-a-custom-regex-versioning-scheme
https://docs.renovatebot.com/modules/versioning/#regular-expression-versioning


