### PR TITLE
UriTemplateFactoryTest: fix "Creation of dynamic property is deprecated"

### DIFF
--- a/api/tests/Metadata/Resource/Factory/UriTemplateFactoryTest.php
+++ b/api/tests/Metadata/Resource/Factory/UriTemplateFactoryTest.php
@@ -30,6 +30,7 @@ class UriTemplateFactoryTest extends TestCase {
     private MockObject|IriConverterInterface $iriConverter;
     private PaginationOptions $paginationOptions;
     private ResourceNameCollection $resourceNameCollection;
+    private ResourceMetadataCollection $resourceMetadataCollection;
     private ApiResource $apiResource;
 
     protected function setUp(): void {


### PR DESCRIPTION
 9x: Creation of dynamic property App\Tests\Metadata\Resource\Factory\UriTemplateFactoryTest::$resourceMetadataCollection is deprecated
    9x in UriTemplateFactoryTest::setUp from App\Tests\Metadata\Resource\Factory