### PR TITLE
UnitTest testSqlQueryCount for GetEntity and GetCollection

### DIFF
--- a/api/tests/Api/Activities/ListActivitiesTest.php
+++ b/api/tests/Api/Activities/ListActivitiesTest.php
@@ -88,4 +88,12 @@ class ListActivitiesTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('activity1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/activities');
+
+        $this->assertSqlQueryCount($client, 19);
+    }
 }

--- a/api/tests/Api/Activities/ReadActivityTest.php
+++ b/api/tests/Api/Activities/ReadActivityTest.php
@@ -132,4 +132,15 @@ class ReadActivityTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var Activity $activity */
+        $activity = static::$fixtures['activity1'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/activities/'.$activity->getId());
+
+        $this->assertSqlQueryCount($client, 29);
+    }
 }

--- a/api/tests/Api/ActivityProgressLabel/ListActivityProgressLabelTest.php
+++ b/api/tests/Api/ActivityProgressLabel/ListActivityProgressLabelTest.php
@@ -76,4 +76,12 @@ class ListActivityProgressLabelTest extends ECampApiTestCase {
         $this->assertJsonContains(['totalItems' => 0]);
         $this->assertArrayNotHasKey('items', $response->toArray()['_links']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/activity_progress_labels');
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }

--- a/api/tests/Api/ActivityProgressLabel/ReadActivityProgressLabelTest.php
+++ b/api/tests/Api/ActivityProgressLabel/ReadActivityProgressLabelTest.php
@@ -92,4 +92,15 @@ class ReadActivityProgressLabelTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var ActivityProgressLabel $activityProgressLabel */
+        $activityProgressLabel = static::$fixtures['activityProgressLabel1'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/activity_progress_labels/'.$activityProgressLabel->getId());
+
+        $this->assertSqlQueryCount($client, 5);
+    }
 }

--- a/api/tests/Api/ActivityResponsibles/ListActivityResponsiblesTest.php
+++ b/api/tests/Api/ActivityResponsibles/ListActivityResponsiblesTest.php
@@ -135,4 +135,12 @@ class ListActivityResponsiblesTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('activityResponsible1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/activity_responsibles');
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }

--- a/api/tests/Api/ActivityResponsibles/ReadActivityResponsibleTest.php
+++ b/api/tests/Api/ActivityResponsibles/ReadActivityResponsibleTest.php
@@ -105,4 +105,15 @@ class ReadActivityResponsibleTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var ActivityResponsible $activityResponsible */
+        $activityResponsible = static::$fixtures['activityResponsible1campPrototype'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/activity_responsibles/'.$activityResponsible->getId());
+
+        $this->assertSqlQueryCount($client, 6);
+    }
 }

--- a/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
+++ b/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
@@ -108,4 +108,12 @@ class ListCampCollaborationsTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('campCollaboration1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/camp_collaborations');
+
+        $this->assertSqlQueryCount($client, 23);
+    }
 }

--- a/api/tests/Api/CampCollaborations/ReadCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/ReadCampCollaborationTest.php
@@ -117,4 +117,15 @@ class ReadCampCollaborationTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::$fixtures['campCollaboration1manager'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/camp_collaborations/'.$campCollaboration->getId());
+
+        $this->assertSqlQueryCount($client, 13);
+    }
 }

--- a/api/tests/Api/Camps/ListCampsTest.php
+++ b/api/tests/Api/Camps/ListCampsTest.php
@@ -71,4 +71,12 @@ class ListCampsTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/camps');
+
+        $this->assertSqlQueryCount($client, 27);
+    }
 }

--- a/api/tests/Api/Camps/ReadCampTest.php
+++ b/api/tests/Api/Camps/ReadCampTest.php
@@ -211,4 +211,15 @@ class ReadCampTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var Camp $camp */
+        $camp = static::$fixtures['camp1'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/camps/'.$camp->getId());
+
+        $this->assertSqlQueryCount($client, 26);
+    }
 }

--- a/api/tests/Api/Categories/ListCategoriesTest.php
+++ b/api/tests/Api/Categories/ListCategoriesTest.php
@@ -96,4 +96,12 @@ class ListCategoriesTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('category1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/categories');
+
+        $this->assertSqlQueryCount($client, 9);
+    }
 }

