### PR TITLE
chore: add filter to query for all dayResponsibles of a period

### DIFF
--- a/api/src/Entity/DayResponsible.php
+++ b/api/src/Entity/DayResponsible.php
@@ -38,7 +38,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     denormalizationContext: ['groups' => ['write']],
     normalizationContext: ['groups' => ['read']]
 )]
-#[ApiFilter(filterClass: SearchFilter::class, properties: ['day'])]
+#[ApiFilter(filterClass: SearchFilter::class, properties: ['day', 'day.period'])]
 #[UniqueEntity(
     fields: ['campCollaboration', 'day'],
     message: 'This campCollaboration (user) is already responsible for this day.',

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -261,6 +261,19 @@ class Period extends BaseEntity implements BelongsToCampInterface {
     }
 
     /**
+     * A link to all the DayResponsibles in this period.
+     * The list is anyway replaced by a RelatedCollectionLink, thus we don't need to fetch the data now.
+     *
+     * @return DayResponsible[]
+     */
+    #[ApiProperty(writable: false, example: '["/day_responsibles/1a2b3c4d"]')]
+    #[RelatedCollectionLink(DayResponsible::class, ['day.period' => '$this'])]
+    #[Groups(['read'])]
+    public function getDayResponsibles(): array {
+        return [];
+    }
+
+    /**
      * @return MaterialItem[]
      */
     #[ApiProperty(writable: false, example: '["/material_items/1a2b3c4d"]')]

--- a/api/tests/Api/Periods/ReadPeriodTest.php
+++ b/api/tests/Api/Periods/ReadPeriodTest.php
@@ -64,6 +64,8 @@ class ReadPeriodTest extends ECampApiTestCase {
                 'materialItems' => ['href' => '/material_items?period=%2Fperiods%2F'.$period->getId()],
                 'days' => ['href' => '/days?period=%2Fperiods%2F'.$period->getId()],
                 'scheduleEntries' => ['href' => '/schedule_entries?period=%2Fperiods%2F'.$period->getId()],
+                'contentNodes' => ['href' => '/content_nodes?period=%2Fperiods%2F'.$period->getId()],
+                'dayResponsibles' => ['href' => '/day_responsibles?day.period=%2Fperiods%2F'.$period->getId()],
             ],
         ]);
     }

--- a/common/helpers/__tests__/dayResponsibles.spec.js
+++ b/common/helpers/__tests__/dayResponsibles.spec.js
@@ -1,46 +1,82 @@
-import { dayResponsiblesCommaSeparated } from '../dayResponsibles'
+import {
+  dayResponsiblesCommaSeparated,
+  filterDayResponsiblesByDay,
+} from '../dayResponsibles'
 
