### PR TITLE
Fix off-by-one error which resulted in wrong positioning of schedule entries at day start

### DIFF
--- a/frontend/src/components/print/print-react/components/picasso/DayColumn.jsx
+++ b/frontend/src/components/print/print-react/components/picasso/DayColumn.jsx
@@ -20,12 +20,12 @@ function getWeightsSum(times) {
 
 function percentage(seconds, times) {
   const hours = seconds / 3600.0
-  let matchingTimeIndex = times.findIndex(([time, _]) => time >= hours) - 1
+  let matchingTimeIndex = times.findIndex(([time, _]) => time > hours) - 1
   matchingTimeIndex = Math.min(
     Math.max(matchingTimeIndex === -2 ? times.length : matchingTimeIndex, 0),
     times.length - 1
   )
-  const remainder = hours - times[matchingTimeIndex][0]
+  const remainder = (hours - times[matchingTimeIndex][0]) / times[matchingTimeIndex][1]
   const weightsSum =
     getWeightsSum(times.slice(0, matchingTimeIndex)) +
     remainder * times[Math.min(matchingTimeIndex, times.length)][1]


### PR DESCRIPTION
Before: Notice the earliest schedule entries start at 8:00 AM but are rendered at 7:45 AM
[GRGR-81.pdf](https://github.com/ecamp/ecamp3/files/11856867/GRGR-81.pdf)

After: The schedule entries at day start are now rendered correctly
[GRGR-82.pdf](https://github.com/ecamp/ecamp3/files/11856869/GRGR-82.pdf)



Either of the two changes would fix the noticed problem on their own.

The >= vs > fix is an off-by one error, which caused the percentage algorithm to calculate a remainder which was larger than necessary.

The division change fixes a mistake, due to which the calculated remainder would ignore the local weight scaling.

Due to the first fix, the remainder is now zero in the edge case, and due to the second fix, the remainder is now scaled correctly (but it does not matter anymore in the problematic edge case because then the remainder is zero).