### PR TITLE
Fix division by zero in camps with multi-day schedule entries

### DIFF
--- a/frontend/src/components/print/print-react/components/picasso/DayColumn.jsx
+++ b/frontend/src/components/print/print-react/components/picasso/DayColumn.jsx
@@ -25,7 +25,10 @@ function percentage(seconds, times) {
     Math.max(matchingTimeIndex === -2 ? times.length : matchingTimeIndex, 0),
     times.length - 1
   )
-  const remainder = (hours - times[matchingTimeIndex][0]) / times[matchingTimeIndex][1]
+  const remainder =
+    times[matchingTimeIndex][1] !== 0
+      ? (hours - times[matchingTimeIndex][0]) / times[matchingTimeIndex][1]
+      : 0 // avoid division by zero, in case the schedule entry ends on a later day
   const weightsSum =
     getWeightsSum(times.slice(0, matchingTimeIndex)) +
     remainder * times[Math.min(matchingTimeIndex, times.length)][1]


### PR DESCRIPTION
A division by zero was introduced in #3542. It happens in camps where a schedule entry starts on one day and ends on a later day (e.g. a multi-day hike). The bug prevents the React PDF to be printed when it includes a Picasso.

Since this could affect quite a few (summer) camps, I'd like to release this as soon as possible, i.e. this week.

Fixes https://ecamp.sentry.io/issues/4274228383/