### PR TITLE
Period: do not fetch ContentNodes

### DIFF
--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -249,20 +249,15 @@ class Period extends BaseEntity implements BelongsToCampInterface {
     /**
      * All the content nodes used in some activity which is carried out (has a schedule entry) in this period.
      *
+     * The list is anyway replaced by a RelatedCollectionLink, thus we don't need to fetch the data now.
+     *
      * @return ContentNode[]
      */
     #[ApiProperty(writable: false, example: '["/content_nodes/1a2b3c4d"]')]
     #[RelatedCollectionLink(ContentNode::class, ['period' => '$this'])]
     #[Groups(['read'])]
     public function getContentNodes(): array {
-        $listOfDescendantLists = array_map(
-            function (ScheduleEntry $scheduleEntry) {
-                return $scheduleEntry->activity->getRootContentNode()->getRootDescendants();
-            },
-            $this->getScheduleEntries()
-        );
-
-        return array_values(array_unique(array_merge(...array_values($listOfDescendantLists)), SORT_REGULAR));
+        return [];
     }
 
     /**

--- a/api/tests/Entity/PeriodTest.php
+++ b/api/tests/Entity/PeriodTest.php
@@ -2,13 +2,9 @@
 
 namespace App\Tests\Entity;
 
-use App\Entity\Activity;
 use App\Entity\Camp;
-use App\Entity\ContentNode\ColumnLayout;
-use App\Entity\ContentNode\SingleText;
 use App\Entity\Day;
 use App\Entity\Period;
-use App\Entity\ScheduleEntry;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -35,41 +31,5 @@ class PeriodTest extends TestCase {
 
         $this->assertEquals(3, $period1->getFirstDayNumber());
         $this->assertEquals(1, $period2->getFirstDayNumber());
-    }
-
-    public function testGetContentNodes() {
-        $camp = new Camp();
-
-        $period = new Period();
-        $period->start = new \DateTime('2020-09-14');
-        $camp->addPeriod($period);
-        $scheduleEntry1 = new ScheduleEntry();
-        $scheduleEntry2 = new ScheduleEntry();
-        $scheduleEntry3 = new ScheduleEntry();
-        $period->addScheduleEntry($scheduleEntry1);
-        $period->addScheduleEntry($scheduleEntry2);
-        $period->addScheduleEntry($scheduleEntry3);
-
-        $activity1 = new Activity();
-        $columnLayout1 = new ColumnLayout();
-        $singleText1 = new SingleText();
-        $columnLayout1->addRootDescendant($singleText1);
-        $columnLayout1->addChild($singleText1);
-        $activity1->setRootContentNode($columnLayout1);
-        $scheduleEntry1->activity = $activity1;
-        $scheduleEntry2->activity = $activity1;
-
-        $activity2 = new Activity();
-        $columnLayout2 = new ColumnLayout();
-        $singleText2 = new SingleText();
-        $columnLayout2->addRootDescendant($singleText2);
-        $columnLayout2->addChild($singleText2);
-        $activity2->setRootContentNode($columnLayout2);
-        $scheduleEntry3->activity = $activity2;
-
-        $this->assertEquals(
-            [$singleText1, $columnLayout1, $singleText2, $columnLayout2],
-            $period->getContentNodes()
-        );
     }
 }


### PR DESCRIPTION
Else the Get endpoint of camp executes a lot of additonal queries to fetch the ContentNodes.
This breaks the json-ld support for this endpoint. (See #2829)

Issue: #3539