### PR TITLE
PrintDataController Entpoint draft

### DIFF
--- a/api/src/Controller/PrintDataController.php
+++ b/api/src/Controller/PrintDataController.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Activity;
+use App\Entity\Camp;
+use App\Entity\Category;
+use App\Entity\Day;
+use App\Entity\Period;
+use App\Entity\ScheduleEntry;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\Context\Normalizer\JsonSerializableNormalizerContextBuilder;
+use Symfony\Component\Serializer\Context\Normalizer\ObjectNormalizerContextBuilder;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class PrintDataController extends AbstractController {
+    public function __construct(
+        private EntityManagerInterface $em,
+        private NormalizerInterface $normalizer
+    ) {
+    }
+
+    #[Route('/print/camp/{campId}', 'print-camp')]
+    public function camp($campId) {
+        // api_platform.hal.normalizer.item
+
+        /** @var Camp */
+        $camp = $this->em->find(Camp::class, $campId);
+
+        $q = $this->em->createQueryBuilder();
+        $q->select('p');
+        $q->from(Period::class, 'p');
+        $q->where('p.camp = ?1');
+        $q->setParameter(1, $campId);
+        $periods = $q->getQuery()->getResult();
+
+        $q = $this->em->createQueryBuilder();
+        $q->select('d');
+        $q->from(Day::class, 'd');
+        $q->join('d.period', 'p');
+        $q->where('p.camp = ?1');
+        $q->setParameter(1, $campId);
+        $days = $q->getQuery()->getResult();
+
+        $q = $this->em->createQueryBuilder();
+        $q->select('c');
+        $q->from(Category::class, 'c');
+        $q->where('c.camp = ?1');
+        $q->setParameter(1, $campId);
+        $categories = $q->getQuery()->getResult();
+
+        $q = $this->em->createQueryBuilder();
+        $q->select('a');
+        $q->from(Activity::class, 'a');
+        $q->where('a.camp = ?1');
+        $q->setParameter(1, $campId);
+        $activities = $q->getQuery()->getResult();
+        
+        $q = $this->em->createQueryBuilder();
+        $q->select('s');
+        $q->from(ScheduleEntry::class, 's');
+        $q->join('s.activity', 'a');
+        $q->where('a.camp = ?1');
+        $q->setParameter(1, $campId);
+        $scheduleEntries = $q->getQuery()->getResult();
+
+        $contextBuilder = (new ObjectNormalizerContextBuilder())
+            ->withContext([])
+            ->withGroups(['print'])
+        ;
+        $contextBuilder = (new JsonSerializableNormalizerContextBuilder())
+            ->withContext($contextBuilder)
+        ;
+
+        $campJson = $this->normalizer->normalize($camp, 'jsonhal', $contextBuilder->toArray());
+        $periodsJson = $this->normalizer->normalize($periods, 'jsonhal', $contextBuilder->toArray());
+        $daysJson = $this->normalizer->normalize($days, 'jsonhal', $contextBuilder->toArray());
+        $categoriesJson = $this->normalizer->normalize($categories, 'jsonhal', $contextBuilder->toArray());
+        $activitiesJson = $this->normalizer->normalize($activities, 'jsonhal', $contextBuilder->toArray());
+        $scheduleEntriesJson = $this->normalizer->normalize($scheduleEntries, 'jsonhal', $contextBuilder->toArray());
+
+        return new \Symfony\Component\HttpFoundation\JsonResponse([
+            'camp' => array_merge_recursive(
+                $campJson,
+                $this->createLinkCollection('periods', $periodsJson),
+                $this->createLinkCollection('categories', $categoriesJson)
+            ),
+            'periods' => array_map(
+                fn ($p) => array_merge_recursive(
+                    $p,
+                    $this->createLinkCollectionFiltered($p, 'days', $daysJson, 'period'),
+                ),
+                $periodsJson
+            ),
+            'days' => $daysJson,
+            'categories' => $categoriesJson,
+            'activities' => $activitiesJson,
+            'scheduleEntries' => $scheduleEntriesJson
+        ]);
+    }
+
+    private function createLinkCollection($listName, $list) {
+        return [
+            '_embedded' => [
+                $listName => array_map(
+                    function ($p) {
+                        return [
+                            '_links' => [
+                                'self' => [
+                                    'href' => $p['_links']['self']['href'],
+                                ],
+                            ],
+                        ];
+                    },
+                    $list
+                ),
+            ],
+        ];
+    }
+
+    private function createLinkCollectionFiltered($item, $listName, $childrenList, $parentLink) {
+        $children = [];
+        foreach ($childrenList as $child) {
+            if ($child['_links'][$parentLink]['href'] == $item['_links']['self']['href']) {
+                $children[] = $child;
+            }
+        }
+
+        return $this->createLinkCollection($listName, $children);
+    }
+}

