### PR TITLE
Do not use v-html

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -409,7 +409,7 @@
         "email": "E-Mail",
         "infoText": {
           "beta": "Dies ist die Beta-Version von eCamp v3. Kann für echte aber nicht zeitkritische Lagerplanung verwendet werden. Die beschränkte Anzahl an Nutzenden der Beta-Version müssen mit Wartungsunterbrüchen rechnen.",
-          "dev": "Dies ist die Entwickler-Version von eCamp v3.<br>WICHTIG: Nur für Entwickler-Gebrauch geeignet. Alle Daten sind öffentlich und werden periodisch gelöscht!<br>Login: test@example.com / test"
+          "dev": "Dies ist die Entwickler-Version von eCamp v3.{br}WICHTIG: Nur für Entwickler-Gebrauch geeignet. Alle Daten sind öffentlich und werden periodisch gelöscht!{br}Login: test@example.com / test"
         },
         "loginCallback": {
           "loginInProgress": "Du wirst eingeloggt"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -409,7 +409,7 @@
         "email": "Email",
         "infoText": {
           "beta": "This is the beta version of eCamp v3. It can be used for real but not time-critical camp planning. The limited number of beta users must expect maintenance interruptions.",
-          "dev": "This is the development version of eCamp v3.<br>IMPORTANT: This is meant for development usage only. All data is public and will be deleted periodically!<br>Login: test@example.com / test"
+          "dev": "This is the development version of eCamp v3.{br}IMPORTANT: This is meant for development usage only. All data is public and will be deleted periodically!{br}Login: test@example.com / test"
         },
         "loginCallback": {
           "loginInProgress": "You will be logged in"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -409,7 +409,7 @@
         "email": "Courriel",
         "infoText": {
           "beta": "Il s'agit de la version bêta d'eCamp v3. Elle peut être utilisée pour une planification réelle du camp, mais pas pour une planification urgente. Le nombre limité d'utilisateurs de la version bêta doit s'attendre à des interruptions de maintenance.",
-          "dev": "Ceci est la version de développement d'eCamp v3.<br>IMPORTANT : Ceci est destiné à un usage de développement uniquement. Toutes les données sont publiques et seront supprimées périodiquement !<br>Login : test@example.com / test"
+          "dev": "Ceci est la version de développement d'eCamp v3.{br}IMPORTANT : Ceci est destiné à un usage de développement uniquement. Toutes les données sont publiques et seront supprimées périodiquement !{br}Login : test@example.com / test"
         },
         "loginCallback": {
           "loginInProgress": "Vous serez connecté"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -409,7 +409,7 @@
         "email": "Indirizzo e-mail",
         "infoText": {
           "beta": "Questa è la versione beta di eCamp v3, che può essere utilizzata per la pianificazione di un campo reale, ma non per la pianificazione del tempo. Il numero limitato di utenti della versione beta deve aspettarsi interruzioni della manutenzione.",
-          "dev": "Questa è la versione di sviluppo di eCamp v3.<br>IMPORTANTE: è destinata esclusivamente all'uso per lo sviluppo. Tutti i dati sono pubblici e verranno cancellati periodicamente!<br>Login: test@example.com / test"
+          "dev": "Questa è la versione di sviluppo di eCamp v3.{br}IMPORTANTE: è destinata esclusivamente all'uso per lo sviluppo. Tutti i dati sono pubblici e verranno cancellati periodicamente!{br}Login: test@example.com / test"
         },
         "loginCallback": {
           "loginInProgress": "Sarai loggato"

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -12,7 +12,7 @@
     >
       <div>
         <i18n :path="infoTextKey">
-          <template #br><br class="linebreak" /></template>
+          <template #br><br /></template>
         </i18n>
       </div>
     </v-alert>

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -10,8 +10,11 @@
       style="hypens: auto"
       color="warning"
     >
-      <!-- eslint-disable-next-line vue/no-v-html -->
-      <div v-html="$tc(infoTextKey)" />
+      <div>
+        <i18n :path="infoTextKey">
+          <template #br><br class="linebreak" /></template>
+        </i18n>
+      </div>
     </v-alert>
     <v-alert v-if="error" outlined text border="left" type="error">
       {{ error }}


### PR DESCRIPTION
It may seem harmless for now in this instance. But we never know what we do in the future with this, and we shouldn't introduce examples of bad practices which future developers could copy and use in different, less safe ways.

(The only occurrence remaining now is in nuxt print where we use v-html to render rich text fields. That usage is way more unsafe than the login page usage, because we're passing user input into v-html there. We should replace that with a read-only tiptap editor as mentioned in #1241)