### PR TITLE
Enable emoji in react-print

### DIFF
--- a/.docker-hub/frontend/Dockerfile
+++ b/.docker-hub/frontend/Dockerfile
@@ -5,9 +5,11 @@ COPY common /common
 
 WORKDIR /app
 COPY frontend/package*.json ./
+COPY frontend/public ./public
+COPY frontend/scripts ./scripts
 # install and uninstall the native dependencies in one single docker RUN instruction,
 # so they do not increase the image layer size
-RUN apk --no-cache add --virtual native-deps g++ make python3 && npm ci && apk del native-deps
+RUN apk --no-cache add --virtual native-deps g++ make python3 git && npm ci && apk del native-deps
 COPY frontend .
 RUN npm run build
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,9 @@ selenium-debug.log
 .env.*.local
 public/environment.js
 
+# Auto-generated files
+public/twemoji/
+
 # Log files
 npm-debug.log*
 yarn-debug.log*

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -2,3 +2,4 @@ src/common/locales/
 src/locales/
 /dist
 .vscode
+/public/twemoji

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "frontend",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@intlify/core": "9.2.2",
         "@mdi/font": "7.1.96",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
     "test:unit": "vue-cli-service test:unit",
     "test:unit:debug": "node --inspect-brk=0.0.0.0:9229 ./node_modules/@vue/cli-service/bin/vue-cli-service.js test:unit --no-cache --runInBand",
-    "test:unit:watch": "vue-cli-service test:unit --watch"
+    "test:unit:watch": "vue-cli-service test:unit --watch",
+    "postinstall": "./scripts/install-twemoji.sh"
   },
   "dependencies": {
     "@intlify/core": "9.2.2",

--- a/frontend/scripts/install-twemoji.sh
+++ b/frontend/scripts/install-twemoji.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+# We need twemoji for emoji support in react printing. Since there is no maintained npm package
+# which includes the actual emoji images, we use this script to install the images. By default,
+# twemoji are usually accessed from CDNs, but for traceability reasons, we self-host them.
+
+set -euo
+
+if [ ! -d "public/twemoji" ]
+then
+  echo 'downloading twemoji images from GitHub...'
+  # Clone as little as possible. No past revisions and only the image files we are interested in.
+  git clone --depth 1 --no-checkout --filter=blob:none --sparse https://github.com/twitter/twemoji.git public/twemoji
+  cd public/twemoji
+  git sparse-checkout set assets/72x72
+  git checkout master
+else
+  echo 'twemoji are already present, updating them to the latest version...'
+  cd public/twemoji
+  git pull
+fi
+
+echo 'twemoji images should be up to date now.'

--- a/frontend/src/components/print/print-react/documents/campPrint/Component.jsx
+++ b/frontend/src/components/print/print-react/documents/campPrint/Component.jsx
@@ -56,6 +56,11 @@ const registerFonts = async () => {
     ],
   })
 
+  Font.registerEmojiSource({
+    formag: 'png',
+    url: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/',
+  })
+
   return await Promise.all([
     Font.load({ fontFamily: 'OpenSans' }),
     Font.load({ fontFamily: 'OpenSans', fontWeight: 600 }),

--- a/frontend/src/components/print/print-react/documents/campPrint/Component.jsx
+++ b/frontend/src/components/print/print-react/documents/campPrint/Component.jsx
@@ -58,7 +58,7 @@ const registerFonts = async () => {
 
   Font.registerEmojiSource({
     formag: 'png',
-    url: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/',
+    url: '/twemoji/assets/72x72/',
   })
 
   return await Promise.all([


### PR DESCRIPTION
Emoji which have been released after 2019 aren't supported yet, I have a PR open at diegomura/react-pdf#2254. Renovate should update us automatically, once that PR is released.