### PR TITLE
Category create improvements

### DIFF
--- a/api/src/Entity/ContentNode/ColumnLayout.php
+++ b/api/src/Entity/ContentNode/ColumnLayout.php
@@ -92,7 +92,7 @@ class ColumnLayout extends ContentNode implements SupportsContentNodeChildren {
         new AssertNoOrphanChildren(),
     ])]
     #[Assert\NotNull]
-    public ?array $data = ['columns' => [['slot' => '1', 'width' => 12]]];
+    public ?array $data = ['columns' => [['slot' => '1', 'width' => 6], ['slot' => '2', 'width' => 6]]];
 
     /**
      * All content nodes that are part of this content node tree.

--- a/api/tests/Api/ContentNodes/ColumnLayout/CreateColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/CreateColumnLayoutTest.php
@@ -39,7 +39,7 @@ class CreateColumnLayoutTest extends CreateContentNodeTestCase {
 
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains(['data' => [
-            'columns' => [['slot' => '1', 'width' => 12]],
+            'columns' => [['slot' => '1', 'width' => 6], ['slot' => '2', 'width' => 6]],
         ]]);
     }
 
@@ -48,7 +48,7 @@ class CreateColumnLayoutTest extends CreateContentNodeTestCase {
 
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains(['data' => [
-            'columns' => [['slot' => '1', 'width' => 12]],
+            'columns' => [['slot' => '1', 'width' => 6], ['slot' => '2', 'width' => 6]],
         ]]);
     }
 

--- a/frontend/src/components/campAdmin/DialogCategoryCreate.vue
+++ b/frontend/src/components/campAdmin/DialogCategoryCreate.vue
@@ -60,13 +60,7 @@ export default {
     async createCategory() {
       const createdCategory = await this.create()
       await this.api.reload(this.camp.categories())
-      await this.$router.push(categoryRoute(this.camp, createdCategory))
-      this.$toast.success(
-        this.$tc('components.campAdmin.dialogCategoryCreate.editLayoutAfterCreating', 1, {
-          categoryShort: createdCategory.short,
-        }),
-        { position: 'bottom-center', timeout: false }
-      )
+      this.$router.push(categoryRoute(this.camp, createdCategory))
     },
   },
 }

--- a/frontend/src/components/campAdmin/DialogCategoryCreate.vue
+++ b/frontend/src/components/campAdmin/DialogCategoryCreate.vue
@@ -18,6 +18,7 @@
 </template>
 
 <script>
+import { categoryRoute } from '@/router.js'
 import DialogForm from '@/components/dialog/DialogForm.vue'
 import DialogBase from '@/components/dialog/DialogBase.vue'
 import DialogCategoryForm from './DialogCategoryForm.vue'
@@ -56,10 +57,16 @@ export default {
     },
   },
   methods: {
-    createCategory() {
-      return this.create().then(() => {
-        this.api.reload(this.camp.categories())
-      })
+    async createCategory() {
+      const createdCategory = await this.create()
+      await this.api.reload(this.camp.categories())
+      await this.$router.push(categoryRoute(this.camp, createdCategory))
+      this.$toast.success(
+        this.$tc('components.campAdmin.dialogCategoryCreate.editLayoutAfterCreating', 1, {
+          categoryShort: createdCategory.short,
+        }),
+        { position: 'bottom-center', timeout: false }
+      )
     },
   },
 }

--- a/frontend/src/components/campAdmin/DialogCategoryForm.vue
+++ b/frontend/src/components/campAdmin/DialogCategoryForm.vue
@@ -24,21 +24,12 @@
       :name="$tc('entity.category.fields.numberingStyle')"
       vee-rules="required"
     />
-
-    <e-select
-      v-model="localCategory.preferredContentTypes"
-      :items="contentTypes"
-      :disabled="contentTypesLoading"
-      :loading="contentTypesLoading"
-      :name="$tc('entity.contentType.name', 2)"
-      multiple
-    />
   </div>
 </template>
 
 <script>
-import { camelCase } from 'lodash'
 import ESelect from '../form/base/ESelect.vue'
+
 export default {
   name: 'DialogCategoryForm',
   components: { ESelect },
@@ -59,24 +50,6 @@ export default {
         value: i,
         text: this.$tc('entity.category.numberingStyles.' + i),
       }))
-    },
-    contentTypes() {
-      if (this.contentTypesLoading) {
-        return []
-      }
-      return this.api
-        .get()
-        .contentTypes()
-        .items.map((ct) => ({
-          value: ct._meta.self,
-          text: this.$tc('contentNode.' + camelCase(ct.name) + '.name'),
-        }))
-        .sort(function (a, b) {
-          return a.text.localeCompare(b.text)
-        })
-    },
-    contentTypesLoading() {
-      return this.api.get().contentTypes()._meta.loading
     },
   },
 }

--- a/frontend/src/components/dialog/DialogBase.vue
+++ b/frontend/src/components/dialog/DialogBase.vue
@@ -112,9 +112,10 @@ export default {
       this.$emit('submit')
       return promise
     },
-    onSuccess() {
+    onSuccess(response) {
       this.$emit('success')
       this.close()
+      return response
     },
     close() {
       this.showDialog = false

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -378,8 +378,9 @@
   "views": {
     "activity": {
       "category": {
-        "backToContents": "Zurück zum Bearbeiten des Inhalts",
-        "changeLayout": "Layout ändern",
+        "changeLayout": "Layout für neue Blöcke ändern",
+        "contents": "Inhalte",
+        "editContents": "Standard-Inhalte für neue Blöcke eingeben",
         "layout": "Layout"
       },
       "printPreview": "Druckvorschau öffnen",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -90,7 +90,6 @@
         "add": "Weiteren Lagerabschnitt hinzufügen"
       },
       "dialogCategoryCreate": {
-        "editLayoutAfterCreating": "Die Kategorie wurde erfolgreich erstellt. Bitte lege nun fest, wie neue {categoryShort}-Blöcke standardmässig aussehen sollen.",
         "title": "Block-Kategorie erstellen"
       },
       "dialogMaterialListCreate": {
@@ -380,6 +379,7 @@
       "category": {
         "changeLayout": "Layout für neue Blöcke ändern",
         "contents": "Inhalte",
+        "createLayoutHelp": "Hier kannst du definieren, wie neue {categoryShort}-Blöcke standardmässig aussehen sollen.{br}Achtung: Falls du bereits {categoryShort}-Blöcke im Lager hast, werden diese nicht automatisch angepasst.",
         "editContents": "Standard-Inhalte für neue Blöcke eingeben",
         "layout": "Layout"
       },

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -90,6 +90,7 @@
         "add": "Weiteren Lagerabschnitt hinzufügen"
       },
       "dialogCategoryCreate": {
+        "editLayoutAfterCreating": "Die Kategorie wurde erfolgreich erstellt. Bitte lege nun fest, wie neue {categoryShort}-Blöcke standardmässig aussehen sollen.",
         "title": "Block-Kategorie erstellen"
       },
       "dialogMaterialListCreate": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -378,6 +378,7 @@
     "activity": {
       "category": {
         "changeLayout": "Change layout for new activities",
+        "createLayoutHelp": "Here you can define how new {categoryShort} activities should look by default.{br}Note: If you already have {categoryShort} activities in the camp, they will not be automatically adjusted.",
         "contents": "Contents",
         "editContents": "Set default contents for new activities",
         "layout": "Layout"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -377,8 +377,9 @@
   "views": {
     "activity": {
       "category": {
-        "backToContents": "Back to editing content",
-        "changeLayout": "Change layout",
+        "changeLayout": "Change layout for new activities",
+        "contents": "Contents",
+        "editContents": "Set default contents for new activities",
         "layout": "Layout"
       },
       "printPreview": "Open print preview",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -377,8 +377,9 @@
   "views": {
     "activity": {
       "category": {
-        "backToContents": "Retour à l'édition du contenu",
-        "changeLayout": "Change la mise en page",
+        "changeLayout": "Modifier la mise en page",
+        "contents": "Contenu",
+        "editContents": "Définir le contenu par défaut",
         "layout": "Mise en page"
       },
       "printPreview": "Ouvre l'aperçu avant impression",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -379,6 +379,7 @@
       "category": {
         "changeLayout": "Modifier la mise en page",
         "contents": "Contenu",
+        "createLayoutHelp": "Ici, tu peux définir l'apparence par défaut des nouveaux activités {categoryShort}.{br}Attention : Si tu as déjà des activités {categoryShort} dans le camp, ils ne seront pas automatiquement adaptés.",
         "editContents": "Définir le contenu par défaut",
         "layout": "Mise en page"
       },

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -379,6 +379,7 @@
       "category": {
         "changeLayout": "Cambia il layout",
         "contents": "Contenuti",
+        "createLayoutHelp": "Qui si può definire la forma predefinita delle nuove attività {categoryShort}.{br}Nota: se si dispone già di attività {categoryShort} in campo, questi non verranno adattati automaticamente.",
         "editContents": "Definire il contenuto predefinito",
         "layout": "Layout"
       },

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -377,8 +377,9 @@
   "views": {
     "activity": {
       "category": {
-        "backToContents": "Torna alla modifica dei contenuti",
         "changeLayout": "Cambia il layout",
+        "contents": "Contenuti",
+        "editContents": "Definire il contenuto predefinito",
         "layout": "Layout"
       },
       "printPreview": "Apri l'anteprima di stampa",

--- a/frontend/src/views/activity/Category.vue
+++ b/frontend/src/views/activity/Category.vue
@@ -30,6 +30,15 @@
       <v-card-text class="px-0 py-0">
         <v-skeleton-loader v-if="loading" type="article" />
 
+        <div
+          v-if="!loading && category().rootContentNode().children().items.length === 0"
+          class="text-center blue lighten-4 blue--text py-4 px-2 text--darken-4 create-layout-help"
+        >
+          <i18n path="views.activity.category.createLayoutHelp">
+            <template #categoryShort>{{ category().short }}</template>
+            <template #br><br /></template>
+          </i18n>
+        </div>
         <root-node
           v-if="!loading"
           :content-node="category().rootContentNode()"
@@ -93,4 +102,8 @@ export default {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+.v-application .create-layout-help {
+  border-bottom: 1px solid #90caf9 !important;
+}
+</style>

--- a/frontend/src/views/activity/Category.vue
+++ b/frontend/src/views/activity/Category.vue
@@ -21,10 +21,10 @@
         </v-btn>
         <v-btn v-else color="success" outlined @click="layoutMode = false">
           <template v-if="$vuetify.breakpoint.smAndUp">
-            <v-icon left>mdi-check</v-icon>
-            {{ $tc('views.activity.category.backToContents') }}
+            <v-icon left>mdi-file-document-arrow-right-outline</v-icon>
+            {{ $tc('views.activity.category.editContents') }}
           </template>
-          <template v-else>{{ $tc('global.button.back') }}</template>
+          <template v-else>{{ $tc('views.activity.category.contents') }}</template>
         </v-btn>
       </template>
       <v-card-text class="px-0 py-0">


### PR DESCRIPTION
Several small improvements in the region of categories, which surfaced in a Basis course in spring.

https://github.com/ecamp/ecamp3/assets/7566995/1797180f-297d-4efb-95b1-24052cb4b79a

- Redirects the user to the layout edit page after creating a category, with a toast asking them to define the layout of the new category.
- Improves the button texts so they make sense for category layout editing
- When adding a new column layout to any layout, add two columns by default, so users are less confused
- Hide the preferredContentTypes input for now, it only confuses users in the current form (as discussed with @manuelmeister)