### PR TITLE
(api,e2e)/README.md: make shell commands executable in JetBrains IDE's

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -8,7 +8,7 @@ To use the API, you will need to log in. You can use the "Login" endpoint offere
 
 If you ever need to get an API token for manual use, you can use the following command:
 
-```
+```shell
 docker compose exec php bin/console lexik:jwt:generate-token test@example.com --no-debug
 ```
 
@@ -20,13 +20,23 @@ See https://jwt.io for more info on the structure of JWT tokens, and https://med
 We are using the following toolchain to ensure code quality standards:
 
 - **PHP CS Fixer**\
-  Run `docker compose exec php composer cs-fix` before committing\
+  Run
+  ```shell
+  docker compose exec php composer cs-fix
+  ```
+  before committing\
   cs-check is integrated into CI (pull request will not pass)
 - **Phpstan**\
-  Run `docker compose exec php composer phpstan`\
+  Run
+  ```shell
+  docker compose exec php composer phpstan
+  ```
   phpstan is integrated into CI (pull request will not pass)
 - **Psalm**\
-  Run `docker compose exec php composer psalm`\
+  Run
+  ```shell
+  docker compose exec php composer psalm
+  ```
   psalm is integrated into CI (pull request will not pass)
 
 ### Debugging
@@ -39,8 +49,12 @@ For phpstorm:\
 For vscode:\
 `XDEBUG_CONFIG="client_host=docker-host idekey=VSCODE"`
 
-After you changed the .env file, you need to recreate the container that the change has an effect.\
-`docker compose down && docker compose up`\
-or\
-`docker-compsoe stop php; docker compose rm php; docker compose up`\  
+After you changed the .env file, you need to recreate the container that the change has an effect.
+```shell
+docker compose down && docker compose up
+```
+or
+```shell
+docker-compsoe stop php; docker compose rm php; docker compose up
+```  
 if you don't want to restart the frontend.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,7 +6,7 @@ If not, please follow the documentation links in the README.md in the root of th
 ## Option A: Run end-to-end tests in Docker container (headless)
 
 ### Preparation
-```
+```shell
 # Only necessary on Mac OS: install xhost. Restart your Mac after this.
 brew cask install xquartz
 
@@ -16,23 +16,23 @@ xhost local:root
 ```
 
 ### Run all e2e tests
-```
+```shell
 docker compose --profile e2e run --rm e2e
 ```
 
 ### Run a specific e2e test
-```
+```shell
 docker compose --profile e2e run --rm e2e --spec specs/login.cy.js
 ```
 
 ### Run tests using a specific browser
 Supported browsers: `chrome`, `edge`, `electron` (default), `firefox`
-```
+```shell
 docker compose --profile e2e run --rm e2e --browser chrome
 ```
 
 ### Open the cypress UI and visually see the tests run
-```
+```shell
 docker compose --profile e2e run --entrypoint "cypress open --project ." e2e
 ```
 
@@ -40,20 +40,20 @@ docker compose --profile e2e run --entrypoint "cypress open --project ." e2e
 
 ### Install cypress
 
-```
+```shell
 npm install
 ```
 
 ### Run end-to-end tests (CLI)
 
-```
+```shell
 docker compose up -d
 npm run cypress:run
 ```
 
 ### Open cypress test runner
 
-```
+```shell
 docker compose up -d
 npm run cypress:open
 ```


### PR DESCRIPTION
With npm commands the JetBrains IDE's directly make the command executable from the Markdown view and from the preview.
For the docker compose command the IDE needs a hint which language it is.

![grafik](https://github.com/ecamp/ecamp3/assets/1506818/56c0ef29-df1e-46a0-ac3c-f06179bdc881)
