### PR TITLE
Upload generated pdf in e2e tests as artifacts

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -363,8 +363,7 @@ jobs:
         with:
           name: cypress-output
           path: |
-            ./cypress/screenshots
-            ./cypress/videos
+            e2e/data/**/*
 
       # print docker container logs (good for debugging; can be disabled again later on)
       - run: docker compose logs --tail="all"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -361,7 +361,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: cypress-output
+          name: cypress-output-${{ matrix.browser }}
           path: |
             e2e/data/**/*
 

--- a/e2e/cypress.config.js
+++ b/e2e/cypress.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require('cypress')
+const { moveDownloads } = require('./tasks/moveDownloads')
 const { deleteDownloads } = require('./tasks/deleteDownloads')
 
 module.exports = defineConfig({
@@ -13,6 +14,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       on('task', {
         deleteDownloads: () => deleteDownloads(config),
+        moveDownloads: (destSubDir) => moveDownloads(config, destSubDir),
       })
     },
     specPattern: 'specs/**/*.cy.{js,jsx,ts,tsx}',

--- a/e2e/specs/nuxtPrint.cy.js
+++ b/e2e/specs/nuxtPrint.cy.js
@@ -47,6 +47,6 @@ describe('Nuxt print test', () => {
 
     const downloadsFolder = Cypress.config('downloadsFolder')
     cy.readFile(path.join(downloadsFolder, 'GRGR.pdf'), { timeout: 30000 })
-    cy.task('deleteDownloads')
+    cy.moveDownloads()
   })
 })

--- a/e2e/specs/reactPrint.cy.js
+++ b/e2e/specs/reactPrint.cy.js
@@ -14,6 +14,6 @@ describe('React print test', () => {
 
     const downloadsFolder = Cypress.config('downloadsFolder')
     cy.readFile(path.join(downloadsFolder, 'GRGR.pdf'), { timeout: 30000 })
-    cy.task('deleteDownloads')
+    cy.moveDownloads()
   })
 })

--- a/e2e/support/commands.js
+++ b/e2e/support/commands.js
@@ -33,3 +33,7 @@ Cypress.Commands.add('login', (identifier) => {
     })
   })
 })
+
+Cypress.Commands.add('moveDownloads', () => {
+  cy.task('moveDownloads', `${Cypress.spec.name}/${Cypress.currentTest.title}`)
+})

--- a/e2e/support/index.js
+++ b/e2e/support/index.js
@@ -18,12 +18,3 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
-
-Cypress.on('test:before:run', () => {
-  Cypress.automation('remote:debugger:protocol', {
-    command: 'Emulation.setLocaleOverride',
-    params: {
-      locale: 'en-GB',
-    },
-  })
-})

--- a/e2e/tasks/deleteDownloads.js
+++ b/e2e/tasks/deleteDownloads.js
@@ -3,16 +3,21 @@ const path = require('path')
 
 function deleteDownloads(config) {
   const dirPath = config.downloadsFolder
-  fs.readdir(dirPath, (err, files) => {
+  fs.readdir(dirPath, { withFileTypes: true }, (err, files) => {
     if (err) {
       console.log(err)
     } else {
       files.forEach((file) => {
-        if (file !== '.gitkeep') {
-          fs.unlink(path.join(dirPath, file), () => {
-            console.log('Removed ' + file)
-          })
+        if (file.name === '.gitkeep') {
+          return
         }
+        if (file.isDirectory()) {
+          console.log(`not deleting directory ${path.join(dirPath, file.name)}`)
+          return
+        }
+        fs.unlink(path.join(dirPath, file), () => {
+          console.log('Removed ' + file)
+        })
       })
     }
   })

--- a/e2e/tasks/moveDownloads.js
+++ b/e2e/tasks/moveDownloads.js
@@ -1,0 +1,32 @@
+const fs = require('fs')
+const path = require('path')
+
+function moveDownloads(config, destSubDir) {
+  const downloadsFolder = config.downloadsFolder
+  const destDirName = path.join(downloadsFolder, destSubDir)
+  fs.mkdirSync(destDirName, { recursive: true })
+  fs.readdir(downloadsFolder, { withFileTypes: true }, (err, files) => {
+    if (err) {
+      console.log(err)
+    } else {
+      files.forEach((file) => {
+        if (file.isDirectory()) {
+          console.log(`not moving directory ${path.join(downloadsFolder, file.name)}`)
+          return
+        }
+        if (file.name !== '.gitkeep') {
+          const oldPath = path.join(downloadsFolder, file.name)
+          const newPath = path.join(destDirName, file.name)
+          fs.rename(oldPath, newPath, () => {
+            console.log(`moved file from ${oldPath} to ${newPath}`)
+          })
+        }
+      })
+    }
+  })
+  return null
+}
+
+module.exports = {
+  moveDownloads
+}


### PR DESCRIPTION
1. continuous-integration.yml: upload the correct folder as artifact 


2.  e2e: move downloads folder instead of clearing it

That we can see the pdf generated.

Remove setting the language before the test.
This breaks the tests for firefox when you use tasks. Then the tasks don't get executed.
If you start to use beforeEach in combination with it, the tests fail directly with the error:
"No handler specified for remote:debugger:protocol"
In the container we anyway have only english.

This can be seen here:
chrome executes the tasks: https://github.com/BacLuc/ecamp3/actions/runs/4963717384/jobs/8883232814
firefox does not: https://github.com/BacLuc/ecamp3/actions/runs/4963717384/jobs/8883232880
For commit https://github.com/BacLuc/ecamp3/tree/a916dd60a557c99c141d57164b031bb42ed93098/e2e

3. continuous-integration.yml: store e2e output in browser specific artifacts

That we have the downloads and screenshots of all browsers.
If we use the same artifact in a matrix, the contents get overwritten.