### PR TITLE
chore(frontend): minimize network requests for story overview

### DIFF
--- a/print/components/story/StoryDay.vue
+++ b/print/components/story/StoryDay.vue
@@ -6,7 +6,7 @@
 
     <template v-if="entriesWithStory.length">
       <template v-for="{ scheduleEntry, storyChapters } in entriesWithStory">
-        <div v-for="chapter in storyChapters" :key="chapter._meta.uri" class="tw-mb-3">
+        <div v-for="chapter in storyChapters" :key="chapter._meta.self" class="tw-mb-3">
           <h4 class="tw-text-lg tw-font-bold tw-break-after-avoid">
             <span class="d-inline-flex align-center">
               <span>{{ scheduleEntry.number }}</span>

--- a/print/components/story/StoryPeriod.vue
+++ b/print/components/story/StoryPeriod.vue
@@ -50,7 +50,7 @@ export default {
         .$loadItems(),
       this.period.days().$loadItems(),
       this.period.scheduleEntries().$loadItems(),
-      this.$api.get().contentNodes({ period: this.period._meta.self }).$loadItems(),
+      this.period.camp().categories().$loadItems(),
     ])
 
     this.days = this.period.days().items


### PR DESCRIPTION
Most of the code is copied from nuxt print (where minimizing network requests was already implemented)

On period change, data is always reloaded for days, scheduleEntries & contentNodes. The UI will not wait for this however, stale data is displayed immediately when available.

### Before

https://github.com/ecamp/ecamp3/assets/449555/49d98d85-34df-4324-b09a-a38f64ff7bd8


### After

https://github.com/ecamp/ecamp3/assets/449555/36d7a842-e1a6-4b3e-a715-9ff6d080d534