--- a/api/src/Entity/Activity.php
+++ b/api/src/Entity/Activity.php
@@ -115,7 +115,7 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
      */
     #[ApiProperty(example: '/categories/1a2b3c4d')]
     #[AssertBelongsToSameCamp(groups: ['update'])]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'activities')]
     #[ORM\JoinColumn(nullable: false)]
     public ?Category $category = null;
@@ -125,7 +125,7 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
      */
     #[ApiProperty(example: '/progress_labels/1a2b3c4d')]
     #[AssertBelongsToSameCamp(groups: ['update'])]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: ActivityProgressLabel::class, inversedBy: 'activities')]
     #[ORM\JoinColumn(nullable: true)]
     public ?ActivityProgressLabel $progressLabel = null;
@@ -138,7 +138,7 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
     #[Assert\NotBlank]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Sportolympiade')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text')]
     public ?string $title = null;
 
@@ -149,7 +149,7 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
     #[InputFilter\CleanText]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: 'Spielwiese')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text')]
     public string $location = '';
 

--- a/api/src/Entity/ActivityProgressLabel.php
+++ b/api/src/Entity/ActivityProgressLabel.php
@@ -68,7 +68,7 @@ class ActivityProgressLabel extends BaseEntity implements BelongsToCampInterface
      */
     #[ApiProperty(example: '/camps/1a2b3c4d')]
     #[Gedmo\SortableGroup]
-    #[Groups(['read', 'create'])]
+    #[Groups(['read', 'create', 'print'])]
     #[ORM\ManyToOne(targetEntity: Camp::class, inversedBy: 'progressLabels')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     public ?Camp $camp = null;
@@ -87,7 +87,7 @@ class ActivityProgressLabel extends BaseEntity implements BelongsToCampInterface
 
     #[ApiProperty(example: 0)]
     #[Gedmo\SortablePosition]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(name: 'position', type: 'integer', nullable: false)]
     public int $position = -1;
 
@@ -96,7 +96,7 @@ class ActivityProgressLabel extends BaseEntity implements BelongsToCampInterface
     #[Assert\NotBlank]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Planned')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text')]
     public ?string $title = null;
 

--- a/api/src/Entity/ActivityResponsible.php
+++ b/api/src/Entity/ActivityResponsible.php
@@ -50,7 +50,7 @@ class ActivityResponsible extends BaseEntity implements BelongsToCampInterface {
      */
     #[Assert\NotNull]
     #[ApiProperty(example: '/activities/1a2b3c4d')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: Activity::class, inversedBy: 'activityResponsibles')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?Activity $activity = null;
@@ -60,7 +60,7 @@ class ActivityResponsible extends BaseEntity implements BelongsToCampInterface {
      */
     #[ApiProperty(example: '/camp_collaborations/1a2b3c4d')]
     #[AssertBelongsToSameCamp]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: CampCollaboration::class, inversedBy: 'activityResponsibles')]
     #[ORM\JoinColumn(nullable: false)]
     public ?CampCollaboration $campCollaboration = null;

--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -159,7 +159,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\NotBlank]
     #[ApiProperty(example: 'SoLa 2022')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'string', length: 32)]
     public string $name;
 
@@ -171,7 +171,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[Assert\NotBlank]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Abteilungs-Sommerlager 2022')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text')]
     public string $title;
 
@@ -182,7 +182,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 128)]
     #[ApiProperty(example: 'Piraten')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $motto = null;
 
@@ -193,7 +193,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 128)]
     #[ApiProperty(example: 'Wiese hinter der alten Mühle')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $addressName = null;
 
@@ -204,7 +204,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 128)]
     #[ApiProperty(example: 'Schönriedweg 23')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $addressStreet = null;
 
@@ -215,7 +215,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 128)]
     #[ApiProperty(example: '1234')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $addressZipcode = null;
 
