### PR TITLE
Bugfix: Apply the user's selected locale after normal login

### DIFF
--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -198,13 +198,12 @@ export default {
       this.$auth
         .login(this.email, this.password)
         .then(async () => {
-          this.$router.replace(this.$route.query.redirect || '/')
-
           const user = await this.$auth.loadUser()
           const profile = await user.profile()._meta.load
           if (VueI18n.availableLocales.includes(profile.language)) {
-            this.$store.commit('setLanguage', profile.language)
+            await this.$store.commit('setLanguage', profile.language)
           }
+          this.$router.replace(this.$route.query.redirect || '/')
         })
         .catch((e) => {
           this.authenticationInProgress = false

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -144,6 +144,7 @@
 
 <script>
 import { isLoggedIn } from '@/plugins/auth'
+import VueI18n from '@/plugins/i18n/index.js'
 import AuthContainer from '@/components/layout/AuthContainer.vue'
 import HorizontalRule from '@/components/layout/HorizontalRule.vue'
 import IconSpacer from '@/components/layout/IconSpacer.vue'
@@ -196,8 +197,14 @@ export default {
       this.error = null
       this.$auth
         .login(this.email, this.password)
-        .then(() => {
+        .then(async () => {
           this.$router.replace(this.$route.query.redirect || '/')
+
+          const user = await this.$auth.loadUser()
+          const profile = await user.profile()._meta.load
+          if (VueI18n.availableLocales.includes(profile.language)) {
+            this.$store.commit('setLanguage', profile.language)
+          }
         })
         .catch((e) => {
           this.authenticationInProgress = false


### PR DESCRIPTION
If a user has set their ecamp user locale differently from their browser locale, on (normal, non-OAuth) login the browser locale persists, until the first refresh. So when logging in, we need to set the locale while the SPA is still running.

I also checked the following scenarios, which all work fine already:
- On logout, the locale should revert to the browser locale (works because in the Login.vue `mounted` hook, we set the locale to the browser locale)
- After login via OAuth, the locale of the user should be used (works because coming from OAuth, there is a new page load, and the `mounted` hook of App.vue runs again, setting the user's preferred locale)
- After registering, the user is not automatically logged in. The browser locale is still applied.
- After activating an account, the user is not automatically logged in. The browser locale is still applied.
- After changing their password, the user is not automatically logged in. The browser locale is still applied.