### PR TITLE
Add team sort

### DIFF
--- a/frontend/src/components/collaborator/CollaboratorList.vue
+++ b/frontend/src/components/collaborator/CollaboratorList.vue
@@ -1,0 +1,57 @@
+<template>
+  <v-list class="mx-n2">
+    <transition-group v-if="isManager" name="list">
+      <div v-for="collaborator in sortedCollaborators" :key="collaborator._meta.self">
+        <CollaboratorEdit :collaborator="collaborator" :inactive="inactive" />
+      </div>
+    </transition-group>
+    <template v-else>
+      <CollaboratorListItem
+        v-for="collaborator in sortedCollaborators"
+        :key="collaborator._meta.self"
+        :collaborator="collaborator"
+        :inactive="inactive"
+      />
+    </template>
+  </v-list>
+</template>
+
+<script>
+import CollaboratorEdit from '@/components/collaborator/CollaboratorEdit.vue'
+import CollaboratorListItem from '@/components/collaborator/CollaboratorListItem.vue'
+
+const ROLE_ORDER = ['manager', 'member', 'guest']
+
+export default {
+  name: 'CollaboratorList',
+  components: {
+    CollaboratorListItem,
+    CollaboratorEdit,
+  },
+  props: {
+    collaborators: { type: Array, required: true },
+    isManager: { type: Boolean, default: false },
+    inactive: { type: Boolean, default: false },
+  },
+  computed: {
+    sortedCollaborators() {
+      return [...this.collaborators].sort(
+        (a, b) => ROLE_ORDER.indexOf(a.role) - ROLE_ORDER.indexOf(b.role)
+      )
+    },
+  },
+}
+</script>
+
+<style scoped>
+/* apply transition to moving elements */
+.list-move {
+  transition: transform 0.5s ease;
+}
+
+/* ensure leaving items are taken out of layout flow so that moving
+   animations can be calculated correctly. */
+.list-leave-active {
+  position: absolute;
+}
+</style>

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -4,98 +4,41 @@ Displays collaborators of a single camp.
 <template>
   <content-card :title="$tc('views.camp.collaborators.title')" toolbar>
     <v-card-text>
-      <content-group :title="$tc('views.camp.collaborators.members')">
+      <ContentGroup :title="$tc('views.camp.collaborators.members')">
         <template #title-actions>
           <CollaboratorCreate v-if="isManager" :camp="camp()" />
         </template>
-        <v-list class="mx-n2">
-          <v-skeleton-loader
-            v-if="collaborators.length <= 0"
-            type="list-item-avatar-two-line@3"
-            class="px-0"
-          />
-          <CollaboratorEdit
-            v-for="collaborator in establishedCollaborators"
-            v-else-if="isManager"
-            :key="collaborator._meta.self"
-            :collaborator="collaborator"
-            @success="reloadCollaborations"
-          />
-          <CollaboratorListItem
-            v-for="collaborator in establishedCollaborators"
-            v-else
-            :key="collaborator._meta.self"
-            :collaborator="collaborator"
-          />
-        </v-list>
-      </content-group>
-
-      <ContentGroup
-        v-if="invitedCollaborators.length > 0"
-        :title="$tc('views.camp.collaborators.openInvitations')"
-      >
-        <v-list class="mx-n2">
-          <template v-if="isManager">
-            <CollaboratorEdit
-              v-for="collaborator in invitedCollaborators"
-              :key="collaborator._meta.self"
-              :collaborator="collaborator"
-              @success="reloadCollaborations"
-            />
-          </template>
-          <CollaboratorListItem
-            v-for="collaborator in invitedCollaborators"
-            v-else
-            :key="collaborator._meta.self"
-            :collaborator="collaborator"
-          />
-        </v-list>
+        <CollaboratorList :collaborators="established" :is-manager="isManager" />
       </ContentGroup>
 
       <ContentGroup
-        v-if="inactiveCollaborators.length > 0"
+        v-if="invited.length > 0"
+        :title="$tc('views.camp.collaborators.openInvitations')"
+      >
+        <CollaboratorList :collaborators="invited" :is-manager="isManager" />
+      </ContentGroup>
+
+      <ContentGroup
+        v-if="inactive.length > 0"
         :title="$tc('views.camp.collaborators.inactiveCollaborators')"
       >
-        <v-list class="mx-n2">
-          <template v-if="isManager">
-            <CollaboratorEdit
-              v-for="collaborator in inactiveCollaborators"
-              :key="collaborator._meta.self"
-              :collaborator="collaborator"
-              inactive
-              @success="reloadCollaborations"
-            />
-          </template>
-          <CollaboratorListItem
-            v-for="collaborator in inactiveCollaborators"
-            v-else
-            :key="collaborator._meta.self"
-            :collaborator="collaborator"
-            inactive
-          />
-        </v-list>
+        <CollaboratorList :collaborators="inactive" :is-manager="isManager" inactive />
       </ContentGroup>
     </v-card-text>
   </content-card>
 </template>
 <script>
 import CollaboratorCreate from '@/components/collaborator/CollaboratorCreate.vue'
-import CollaboratorEdit from '@/components/collaborator/CollaboratorEdit.vue'
 import ContentCard from '@/components/layout/ContentCard.vue'
 import ContentGroup from '@/components/layout/ContentGroup.vue'
 import { campRoleMixin } from '@/mixins/campRoleMixin'
