### PR TITLE
chore(deps): update dependency phpstan to 1.10.14

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -53,7 +53,7 @@
         "hautelook/alice-bundle": "2.12.0",
         "justinrainbow/json-schema": "5.2.12",
         "php-coveralls/php-coveralls": "2.5.3",
-        "phpstan/phpstan": "1.10.10",
+        "phpstan/phpstan": "1.10.14",
         "phpunit/phpunit": "9.6.7",
         "rector/rector": "0.15.24",
         "symfony/browser-kit": "6.2.7",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "acd7c78c190b9f9d72af0976ce317eab",
+    "content-hash": "cd4e0c306710f797a2358f6d0b479bb9",
     "packages": [
         {
             "name": "api-platform/core",
@@ -11829,16 +11829,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.10",
+            "version": "1.10.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "f1e22c9b17a879987f8743d81533250a5fff47f9"
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f1e22c9b17a879987f8743d81533250a5fff47f9",
-                "reference": "f1e22c9b17a879987f8743d81533250a5fff47f9",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
                 "shasum": ""
             },
             "require": {
@@ -11887,7 +11887,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-01T17:06:15+00:00"
+            "time": "2023-04-19T13:47:27+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
Extract update of phpstan from #3398, that we can update rector (#3423).
Then we are not blocked by the update of php-cs-fixer.