--- a/api/tests/Api/Categories/ReadCategoryTest.php
+++ b/api/tests/Api/Categories/ReadCategoryTest.php
@@ -128,4 +128,15 @@ class ReadCategoryTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var Category $category */
+        $category = static::$fixtures['category1'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/categories/'.$category->getId());
+
+        $this->assertSqlQueryCount($client, 7);
+    }
 }

--- a/api/tests/Api/ContentTypes/ListContentTypesTest.php
+++ b/api/tests/Api/ContentTypes/ListContentTypesTest.php
@@ -38,4 +38,12 @@ class ListContentTypesTest extends ECampApiTestCase {
         ]);
         $this->assertCount(7, $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/content_types');
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }

--- a/api/tests/Api/ContentTypes/ReadContentTypeTest.php
+++ b/api/tests/Api/ContentTypes/ReadContentTypeTest.php
@@ -42,4 +42,15 @@ class ReadContentTypeTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var ContentType $contentType */
+        $contentType = static::$fixtures['contentTypeSafetyConcept'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/content_types/'.$contentType->getId());
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }

--- a/api/tests/Api/DayResponsibles/ListDayResponsiblesTest.php
+++ b/api/tests/Api/DayResponsibles/ListDayResponsiblesTest.php
@@ -101,4 +101,12 @@ class ListDayResponsiblesTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('dayResponsible1day1period1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/day_responsibles');
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }

--- a/api/tests/Api/DayResponsibles/ReadDayResponsibleTest.php
+++ b/api/tests/Api/DayResponsibles/ReadDayResponsibleTest.php
@@ -105,4 +105,15 @@ class ReadDayResponsibleTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var DayResponsible $dayResponsible */
+        $dayResponsible = static::$fixtures['dayResponsible1'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/day_responsibles/'.$dayResponsible->getId());
+
+        $this->assertSqlQueryCount($client, 7);
+    }
 }

--- a/api/tests/Api/Days/ListDaysTest.php
+++ b/api/tests/Api/Days/ListDaysTest.php
@@ -122,4 +122,12 @@ class ListDaysTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('day1period1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/days');
+
+        $this->assertSqlQueryCount($client, 15);
+    }
 }

--- a/api/tests/Api/Days/ReadDayTest.php
+++ b/api/tests/Api/Days/ReadDayTest.php
@@ -165,4 +165,15 @@ class ReadDayTest extends ECampApiTestCase {
             'end' => '2023-05-02T00:00:00+00:00',
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var Day $day */
+        $day = static::$fixtures['day1period1'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/days/'.$day->getId());
+
+        $this->assertSqlQueryCount($client, 9);
+    }
 }

--- a/api/tests/Api/ECampApiTestCase.php
+++ b/api/tests/Api/ECampApiTestCase.php
@@ -16,6 +16,7 @@ use App\Entity\Profile;
 use App\Entity\User;
 use App\Metadata\Resource\OperationHelper;
 use App\Repository\ProfileRepository;
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use Doctrine\ORM\EntityManagerInterface;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use Symfony\Component\BrowserKit\Cookie;
@@ -296,5 +297,16 @@ abstract class ECampApiTestCase extends ApiTestCase {
 
         $this->assertEquals($propertyName, $responseArray['violations'][0]['propertyPath']);
         $this->assertStringStartsWith('Provided JSON doesn\'t match required schema', $responseArray['violations'][0]['message']);
+    }
+
+    /**
+     * Validates the number of executed SqlQueries.
+     * requieres $client->enableProfiler().
+     */
+    protected function assertSqlQueryCount(Client $client, int $expected) {
+        /** @var DoctrineDataCollector $collector */
+        $collector = $client->getProfile()->getCollector('db');
+
+        $this->assertEquals($expected, $collector->getQueryCount());
     }
 }

--- a/api/tests/Api/MaterialItems/ListMaterialItemsTest.php
+++ b/api/tests/Api/MaterialItems/ListMaterialItemsTest.php
@@ -164,4 +164,12 @@ class ListMaterialItemsTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('materialItem1period1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/material_items');
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }

--- a/api/tests/Api/MaterialItems/ReadMaterialItemTest.php
+++ b/api/tests/Api/MaterialItems/ReadMaterialItemTest.php
@@ -121,4 +121,15 @@ class ReadMaterialItemTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var MaterialItem $materialItem */
+        $materialItem = static::$fixtures['materialItem1'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/material_items/'.$materialItem->getId());
+
+        $this->assertSqlQueryCount($client, 6);
+    }
 }

