### PR TITLE
generatePdfMixin.js: report react-print errors to sentry

### DIFF
--- a/frontend/src/components/print/print-react/generatePdfMixin.js
+++ b/frontend/src/components/print/print-react/generatePdfMixin.js
@@ -1,5 +1,6 @@
 import { saveAs } from 'file-saver'
 import slugify from 'slugify'
+import * as Sentry from '@sentry/browser'
 
 const RENDER_IN_WORKER = true
 
@@ -35,6 +36,7 @@ export const generatePdfMixin = {
 
       if (error) {
         this.$toast.error(this.$tc('components.print.printReact.generatePdfMixin.error'))
+        Sentry.captureException(new Error(error))
         this.loading = false
         return
       }


### PR DESCRIPTION
Maybe we have to go through the code and decide if we want to report the errors when they happen,
or if we want to use this catch all solution.

At least we see the errors: https://ecamp.sentry.io/issues/4227267039/?environment=pr3494.ecamp3.ch&project=5602507&query=is%3Aunresolved&referrer=issue-stream&stream_index=0