@@ -226,7 +226,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 128)]
     #[ApiProperty(example: 'Hintertüpfingen')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $addressCity = null;
 
@@ -241,7 +241,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: 'Pfadi Luftig')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $organizer = null;
 
@@ -256,7 +256,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: 'Zeltlager')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $kind = null;
 
@@ -271,7 +271,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: 'Albert Anderegg')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $coachName = null;
 
@@ -286,7 +286,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: 'PBS AG 123-23')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $courseNumber = null;
 
@@ -301,7 +301,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: 'PBS AG 123-23')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $courseKind = null;
 
@@ -316,7 +316,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[InputFilter\CleanText]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: 'Albert Anderegg')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $trainingAdvisorName = null;
 
@@ -328,7 +328,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      * The logo is required for Y+S courses.
      */
     #[ApiProperty(default: null, example: true)]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'boolean', options: ['default' => false])]
     public bool $printYSLogoOnPicasso = false;
 

--- a/api/src/Entity/CampCollaboration.php
+++ b/api/src/Entity/CampCollaboration.php
@@ -151,7 +151,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
      */
     #[AssertEitherIsNull(other: 'inviteEmail')]
     #[ApiProperty(example: '/users/1a2b3c4d')]
-    #[Groups(['read', 'create'])]
+    #[Groups(['read', 'create', 'print'])]
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'collaborations')]
     #[ORM\JoinColumn(nullable: true, onDelete: 'cascade')]
     public ?User $user = null;
@@ -161,7 +161,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
      */
     #[Assert\Valid]
     #[ApiProperty(example: '/camps/1a2b3c4d')]
-    #[Groups(['read', 'create'])]
+    #[Groups(['read', 'create', 'print'])]
     #[ORM\ManyToOne(targetEntity: Camp::class, inversedBy: 'collaborations')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?Camp $camp = null;
@@ -185,7 +185,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
         groups: ['update']
     )]
     #[ApiProperty(example: self::STATUS_INACTIVE)]
-    #[Groups(['read', 'update'])]
+    #[Groups(['read', 'update', 'print'])]
     #[ORM\Column(type: 'string', length: 16, nullable: false)]
     public string $status = self::STATUS_INVITED;
 
@@ -195,7 +195,7 @@ class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
      */
     #[Assert\Choice(choices: self::VALID_ROLES)]
     #[ApiProperty(example: self::ROLE_MEMBER)]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'string', length: 16, nullable: false)]
     public string $role;
 

--- a/api/src/Entity/Category.php
+++ b/api/src/Entity/Category.php
@@ -78,7 +78,7 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
      * The camp to which this category belongs. May not be changed once the category is created.
      */
     #[ApiProperty(example: '/camps/1a2b3c4d')]
-    #[Groups(['read', 'create'])]
+    #[Groups(['read', 'create', 'print'])]
     #[ORM\ManyToOne(targetEntity: Camp::class, inversedBy: 'categories')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?Camp $camp = null;
@@ -124,7 +124,7 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
     #[Assert\NotBlank]
     #[Assert\Length(max: 16)]
     #[ApiProperty(example: 'LS')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: false)]
     public ?string $short = null;
 
@@ -136,7 +136,7 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
     #[Assert\NotBlank]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Lagersport')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: false)]
     public ?string $name = null;
 
@@ -145,7 +145,7 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
      */
     #[Assert\Regex(pattern: '/^#[0-9a-zA-Z]{6}$/')]
     #[ApiProperty(example: '#4DBB52')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'string', length: 8, nullable: false)]
     public ?string $color = null;
 
@@ -155,7 +155,7 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
      */
     #[Assert\Choice(choices: ['a', 'A', 'i', 'I', '1'])]
     #[ApiProperty(example: '1')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'string', length: 1, nullable: false)]
     public string $numberingStyle = '1';
 

--- a/api/src/Entity/ContentNode.php
+++ b/api/src/Entity/ContentNode.php
@@ -57,7 +57,7 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
      */
     #[ApiProperty(writable: false, example: '/content_nodes/1a2b3c4d')]
     #[Gedmo\SortableGroup] // this is needed to avoid that all root nodes are in the same sort group (parent:null, slot: '')
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     #[ORM\ManyToOne(targetEntity: ColumnLayout::class, inversedBy: 'rootDescendants')]
     #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')] // TODO make not null in the DB using a migration, and get fixtures to run
     public ?ColumnLayout $root = null;
