### PR TITLE
Propose same activity name and category as the last time

### DIFF
--- a/frontend/src/components/program/DialogActivityCreate.vue
+++ b/frontend/src/components/program/DialogActivityCreate.vue
@@ -50,7 +50,7 @@ export default {
     showDialog: function (showDialog) {
       if (showDialog) {
         this.setEntityData({
-          title: this.$tc('entity.activity.new'),
+          title: this.entityData?.title || this.$tc('entity.activity.new'),
           location: '',
           scheduleEntries: [
             {
@@ -63,8 +63,9 @@ export default {
           ],
         })
       } else {
-        // clear form on exit
-        this.clearEntityData()
+        // clear the variable parts of the form on exit
+        this.entityData.location = ''
+        this.entityData.scheduleEntries = []
       }
     },
   },


### PR DESCRIPTION
Might make the life of camp leaders a little easier, if they add many activities with the same category in a row.
People who instead add many activities with mixed categories do not have more work after this PR than before.