### PR TITLE
continuous-integration.yml: use COVERALLS_TOKEN to send coveralls rep…

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -212,7 +212,7 @@ jobs:
           sed -i "s|src/|frontend/src/|g" frontend/data/coverage/lcov.info
           cat frontend/data/coverage/lcov.info | npx coveralls .
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           COVERALLS_SERVICE_NAME: github
           COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}
           CI_PULL_REQUEST: ${{ github.event.number }}
@@ -252,7 +252,7 @@ jobs:
           sed -i "s|SF:|SF:print/|g" print/coverage/lcov.info
           cat print/coverage/lcov.info | npx coveralls .
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           COVERALLS_SERVICE_NAME: github
           COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}
           CI_PULL_REQUEST: ${{ github.event.number }}


### PR DESCRIPTION
…orts

This is how it is documented in https://github.com/nickmerwin/node-coveralls#usage I dont know why this worked before.

For php we use the github action, and there we only need this special token for sending local coverage info to coveralls: https://github.com/marketplace/actions/coveralls-github-action For the github action, the GITHUB_ACTION token suffices.