### PR TITLE
Add metrics port to api service

### DIFF
--- a/.helm/deploy-to-cluster.sh
+++ b/.helm/deploy-to-cluster.sh
@@ -56,9 +56,14 @@ for i in 1; do
   values="$values --set deployedVersion=\"$(git rev-parse --short HEAD)\""
   values="$values --set featureToggle.developer=true"
 
-  for imagespec in "frontend" "php" "caddy" "print"; do
+  for imagespec in "frontend" "print"; do
     values="$values --set $imagespec.image.pullPolicy=$pull_policy"
     values="$values --set $imagespec.image.repository=docker.io/${docker_hub_account}/ecamp3-$imagespec"
+  done
+
+  for imagespec in "php" "caddy"; do
+    values="$values --set $imagespec.image.pullPolicy=$pull_policy"
+    values="$values --set $imagespec.image.repository=docker.io/${docker_hub_account}/ecamp3-api-$imagespec"
   done
 
   helm uninstall ecamp3-"$instance_name"-"$i" || true

--- a/.helm/ecamp3/templates/api_deployment.yaml
+++ b/.helm/ecamp3/templates/api_deployment.yaml
@@ -51,7 +51,10 @@ spec:
                   key: mercure-jwt-secret
           ports:
             - name: api-http
-              containerPort: 3001
+              containerPort: {{ .Values.api.service.port }}
+              protocol: TCP
+            - name: api-metrics
+              containerPort: {{ .Values.api.metrics.port }}
               protocol: TCP
           volumeMounts:
             - mountPath: /var/run/php

--- a/.helm/ecamp3/templates/api_service.yaml
+++ b/.helm/ecamp3/templates/api_service.yaml
@@ -12,5 +12,9 @@ spec:
       targetPort: api-http
       protocol: TCP
       name: api-http
+    - port: {{ .Values.api.metrics.port }}
+      targetPort: api-metrics
+      protocol: TCP
+      name: api-metrics
   selector:
     {{- include "api.selectorLabels" . | nindent 4 }}

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -19,6 +19,8 @@ api:
   service:
     type: ClusterIP
     port: 3001
+  metrics:
+    port: 2019
   # If you use Mercure, you need the managed or the On Premise version to deploy more than one pod: https://mercure.rocks/docs/hub/cluster
   replicaCount: 1
 

--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -3,9 +3,10 @@
 	{$CADDY_DEBUG}
 
 	auto_https disable_redirects
-	# make it possible to connect from host to admin endpoint inside container
+	# make it possible to connect from remote host to admin endpoint
 	# https://caddyserver.com/docs/caddyfile/options#admin
-	# https://caddy.community/t/question-on-admin-api-from-a-docker-container/8724/11
+	# note, restricting to specific origins is not possible with the wildcard interface
+	# due to https://github.com/caddyserver/caddy/commit/f5ccb904a3db2bffd980feee685afaa762224cb2
 	admin 0.0.0.0:2019
 	# enable Prometheus metrics endpoint https://caddyserver.com/docs/metrics
 	servers {

--- a/api/docker/caddy/Caddyfile.prod
+++ b/api/docker/caddy/Caddyfile.prod
@@ -5,6 +5,11 @@
 	http_port 3001
 	https_port 3443
 	auto_https off
+	# make it possible to connect from remote host to admin endpoint
+	# https://caddyserver.com/docs/caddyfile/options#admin
+	# note, restricting to specific origins is not possible with the wildcard interface
+	# due to https://github.com/caddyserver/caddy/commit/f5ccb904a3db2bffd980feee685afaa762224cb2
+	admin 0.0.0.0:2019
 	# enable Prometheus metrics endpoint https://caddyserver.com/docs/metrics
 	servers {
 		metrics


### PR DESCRIPTION
- Fix `deploy-to-cluster.sh` script (image names include `api`)
- Listen to wildcard network interfaces in prod Caddy admin endpoint
  - needed to allow Prometheus to fetch` /metrics` endpoint for scraping
  - no ingress on metrics port, so accessing admin from outside the cluster is not possible
- Add metrics port to `api_service`