### PR TITLE
Only open pickers when clicking the picker button

### DIFF
--- a/frontend/src/components/form/base/BasePicker.vue
+++ b/frontend/src/components/form/base/BasePicker.vue
@@ -27,7 +27,6 @@ Displays a field as a picker (can be used with v-model)
           :error-messages="combinedErrorMessages"
           :filled="filled"
           :disabled="disabled"
-          @click="(...args) => onMenuOpen(on, ...args)"
           @input="debouncedParseValue"
         >
           <template v-if="icon" #prepend>

--- a/frontend/src/components/form/base/BasePicker.vue
+++ b/frontend/src/components/form/base/BasePicker.vue
@@ -27,6 +27,7 @@ Displays a field as a picker (can be used with v-model)
           :error-messages="combinedErrorMessages"
           :filled="filled"
           :disabled="disabled"
+          @click="(...args) => (openOnTextFieldClick ? onMenuOpen(on, ...args) : null)"
           @input="debouncedParseValue"
         >
           <template v-if="icon" #prepend>
@@ -67,6 +68,7 @@ export default {
     readonly: { type: Boolean, required: false, default: false },
     disabled: { type: Boolean, required: false, default: false },
     errorMessages: { type: Array, required: false, default: () => [] },
+    openOnTextFieldClick: { type: Boolean, required: false, default: false },
     closeOnPickerInput: { type: Boolean, required: false, default: false },
     buttonAriaLabelI18nKey: { type: String, required: true },
 

--- a/frontend/src/components/form/base/EColorPicker.vue
+++ b/frontend/src/components/form/base/EColorPicker.vue
@@ -12,6 +12,7 @@ Displays a field as a color picker (can be used with v-model)
     :vee-rules="veeRules || { regex: /#([a-f0-9]{3}){1,2}\b/i }"
     :required="required"
     button-aria-label-i18n-key="components.form.base.eColorPicker.openPicker"
+    open-on-text-field-click
     @input="$emit('input', $event)"
   >
     <template #default="picker">

--- a/frontend/src/components/form/base/__tests__/EColorPicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/EColorPicker.spec.js
@@ -54,7 +54,7 @@ describe('An EColorPicker', () => {
     expect(snapshotOf(container)).toMatchSnapshot('pickeropen')
   })
 
-  it('does not open the picker when the text field is clicked', async () => {
+  it('opens the picker when the text field is clicked', async () => {
     // given
     render(EColorPicker, {
       props: { value: COLOR1, name: 'test' },
@@ -65,10 +65,9 @@ describe('An EColorPicker', () => {
     await user.click(inputField)
 
     // then
-    // menu should not appear
-    await expect(screen.findByText('Schliessen')).rejects.toThrow(
-      /Unable to find an element with the text/
-    )
+    await waitFor(async () => {
+      expect(await screen.findByText('Schliessen')).toBeVisible()
+    })
   })
 
   it('opens the picker when the icon button is clicked', async () => {

--- a/frontend/src/components/form/base/__tests__/EColorPicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/EColorPicker.spec.js
@@ -54,7 +54,7 @@ describe('An EColorPicker', () => {
     expect(snapshotOf(container)).toMatchSnapshot('pickeropen')
   })
 
-  it('opens the picker when the text field is clicked', async () => {
+  it('does not open the picker when the text field is clicked', async () => {
     // given
     render(EColorPicker, {
       props: { value: COLOR1, name: 'test' },
@@ -63,6 +63,23 @@ describe('An EColorPicker', () => {
 
     // when
     await user.click(inputField)
+
+    // then
+    // menu should not appear
+    await expect(screen.findByText('Schliessen')).rejects.toThrow(
+      /Unable to find an element with the text/
+    )
+  })
+
+  it('opens the picker when the icon button is clicked', async () => {
+    // given
+    render(EColorPicker, {
+      props: { value: COLOR1, name: 'test' },
+    })
+    const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
+
+    // when
+    await user.click(button)
 
     // then
     await waitFor(async () => {
@@ -75,8 +92,8 @@ describe('An EColorPicker', () => {
     render(EColorPicker, {
       props: { value: COLOR1, name: 'test' },
     })
-    const inputField = await screen.findByDisplayValue(COLOR1)
-    await user.click(inputField)
+    const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
+    await user.click(button)
     await waitFor(async () => {
       expect(await screen.findByText('Schliessen')).toBeVisible()
     })
@@ -96,8 +113,8 @@ describe('An EColorPicker', () => {
     render(EColorPicker, {
       props: { value: COLOR1, name: 'test' },
     })
-    const inputField = await screen.findByDisplayValue(COLOR1)
-    await user.click(inputField)
+    const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
+    await user.click(button)
     await waitFor(async () => {
       expect(await screen.findByText('Schliessen')).toBeVisible()
     })
@@ -116,8 +133,8 @@ describe('An EColorPicker', () => {
     render(EColorPicker, {
       props: { value: COLOR1, name: 'test' },
     })
-    const inputField = await screen.findByDisplayValue(COLOR1)
-    await user.click(inputField)
+    const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
+    await user.click(button)
     await waitFor(async () => {
       expect(await screen.findByText('Schliessen')).toBeVisible()
     })
@@ -136,8 +153,8 @@ describe('An EColorPicker', () => {
     const { container } = render(EColorPicker, {
       props: { value: COLOR1, name: 'test' },
     })
-    const inputField = await screen.findByDisplayValue(COLOR1)
-    await user.click(inputField)
+    const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
+    await user.click(button)
     await waitFor(async () => {
       expect(await screen.findByText('Schliessen')).toBeVisible()
     })
@@ -191,10 +208,11 @@ describe('An EColorPicker', () => {
       props: { value: COLOR1, name: 'test' },
     })
     await screen.findByDisplayValue(COLOR1)
+    const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
 
     // when
     // click the button to open the picker
-    await user.click(screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT))
+    await user.click(button)
     // click inside the color picker canvas to select a different color
     const canvas = container.querySelector('canvas')
     await user.click(canvas, { clientX: 10, clientY: 10 })
@@ -239,8 +257,9 @@ describe('An EColorPicker', () => {
       props: { value: COLOR1, name: 'test' },
     })
     const inputField = await screen.findByDisplayValue(COLOR1)
+    const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
     // click the button to open the picker
-    await user.click(screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT))
+    await user.click(button)
 
     // when
     await user.clear(inputField)

--- a/frontend/src/components/form/base/__tests__/EDatePicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/EDatePicker.spec.js
@@ -71,7 +71,7 @@ describe('An EDatePicker', () => {
       expect(snapshotOf(container)).toMatchSnapshot('pickeropen')
     })
 
-    it('opens the picker when the text field is clicked', async () => {
+    it('does not open the picker when the text field is clicked', async () => {
       // given
       render(EDatePicker, {
         props: { value: DATE1_ISO, name: 'test' },
@@ -80,6 +80,23 @@ describe('An EDatePicker', () => {
 
       // when
       await user.click(inputField)
+
+      // then
+      // menu should not appear
+      await expect(screen.findByText(data.date1Heading)).rejects.toThrow(
+        /Unable to find an element with the text/
+      )
+    })
+
+    it('opens the picker when the icon button is clicked', async () => {
+      // given
+      render(EDatePicker, {
+        props: { value: DATE1_ISO, name: 'test' },
+      })
+      const button = await screen.getByLabelText(data.labelText)
+
+      // when
+      await user.click(button)
 
       // then
       await waitFor(async () => {
@@ -92,8 +109,8 @@ describe('An EDatePicker', () => {
       render(EDatePicker, {
         props: { value: DATE1_ISO, name: 'test' },
       })
-      const inputField = await screen.findByDisplayValue(data.date1)
-      await user.click(inputField)
+      const button = await screen.getByLabelText(data.labelText)
+      await user.click(button)
       await waitFor(async () => {
         expect(await screen.findByText(data.date1Heading)).toBeVisible()
       })
@@ -113,8 +130,8 @@ describe('An EDatePicker', () => {
       render(EDatePicker, {
         props: { value: DATE1_ISO, name: 'test' },
       })
-      const inputField = await screen.findByDisplayValue(data.date1)
-      await user.click(inputField)
+      const button = await screen.getByLabelText(data.labelText)
+      await user.click(button)
       await waitFor(async () => {
         expect(await screen.findByText(data.date1Heading)).toBeVisible()
       })
@@ -133,8 +150,8 @@ describe('An EDatePicker', () => {
       render(EDatePicker, {
         props: { value: DATE1_ISO, name: 'test' },
       })
-      const inputField = await screen.findByDisplayValue(data.date1)
-      await user.click(inputField)
+      const button = await screen.getByLabelText(data.labelText)
+      await user.click(button)
       await waitFor(async () => {
         expect(await screen.findByText(data.date1Heading)).toBeVisible()
       })
@@ -153,8 +170,8 @@ describe('An EDatePicker', () => {
       render(EDatePicker, {
         props: { value: DATE1_ISO, name: 'test' },
       })
-      const inputField = await screen.findByDisplayValue(data.date1)
-      await user.click(inputField)
+      const button = await screen.getByLabelText(data.labelText)
+      await user.click(button)
       await waitFor(async () => {
         expect(await screen.findByText(data.date1Heading)).toBeVisible()
       })
@@ -169,13 +186,13 @@ describe('An EDatePicker', () => {
       })
     })
 
-    it('re-opens the picker when clicking the text field again after selecting a date', async () => {
+    it('re-opens the picker when clicking the button again after selecting a date', async () => {
       // given
       render(EDatePicker, {
         props: { value: DATE1_ISO, name: 'test' },
       })
-      const inputField = await screen.findByDisplayValue(data.date1)
-      await user.click(inputField)
+      const button = await screen.getByLabelText(data.labelText)
+      await user.click(button)
       await waitFor(async () => {
         expect(await screen.findByText(data.date1Heading)).toBeVisible()
       })
@@ -186,7 +203,7 @@ describe('An EDatePicker', () => {
       })
 
       // when
-      await user.click(inputField)
+      await user.click(button)
 
       // then
       await waitFor(async () => {
@@ -229,10 +246,11 @@ describe('An EDatePicker', () => {
         props: { value: DATE1_ISO, name: 'test' },
       })
       await screen.findByDisplayValue(data.date1)
+      const button = await screen.getByLabelText(data.labelText)
 
       // when
       // click the button to open the picker
-      await user.click(screen.getByLabelText(data.labelText))
+      await user.click(button)
       // click the 19th day of the month
       await user.click(screen.getByText('19'))
 
@@ -293,9 +311,10 @@ describe('An EDatePicker', () => {
       render(EDatePicker, {
         props: { value: '', name: 'test', min: '2111-01-01' },
       })
+      const button = await screen.getByLabelText(data.labelText)
 
       // when
-      await user.click(screen.getByLabelText(data.labelText))
+      await user.click(button)
 
       // then
       await waitFor(async () => {
@@ -308,9 +327,10 @@ describe('An EDatePicker', () => {
       render(EDatePicker, {
         props: { value: DATE1_ISO, name: 'test', min: '2111-01-01' },
       })
+      const button = await screen.getByLabelText(data.labelText)
 
       // when
-      await user.click(screen.getByLabelText(data.labelText))
+      await user.click(button)
 
       // then
       await expect(async () => {
@@ -323,9 +343,10 @@ describe('An EDatePicker', () => {
       render(EDatePicker, {
         props: { value: '', name: 'test', min: '1999-01-01' },
       })
+      const button = await screen.getByLabelText(data.labelText)
 
       // when
-      await user.click(screen.getByLabelText(data.labelText))
+      await user.click(button)
 
       // then
       await expect(async () => {
@@ -338,9 +359,10 @@ describe('An EDatePicker', () => {
       render(EDatePicker, {
         props: { value: '', name: 'test', max: '1999-01-01' },
       })
+      const button = await screen.getByLabelText(data.labelText)
 
       // when
-      await user.click(screen.getByLabelText(data.labelText))
+      await user.click(button)
 
       // then
       await waitFor(async () => {
@@ -353,9 +375,10 @@ describe('An EDatePicker', () => {
       render(EDatePicker, {
         props: { value: '', name: 'test', max: '2111-01-01' },
       })
+      const button = await screen.getByLabelText(data.labelText)
 
       // when
-      await user.click(screen.getByLabelText(data.labelText))
+      await user.click(button)
 
       // then
       await expect(async () => {
@@ -368,9 +391,10 @@ describe('An EDatePicker', () => {
       render(EDatePicker, {
         props: { value: DATE1_ISO, name: 'test', max: '1999-01-01' },
       })
+      const button = await screen.getByLabelText(data.labelText)
 
       // when
-      await user.click(screen.getByLabelText(data.labelText))
+      await user.click(button)
 
       // then
       await expect(async () => {

--- a/frontend/src/components/form/base/__tests__/ETimePicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/ETimePicker.spec.js
@@ -90,7 +90,7 @@ describe('An ETimePicker', () => {
       screen.getByLabelText(data.labelText)
     })
 
-    it('opens the picker when the text field is clicked', async () => {
+    it('does not open the picker when the text field is clicked', async () => {
       // given
       render(ETimePicker, {
         props: { value: TIME1_ISO, name: 'test' },
@@ -99,6 +99,23 @@ describe('An ETimePicker', () => {
 
       // when
       await user.click(inputField)
+
+      // then
+      // menu should not appear
+      await expect(screen.findByText(data.closeButton)).rejects.toThrow(
+        /Unable to find an element with the text/
+      )
+    })
+
+    it('opens the picker when the icon button is clicked', async () => {
+      // given
+      render(ETimePicker, {
+        props: { value: TIME1_ISO, name: 'test' },
+      })
+      const button = await screen.getByLabelText(data.labelText)
+
+      // when
+      await user.click(button)
 
       // then
       await waitFor(async () => {
@@ -111,8 +128,8 @@ describe('An ETimePicker', () => {
       render(ETimePicker, {
         props: { value: TIME1_ISO, name: 'test' },
       })
-      const inputField = await screen.findByDisplayValue(data.time1)
-      user.click(inputField)
+      const button = await screen.getByLabelText(data.labelText)
+      await user.click(button)
       await waitFor(async () => {
         expect(await screen.findByText(data.closeButton)).toBeVisible()
       })
@@ -132,8 +149,8 @@ describe('An ETimePicker', () => {
       render(ETimePicker, {
         props: { value: TIME1_ISO, name: 'test' },
       })
-      const inputField = await screen.findByDisplayValue(data.time1)
-      user.click(inputField)
+      const button = await screen.getByLabelText(data.labelText)
+      await user.click(button)
       await waitFor(async () => {
         expect(await screen.findByText(data.closeButton)).toBeVisible()
       })
@@ -152,8 +169,8 @@ describe('An ETimePicker', () => {
       render(ETimePicker, {
         props: { value: TIME1_ISO, name: 'test' },
       })
-      const inputField = await screen.findByDisplayValue(data.time1)
-      user.click(inputField)
+      const button = await screen.getByLabelText(data.labelText)
+      await user.click(button)
       await waitFor(async () => {
         expect(await screen.findByText(data.closeButton)).toBeVisible()
       })
@@ -172,8 +189,8 @@ describe('An ETimePicker', () => {
       render(ETimePicker, {
         props: { value: TIME1_ISO, name: 'test' },
       })
-      const inputField = await screen.findByDisplayValue(data.time1)
-      user.click(inputField)
+      const button = await screen.getByLabelText(data.labelText)
+      await user.click(button)
       await waitFor(async () => {
         expect(await screen.findByText(data.closeButton)).toBeVisible()
       })
@@ -228,10 +245,11 @@ describe('An ETimePicker', () => {
         props: { value: TIME1_ISO, name: 'test' },
       })
       await screen.findByDisplayValue(data.time1)
+      const button = await screen.getByLabelText(data.labelText)
 
       // when
       // click the button to open the picker
-      await user.click(screen.getByLabelText(data.labelText))
+      await user.click(button)
       // Click the 0th hour. We can only click this one, because
       // testing library is missing the vuetify styles, and all the
       // number elements overlap


### PR DESCRIPTION
The time picker opening automatically when clicking into the text field is very confusing for users. This has been reported multiple independent times via email, and was also evident when observing young first-time users in a course.

Many people wish for the ability to edit the time in the time picker manually, i.e. by typing the time value into an input field. They do not notice that this is already possible. Some of them can't be blamed: On certain screen sizes (especially on small laptops and tablets), the time picker completely covers the input. Have a look:

[timepicker.webm](https://github.com/ecamp/ecamp3/assets/7566995/bd81ff53-8c6d-4a53-941b-147efa1fcdde)

For this reason, I'd like to only display the picker when explicitly clicking the picker button. To keep the behaviour consistent between all pickers (and because it was easier to implement this way), I did the change for all pickers (date picker, time picker, color picker).