@@ -76,7 +76,7 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
     )]
     #[ApiProperty(example: '/content_nodes/1a2b3c4d')]
     #[Gedmo\SortableGroup]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: ContentNode::class, inversedBy: 'children')]
     #[ORM\JoinColumn(onDelete: 'CASCADE')]
     public ?ContentNode $parent = null;
@@ -93,7 +93,7 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
      * Holds the actual data of the content node.
      */
     #[ApiProperty(example: ['text' => 'dummy text'])]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'json', nullable: true, options: ['jsonb' => true])]
     public ?array $data = null;
 
@@ -107,7 +107,7 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
     #[AssertSlotSupportedByParent]
     #[ApiProperty(example: '1')]
     #[Gedmo\SortableGroup]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $slot = null;
 
@@ -117,7 +117,7 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
      */
     #[ApiProperty(example: '0')]
     #[Gedmo\SortablePosition]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'integer', nullable: false)]
     public int $position = -1;
 
@@ -129,7 +129,7 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
     #[InputFilter\CleanText]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Schlechtwetterprogramm')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $instanceName = null;
 
@@ -139,7 +139,7 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
      * in a content node. The content type may not be changed once the content node is created.
      */
     #[ApiProperty(example: '/content_types/1a2b3c4d')]
-    #[Groups(['read', 'create'])]
+    #[Groups(['read', 'create', 'print'])]
     #[AssertContentTypeCompatible]
     #[ORM\ManyToOne(targetEntity: ContentType::class)]
     #[ORM\JoinColumn(nullable: false)]
@@ -154,7 +154,7 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
      * The name of the content type of this content node. Read-only, for convenience.
      */
     #[ApiProperty(example: 'SafetyConcept')]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     public function getContentTypeName(): string {
         return $this->contentType?->name;
     }