-import { transformViolations } from '@/helpers/serverError'
-import CollaboratorListItem from '@/components/collaborator/CollaboratorListItem.vue'
-
-const DEFAULT_INVITE_ROLE = 'member'
-const ROLE_ORDER = ['manager', 'member', 'guest']
+import CollaboratorList from '@/components/collaborator/CollaboratorList.vue'
 
 export default {
   name: 'Collaborators',
   components: {
-    CollaboratorListItem,
+    CollaboratorList,
     CollaboratorCreate,
-    CollaboratorEdit,
     ContentGroup,
     ContentCard,
   },
@@ -103,74 +46,22 @@ export default {
   props: {
     camp: { type: Function, required: true },
   },
-  data() {
-    return {
-      editing: false,
-      inviteEmailMessages: [],
-      inviteEmail: '',
-      inviteRole: DEFAULT_INVITE_ROLE,
-      isSaving: false,
-    }
-  },
   computed: {
     collaborators() {
       return this.camp().campCollaborations().items
     },
-    establishedCollaborators() {
-      return this.collaborators
-        .filter((c) => c.status === 'established')
-        .sort((a, b) => ROLE_ORDER.indexOf(a.role) - ROLE_ORDER.indexOf(b.role))
+    established() {
+      return this.collaborators.filter((c) => c.status === 'established')
     },
-    invitedCollaborators() {
-      return this.collaborators
-        .filter((c) => c.status === 'invited')
-        .sort((a, b) => ROLE_ORDER.indexOf(a.role) - ROLE_ORDER.indexOf(b.role))
+    invited() {
+      return this.collaborators.filter((c) => c.status === 'invited')
     },
-    inactiveCollaborators() {
-      return this.collaborators
-        .filter((c) => c.status === 'inactive')
-        .sort((a, b) => ROLE_ORDER.indexOf(a.role) - ROLE_ORDER.indexOf(b.role))
+    inactive() {
+      return this.collaborators.filter((c) => c.status === 'inactive')
     },
   },
   created() {
     return this.camp().campCollaborations()
-  },
-  methods: {
-    invite() {
-      this.isSaving = true
-      this.api
-        .href(this.api.get(), 'campCollaborations')
-        .then((url) =>
-          this.api.post(url, {
-            camp: this.camp()._meta.self,
-            inviteEmail: this.inviteEmail,
-            role: this.inviteRole,
-          })
-        )
-        .then(this.refreshCamp, this.handleError)
-        .finally(() => {
-          this.isSaving = false
-        })
-    },
-    reloadCollaborations() {
-      this.api.reload(this.camp().campCollaborations()._meta.self)
-    },
-    handleError(e) {
-      const violations = transformViolations(e, this.$i18n)
-      this.inviteEmailMessages = Object.values(violations).flatMap(
-        (violationsOfProperty) => violationsOfProperty
-      )
-    },
-    refreshCamp() {
-      this.inviteEmail = null
-      this.inviteRole = DEFAULT_INVITE_ROLE
-      this.$refs.validation.reset()
-      this.clearMessages()
-      this.api.reload(this.camp()._meta.self)
-    },
-    clearMessages() {
-      this.inviteEmailMessages = []
-    },
   },
 }
 </script>

--- a/frontend/src/views/camp/Collaborators.vue
+++ b/frontend/src/views/camp/Collaborators.vue
@@ -19,6 +19,7 @@ Displays collaborators of a single camp.
             v-else-if="isManager"
             :key="collaborator._meta.self"
             :collaborator="collaborator"
+            @success="reloadCollaborations"
           />
           <CollaboratorListItem
             v-for="collaborator in establishedCollaborators"
@@ -39,6 +40,7 @@ Displays collaborators of a single camp.
               v-for="collaborator in invitedCollaborators"
               :key="collaborator._meta.self"
               :collaborator="collaborator"
+              @success="reloadCollaborations"
             />
           </template>
           <CollaboratorListItem
@@ -61,6 +63,7 @@ Displays collaborators of a single camp.
               :key="collaborator._meta.self"
               :collaborator="collaborator"
               inactive
+              @success="reloadCollaborations"
             />
           </template>
           <CollaboratorListItem
@@ -85,6 +88,7 @@ import { transformViolations } from '@/helpers/serverError'
 import CollaboratorListItem from '@/components/collaborator/CollaboratorListItem.vue'
 
 const DEFAULT_INVITE_ROLE = 'member'
+const ROLE_ORDER = ['manager', 'member', 'guest']
 
 export default {
   name: 'Collaborators',
@@ -113,13 +117,19 @@ export default {
       return this.camp().campCollaborations().items
     },
     establishedCollaborators() {
-      return this.collaborators.filter((c) => c.status === 'established')
+      return this.collaborators
+        .filter((c) => c.status === 'established')
+        .sort((a, b) => ROLE_ORDER.indexOf(a.role) - ROLE_ORDER.indexOf(b.role))
     },
     invitedCollaborators() {
-      return this.collaborators.filter((c) => c.status === 'invited')
+      return this.collaborators
+        .filter((c) => c.status === 'invited')
+        .sort((a, b) => ROLE_ORDER.indexOf(a.role) - ROLE_ORDER.indexOf(b.role))
     },
     inactiveCollaborators() {
-      return this.collaborators.filter((c) => c.status === 'inactive')
+      return this.collaborators
+        .filter((c) => c.status === 'inactive')
+        .sort((a, b) => ROLE_ORDER.indexOf(a.role) - ROLE_ORDER.indexOf(b.role))
     },
   },
   created() {
@@ -141,6 +151,9 @@ export default {
         .finally(() => {
           this.isSaving = false
         })
+    },
+    reloadCollaborations() {
+      this.api.reload(this.camp().campCollaborations()._meta.self)
     },
     handleError(e) {
       const violations = transformViolations(e, this.$i18n)


### PR DESCRIPTION
Sort collaborators according to their role. I think it is best to only do it very minimally because otherwise, people will think we need to add a section coach, main camp leader, … 
This way it is organized without adding too much.

Closes #3492