-describe('dayResponsibles', () => {
-  it('resolves camp collaboration with and without user', () => {
-    expect(
-      dayResponsiblesCommaSeparated(
+const dayWith2Responsibles = {
+  _meta: {
+    self: '/day/1',
+  },
+  period: () => ({
+    dayResponsibles: () => ({
+      items: [
         {
-          dayResponsibles: () => ({
-            items: [
-              {
-                campCollaboration: () => ({
-                  inviteEmail: 'test@example.com',
-                }),
-              },
-              {
-                campCollaboration: () => ({
-                  user: () => ({
-                    displayName: 'dummyUser',
-                  }),
-                }),
-              },
-            ],
+          campCollaboration: () => ({
+            inviteEmail: 'test@example.com',
+          }),
+          day: () => ({
+            _meta: { self: '/day/1' },
           }),
         },
-        null
-      )
-    ).toEqual('test@example.com, dummyUser')
+        {
+          campCollaboration: () => ({
+            user: () => ({
+              displayName: 'dummyUser',
+            }),
+          }),
+          day: () => ({
+            _meta: { self: '/day/1' },
+          }),
+        },
+        {
+          campCollaboration: () => ({
+            user: () => ({
+              displayName: 'responsibleUserOnAnotherDay',
+            }),
+          }),
+          day: () => ({
+            _meta: { self: '/day/2' },
+          }),
+        },
+      ],
+    }),
+  }),
+}
+
+const dayWithoutResponsibles = {
+  period: () => ({
+    dayResponsibles: () => ({
+      items: [],
+    }),
+  }),
+}
+
+describe('dayResponsiblesCommaSeparated', () => {
+  it('resolves camp collaboration with and without user', () => {
+    expect(dayResponsiblesCommaSeparated(dayWith2Responsibles, null)).toEqual(
+      'test@example.com, dummyUser'
+    )
   })
 
-  it('return empty string if no resonsibles', () => {
-    expect(
-      dayResponsiblesCommaSeparated(
-        {
-          dayResponsibles: () => ({
-            items: [],
-          }),
-        },
-        null
-      )
-    ).toEqual('')
+  it('return empty string if no responsibles', () => {
+    expect(dayResponsiblesCommaSeparated(dayWithoutResponsibles, null)).toEqual('')
   })
 
   it('return empty string for null object', () => {
     expect(dayResponsiblesCommaSeparated(null, null)).toEqual('')
+  })
+})
+
+describe('filterDayResponsiblesByDay', () => {
+  it('resolves camp collaboration with and without user', () => {
+    expect(filterDayResponsiblesByDay(dayWith2Responsibles).length).toEqual(2)
+  })
+
+  it('return empty string if no responsibles', () => {
+    expect(filterDayResponsiblesByDay(dayWithoutResponsibles)).toEqual([])
+  })
+
+  it('return empty string for null object', () => {
+    expect(filterDayResponsiblesByDay(null)).toEqual([])
   })
 })

--- a/common/helpers/dayResponsibles.js
+++ b/common/helpers/dayResponsibles.js
@@ -1,14 +1,26 @@
 import campCollaborationDisplayName from './campCollaborationDisplayName.js'
 
+/**
+ * Local filtering of dayResponsibles by day
+ * (avoids separate network request for each day)
+ */
+const filterDayResponsiblesByDay = (day) => {
+  if (!day) return []
+
+  return day
+    .period()
+    .dayResponsibles()
+    .items.filter((dayResponsible) => dayResponsible.day()._meta.self === day._meta.self)
+}
+
 const dayResponsiblesCommaSeparated = (day, tc) => {
   if (!day) return ''
 
-  return day
-    .dayResponsibles()
-    .items.map((dayResponsible) =>
+  return filterDayResponsiblesByDay(day)
+    .map((dayResponsible) =>
       campCollaborationDisplayName(dayResponsible.campCollaboration(), tc)
     )
     .join(', ')
 }
 
-export { dayResponsiblesCommaSeparated }
+export { filterDayResponsiblesByDay, dayResponsiblesCommaSeparated }

--- a/frontend/src/components/print/print-react/components/picasso/DayHeader.jsx
+++ b/frontend/src/components/print/print-react/components/picasso/DayHeader.jsx
@@ -3,21 +3,19 @@ import React from 'react'
 import { Text, View } from '@react-pdf/renderer'
 import dayjs from '@/common/helpers/dayjs.js'
 import picassoStyles from './picassoStyles.js'
-import campCollaborationDisplayName from '../../../../../common/helpers/campCollaborationDisplayName.js'
+import {
+  dayResponsiblesCommaSeparated,
+  filterDayResponsiblesByDay,
+} from '../../../../../common/helpers/dayResponsibles.js'
 
 function renderDate(day) {
   return dayjs.utc(day.start).hour(0).minute(0).second(0).format('ddd LL')
 }
 
 function dayResponsibles(day, $tc) {
-  const responsibles = day.dayResponsibles().items
-  if (responsibles.length === 0) return ''
+  if (filterDayResponsiblesByDay(day).length === 0) return ''
   const label = $tc('entity.day.fields.dayResponsibles')
-  const displayNames = responsibles
-    .map((responsible) =>
-      campCollaborationDisplayName(responsible.campCollaboration(), $tc)
-    )
-    .join(', ')
+  const displayNames = dayResponsiblesCommaSeparated(day, $tc)
   return `${label}: ${displayNames}`
 }
 

--- a/frontend/src/components/print/print-react/components/picasso/PicassoPage.jsx
+++ b/frontend/src/components/print/print-react/components/picasso/PicassoPage.jsx
@@ -10,6 +10,7 @@ import DayHeader from './DayHeader.jsx'
 import PicassoFooter from './PicassoFooter.jsx'
 import YSLogo from './YSLogo.jsx'
 import Categories from './Categories.jsx'
+import { filterDayResponsiblesByDay } from '../../../../../common/helpers/dayResponsibles.js'
 
 /**
  * Generates an array of time row descriptions, used for labeling the vertical axis of the picasso.
@@ -38,7 +39,9 @@ function PicassoPage(props) {
   const period = props.period
   const days = props.days
   const orientation = props.content.options.orientation
-  const anyDayResponsibles = days.some((day) => day.dayResponsibles().items.length > 0)
+  const anyDayResponsibles = days.some(
+    (day) => filterDayResponsiblesByDay(day).length > 0
+  )
   const scheduleEntries = period.scheduleEntries().items
   const times = generateTimes({
     getUpTime: props.getUpTime,

--- a/frontend/src/components/print/print-react/documents/campPrint/index.js
+++ b/frontend/src/components/print/print-react/documents/campPrint/index.js
@@ -35,14 +35,8 @@ const picassoData = (config) => {
             return Promise.all([
               period.scheduleEntries().$loadItems(),
               period.contentNodes().$loadItems(),
-              period
-                .days()
-                .$loadItems()
-                .then((days) => {
-                  return Promise.all(
-                    days.items.map((day) => day.dayResponsibles().$loadItems())
-                  )
-                }),
+              period.days().$loadItems(),
+              period.dayResponsibles().$loadItems(),
             ])
           })
         )

--- a/print/components/PicassoChunk.vue
+++ b/print/components/PicassoChunk.vue
@@ -126,7 +126,10 @@
 
 <script>
 import { activityResponsiblesCommaSeparated } from '@/../common/helpers/activityResponsibles.js'
-import { dayResponsiblesCommaSeparated } from '@/../common/helpers/dayResponsibles.js'
+import {
+  dayResponsiblesCommaSeparated,
+  filterDayResponsiblesByDay,
+} from '@/../common/helpers/dayResponsibles.js'
 import { contrastColor } from '@/../common/helpers/colors.js'
 import CategoryLabel from './generic/CategoryLabel.vue'
 import dayjs from '@/../common/helpers/dayjs.js'
@@ -225,7 +228,7 @@ export default {
     hasDayResponsibles(date) {
       const day = this.getDayByDate(date)
       if (!day) return false
-      return day.dayResponsibles().items.length > 0
+      return filterDayResponsiblesByDay(day).length > 0
     },
 
     getDayByDate(date) {

--- a/print/components/PicassoPeriod.vue
+++ b/print/components/PicassoPeriod.vue
@@ -58,26 +58,18 @@ export default {
           )
         }),
       this.camp.categories().$loadItems(),
+      this.period.days().$loadItems(),
       this.period
-        .days()
+        .dayResponsibles()
         .$loadItems()
-        .then((days) => {
+        .then((dayResponsibles) => {
           return Promise.all(
-            days.items.map((day) =>
-              day
-                .dayResponsibles()
-                .$loadItems()
-                .then((dayResponsibles) => {
-                  return Promise.all(
-                    dayResponsibles.items.map((dayResponsible) => {
-                      if (dayResponsible.campCollaboration().user === null) {
-                        return Promise.resolve(null)
-                      }
-                      return dayResponsible.campCollaboration().user()._meta.load
-                    })
-                  )
-                })
-            )
+            dayResponsibles.items.map((dayResponsible) => {
+              if (dayResponsible.campCollaboration().user === null) {
+                return Promise.resolve(null)
+              }
+              return dayResponsible.campCollaboration().user()._meta.load
+            })
           )
         }),
     ])


### PR DESCRIPTION
This avoids the need for a separate network request for each day, to load it's day responsibles. 

For printing, this is the last item, where the number of requests scales with the actual data. For all the rest, network requests are only executed once per camp or once per period.

Implemented in backend and "frontend-side" for both prints.

Haven't done it for the actual frontend-picasso: this is a bit more complex, because we also write on the day.dayResponsible() collection