### PR TITLE
Disable invalid form submit #2896

### DIFF
--- a/frontend/src/components/form/base/ESelect.vue
+++ b/frontend/src/components/form/base/ESelect.vue
@@ -6,6 +6,7 @@
     :vid="veeId"
     :rules="veeRules"
     :required="required"
+    :immediate="immediateValidation"
     class="e-form-container"
   >
     <v-select
@@ -35,5 +36,8 @@ export default {
   name: 'ESelect',
   components: { ValidationProvider },
   mixins: [formComponentPropsMixin, formComponentMixin],
+  props: {
+    immediateValidation: { type: Boolean, default: false },
+  },
 }
 </script>

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -92,7 +92,7 @@ Displays collaborators of a single camp.
                     :my="0"
                     dense
                     vee-rules="required"
-                    :immediate-validation="true"
+                    immediate-validation
                   />
                 </v-col>
                 <v-col cols="3">

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -49,7 +49,11 @@ Displays collaborators of a single camp.
       </content-group>
 
       <content-group v-if="isManager" :title="$tc('views.camp.collaborators.invite')">
-        <ValidationObserver v-slot="{ handleSubmit }" ref="validation" mode="passive">
+        <ValidationObserver
+          v-slot="{ handleSubmit, passed }"
+          ref="validation"
+          mode="passive"
+        >
           <v-form ref="form" @submit.prevent="handleSubmit(invite)">
             <v-container>
               <v-row align="start">
@@ -88,10 +92,16 @@ Displays collaborators of a single camp.
                     :my="0"
                     dense
                     vee-rules="required"
+                    :immediate-validation="true"
                   />
                 </v-col>
                 <v-col cols="3">
-                  <button-add type="submit" :loading="isSaving" icon="mdi-account-plus">
+                  <button-add
+                    type="submit"
+                    :disabled="!passed"
+                    :loading="isSaving"
+                    icon="mdi-account-plus"
+                  >
                     {{ $tc('views.camp.collaborators.invite') }}
                   </button-add>
                 </v-col>


### PR DESCRIPTION
Fixes #2896 
Submit button is disabled until form validation is passed

I noticed this too late but I assume that issue is fixed in #3348 
