### PR TITLE
api: trim email for password reset

### DIFF
--- a/api/src/DTO/ResetPassword.php
+++ b/api/src/DTO/ResetPassword.php
@@ -7,6 +7,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use App\InputFilter;
 use App\State\ResetPasswordCreateProcessor;
 use App\State\ResetPasswordProvider;
 use App\State\ResetPasswordUpdateProcessor;
@@ -48,6 +49,7 @@ class ResetPassword {
     #[Groups(['read'])]
     public ?string $id = null;
 
+    #[InputFilter\Trim]
     #[ApiProperty(readable: true, writable: true)]
     #[Groups(['create', 'read'])]
     public ?string $email = null;

--- a/api/tests/Api/ResetPassword/ResetPasswordTest.php
+++ b/api/tests/Api/ResetPassword/ResetPasswordTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Tests\Api\ResetPassword;
+
+use App\Entity\User;
+use App\Tests\Api\ECampApiTestCase;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * @internal
+ */
+class ResetPasswordTest extends ECampApiTestCase {
+    public function testPostResetPasswordResetsPasswordForAnonymousUser() {
+        /** @var User $user */
+        $user = static::$fixtures['user1manager'];
+
+        $this->createBasicClient()->request(
+            'POST',
+            '/auth/reset_password',
+            [
+                'json' => [
+                    'email' => $user->getEmail(),
+                ],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(204);
+        self::assertEmailCount(1);
+        $mailerMessage = self::getMailerMessage();
+        self::assertEmailAddressContains($mailerMessage, 'To', $user->getEmail());
+        self::assertEmailHeaderSame($mailerMessage, 'subject', '[eCamp3] Password reset');
+
+        self::assertEmailHtmlBodyContains($mailerMessage, $user->getDisplayName());
+        self::assertEmailHtmlBodyContains($mailerMessage, 'http://localhost:3000/reset-password/');
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public function testPostResetPasswordResetsPasswordForUserLoggedInWithThisEmail() {
+        /** @var User $user */
+        $user = static::$fixtures['user1manager'];
+
+        $this->createClientWithCredentials(['email' => $user->getEmail()])
+            ->request(
+                'POST',
+                '/auth/reset_password',
+                [
+                    'json' => [
+                        'email' => $user->getEmail(),
+                    ],
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(204);
+        self::assertEmailCount(1);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public function testPostResetPasswordResetsPasswordForUserLoggedInWithAnotherEmail() {
+        /** @var User $user */
+        $user = static::$fixtures['user1manager'];
+
+        $this->createClientWithCredentials(['email' => static::$fixtures['user2member']->getEmail()])
+            ->request(
+                'POST',
+                '/auth/reset_password',
+                [
+                    'json' => [
+                        'email' => $user->getEmail(),
+                    ],
+                ]
+            )
+        ;
+
+        $this->assertResponseStatusCodeSame(204);
+        self::assertEmailCount(1);
+    }
+
+    public function testPostResetPasswordTrimsEmail() {
+        /** @var User $user */
+        $user = static::$fixtures['user1manager'];
+
+        $this->createBasicClient()->request(
+            'POST',
+            '/auth/reset_password',
+            [
+                'json' => [
+                    'email' => " {$user->getEmail()}\t ",
+                ],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(204);
+        self::assertEmailCount(1);
+    }
+
+    public function testPostResetPasswordReturns204ForUnknownEmailButSendsNoEmails() {
+        $this->createBasicClient()->request(
+            'POST',
+            '/auth/reset_password',
+            [
+                'json' => [
+                    'email' => 'a@b.com',
+                ],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(204);
+        self::assertEmailCount(0);
+    }
+}


### PR DESCRIPTION
Else people will write emails to support because the password reset does not work with there email with a space at the end.