### PR TITLE
Fix console warning

### DIFF
--- a/frontend/src/mixins/campRoleMixin.js
+++ b/frontend/src/mixins/campRoleMixin.js
@@ -18,7 +18,7 @@ export const campRoleMixin = {
         .filter((coll) => typeof coll.user === 'function')
         .find((coll) => coll.user()._meta.self === currentUserLink)
 
-      if (result._meta.loading) return null
+      if (result?._meta.loading) return null
       return result?.role
     },
     _campCollaborations() {


### PR DESCRIPTION
https://ecamp.sentry.io/issues/4272728921/events/a9f1395b78e247398a7ee2fba2b6a961/

`result` may sometimes be undefined here for some reason. One reason is being an admin and visiting a camp template in which one does not have a campCollaboration. But this morning it also happened to a normal user in a real camp. Not sure what the problem was there, but this should make it safer.