### PR TITLE
continuous-integration.yml: set fail-fast for e2e-tests-run to false

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -311,6 +311,7 @@ jobs:
     needs: e2e-tests-build
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         browser:
           - electron


### PR DESCRIPTION
That the tests on all browsers are run, and you see quickly if you really screwed up or there is an error in only one browser.