### PR TITLE
e2e: fix join of Dirent instance

### DIFF
--- a/e2e/tasks/deleteDownloads.js
+++ b/e2e/tasks/deleteDownloads.js
@@ -15,7 +15,7 @@ function deleteDownloads(config) {
           console.log(`not deleting directory ${path.join(dirPath, file.name)}`)
           return
         }
-        fs.unlink(path.join(dirPath, file), () => {
+        fs.unlink(path.join(dirPath, file.name), () => {
           console.log('Removed ' + file)
         })
       })


### PR DESCRIPTION
You should always use the name property to join paths.