### PR TITLE
api: set mercure.include_type to true

### DIFF
--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -20,8 +20,9 @@ api_platform:
     swagger:
         versions: [3]
     # Mercure integration, remove if unwanted
-    #mercure:
-    #    hub_url: '%env(resolve:MERCURE_SUBSCRIBE_URL)%'
+    mercure:
+        #hub_url: '%env(resolve:MERCURE_SUBSCRIBE_URL)%'
+        include_type: true
     defaults:
         stateless: true
         cache_headers:


### PR DESCRIPTION
Fixes:
585x: Since api-platform/core 3.1: Having mercure.include_type (always include @type in Mercure updates, even delete ones) set to false in the configuration is deprecated. It will be true by default in API Platform 4.0.
    4x in CreateColumnLayoutTest::testCreateRejectsParentsWhichDontSupportChildren from App\Tests\Api\ContentNodes\ColumnLayout
    4x in UpdateColumnLayoutTest::testPatchRejectsParentsWhichDontSupportChildren from App\Tests\Api\ContentNodes\ColumnLayout
    4x in CreateMaterialNodeTest::testCreateRejectsParentsWhichDontSupportChildren from App\Tests\Api\ContentNodes\MaterialNode
    4x in UpdateMaterialNodeTest::testPatchRejectsParentsWhichDontSupportChildren from App\Tests\Api\ContentNodes\MaterialNode
    4x in CreateMultiSelectTest::testCreateRejectsParentsWhichDontSupportChildren from App\Tests\Api\ContentNodes\MultiSelect

See https://github.com/api-platform/core/pull/2688