### PR TITLE
Show days sorted by dayOffset

### DIFF
--- a/frontend/src/components/story/StoryDay.vue
+++ b/frontend/src/components/story/StoryDay.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-expansion-panel>
+  <v-expansion-panel :day-end="day.end">
     <v-expansion-panel-header>
       <h3>{{ dateLong(day.start) }}</h3>
     </v-expansion-panel-header>

--- a/frontend/src/components/story/StoryDay.vue
+++ b/frontend/src/components/story/StoryDay.vue
@@ -121,6 +121,9 @@ export default {
   },
   methods: {
     updatePanelValue(day) {
+      // Mark the component with the date of the day.
+      // This allows the use of the date in the parent component.
+      // See StoryPeriod.vue: v-expansion-panels.v-model
       this.$refs.panel.value = day.start.substr(0, 10)
     },
   },

--- a/frontend/src/components/story/StoryDay.vue
+++ b/frontend/src/components/story/StoryDay.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-expansion-panel :day-date="day.start.substr(0, 10)">
+  <v-expansion-panel ref="panel">
     <v-expansion-panel-header>
       <h3>{{ dateLong(day.start) }}</h3>
     </v-expansion-panel-header>
@@ -100,7 +100,13 @@ export default {
       return this.entries.filter(({ storyChapters }) => storyChapters.length)
     },
   },
+  watch: {
+    day(value) {
+      this.updatePanelValue(value)
+    },
+  },
   async mounted() {
+    this.updatePanelValue(this.day)
     // refresh to get new schedule entries
     await this.day.scheduleEntries().$reload()
     // refresh individual schedule entries to get new story content nodes
@@ -112,6 +118,11 @@ export default {
           ._meta.load.then((contentNodes) => this.api.reload(contentNodes))
       )
     )
+  },
+  methods: {
+    updatePanelValue(day) {
+      this.$refs.panel.value = day.start.substr(0, 10)
+    },
   },
 }
 </script>

--- a/frontend/src/components/story/StoryDay.vue
+++ b/frontend/src/components/story/StoryDay.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-expansion-panel :day-end="day.end">
+  <v-expansion-panel :day-date="day.start.substr(0, 10)">
     <v-expansion-panel-header>
       <h3>{{ dateLong(day.start) }}</h3>
     </v-expansion-panel-header>

--- a/frontend/src/components/story/StoryPeriod.vue
+++ b/frontend/src/components/story/StoryPeriod.vue
@@ -36,9 +36,7 @@ export default {
     period: {
       immediate: true,
       async handler(newPeriod, oldPeriod) {
-        const newPeriodId = newPeriod == undefined ? null : newPeriod.id
-        const oldPeriodId = oldPeriod == undefined ? null : oldPeriod.id
-        if (newPeriodId != oldPeriodId) {
+        if (newPeriod?._meta.self !== oldPeriod?._meta.self) {
           await this.updateComponentData(newPeriod)
         }
       },
@@ -67,7 +65,7 @@ export default {
 
           return periodHasPassed || dayEndIsInTheFuture ? dayKey : null
         })
-        .filter((idx) => !!idx)
+        .filter((dayKey) => !!dayKey)
     },
   },
 }

--- a/frontend/src/components/story/StoryPeriod.vue
+++ b/frontend/src/components/story/StoryPeriod.vue
@@ -1,14 +1,12 @@
 <template>
-  <div>
-    <v-expansion-panels ref="dayPanels" v-model="expandedDays" accordion flat multiple>
-      <story-day
-        v-for="day in sortedDays"
-        :key="day._meta.self"
-        :day="day"
-        :editing="editing"
-      />
-    </v-expansion-panels>
-  </div>
+  <v-expansion-panels ref="dayPanels" v-model="expandedDays" accordion flat multiple>
+    <story-day
+      v-for="day in sortedDays"
+      :key="day._meta.self"
+      :day="day"
+      :editing="editing"
+    />
+  </v-expansion-panels>
 </template>
 <script>
 import { sortBy } from 'lodash'

