### PR TITLE
fix(frontend): fix and simplify picasso drag-and-drop

### DIFF
--- a/frontend/src/components/program/picasso/Picasso.vue
+++ b/frontend/src/components/program/picasso/Picasso.vue
@@ -211,7 +211,6 @@ export default {
     const dragAndDropResize = useDragAndDropResize(
       editable,
       updateEntry,
-      calenderStartTimestamp,
       calendarEndTimestamp
     )
     const dragAndDropNew = useDragAndDropNew(editable, createEntry)

--- a/frontend/src/components/program/picasso/Picasso.vue
+++ b/frontend/src/components/program/picasso/Picasso.vue
@@ -86,7 +86,7 @@ import {
   utcStringToTimestamp,
 } from '@/common/helpers/dateHelperVCalendar.js'
 import DayResponsibles from './DayResponsibles.vue'
-import { ONE_DAY } from '@/helpers/vCalendarDragAndDrop.js'
+import { ONE_DAY_IN_MILLISECONDS } from '@/helpers/vCalendarDragAndDrop.js'
 import { errorToMultiLineToast } from '@/components/toast/toasts'
 import PicassoEntry from './PicassoEntry.vue'
 
@@ -195,7 +195,7 @@ export default {
     }
 
     const calenderStartTimestamp = utcStringToTimestamp(props.start)
-    const calendarEndTimestamp = utcStringToTimestamp(props.end) + ONE_DAY
+    const calendarEndTimestamp = utcStringToTimestamp(props.end) + ONE_DAY_IN_MILLISECONDS
 
     const dragAndDropMove = useDragAndDropMove(
       editable,

--- a/frontend/src/components/program/picasso/Picasso.vue
+++ b/frontend/src/components/program/picasso/Picasso.vue
@@ -180,18 +180,14 @@ export default {
       timed: true,
       tmpEvent: true,
     })
-    const createEntry = (startTimestamp, endTimestamp, finished) => {
+    const updatePlaceholder = (startTimestamp, endTimestamp) => {
+      placeholder.startTimestamp = startTimestamp
+      placeholder.endTimestamp = endTimestamp
+    }
+    const createEntry = (startTimestamp, endTimestamp) => {
       const start = timestampToUtcString(startTimestamp)
       const end = timestampToUtcString(endTimestamp)
-
-      if (finished) {
-        placeholder.startTimestamp = 0
-        placeholder.endTimestamp = 0
-        emit('newEntry', start, end)
-      } else {
-        placeholder.startTimestamp = startTimestamp
-        placeholder.endTimestamp = endTimestamp
-      }
+      emit('newEntry', start, end)
     }
 
     const showReminder = (move) => {
@@ -213,7 +209,7 @@ export default {
       updateEntry,
       calendarEndTimestamp
     )
-    const dragAndDropNew = useDragAndDropNew(editable, createEntry)
+    const dragAndDropNew = useDragAndDropNew(editable, updatePlaceholder, createEntry)
     const dragAndDropReminder = useDragAndDropReminder(editable, showReminder)
 
     // merge mouseleave handlers

--- a/frontend/src/components/program/picasso/PicassoEntry.vue
+++ b/frontend/src/components/program/picasso/PicassoEntry.vue
@@ -109,7 +109,7 @@ import { scheduleEntryRoute } from '@/router.js'
 import { contrastColor } from '@/common/helpers/colors.js'
 import { useClickDetector } from './useClickDetector.js'
 import AvatarRow from '@/components/generic/AvatarRow.vue'
-import { ONE_MINUTE } from '@/helpers/vCalendarDragAndDrop.js'
+import { ONE_MINUTE_IN_MILLISECONDS } from '@/helpers/vCalendarDragAndDrop.js'
 
 export default {
   name: 'PicassoEntry',
@@ -170,7 +170,7 @@ export default {
       return this.scheduleEntry.endTimestamp - this.scheduleEntry.startTimestamp
     },
     isTinyDuration() {
-      return this.duration <= 40 * ONE_MINUTE
+      return this.duration <= 40 * ONE_MINUTE_IN_MILLISECONDS
     },
     isLongDuration() {
       return this.scrollHeight <= this.clientHeight

--- a/frontend/src/components/program/picasso/PicassoEntry.vue
+++ b/frontend/src/components/program/picasso/PicassoEntry.vue
@@ -2,8 +2,9 @@
   <!-- edit mode: normal div with drag & drop -->
   <div
     v-if="editable"
-    class="e-picasso-entry e-picasso-entry--editable"
+    class="e-picasso-entry"
     :class="{
+      'e-picasso-entry--editable': !scheduleEntry.tmpEvent,
       'e-picasso-entry--temporary elevation-4 v-event--temporary': scheduleEntry.tmpEvent,
     }"
     :style="colorStyles"
@@ -11,7 +12,7 @@
   >
     <!-- edit button & dialog -->
     <dialog-activity-edit
-      v-if="editable && !scheduleEntry.tmpEvent"
+      v-if="!scheduleEntry.tmpEvent"
       ref="editDialog"
       :schedule-entry="scheduleEntry"
       @activityUpdated="$emit('finishEdit')"
@@ -60,7 +61,7 @@
 
     <!-- resize handle -->
     <div
-      v-if="editable"
+      v-if="!scheduleEntry.tmpEvent"
       class="e-picasso-entry__drag-bottom"
       @mousedown.stop="$emit('startResize')"
     />
@@ -347,6 +348,10 @@ export default {
     opacity: 0.8;
     content: '';
   }
+}
+
+.e-picasso-entry--temporary {
+  cursor: default;
 }
 
 .e-picasso-entry small {

--- a/frontend/src/components/program/picasso/useDragAndDropMove.js
+++ b/frontend/src/components/program/picasso/useDragAndDropMove.js
@@ -1,4 +1,4 @@
-import { toTime, roundTimeDown } from '@/helpers/vCalendarDragAndDrop.js'
+import { toTime, roundTimeToNearestQuarterHour } from '@/helpers/vCalendarDragAndDrop.js'
 
 /**
  * @param enabled {Ref<boolean>} drag & drop is disabled if enabled=false
@@ -50,7 +50,7 @@ export function useDragAndDropMove(
     const end = draggedEntry.endTimestamp
     const duration = end - start
 
-    const newStart = roundTimeDown(mouse - mouseOffset)
+    const newStart = roundTimeToNearestQuarterHour(mouse - mouseOffset)
     const newEnd = newStart + duration
 
     if (newStart >= minTimestamp && newEnd <= maxTimestamp) {

--- a/frontend/src/components/program/picasso/useDragAndDropNew.js
+++ b/frontend/src/components/program/picasso/useDragAndDropNew.js
@@ -3,10 +3,11 @@ import { toTime, roundTimeToNearestQuarterHour } from '@/helpers/vCalendarDragAn
 /**
  *
  * @param enabled {Ref<boolean>} drag & drop is disabled if enabled=false
- * @param createEntry {(startTime:number, endTime:number, finished:boolean) => void}
+ * @param updatePlaceholder {(startTime:number, endTime:number) => void}
+ * @param createEntry {(startTime:number, endTime:number) => void}
  * @returns
  */
-export function useDragAndDropNew(enabled, createEntry) {
+export function useDragAndDropNew(enabled, updatePlaceholder, createEntry) {
   /**
    * internal data (not exposed)
    */
@@ -28,10 +29,11 @@ export function useDragAndDropNew(enabled, createEntry) {
     newEntry = null
     mouseStartTimestamp = null
     entryWasClicked = false
+    updatePlaceholder(0, 0)
   }
 
   // this creates a placeholder for a new schedule entry and make it resizable
-  const createNewEntry = (time) => {
+  const startDragOperation = (time) => {
     newEntry = {
       startTimestamp: time,
       endTimestamp: time,
@@ -87,7 +89,7 @@ export function useDragAndDropNew(enabled, createEntry) {
       // No entry is being dragged --> create a placeholder for a new schedule entry
       const mouseTime = toTime(tms)
       mouseStartTimestamp = roundTimeToNearestQuarterHour(mouseTime)
-      createNewEntry(mouseStartTimestamp)
+      startDragOperation(mouseStartTimestamp)
     }
   }
 
@@ -103,7 +105,7 @@ export function useDragAndDropNew(enabled, createEntry) {
       resizeEntry(newEntry, mouseTime)
 
       if (newEntry.endTimestamp - newEntry.startTimestamp > 0) {
-        createEntry(newEntry.startTimestamp, newEntry.endTimestamp, false)
+        updatePlaceholder(newEntry.startTimestamp, newEntry.endTimestamp)
       }
     }
   }
@@ -116,7 +118,7 @@ export function useDragAndDropNew(enabled, createEntry) {
 
     if (newEntry && newEntry.endTimestamp - newEntry.startTimestamp > 0) {
       // placeholder for new schedule entry was created --> open dialog to create new activity
-      createEntry(newEntry.startTimestamp, newEntry.endTimestamp, true)
+      createEntry(newEntry.startTimestamp, newEntry.endTimestamp)
     }
 
     clear()

--- a/frontend/src/components/program/picasso/useDragAndDropNew.js
+++ b/frontend/src/components/program/picasso/useDragAndDropNew.js
@@ -1,4 +1,4 @@
-import { toTime, roundTime } from '@/helpers/vCalendarDragAndDrop.js'
+import { toTime, roundTimeToNearestQuarterHour } from '@/helpers/vCalendarDragAndDrop.js'
 
 /**
  *
@@ -31,17 +31,20 @@ export function useDragAndDropNew(enabled, createEntry) {
   }
 
   // this creates a placeholder for a new schedule entry and make it resizable
-  const createNewEntry = (mouse) => {
+  const createNewEntry = (time) => {
     newEntry = {
-      startTimestamp: roundTime(mouse),
-      endTimestamp: roundTime(mouse),
+      startTimestamp: time,
+      endTimestamp: time,
     }
   }
 
   // resize placeholder entry
   const resizeEntry = (entry, mouse) => {
-    const minTimestamp = Math.min(roundTime(mouseStartTimestamp), roundTime(mouse))
-    const maxTimestamp = Math.max(roundTime(mouseStartTimestamp), roundTime(mouse))
+    const dragStart = mouseStartTimestamp
+    const dragEnd = roundTimeToNearestQuarterHour(mouse)
+
+    const minTimestamp = Math.min(dragStart, dragEnd)
+    const maxTimestamp = Math.max(dragStart, dragEnd)
 
     if (minTimestamp !== maxTimestamp) {
       entry.startTimestamp = minTimestamp
@@ -83,8 +86,8 @@ export function useDragAndDropNew(enabled, createEntry) {
     if (!entryWasClicked) {
       // No entry is being dragged --> create a placeholder for a new schedule entry
       const mouseTime = toTime(tms)
-      mouseStartTimestamp = mouseTime
-      createNewEntry(mouseTime)
+      mouseStartTimestamp = roundTimeToNearestQuarterHour(mouseTime)
+      createNewEntry(mouseStartTimestamp)
     }
   }
 

--- a/frontend/src/components/program/picasso/useDragAndDropNew.js
+++ b/frontend/src/components/program/picasso/useDragAndDropNew.js
@@ -1,4 +1,4 @@
-import { toTime, roundTimeDown, minMaxTime } from '@/helpers/vCalendarDragAndDrop.js'
+import { toTime, roundTime } from '@/helpers/vCalendarDragAndDrop.js'
 
 /**
  *
@@ -33,17 +33,20 @@ export function useDragAndDropNew(enabled, createEntry) {
   // this creates a placeholder for a new schedule entry and make it resizable
   const createNewEntry = (mouse) => {
     newEntry = {
-      startTimestamp: roundTimeDown(mouse),
-      endTimestamp: roundTimeDown(mouse),
+      startTimestamp: roundTime(mouse),
+      endTimestamp: roundTime(mouse),
     }
   }
 
   // resize placeholder entry
   const resizeEntry = (entry, mouse) => {
-    const { min, max } = minMaxTime(mouse, mouseStartTimestamp)
+    const minTimestamp = Math.min(roundTime(mouseStartTimestamp), roundTime(mouse))
+    const maxTimestamp = Math.max(roundTime(mouseStartTimestamp), roundTime(mouse))
 
-    entry.startTimestamp = min
-    entry.endTimestamp = max
+    if (minTimestamp !== maxTimestamp) {
+      entry.startTimestamp = minTimestamp
+      entry.endTimestamp = maxTimestamp
+    }
   }
 
   /**
@@ -96,7 +99,9 @@ export function useDragAndDropNew(enabled, createEntry) {
       const mouseTime = toTime(tms)
       resizeEntry(newEntry, mouseTime)
 
-      createEntry(newEntry.startTimestamp, newEntry.endTimestamp, false)
+      if (newEntry.endTimestamp - newEntry.startTimestamp > 0) {
+        createEntry(newEntry.startTimestamp, newEntry.endTimestamp, false)
+      }
     }
   }
 

--- a/frontend/src/components/program/picasso/useDragAndDropReminder.js
+++ b/frontend/src/components/program/picasso/useDragAndDropReminder.js
@@ -1,4 +1,4 @@
-import { toTime, minMaxTime, ONE_HOUR } from '@/helpers/vCalendarDragAndDrop.js'
+import { toTime, ONE_HOUR } from '@/helpers/vCalendarDragAndDrop.js'
 
 /**
  *
@@ -66,9 +66,9 @@ export function useDragAndDropReminder(enabled, showReminder) {
       return
     }
 
-    const { min, max } = minMaxTime(mouseStartTimestamp, toTime(tms))
+    const mouseMoveDistance = Math.abs(toTime(tms) - mouseStartTimestamp)
 
-    if (max - min >= ONE_HOUR) {
+    if (mouseMoveDistance >= ONE_HOUR) {
       showReminder(entryWasClicked)
     }
   }

--- a/frontend/src/components/program/picasso/useDragAndDropReminder.js
+++ b/frontend/src/components/program/picasso/useDragAndDropReminder.js
@@ -1,4 +1,4 @@
-import { toTime, ONE_HOUR } from '@/helpers/vCalendarDragAndDrop.js'
+import { toTime, ONE_HOUR_IN_MILLISECONDS } from '@/helpers/vCalendarDragAndDrop.js'
 
 /**
  *
@@ -68,7 +68,7 @@ export function useDragAndDropReminder(enabled, showReminder) {
 
     const mouseMoveDistance = Math.abs(toTime(tms) - mouseStartTimestamp)
 
-    if (mouseMoveDistance >= ONE_HOUR) {
+    if (mouseMoveDistance >= ONE_HOUR_IN_MILLISECONDS) {
       showReminder(entryWasClicked)
     }
   }

--- a/frontend/src/components/program/picasso/useDragAndDropResize.js
+++ b/frontend/src/components/program/picasso/useDragAndDropResize.js
@@ -1,4 +1,4 @@
-import { toTime, minMaxTime } from '@/helpers/vCalendarDragAndDrop.js'
+import { toTime, roundTimeUpToNextQuarterHour } from '@/helpers/vCalendarDragAndDrop.js'
 
 /**
  *
@@ -8,16 +8,13 @@ import { toTime, minMaxTime } from '@/helpers/vCalendarDragAndDrop.js'
  * @param maxTimestamp {number}  maximum allowed end timestamp (calendar end)
  * @returns
  */
-export function useDragAndDropResize(enabled, update, minTimestamp, maxTimestamp) {
+export function useDragAndDropResize(enabled, update, maxTimestamp) {
   /**
    * internal data (not exposed)
    */
 
   // existing entry that is being resized
   let resizedEntry = null
-
-  // original start time of entry which is being resized
-  let originalStartTimestamp = null
 
   // original end time of entry which is being resized
   let originalEndTimestamp = null
@@ -28,19 +25,17 @@ export function useDragAndDropResize(enabled, update, minTimestamp, maxTimestamp
 
   // resize an entry (existing or new placeholder)
   const resizeEntry = (entry, mouse) => {
-    const { min: newStart, max: newEnd } = minMaxTime(originalStartTimestamp, mouse)
+    const newEndTimestamp = roundTimeUpToNextQuarterHour(mouse)
 
-    if (newStart >= minTimestamp && newEnd <= maxTimestamp && newEnd - newStart > 0) {
+    if (newEndTimestamp <= maxTimestamp && newEndTimestamp - entry.startTimestamp > 0) {
       // TODO review: Here we're changing the store value directly.
-      entry.startTimestamp = newStart
-      entry.endTimestamp = newEnd
+      entry.endTimestamp = newEndTimestamp
     }
   }
 
   const clear = () => {
     resizedEntry = null
     originalEndTimestamp = null
-    originalStartTimestamp = null
   }
 
   /**
@@ -81,7 +76,6 @@ export function useDragAndDropResize(enabled, update, minTimestamp, maxTimestamp
   // start resize operation (needs to be called manually from resize handle)
   const startResize = (event) => {
     resizedEntry = event
-    originalStartTimestamp = event.startTimestamp
     originalEndTimestamp = event.endTimestamp
   }
 

--- a/frontend/src/helpers/__tests__/vCalendarDragAndDrop.spec.js
+++ b/frontend/src/helpers/__tests__/vCalendarDragAndDrop.spec.js
@@ -1,8 +1,7 @@
 import {
   toTime,
-  roundTimeDown,
-  roundTimeUp,
-  minMaxTime,
+  roundTimeToNearestQuarterHour,
+  roundTimeUpToNextQuarterHour,
 } from '@/helpers/vCalendarDragAndDrop.js'
 
 describe('toTime', () => {
@@ -66,35 +65,24 @@ describe('toTime', () => {
   })
 })
 
-describe('roundTimeDown', () => {
+describe('roundTimeToNearestQuarterHour', () => {
   it.each([
     [1649190120000, 1649189700000],
     [1683447600000, 1683447300000],
     [1683543980000, 1683543600000],
-    [1683547980999, 1683547200000],
+    [1683547980999, 1683548100000],
   ])('maps %p to %p', (input, expected) => {
-    expect(roundTimeDown(input)).toEqual(expected)
+    expect(roundTimeToNearestQuarterHour(input)).toEqual(expected)
   })
 })
 
-describe('roundTimeUp', () => {
+describe('roundTimeUpToNextQuarterHour', () => {
   it.each([
     [1649190120000, 1649190600000],
     [1683447600000, 1683448200000],
     [1683543980000, 1683544500000],
     [1683547980999, 1683548100000],
   ])('maps %p to %p', (input, expected) => {
-    expect(roundTimeUp(input)).toEqual(expected)
-  })
-})
-
-describe('minMaxTime', () => {
-  it.each([
-    [[1649190120000, 1639190120000], { min: 1639190700000, max: 1649189700000 }],
-    [[1683447600000, 1683427600000], { min: 1683428400000, max: 1683447300000 }],
-    [[1683543980000, 1683546980000], { min: 1683543600000, max: 1683547200000 }],
-    [[1683547980999, 1683597980999], { min: 1683547200000, max: 1683598500000 }],
-  ])('maps %p to %p', (input, expected) => {
-    expect(minMaxTime(...input)).toEqual(expected)
+    expect(roundTimeUpToNextQuarterHour(input)).toEqual(expected)
   })
 })

--- a/frontend/src/helpers/vCalendarDragAndDrop.js
+++ b/frontend/src/helpers/vCalendarDragAndDrop.js
@@ -2,9 +2,20 @@
  * helpers for VCalendar DragAndDrop composables
  */
 
+const ONE_MINUTE = 60 * 1000
+const ONE_HOUR = 60 * ONE_MINUTE
+const ONE_DAY = 24 * ONE_HOUR
+
+const roundToMinutes = 15 // minutes
+const roundToMilliseconds = roundToMinutes * ONE_MINUTE
+
 // helper function to convert Vuetify day & time object into timestamp
 const toTime = (tms) => {
   return new Date(tms.year, tms.month - 1, tms.day, tms.hour, tms.minute).getTime()
+}
+
+const roundTime = (time) => {
+  return Math.round(time / roundToMilliseconds) * roundToMilliseconds
 }
 
 const roundTimeDown = (time) => {
@@ -29,8 +40,13 @@ const minMaxTime = (start, end) => {
   }
 }
 
-const ONE_MINUTE = 60 * 1000
-const ONE_HOUR = 60 * ONE_MINUTE
-const ONE_DAY = 24 * ONE_HOUR
-
-export { toTime, roundTimeDown, roundTimeUp, minMaxTime, ONE_MINUTE, ONE_HOUR, ONE_DAY }
+export {
+  toTime,
+  roundTime,
+  roundTimeDown,
+  roundTimeUp,
+  minMaxTime,
+  ONE_MINUTE,
+  ONE_HOUR,
+  ONE_DAY,
+}

--- a/frontend/src/helpers/vCalendarDragAndDrop.js
+++ b/frontend/src/helpers/vCalendarDragAndDrop.js
@@ -2,10 +2,10 @@
  * helpers for VCalendar DragAndDrop composables
  */
 
-const ONE_MINUTE = 60 * 1000
-const ONE_HOUR = 60 * ONE_MINUTE
-const ONE_DAY = 24 * ONE_HOUR
-const QUARTER_HOUR = 15 * ONE_MINUTE
+const ONE_MINUTE_IN_MILLISECONDS = 60 * 1000
+const ONE_HOUR_IN_MILLISECONDS = 60 * ONE_MINUTE_IN_MILLISECONDS
+const ONE_DAY_IN_MILLISECONDS = 24 * ONE_HOUR_IN_MILLISECONDS
+const QUARTER_HOUR_IN_MILLISECONDS = 15 * ONE_MINUTE_IN_MILLISECONDS
 
 // helper function to convert Vuetify day & time object into timestamp
 const toTime = (tms) => {
@@ -13,18 +13,18 @@ const toTime = (tms) => {
 }
 
 const roundTimeToNearestQuarterHour = (time) => {
-  return Math.round(time / QUARTER_HOUR) * QUARTER_HOUR
+  return Math.round(time / QUARTER_HOUR_IN_MILLISECONDS) * QUARTER_HOUR_IN_MILLISECONDS
 }
 
 const roundTimeUpToNextQuarterHour = (time) => {
-  return time + (QUARTER_HOUR - (time % QUARTER_HOUR))
+  return Math.ceil(time / QUARTER_HOUR_IN_MILLISECONDS) * QUARTER_HOUR_IN_MILLISECONDS
 }
 
 export {
   toTime,
   roundTimeToNearestQuarterHour,
   roundTimeUpToNextQuarterHour,
-  ONE_MINUTE,
-  ONE_HOUR,
-  ONE_DAY,
+  ONE_MINUTE_IN_MILLISECONDS,
+  ONE_HOUR_IN_MILLISECONDS,
+  ONE_DAY_IN_MILLISECONDS,
 }

--- a/frontend/src/helpers/vCalendarDragAndDrop.js
+++ b/frontend/src/helpers/vCalendarDragAndDrop.js
@@ -5,47 +5,25 @@
 const ONE_MINUTE = 60 * 1000
 const ONE_HOUR = 60 * ONE_MINUTE
 const ONE_DAY = 24 * ONE_HOUR
-
-const roundToMinutes = 15 // minutes
-const roundToMilliseconds = roundToMinutes * ONE_MINUTE
+const QUARTER_HOUR = 15 * ONE_MINUTE
 
 // helper function to convert Vuetify day & time object into timestamp
 const toTime = (tms) => {
   return new Date(tms.year, tms.month - 1, tms.day, tms.hour, tms.minute).getTime()
 }
 
-const roundTime = (time) => {
-  return Math.round(time / roundToMilliseconds) * roundToMilliseconds
+const roundTimeToNearestQuarterHour = (time) => {
+  return Math.round(time / QUARTER_HOUR) * QUARTER_HOUR
 }
 
-const roundTimeDown = (time) => {
-  const roundTo = 15 // minutes
-  const roundDownTime = roundTo * 60 * 1000
-
-  return time - (time % roundDownTime)
-}
-
-const roundTimeUp = (time) => {
-  const roundTo = 15 // minutes
-  const roundDownTime = roundTo * 60 * 1000
-
-  return time + (roundDownTime - (time % roundDownTime))
-}
-
-const minMaxTime = (start, end) => {
-  const startCeil = roundTimeUp(end)
-  return {
-    min: Math.min(startCeil, roundTimeDown(start)),
-    max: Math.max(startCeil, roundTimeDown(start)),
-  }
+const roundTimeUpToNextQuarterHour = (time) => {
+  return time + (QUARTER_HOUR - (time % QUARTER_HOUR))
 }
 
 export {
   toTime,
-  roundTime,
-  roundTimeDown,
-  roundTimeUp,
-  minMaxTime,
+  roundTimeToNearestQuarterHour,
+  roundTimeUpToNextQuarterHour,
   ONE_MINUTE,
   ONE_HOUR,
   ONE_DAY,


### PR DESCRIPTION
Supersedes #3467 

Fixes https://github.com/ecamp/ecamp3/issues/3463 (hopefully)
also adresses https://github.com/ecamp/ecamp3/pull/3410#pullrequestreview-1384144228

The first commit is cherry-picked from #3467 and fixes the bug.

The other commits only simplify and cleanup the code with no major change in functionality, with one exception: I changed the resize operation to disallow negative changes (resizing upwards of the original start time). This makes the code simpler, gives the resize operation a single responsibility (I cannot misuse resize to move an event) and is consistent with other calendars such as Google Calendar.

All operations now use `roundTimeToNearestQuarterHour` with the exception of resize which still uses `roundTimeUpToNextQuarterHour`.  To me this felt more natural to use, because the resize handler is a bit higher up (lower in timestamp) than the border of the event. 

A cosmetic open issue is the display of cursor animations and event hover animations, which is not always consistent during drag & drop. I didn't want to touch on this, because this needs messing with the same CSS, that was already touched by #3411.