--- a/api/src/Entity/ContentType.php
+++ b/api/src/Entity/ContentType.php
@@ -34,7 +34,7 @@ class ContentType extends BaseEntity {
      * identifier of this content type, it is guaranteed to stay fixed.
      */
     #[ApiProperty(writable: false, example: 'SafetyConcept')]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     #[ORM\Column(type: 'string', length: 32, unique: true)]
     public ?string $name = null;
 

--- a/api/src/Entity/Day.php
+++ b/api/src/Entity/Day.php
@@ -70,7 +70,7 @@ class Day extends BaseEntity implements BelongsToCampInterface {
      * The time period that this day belongs to.
      */
     #[ApiProperty(example: '/periods/1a2b3c4d')]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     #[ORM\ManyToOne(targetEntity: Period::class, inversedBy: 'days')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?Period $period = null;
@@ -79,7 +79,7 @@ class Day extends BaseEntity implements BelongsToCampInterface {
      * The 0-based offset in days from the period's start date when this day starts.
      */
     #[ApiProperty(writable: false, example: '1')]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     #[ORM\Column(type: 'integer')]
     public int $dayOffset = 0;
 
@@ -98,7 +98,7 @@ class Day extends BaseEntity implements BelongsToCampInterface {
      */
     #[ApiProperty(example: '2')]
     #[SerializedName('number')]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     public function getDayNumber(): int {
         return $this->period->getFirstDayNumber() + $this->dayOffset;
     }
@@ -126,7 +126,7 @@ class Day extends BaseEntity implements BelongsToCampInterface {
      * The start date and time of the day. This is a read-only convenience property.
      */
     #[ApiProperty(example: '2022-01-02T00:00:00+00:00', openapiContext: ['format' => 'date'])]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     public function getStart(): ?\DateTime {
         try {
             $start = $this->period?->start ? \DateTime::createFromInterface($this->period->start) : null;
@@ -142,7 +142,7 @@ class Day extends BaseEntity implements BelongsToCampInterface {
      * The end date and time of the day. This is a read-only convenience property.
      */
     #[ApiProperty(example: '2022-01-03T00:00:00+00:00', openapiContext: ['format' => 'date'])]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     public function getEnd(): ?\DateTime {
         try {
             $end = $this->period?->start ? \DateTime::createFromInterface($this->period->start) : null;

--- a/api/src/Entity/DayResponsible.php
+++ b/api/src/Entity/DayResponsible.php
@@ -51,7 +51,7 @@ class DayResponsible extends BaseEntity implements BelongsToCampInterface {
      */
     #[Assert\NotNull]
     #[ApiProperty(example: '/days/1a2b3c4d')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: Day::class, inversedBy: 'dayResponsibles')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?Day $day = null;
@@ -61,7 +61,7 @@ class DayResponsible extends BaseEntity implements BelongsToCampInterface {
      */
     #[AssertBelongsToSameCamp]
     #[ApiProperty(example: '/camp_collaborations/1a2b3c4d')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: CampCollaboration::class, inversedBy: 'dayResponsibles')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?CampCollaboration $campCollaboration = null;

--- a/api/src/Entity/HasRootContentNodeTrait.php
+++ b/api/src/Entity/HasRootContentNodeTrait.php
@@ -16,6 +16,7 @@ trait HasRootContentNodeTrait {
      */
     #[Assert\DisableAutoMapping]
     #[ApiProperty(writable: false, readableLink: true, example: '/content_nodes/1a2b3c4d')]
+    #[Groups(['print'])]
     #[ORM\OneToOne(targetEntity: ColumnLayout::class, cascade: ['persist'])]
     #[ORM\JoinColumn(nullable: false, unique: true)]
     public ?ColumnLayout $rootContentNode = null;

--- a/api/src/Entity/MaterialItem.php
+++ b/api/src/Entity/MaterialItem.php
@@ -58,7 +58,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface, CopyFro
      */
     #[AssertBelongsToSameCamp(compareToPrevious: true, groups: ['update'])]
     #[ApiProperty(example: '/material_lists/1a2b3c4d')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: MaterialList::class, inversedBy: 'materialItems')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?MaterialList $materialList = null;
@@ -69,7 +69,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface, CopyFro
     #[AssertBelongsToSameCamp]
     #[AssertEitherIsNull(other: 'materialNode')]
     #[ApiProperty(example: '/periods/1a2b3c4d')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: Period::class, inversedBy: 'materialItems')]
     #[ORM\JoinColumn(nullable: true, onDelete: 'cascade')]
     public ?Period $period = null;
@@ -80,7 +80,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface, CopyFro
     #[AssertBelongsToSameCamp]
     #[AssertEitherisNull(other: 'period')]
     #[ApiProperty(example: '/content_node/material_nodes/1a2b3c4d')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: MaterialNode::class, inversedBy: 'materialItems')]
     #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
     public ?MaterialNode $materialNode = null;
@@ -93,7 +93,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface, CopyFro
     #[Assert\NotBlank]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: 'Volleyball')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: false)]
     public ?string $article = null;
 
@@ -101,7 +101,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface, CopyFro
      * The number of items or the amount in the unit of items that are required.
      */
     #[ApiProperty(example: 1.5)]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'float', nullable: true)]
     public ?float $quantity = null;
 
@@ -112,7 +112,7 @@ class MaterialItem extends BaseEntity implements BelongsToCampInterface, CopyFro
     #[InputFilter\CleanText]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'kg')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $unit = null;
 

--- a/api/src/Entity/MaterialList.php
+++ b/api/src/Entity/MaterialList.php
@@ -68,7 +68,7 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface, CopyFro
      * The camp this material list belongs to.
      */
     #[ApiProperty(example: '/camps/1a2b3c4d')]
-    #[Groups(['read', 'create'])]
+    #[Groups(['read', 'create', 'print'])]
     #[ORM\ManyToOne(targetEntity: Camp::class, inversedBy: 'materialLists')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?Camp $camp = null;
@@ -139,7 +139,7 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface, CopyFro
 
     #[ApiProperty(example: 'Lebensmittel')]
     #[SerializedName('name')]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     public function getName(): ?string {
         return $this->name
             ?? $this->campCollaboration?->user?->getDisplayName()

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -98,7 +98,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
      */
     #[Assert\Valid(groups: ['Period:delete'])]
     #[ApiProperty(example: '/camps/1a2b3c4d')]
-    #[Groups(['read', 'create'])]
+    #[Groups(['read', 'create', 'print'])]
     #[ORM\ManyToOne(targetEntity: Camp::class, inversedBy: 'periods')]
     #[ORM\JoinColumn(nullable: false)]
     public ?Camp $camp = null;
@@ -113,7 +113,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
     #[Assert\NotBlank]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: 'Hauptlager')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $description = null;
 
@@ -128,7 +128,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
         normalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'],
         denormalizationContext: [DateTimeNormalizer::FORMAT_KEY => '!Y-m-d']
     )]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(type: 'date')]
     public ?\DateTimeInterface $start = null;
 
@@ -145,7 +145,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
         normalizationContext: [DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'],
         denormalizationContext: [DateTimeNormalizer::FORMAT_KEY => '!Y-m-d']
     )]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\Column(name: '`end`', type: 'date')]
     public ?\DateTimeInterface $end = null;
 

--- a/api/src/Entity/ScheduleEntry.php
+++ b/api/src/Entity/ScheduleEntry.php
@@ -72,7 +72,7 @@ class ScheduleEntry extends BaseEntity implements BelongsToCampInterface {
     #[Assert\NotNull(groups: ['validPeriod'])] // this is validated before all others
     #[AssertBelongsToSameCamp]
     #[ApiProperty(example: '/periods/1a2b3c4d')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['read', 'write', 'print'])]
     #[ORM\ManyToOne(targetEntity: Period::class, inversedBy: 'scheduleEntries', fetch: 'EAGER')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?Period $period = null;
@@ -85,7 +85,7 @@ class ScheduleEntry extends BaseEntity implements BelongsToCampInterface {
      */
     #[Assert\Valid(groups: ['ScheduleEntry:delete'])]
     #[ApiProperty(example: '/activities/1a2b3c4d')]
-    #[Groups(['read', 'create'])]
+    #[Groups(['read', 'create', 'print'])]
     #[ORM\ManyToOne(targetEntity: Activity::class, inversedBy: 'scheduleEntries')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?Activity $activity = null;
@@ -161,7 +161,7 @@ class ScheduleEntry extends BaseEntity implements BelongsToCampInterface {
      */
     #[ApiProperty(example: '2022-01-02T00:00:00+00:00', required: true, openapiContext: ['format' => 'date-time'])]
     #[Assert\GreaterThanOrEqual(propertyPath: 'period.start')]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     public function getStart(): ?\DateTimeInterface {
         if (null === $this->period?->start) {
             return $this->_start;
@@ -188,7 +188,7 @@ class ScheduleEntry extends BaseEntity implements BelongsToCampInterface {
     #[ApiProperty(example: '2022-01-02T01:30:00+00:00', required: true, openapiContext: ['format' => 'date-time'])]
     #[Assert\GreaterThan(propertyPath: 'start')]
     #[Assert\LessThanOrEqual(propertyPath: 'period.endOfLastDay')]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     public function getEnd(): ?\DateTimeInterface {
         if (null === $this->period?->start) {
             return $this->_end;

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -169,7 +169,7 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
      * A displayable name of the user.
      */
     #[ApiProperty(example: 'Robert Baden-Powell')]
-    #[Groups(['read'])]
+    #[Groups(['read', 'print'])]
     public function getDisplayName(): ?string {
         return $this->profile->getDisplayName();
     }

--- a/api/src/Serializer/Normalizer/ContentTypeNormalizer.php
+++ b/api/src/Serializer/Normalizer/ContentTypeNormalizer.php
@@ -29,7 +29,7 @@ class ContentTypeNormalizer implements NormalizerInterface, SerializerAwareInter
     public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null {
         $data = $this->decorated->normalize($object, $format, $context);
 
-        if ($object instanceof ContentType && isset($object->entityClass)) {
+        if ($object instanceof ContentType && isset($data['contentNodes'], $object->entityClass)) {
             // get uri for the respective ContentNode entity and add ContentType as query parameter
             [$uriTemplate, $templated] = $this->uriTemplateFactory->createFromResourceClass($object->entityClass);
             $uri = $this->uriTemplate->expand($uriTemplate, ['contentType' => $this->iriConverter->getIriFromResource($object)]);


### PR DESCRIPTION
Explicit EndPoint to load all required Data for print in ONE Request.
Motivation: Make print a lot faster; reduce server-request loads.

The Group 'print' allows to control what information should be included.

On my Dev-Environment the HarryPotter-Camp loading all data takes 1.3seconds
On PR-Deplayment the HarryPotter-Camp loading all data takes half a seconds

Check out the response:
https://pr3612.ecamp3.ch/api/print/camp/05ce4b9836e9