### PR TITLE
Fix dayjs locale in react print on deployments

### DIFF
--- a/frontend/src/components/print/print-react/documents/campPrint/renderPdf.worker.js
+++ b/frontend/src/components/print/print-react/documents/campPrint/renderPdf.worker.js
@@ -19,11 +19,16 @@ self.start = (...args) => {
 }
 
 export const renderPdfInWorker = async (data) => {
-  if (data?.config?.language) {
-    // We need to set the locale again here. Otherwise dayjs falls back to the default
-    // on production deployments
-    dayjs.locale(data.config.language)
+  if (!data?.config?.language) {
+    const error = 'language was undefined in react print config'
+    Sentry.captureException(new Error(error))
+    return { error }
   }
+
+  // We need to set the locale again here. Otherwise dayjs falls back to the default
+  // on production deployments
+  dayjs.locale(data.config.language)
+
   const result = { ...(await renderPdf(data)) }
   if (result.error) {
     Sentry.captureException(result.error)

--- a/frontend/src/components/print/print-react/documents/campPrint/renderPdf.worker.js
+++ b/frontend/src/components/print/print-react/documents/campPrint/renderPdf.worker.js
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/browser'
 import '../../globalWorkerShim.js'
 import 'raf/polyfill' // must be imported before renderPdf
 import { renderPdf } from './renderPdf.js'
+import dayjs from '@/common/helpers/dayjs.js'
 
 // Work around an incompatibility between comlink, vite and react-pdf...
 // Comlink works with a globally defined function 'start'. And apparently the way we import
@@ -18,6 +19,11 @@ self.start = (...args) => {
 }
 
 export const renderPdfInWorker = async (data) => {
+  if (data?.config?.language) {
+    // We need to set the locale again here. Otherwise dayjs falls back to the default
+    // on production deployments
+    dayjs.locale(data.config.language)
+  }
   const result = { ...(await renderPdf(data)) }
   if (result.error) {
     Sentry.captureException(result.error)


### PR DESCRIPTION
For some reason, only in deployments, the dayjs copy used in the worker is separate from the copy used in the main thread. So when starting a render job, we have to set the locale again. Setting this once during worker job initialization will then apply to the whole worker job.