### PR TITLE
bugfix: call campCollaborationDisplayName() with $tc

### DIFF
--- a/frontend/src/components/print/print-react/components/picasso/DayHeader.jsx
+++ b/frontend/src/components/print/print-react/components/picasso/DayHeader.jsx
@@ -14,7 +14,9 @@ function dayResponsibles(day, $tc) {
   if (responsibles.length === 0) return ''
   const label = $tc('entity.day.fields.dayResponsibles')
   const displayNames = responsibles
-    .map((responsible) => campCollaborationDisplayName(responsible.campCollaboration()))
+    .map((responsible) =>
+      campCollaborationDisplayName(responsible.campCollaboration(), $tc)
+    )
     .join(', ')
   return `${label}: ${displayNames}`
 }

--- a/frontend/src/components/program/picasso/PicassoEntry.vue
+++ b/frontend/src/components/program/picasso/PicassoEntry.vue
@@ -162,7 +162,7 @@ export default {
     campCollaborationText() {
       if (this.campCollaborations.length === 0) return ''
       return this.campCollaborations
-        .map((item) => campCollaborationDisplayName(item))
+        .map((item) => campCollaborationDisplayName(item, this.$tc.bind(this)))
         .join(', ')
     },
     duration() {


### PR DESCRIPTION
See https://github.com/ecamp/ecamp3/blob/5945bee3d27632cde16bce6c94185763c3d94a5c/common/helpers/campCollaborationDisplayName.js

tc-argument is required if `indicateInactive == true` (which ich the default-value)