### PR TITLE
Double-clicking is not an expected interaction on the web

### DIFF
--- a/frontend/src/components/generic/LockButton.vue
+++ b/frontend/src/components/generic/LockButton.vue
@@ -1,18 +1,19 @@
 <template>
   <v-tooltip :disabled="tooltip == ''" bottom>
     <template #activator="{ on }">
-      <v-icon v-if="value" small v-on="{ click: iconClick, ...on }">
-        mdi-lock-open-variant
-      </v-icon>
-      <v-icon
-        v-else
+      <v-btn
+        icon
         small
-        color="grey"
+        :aria-label="tooltip"
+        :disabled="disabledForGuest"
+        class="e-pointer-events-auto"
         :class="{ 'e-shake-lock': shake }"
-        v-on="{ click: iconClick, ...on }"
+        @click="$emit('click')"
+        v-on="on"
       >
-        mdi-lock
-      </v-icon>
+        <v-icon v-if="value" small>mdi-lock-open-variant</v-icon>
+        <v-icon v-else small>mdi-lock</v-icon>
+      </v-btn>
     </template>
     <span>{{ tooltip }}</span>
   </v-tooltip>
@@ -20,7 +21,7 @@
 
 <script>
 export default {
-  name: 'LockIcon',
+  name: 'LockButton',
   props: {
     value: {
       type: Boolean,
@@ -44,34 +45,27 @@ export default {
   computed: {
     tooltip() {
       if (this.disabledForGuest) {
-        return this.$tc('components.generic.lockIcon.guestsCannotEdit')
+        return this.$tc('components.generic.lockButton.guestsCannotEdit')
       }
       if (this.message) {
         return this.message
       }
       if (!this.value) {
-        return this.$tc('components.generic.lockIcon.clickToUnlock')
+        return this.$tc('components.generic.lockButton.clickToUnlock')
       }
-      return ''
-    },
-  },
-  methods: {
-    iconClick() {
-      if (!this.disabledForGuest) {
-        this.$emit('click')
-      }
+      return this.$tc('components.generic.lockButton.clickToLock')
     },
   },
 }
 </script>
 
 <style scoped>
-.v-icon {
-  cursor: pointer;
-}
-
 .e-shake-lock {
   animation: horizontal-shaking 0.5s linear 1;
+}
+
+.e-pointer-events-auto {
+  pointer-events: auto;
 }
 
 @keyframes horizontal-shaking {

--- a/frontend/src/components/generic/LockButton.vue
+++ b/frontend/src/components/generic/LockButton.vue
@@ -1,19 +1,17 @@
 <template>
   <v-tooltip :disabled="tooltip == ''" bottom>
     <template #activator="{ on }">
-      <v-btn
-        icon
-        small
+      <button
         :aria-label="tooltip"
-        :disabled="disabledForGuest"
-        class="e-pointer-events-auto"
+        :aria-disabled="disabledForGuest"
+        class="v-btn v-btn--icon v-btn--round v-size--small"
         :class="{ 'e-shake-lock': shake }"
-        @click="$emit('click')"
+        @click="onClick"
         v-on="on"
       >
         <v-icon v-if="value" small>mdi-lock-open-variant</v-icon>
         <v-icon v-else small>mdi-lock</v-icon>
-      </v-btn>
+      </button>
     </template>
     <span>{{ tooltip }}</span>
   </v-tooltip>
@@ -56,16 +54,19 @@ export default {
       return this.$tc('components.generic.lockButton.clickToLock')
     },
   },
+  methods: {
+    onClick() {
+      if (!this.disabledForGuest) {
+        this.$emit('click')
+      }
+    },
+  },
 }
 </script>
 
 <style scoped>
 .e-shake-lock {
   animation: horizontal-shaking 0.5s linear 1;
-}
-
-.e-pointer-events-auto {
-  pointer-events: auto;
 }
 
 @keyframes horizontal-shaking {

--- a/frontend/src/components/generic/LockIcon.vue
+++ b/frontend/src/components/generic/LockIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <v-tooltip :disabled="tooltip == ''" bottom>
     <template #activator="{ on }">
-      <v-icon v-if="value" small v-on="{ dblclick: iconDblClick, ...on }">
+      <v-icon v-if="value" small v-on="{ click: iconClick, ...on }">
         mdi-lock-open-variant
       </v-icon>
       <v-icon
@@ -9,7 +9,7 @@
         small
         color="grey"
         :class="{ 'e-shake-lock': shake }"
-        v-on="{ dblclick: iconDblClick, ...on }"
+        v-on="{ click: iconClick, ...on }"
       >
         mdi-lock
       </v-icon>
@@ -50,15 +50,15 @@ export default {
         return this.message
       }
       if (!this.value) {
-        return this.$tc('components.generic.lockIcon.doubleClickToUnlock')
+        return this.$tc('components.generic.lockIcon.clickToUnlock')
       }
       return ''
     },
   },
   methods: {
-    iconDblClick() {
+    iconClick() {
       if (!this.disabledForGuest) {
-        this.$emit('dblclick')
+        this.$emit('click')
       }
     },
   },

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -152,7 +152,8 @@
       }
     },
     "generic": {
-      "lockIcon": {
+      "lockButton": {
+        "clickToLock": "Klicken um zu sperren",
         "clickToUnlock": "Klicken um zu entsperren",
         "guestsCannotEdit": "Gäste können nicht bearbeiten"
       }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -153,8 +153,8 @@
     },
     "generic": {
       "lockIcon": {
-        "doubleClickToUnlock": "Doppelklick um zu entsperren",
-        "guestsCannotEdit": "Gäste haben keinen Bearbeitungszugriff"
+        "clickToUnlock": "Klicken um zu entsperren",
+        "guestsCannotEdit": "Gäste können nicht bearbeiten"
       }
     },
     "layout": {
@@ -432,7 +432,6 @@
         "title": "Admin"
       },
       "campProgram": {
-        "guestsCannotEdit": "Gäste können das Grobprogramm nicht bearbeiten",
         "reminderLockedCreate": "Ziehen zum Erstellen ist nur im entsperrten Modus möglich.",
         "reminderLockedMove": "Ziehen zum Verschieben ist nur im entsperrten Modus möglich.",
         "title": "Grobprogramm"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -152,7 +152,8 @@
       }
     },
     "generic": {
-      "lockIcon": {
+      "lockButton": {
+        "clickToLock": "Click to lock",
         "clickToUnlock": "Click to unlock",
         "guestsCannotEdit": "Guests have no permission to edit"
       }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -153,7 +153,7 @@
     },
     "generic": {
       "lockIcon": {
-        "doubleClickToUnlock": "Double click to unlock",
+        "clickToUnlock": "Click to unlock",
         "guestsCannotEdit": "Guests have no permission to edit"
       }
     },
@@ -432,7 +432,6 @@
         "title": "Admin"
       },
       "campProgram": {
-        "guestsCannotEdit": "A guest cannot edit the picasso",
         "reminderLockedCreate": "Drag to create is only possible in unlocked mode.",
         "reminderLockedMove": "Drag to move is only possible in unlocked mode.",
         "title": "Picasso"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -145,7 +145,7 @@
     },
     "generic": {
       "lockIcon": {
-        "doubleClickToUnlock": "Double-clique pour déverrouiller",
+        "clickToUnlock": "Clique pour déverrouiller",
         "guestsCannotEdit": "Les invités n'ont pas le droit de modifier"
       }
     },
