### PR TITLE
PrintConfigurator.vue: fix error when collecting coverage

### DIFF
--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -7,10 +7,7 @@
         :key="idx"
         :title="$tc('components.print.printConfigurator.config.' + content.type)"
         :landscape="content.options.orientation === 'L'"
-        :multiple="
-          contentComponents[content.type].design.multiple ||
-          content.options?.periods?.length > 1
-        "
+        :multiple="isMultipleMap[idx]"
         @remove="cnf.contents.splice(idx, 1)"
       >
         <component
@@ -108,6 +105,12 @@ import PagesConfig from './configurator/PagesConfig.vue'
 import DownloadNuxtPdfButton from '@/components/print/print-nuxt/DownloadNuxtPdfButton.vue'
 import DownloadReactPdfButton from '@/components/print/print-react/DownloadReactPdfButton.vue'
 
+function isMultiple(content, contentComponent) {
+  const hasMultiplePeriods = content.options?.periods?.length > 1
+  const multipleFlagSet = contentComponent.design.multiple
+  return hasMultiplePeriods || multipleFlagSet
+}
+
 export default {
   name: 'PrintConfigurator',
   components: {
@@ -156,6 +159,11 @@ export default {
     },
     isDev() {
       return window.environment.FEATURE_DEVELOPER ?? false
+    },
+    isMultipleMap() {
+      return this.cnf.contents.map((content) =>
+        isMultiple(content, this.contentComponents[content.type])
+      )
     },
   },
   watch: {


### PR DESCRIPTION
The parser seems to not like multi line values
for props.

Fixes the following message:
Failed to collect coverage from /home/runner/work/ecamp3/ecamp3/frontend/src/components/print/PrintConfigurator.vue ERROR: Unexpected token (2:24)
STACK: SyntaxError: Unexpected token (2:24)
    at Parser.pp$4.raise (/home/runner/work/ecamp3/ecamp3/frontend/node_modules/vue-template-es2015-compiler/buble.js:2757:13)
    at Parser.pp.unexpected (/home/runner/work/ecamp3/ecamp3/frontend/node_modules/vue-template-es2015-compiler/buble.js:647:8)
    ...