### PR TITLE
Improve field naming

### DIFF
--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -108,9 +108,9 @@
         "kind": "Lagerart (Haus-, Zelt-, Unterwegslager, Sommer-, Herbstlager)",
         "organizer": "Organisator",
         "motto": "Motto",
-        "name": "Name",
+        "name": "Lagername",
         "printYSLogoOnPicasso": "J+S-Logo auf Grobprogramm drucken (bei J+S-Kursen aktivieren)",
-        "title": "Titel",
+        "title": "Lagertitel",
         "trainingAdvisorName": "Bürgerlicher Name der Betreuungsperson"
       },
       "name": "Lager",


### PR DESCRIPTION
Quick fix improvement from testing in a Basiskurs
Many first-time ecamp users were confused about the terms "Name" and "Titel" on the camp create screen, and started filling in their own name and title ("Herr", "Frau")

Mid-term I'd like to take up the discussion again on removing one of the "name", "title" and "motto" fields on the camp, they are seriously confusing for users (and myself as well, I can never explain by heart which one is used where...)