### PR TITLE
fix(frontend): UI fixes for sm (small) size devices

### DIFF
--- a/frontend/src/components/layout/ContentCard.vue
+++ b/frontend/src/components/layout/ContentCard.vue
@@ -10,14 +10,14 @@ Displays the content wrapped inside a card.
     class="mx-auto"
   >
     <v-toolbar
-      v-if="back || $vuetify.breakpoint.xsOnly || toolbar"
+      v-if="back || !$vuetify.breakpoint.mdAndUp || toolbar"
       class="ec-content-card__toolbar"
       elevation="0"
       dense
     >
       <v-toolbar-items>
         <button-back
-          v-if="back || ($vuetify.breakpoint.xsOnly && !!$route.query.isDetail)"
+          v-if="back || (!$vuetify.breakpoint.mdAndUp && !!$route.query.isDetail)"
           class="ml-n4"
         />
       </v-toolbar-items>

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -59,7 +59,7 @@
             {{ $tc('global.lokaliseMessage') }}
           </p>
           <v-btn
-            v-if="$vuetify.breakpoint.xsOnly"
+            v-if="!$vuetify.breakpoint.mdAndUp"
             color="red"
             block
             large

--- a/frontend/src/views/camp/Admin.vue
+++ b/frontend/src/views/camp/Admin.vue
@@ -13,7 +13,7 @@ Admin screen of a camp: Displays details & periods of a single camp and allows t
           <camp-conditional-fields :camp="camp" :disabled="!isManager" />
 
           <v-btn
-            v-if="$vuetify.breakpoint.xsOnly"
+            v-if="!$vuetify.breakpoint.mdAndUp"
             :to="{ name: 'camp/collaborators', query: { isDetail: true } }"
           >
             {{ $tc('views.camp.admin.collaborators') }}


### PR DESCRIPTION
Our desktop NavTopbar is displayed for viewports mdAndUp.

For sm and xs we rely on mobile navigation. In a few instances, we displayed navigational elements for xsOnly, leaving sm in the limbo.

This PR enables these elements also for sm. No other visual changes.