--- a/api/tests/Api/MaterialLists/ListMaterialListsTest.php
+++ b/api/tests/Api/MaterialLists/ListMaterialListsTest.php
@@ -102,4 +102,12 @@ class ListMaterialListsTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('materialList1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/material_lists');
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }

--- a/api/tests/Api/MaterialLists/ReadMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/ReadMaterialListTest.php
@@ -109,4 +109,15 @@ class ReadMaterialListTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var MaterialList $materialList */
+        $materialList = static::$fixtures['materialList1'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/material_lists/'.$materialList->getId());
+
+        $this->assertSqlQueryCount($client, 5);
+    }
 }

--- a/api/tests/Api/Periods/ListPeriodsTest.php
+++ b/api/tests/Api/Periods/ListPeriodsTest.php
@@ -94,4 +94,12 @@ class ListPeriodsTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('period1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/periods');
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }

--- a/api/tests/Api/Periods/ReadPeriodTest.php
+++ b/api/tests/Api/Periods/ReadPeriodTest.php
@@ -131,4 +131,15 @@ class ReadPeriodTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var Period $period */
+        $period = static::$fixtures['period1'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/periods/'.$period->getId());
+
+        $this->assertSqlQueryCount($client, 17);
+    }
 }

--- a/api/tests/Api/Profiles/ListProfilesTest.php
+++ b/api/tests/Api/Profiles/ListProfilesTest.php
@@ -111,4 +111,12 @@ class ListProfilesTest extends ECampApiTestCase {
         $this->assertJsonContains(['totalItems' => 0]);
         $this->assertArrayNotHasKey('items', $response->toArray()['_links']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/profiles');
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }

--- a/api/tests/Api/Profiles/ReadProfileTest.php
+++ b/api/tests/Api/Profiles/ReadProfileTest.php
@@ -94,4 +94,15 @@ class ReadProfileTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var Profile $profile */
+        $profile = static::$fixtures['profile2member'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/profiles/'.$profile->getId());
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }

--- a/api/tests/Api/ScheduleEntries/ListScheduleEntriesTest.php
+++ b/api/tests/Api/ScheduleEntries/ListScheduleEntriesTest.php
@@ -375,4 +375,12 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('scheduleEntry2period1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/schedule_entries');
+
+        $this->assertSqlQueryCount($client, 21);
+    }
 }

--- a/api/tests/Api/ScheduleEntries/ReadScheduleEntryTest.php
+++ b/api/tests/Api/ScheduleEntries/ReadScheduleEntryTest.php
@@ -142,4 +142,15 @@ class ReadScheduleEntryTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var ScheduleEntry $scheduleEntry */
+        $scheduleEntry = static::$fixtures['scheduleEntry1'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/schedule_entries/'.$scheduleEntry->getId());
+
+        $this->assertSqlQueryCount($client, 17);
+    }
 }

--- a/api/tests/Api/Users/ListUsersTest.php
+++ b/api/tests/Api/Users/ListUsersTest.php
@@ -21,4 +21,12 @@ class ListUsersTest extends ECampApiTestCase {
         static::createClientWithCredentials()->request('GET', '/users');
         $this->assertResponseStatusCodeSame(403);
     }
+
+    public function testSqlQueryCount() {
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/users');
+
+        $this->assertSqlQueryCount($client, 20);
+    }
 }

--- a/api/tests/Api/Users/ReadUserTest.php
+++ b/api/tests/Api/Users/ReadUserTest.php
@@ -86,4 +86,15 @@ class ReadUserTest extends ECampApiTestCase {
             ],
         ]);
     }
+
+    public function testSqlQueryCount() {
+        /** @var User $user */
+        $user = static::$fixtures['user2member'];
+
+        $client = static::createClientWithCredentials();
+        $client->enableProfiler();
+        $client->request('GET', '/users/'.$user->getId());
+
+        $this->assertSqlQueryCount($client, 4);
+    }
 }


### PR DESCRIPTION
This PR shows an example how we could write UnitTests testing the number of required database queries.
This should prevent us form adding an N+1 performance problem by accident.

What do you think about?