@@ -416,7 +416,6 @@
         "title": "Admin"
       },
       "campProgram": {
-        "guestsCannotEdit": "Un invité ne peut pas modifier le picasso",
         "reminderLockedCreate": "Glisser pour créer n'est possible qu'en mode déverrouillé.",
         "reminderLockedMove": "Faire glisser pour se déplacer n'est possible qu'en mode déverrouillé.",
         "title": "Picasso"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -144,7 +144,8 @@
       }
     },
     "generic": {
-      "lockIcon": {
+      "lockButton": {
+        "clickToLock": "Clique pour verrouiller",
         "clickToUnlock": "Clique pour déverrouiller",
         "guestsCannotEdit": "Les invités n'ont pas le droit de modifier"
       }

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -144,7 +144,8 @@
       }
     },
     "generic": {
-      "lockIcon": {
+      "lockButton": {
+        "clickToLock": "Clic per bloccare",
         "clickToUnlock": "Clic per sbloccare",
         "guestsCannotEdit": "Gli ospiti non hanno il permesso di modificare"
       }

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -145,7 +145,7 @@
     },
     "generic": {
       "lockIcon": {
-        "doubleClickToUnlock": "Doppio clic per sbloccare",
+        "clickToUnlock": "Clic per sbloccare",
         "guestsCannotEdit": "Gli ospiti non hanno il permesso di modificare"
       }
     },
@@ -416,7 +416,6 @@
         "title": "Admin"
       },
       "campProgram": {
-        "guestsCannotEdit": "Un ospite non può modificare il picasso",
         "reminderLockedCreate": "Trascinare per creare è possibile solo in modalità sbloccata.",
         "reminderLockedMove": "Trascinare per spostarsi è possibile solo in modalità sbloccata.",
         "title": "Picasso"

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -7,7 +7,7 @@ Show all activity schedule entries of a single period.
     <template #title-actions>
       <period-switcher :period="period" />
       <v-spacer />
-      <LockIcon
+      <LockButton
         v-model="editMode"
         :shake="showReminder"
         :disabled-for-guest="!isContributor"
@@ -63,7 +63,7 @@ import ScheduleEntries from '@/components/program/ScheduleEntries.vue'
 import PeriodSwitcher from '@/components/program/PeriodSwitcher.vue'
 import DownloadNuxtPdf from '@/components/print/print-nuxt/DownloadNuxtPdfListItem.vue'
 import DownloadReactPdf from '@/components/print/print-react/DownloadReactPdfListItem.vue'
-import LockIcon from '@/components/generic/LockIcon.vue'
+import LockButton from '@/components/generic/LockButton.vue'
 import LockUnlockListItem from '@/components/generic/LockUnlockListItem.vue'
 
 export default {
@@ -75,7 +75,7 @@ export default {
     ContentCard,
     Picasso,
     ScheduleEntries,
-    LockIcon,
+    LockButton,
     LockUnlockListItem,
   },
   mixins: [campRoleMixin],

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -11,8 +11,7 @@ Show all activity schedule entries of a single period.
         v-model="editMode"
         :shake="showReminder"
         :disabled-for-guest="!isContributor"
-        :message="$tc('views.camp.campProgram.guestsCannotEdit')"
-        @dblclick="editMode = !editMode"
+        @click="editMode = !editMode"
       />
       <v-menu offset-y>
         <template #activator="{ on, attrs }">

--- a/frontend/src/views/camp/Story.vue
+++ b/frontend/src/views/camp/Story.vue
@@ -3,7 +3,7 @@
     <template #title-actions>
       <period-switcher :period="period" :route-name="'camp/period/story'" />
       <v-spacer />
-      <LockIcon
+      <LockButton
         v-model="editing"
         :disabled-for-guest="!isContributor"
         @click="editing = !editing"
@@ -36,7 +36,7 @@ import StoryPeriod from '@/components/story/StoryPeriod.vue'
 import { campRoleMixin } from '@/mixins/campRoleMixin'
 import DownloadNuxtPdf from '@/components/print/print-nuxt/DownloadNuxtPdfListItem.vue'
 import DownloadReactPdf from '@/components/print/print-react/DownloadReactPdfListItem.vue'
-import LockIcon from '@/components/generic/LockIcon.vue'
+import LockButton from '@/components/generic/LockButton.vue'
 import LockUnlockListItem from '@/components/generic/LockUnlockListItem.vue'
 
 export default {
@@ -46,7 +46,7 @@ export default {
     ContentCard,
     DownloadReactPdf,
     DownloadNuxtPdf,
-    LockIcon,
+    LockButton,
     LockUnlockListItem,
   },
   mixins: [campRoleMixin],

--- a/frontend/src/views/camp/Story.vue
+++ b/frontend/src/views/camp/Story.vue
@@ -6,7 +6,7 @@
       <LockIcon
         v-model="editing"
         :disabled-for-guest="!isContributor"
-        @dblclick="editing = !editing"
+        @click="editing = !editing"
       />
       <v-menu offset-y>
         <template #activator="{ on, attrs }">


### PR DESCRIPTION
Users are confused by the double-clicking lock icon. People have suggested via email and also in a course, that one could simply click the lock icon to unlock the picasso or story overview. They did not realize that double-clicking the icon is already implemented. This might be in part because the tooltip on the picasso was showing the wrong message, but also because double-clicking is not a common interaction pattern on the web.

This PR changes the interaction from double-clicking to single-clicking, and refactors the lock component to use a button instead of manually implementing some of the button features.