--- a/frontend/src/components/story/StoryPeriod.vue
+++ b/frontend/src/components/story/StoryPeriod.vue
@@ -62,10 +62,9 @@ export default {
         }
         this.expandedDays = this.$refs.dayPanels.items
           .map((dayPanel, idx) => {
-            const dayInLocalTimezone = this.$date(
-              dayPanel.$attrs['day-end'].substr(0, 10)
-            )
-            return dayInLocalTimezone.isAfter(this.$date()) ? idx : null
+            const dayInLocalTimezone = this.$date(dayPanel.$attrs['day-date'])
+            const dayEndInLocalTimezone = dayInLocalTimezone.add(1, 'days')
+            return dayEndInLocalTimezone.isAfter(this.$date()) ? idx : null
           })
           .filter((idx) => !!idx)
       })

--- a/frontend/src/components/story/StoryPeriod.vue
+++ b/frontend/src/components/story/StoryPeriod.vue
@@ -1,7 +1,7 @@
 <template>
   <v-expansion-panels v-model="expandedDays" accordion flat multiple>
     <story-day
-      v-for="day in period.days().items"
+      v-for="day in sortedDays"
       :key="day._meta.self"
       :day="day"
       :editing="editing"
@@ -9,6 +9,7 @@
   </v-expansion-panels>
 </template>
 <script>
+import { sortBy } from 'lodash'
 import StoryDay from './StoryDay.vue'
 
 export default {
@@ -23,6 +24,11 @@ export default {
       expandedDays: [],
     }
   },
+  computed: {
+    sortedDays() {
+      return sortBy(this.period.days().items, (day) => day.dayOffset)
+    },
+  },
   watch: {
     period: {
       immediate: true,
@@ -33,14 +39,14 @@ export default {
   },
   methods: {
     computeExpandedDays(period) {
-      period.days()._meta.load.then((days) => {
+      period.days()._meta.load.then(() => {
         const periodEndInLocalTimezone = this.$date(period.end).add(1, 'days')
 
         if (periodEndInLocalTimezone.isBefore(this.$date())) {
-          this.expandedDays = [...Array(days.items.length).keys()]
+          this.expandedDays = [...Array(this.sortedDays.length).keys()]
           return
         }
-        this.expandedDays = days.items.map((day, idx) => {
+        this.expandedDays = this.sortedDays.map((day, idx) => {
           const dayInLocalTimezone = this.$date(day.end.substr(0, 10))
           return dayInLocalTimezone.isAfter(this.$date()) ? idx : null
         })

--- a/frontend/src/components/story/StoryPeriod.vue
+++ b/frontend/src/components/story/StoryPeriod.vue
@@ -21,13 +21,9 @@ export default {
   },
   data() {
     return {
+      sortedDays: [],
       expandedDays: [],
     }
-  },
-  computed: {
-    sortedDays() {
-      return sortBy(this.period.days().items, (day) => day.dayOffset)
-    },
   },
   watch: {
     period: {
@@ -39,9 +35,17 @@ export default {
   },
   methods: {
     computeExpandedDays(period) {
-      period.days()._meta.load.then(() => {
-        const periodEndInLocalTimezone = this.$date(period.end).add(1, 'days')
+      let days = period.days()
 
+      // show days in store immediately
+      this.sortedDays = sortBy(days.items, (day) => day.dayOffset)
+      this.expandedDays = [...Array(this.sortedDays.length).keys()]
+
+      // reload days of period to ensure all days are loaded
+      days.$reload().then(() => {
+        this.sortedDays = sortBy(this.period.days().items, (day) => day.dayOffset)
+
+        const periodEndInLocalTimezone = this.$date(period.end).add(1, 'days')
         if (periodEndInLocalTimezone.isBefore(this.$date())) {
           this.expandedDays = [...Array(this.sortedDays.length).keys()]
           return


### PR DESCRIPTION
Although the backend delivers the days sorted, you cannot rely on it in the GUI. 

Why:
If you add more days in the 'Admin' tab at the beginning of a period, these days are not yet in the client's cache. If you then return to the 'Story' tab, these days are now added to the cache - but (i guess) at the end of the list. Therefore, the list of days can be displayed in the wrong order.
The list of days must therefore be additionally sorted on the client side.
