### PR TITLE
api: add snapshot tests of the responses

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -55,6 +55,7 @@
         "phpstan/phpstan": "1.10.29",
         "phpunit/phpunit": "9.6.12",
         "rector/rector": "0.18.0",
+        "spatie/phpunit-snapshot-assertions": "4.2.16",
         "symfony/browser-kit": "6.3.2",
         "symfony/css-selector": "6.3.2",
         "symfony/debug-bundle": "6.3.2",
@@ -110,6 +111,11 @@
         "test": [
             "Composer\\Config::disableProcessTimeout",
             "bin/phpunit -d memory_limit=-1"
+        ],
+        "update-snapshots": [
+            "Composer\\Config::disableProcessTimeout",
+            "bin/phpunit -d memory_limit=-1 -d --update-snapshots tests/Api/SnapshotTests",
+            "bin/phpunit -d memory_limit=-1 -d --update-snapshots tests/Util/ArrayDeepSortTest.php"
         ],
         "auto-scripts": {
             "cache:clear": "symfony-cmd",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24c094ee09b201fc4c7d8dffae269186",
+    "content-hash": "007a86cef75cb8805ad4f7573661c3a0",
     "packages": [
         {
             "name": "api-platform/core",
@@ -13290,6 +13290,74 @@
             "time": "2023-07-19T18:30:26+00:00"
         },
         {
+            "name": "spatie/phpunit-snapshot-assertions",
+            "version": "4.2.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/phpunit-snapshot-assertions.git",
+                "reference": "4c325139313c06b656ba10d5b60306c0de728c1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/phpunit-snapshot-assertions/zipball/4c325139313c06b656ba10d5b60306c0de728c1f",
+                "reference": "4c325139313c06b656ba10d5b60306c0de728c1f",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "php": "^7.3|^7.4|^8.0",
+                "phpunit/phpunit": "^8.3|^9.0",
+                "symfony/property-access": "^4.0|^5.0|^6.0",
+                "symfony/serializer": "^4.0|^5.0|^6.0",
+                "symfony/yaml": "^4.0|^5.0|^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Snapshots\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Snapshot testing with PHPUnit",
+            "homepage": "https://github.com/spatie/phpunit-snapshot-assertions",
+            "keywords": [
+                "assert",
+                "phpunit",
+                "phpunit-snapshot-assertions",
+                "snapshot",
+                "spatie",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/phpunit-snapshot-assertions/issues",
+                "source": "https://github.com/spatie/phpunit-snapshot-assertions/tree/4.2.16"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2022-10-10T15:58:50+00:00"
+        },
+        {
             "name": "symfony/browser-kit",
             "version": "v6.3.2",
             "source": {
@@ -14075,5 +14143,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/api/src/Util/ArrayDeepSort.php
+++ b/api/src/Util/ArrayDeepSort.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Util;
+
+class ArrayDeepSort {
+    /**
+     * @phpstan-template T
+     *
+     * @phpstan-param T $input
+     *
+     * @psalm-param mixed $input
+     *
+     * @phpstan-return T
+     *
+     * @psalm-return mixed
+     */
+    public static function sort(mixed $input): mixed {
+        if (!is_array($input)) {
+            return $input;
+        }
+        $sorted_children = array_map([ArrayDeepSort::class, 'sort'], $input);
+
+        if (array_is_list($sorted_children)) {
+            uasort($sorted_children, function ($a, $b) {
+                $valueStringA = json_encode($a);
+                $valueStringB = json_encode($b);
+
+                return strcmp($valueStringA, $valueStringB);
+            });
+
+            return array_values($sorted_children);
+        }
+
+        ksort($sorted_children);
+
+        return $sorted_children;
+    }
+}

--- a/api/tests/Api/Activities/CreateActivityTest.php
+++ b/api/tests/Api/Activities/CreateActivityTest.php
@@ -7,6 +7,14 @@ use ApiPlatform\Metadata\Post;
 use App\Entity\Activity;
 use App\Entity\User;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -467,6 +475,33 @@ class CreateActivityTest extends ECampApiTestCase {
         );
 
         $this->assertResponseStatusCodeSame(422);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/activities',
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/ActivityProgressLabel/CreateActivityProgressLabelTest.php
+++ b/api/tests/Api/ActivityProgressLabel/CreateActivityProgressLabelTest.php
@@ -6,6 +6,14 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
 use App\Entity\ActivityProgressLabel;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -163,6 +171,33 @@ class CreateActivityProgressLabelTest extends ECampApiTestCase {
                 ],
             ],
         ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/activity_progress_labels',
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/ActivityResponsibles/CreateActivityResponsibleTest.php
+++ b/api/tests/Api/ActivityResponsibles/CreateActivityResponsibleTest.php
@@ -6,6 +6,14 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
 use App\Entity\ActivityResponsible;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -129,6 +137,33 @@ class CreateActivityResponsibleTest extends ECampApiTestCase {
                 ],
             ],
         ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/activity_responsibles',
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/CreateCampCollaborationTest.php
@@ -7,6 +7,14 @@ use ApiPlatform\Metadata\Post;
 use App\Entity\CampCollaboration;
 use App\Entity\User;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -532,6 +540,38 @@ class CreateCampCollaborationTest extends ECampApiTestCase {
                 ],
             ],
         ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/camp_collaborations',
+            [
+                'json' => $this->getExampleWritePayload(
+                    [
+                        'inviteEmail' => 'someone@example.com',
+                    ],
+                    ['user']
+                ),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/Camps/CreateCampTest.php
+++ b/api/tests/Api/Camps/CreateCampTest.php
@@ -8,6 +8,14 @@ use App\Entity\Camp;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -777,6 +785,33 @@ class CreateCampTest extends ECampApiTestCase {
                 ],
             ],
         ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/camps',
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/ContentNodes/CreateContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/CreateContentNodeTestCase.php
@@ -5,6 +5,14 @@ namespace App\Tests\Api\ContentNodes;
 use App\Entity\ContentNode;
 use App\Entity\ContentType;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * Base CREATE (post) test case to be used for various ContentNode types.
@@ -217,6 +225,33 @@ abstract class CreateContentNodeTestCase extends ECampApiTestCase {
         $this->assertJsonContains([
             'instanceName' => 'control',
         ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            $this->endpoint,
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     protected function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/DayResponsibles/CreateDayResponsibleTest.php
+++ b/api/tests/Api/DayResponsibles/CreateDayResponsibleTest.php
@@ -6,6 +6,14 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
 use App\Entity\DayResponsible;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -130,6 +138,33 @@ class CreateDayResponsibleTest extends ECampApiTestCase {
                 ],
             ],
         ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/day_responsibles',
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/ECampApiTestCase.php
+++ b/api/tests/Api/ECampApiTestCase.php
@@ -16,11 +16,14 @@ use App\Entity\Profile;
 use App\Entity\User;
 use App\Metadata\Resource\OperationHelper;
 use App\Repository\ProfileRepository;
+use App\Util\ArrayDeepSort;
 use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use Doctrine\ORM\EntityManagerInterface;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
+use Spatie\Snapshots\MatchesSnapshots;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -28,6 +31,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 abstract class ECampApiTestCase extends ApiTestCase {
     use RefreshDatabaseTrait;
+    use MatchesSnapshots;
 
     protected string $endpoint = '';
     protected string $routePrefix = '';
@@ -55,6 +59,19 @@ abstract class ECampApiTestCase extends ApiTestCase {
         date_default_timezone_set($this->currentTimezone);
 
         parent::tearDown();
+    }
+
+    public static function escapeArrayValues(array $array): array {
+        $clonedArray = self::deepCloneArray($array);
+        array_walk_recursive($clonedArray, fn (mixed & $value) => self::escapeValues($value));
+
+        return $clonedArray;
+    }
+
+    public static function deepCloneArray(array $array): mixed {
+        $json_encode = json_encode($array);
+
+        return json_decode($json_encode, true);
     }
 
     /**
@@ -308,5 +325,39 @@ abstract class ECampApiTestCase extends ApiTestCase {
         $collector = $client->getProfile()->getCollector('db');
 
         $this->assertEquals($expected, $collector->getQueryCount());
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    protected function assertMatchesEscapedResponseSnapshot(ResponseInterface $response): void {
+        $responseArray = $response->toArray(false);
+        $escapedArrayValues = self::escapeArrayValues($responseArray);
+        $sortedResponseArray = ArrayDeepSort::sort($escapedArrayValues);
+        $this->assertMatchesJsonSnapshot($sortedResponseArray);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    protected function assertMatchesResponseSnapshot(ResponseInterface $response): void {
+        $responseArray = $response->toArray(false);
+
+        $sortedResponseArray = ArrayDeepSort::sort($responseArray);
+        $this->assertMatchesJsonSnapshot($sortedResponseArray);
+    }
+
+    private static function escapeValues(mixed &$object): void {
+        if (!is_array($object)) {
+            $object = 'escaped_value';
+        }
     }
 }

--- a/api/tests/Api/MaterialItems/CreateMaterialItemTest.php
+++ b/api/tests/Api/MaterialItems/CreateMaterialItemTest.php
@@ -6,6 +6,14 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
 use App\Entity\MaterialItem;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -405,6 +413,33 @@ class CreateMaterialItemTest extends ECampApiTestCase {
         $this->assertJsonContains([
             'unit' => 'unit',
         ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/material_items',
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/MaterialLists/CreateMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/CreateMaterialListTest.php
@@ -6,6 +6,14 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
 use App\Entity\MaterialList;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -190,6 +198,33 @@ class CreateMaterialListTest extends ECampApiTestCase {
         $this->assertJsonContains([
             'name' => '<b>t</b',
         ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/material_lists',
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/Periods/CreatePeriodTest.php
+++ b/api/tests/Api/Periods/CreatePeriodTest.php
@@ -6,6 +6,14 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
 use App\Entity\Period;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -304,6 +312,33 @@ class CreatePeriodTest extends ECampApiTestCase {
         $period = $this->getEntityManager()->getRepository(Period::class)->find($response->toArray()['id']);
 
         $this->assertCount(4, $period->days);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/periods',
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getPeriodResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getPeriodResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/ScheduleEntries/CreateScheduleEntryTest.php
+++ b/api/tests/Api/ScheduleEntries/CreateScheduleEntryTest.php
@@ -6,6 +6,14 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
 use App\Entity\ScheduleEntry;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -215,6 +223,33 @@ class CreateScheduleEntryTest extends ECampApiTestCase {
             'start' => '2023-05-01T04:00:00+00:00',
             'end' => '2023-05-01T05:00:00+00:00',
         ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/schedule_entries',
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = []) {

--- a/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
+++ b/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Api\SnapshotTests;
 
 use App\Entity\BaseEntity;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
@@ -11,7 +12,6 @@ use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 use function PHPUnit\Framework\assertThat;
-use function PHPUnit\Framework\equalTo;
 
 /**
  * @internal
@@ -153,7 +153,7 @@ class ResponseSnapshotTest extends ECampApiTestCase {
         ;
         $this->assertResponseStatusCodeSame(200);
 
-        assertThat($itemResponse->toArray(), equalTo($patchResponse->toArray()));
+        assertThat($itemResponse->toArray(), CompatibleHalResponse::isHalCompatibleWith($patchResponse->toArray()));
     }
 
     /**
@@ -172,8 +172,6 @@ class ResponseSnapshotTest extends ECampApiTestCase {
                 '/content_types' => false,
                 '/days' => false,
                 '/day_responsibles' => false,
-                // patch and getItem of period have different embeddings
-                '/periods' => false,
                 default => true,
             };
         });

--- a/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
+++ b/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace App\Tests\Api\SnapshotTests;
+
+use App\Entity\BaseEntity;
+use App\Tests\Api\ECampApiTestCase;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
+use function PHPUnit\Framework\equalTo;
+
+/**
+ * @internal
+ */
+class ResponseSnapshotTest extends ECampApiTestCase {
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testRootEndpointMatchesSnapshot() {
+        $response = static::createClientWithCredentials()->request('GET', '/');
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertMatchesResponseSnapshot($response);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     *
+     * @dataProvider getCollectionEndpoints
+     */
+    public function testGetCollectionMatchesStructure(string $endpoint) {
+        $response = static::createClientWithCredentials()->request('GET', $endpoint);
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertMatchesEscapedResponseSnapshot($response);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public static function getCollectionEndpoints() {
+        static::bootKernel();
+        $response = static::createClientWithCredentials()->request('GET', '/');
+
+        $responseArray = $response->toArray();
+        $onlyUrls = array_map(fn (array $item) => $item['href'], $responseArray['_links']);
+        $withoutParameters = array_map(fn (string $uriTemplate) => preg_replace('/\\{[^}]*}/', '', $uriTemplate), $onlyUrls);
+        $normalEndpoints = array_filter($withoutParameters, function (string $endpoint) {
+            // @noinspection PhpDuplicateMatchArmBodyInspection
+            return match ($endpoint) {
+                '/' => false,
+                '/authentication_token' => false,
+                '/auth/google' => false,
+                '/auth/pbsmidata' => false,
+                '/auth/cevidb' => false,
+                '/auth/jubladb' => false,
+                '/auth/reset_password' => false,
+                '/invitations' => false,
+                '/users' => false,
+                default => true
+            };
+        });
+
+        /** @noinspection PhpUnnecessaryLocalVariableInspection */
+        $withUrlAsKey = array_reduce($normalEndpoints, function (?array $left, string $right) {
+            $newArray = $left ?? [];
+            $newArray[$right] = [$right];
+
+            return $newArray;
+        });
+
+        return $withUrlAsKey;
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     *
+     * @dataProvider getItemEndpoints
+     */
+    public function testGetItemMatchesStructure(string $endpoint) {
+        /** @var BaseEntity $fixtureFor */
+        $fixtureFor = $this->getFixtureFor($endpoint);
+
+        $itemResponse = static::createClientWithCredentials()->request('GET', "{$endpoint}/{$fixtureFor->getId()}");
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertMatchesEscapedResponseSnapshot($itemResponse);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public static function getItemEndpoints() {
+        return array_filter(self::getCollectionEndpoints(), function (array $endpoint) {
+            return match ($endpoint[0]) {
+                '/content_nodes' => false,
+                default => true,
+            };
+        });
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     *
+     * @dataProvider getPatchEndpoints
+     */
+    public function testPatchResponseMatchesGetItemResponse(string $endpoint) {
+        /** @var BaseEntity $fixtureFor */
+        $fixtureFor = $this->getFixtureFor($endpoint);
+
+        $itemResponse = static::createClientWithCredentials()->request('GET', "{$endpoint}/{$fixtureFor->getId()}");
+        $this->assertResponseStatusCodeSame(200);
+
+        $patchResponse = static::createClientWithCredentials()
+            ->request(
+                'PATCH',
+                "{$endpoint}/{$fixtureFor->getId()}",
+                [
+                    'json' => [],
+                    'headers' => [
+                        'Content-Type' => 'application/merge-patch+json',
+                    ],
+                ]
+            )
+        ;
+        $this->assertResponseStatusCodeSame(200);
+
+        assertThat($itemResponse->toArray(), equalTo($patchResponse->toArray()));
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public static function getPatchEndpoints() {
+        return array_filter(self::getItemEndpoints(), function (array $endpoint) {
+            return match ($endpoint[0]) {
+                '/activity_responsibles' => false,
+                // column layout has a problem with an empty patch
+                '/content_node/column_layouts' => false,
+                '/content_types' => false,
+                '/days' => false,
+                '/day_responsibles' => false,
+                // patch and getItem of period have different embeddings
+                '/periods' => false,
+                default => true,
+            };
+        });
+    }
+
+    private function getFixtureFor(string $collectionEndpoint) {
+        $fixtures = static::$fixtures;
+
+        return match ($collectionEndpoint) {
+            '/activities' => $fixtures['activity1'],
+            '/activity_progress_labels' => $fixtures['activityProgressLabel1'],
+            '/activity_responsibles' => $fixtures['activityResponsible1'],
+            '/camp_collaborations' => $fixtures['campCollaboration1manager'],
+            '/camps' => $fixtures['camp1'],
+            '/categories' => $fixtures['category1'],
+            '/content_node/column_layouts' => $fixtures['columnLayout2'],
+            '/content_types' => $fixtures['contentTypeSafetyConcept'],
+            '/day_responsibles' => $fixtures['dayResponsible1'],
+            '/days' => $fixtures['day1period1'],
+            '/material_items' => $fixtures['materialItem1'],
+            '/material_lists' => $fixtures['materialList1'],
+            '/content_node/material_nodes' => $fixtures['materialNode2'],
+            '/content_node/multi_selects' => $fixtures['multiSelect1'],
+            '/periods' => $fixtures['period1'],
+            '/profiles' => $fixtures['profile1manager'],
+            '/schedule_entries' => $fixtures['scheduleEntry1period1camp1'],
+            '/content_node/single_texts' => $fixtures['singleText1'],
+            '/content_node/storyboards' => $fixtures['storyboard1'],
+            default => throw new \RuntimeException("no fixture defined for endpoint {$collectionEndpoint}")
+        };
+    }
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set activities__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set activities__1.json
@@ -1,0 +1,508 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "activityResponsibles": [],
+                    "progressLabel": "escaped_value",
+                    "rootContentNode": {
+                        "_links": {
+                            "children": [
+                                {
+                                    "href": "escaped_value"
+                                }
+                            ],
+                            "contentType": {
+                                "href": "escaped_value"
+                            },
+                            "parent": "escaped_value",
+                            "root": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "contentTypeName": "escaped_value",
+                        "data": {
+                            "columns": [
+                                {
+                                    "slot": "escaped_value",
+                                    "width": "escaped_value"
+                                }
+                            ]
+                        },
+                        "id": "escaped_value",
+                        "instanceName": "escaped_value",
+                        "position": "escaped_value",
+                        "slot": "escaped_value"
+                    },
+                    "scheduleEntries": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayNumber": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "left": "escaped_value",
+                            "number": "escaped_value",
+                            "scheduleEntryNumber": "escaped_value",
+                            "start": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "activityResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "category": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "progressLabel": "escaped_value",
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "location": "escaped_value",
+                "title": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "activityResponsibles": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ],
+                    "progressLabel": "escaped_value",
+                    "rootContentNode": {
+                        "_links": {
+                            "children": [],
+                            "contentType": {
+                                "href": "escaped_value"
+                            },
+                            "parent": "escaped_value",
+                            "root": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "contentTypeName": "escaped_value",
+                        "data": {
+                            "columns": [
+                                {
+                                    "slot": "escaped_value",
+                                    "width": "escaped_value"
+                                }
+                            ]
+                        },
+                        "id": "escaped_value",
+                        "instanceName": "escaped_value",
+                        "position": "escaped_value",
+                        "slot": "escaped_value"
+                    },
+                    "scheduleEntries": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayNumber": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "left": "escaped_value",
+                            "number": "escaped_value",
+                            "scheduleEntryNumber": "escaped_value",
+                            "start": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayNumber": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "left": "escaped_value",
+                            "number": "escaped_value",
+                            "scheduleEntryNumber": "escaped_value",
+                            "start": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "activityResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "category": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "progressLabel": "escaped_value",
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "location": "escaped_value",
+                "title": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "activityResponsibles": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ],
+                    "progressLabel": "escaped_value",
+                    "rootContentNode": {
+                        "_links": {
+                            "children": [
+                                {
+                                    "href": "escaped_value"
+                                },
+                                {
+                                    "href": "escaped_value"
+                                },
+                                {
+                                    "href": "escaped_value"
+                                },
+                                {
+                                    "href": "escaped_value"
+                                },
+                                {
+                                    "href": "escaped_value"
+                                },
+                                {
+                                    "href": "escaped_value"
+                                }
+                            ],
+                            "contentType": {
+                                "href": "escaped_value"
+                            },
+                            "parent": "escaped_value",
+                            "root": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "contentTypeName": "escaped_value",
+                        "data": {
+                            "columns": [
+                                {
+                                    "slot": "escaped_value",
+                                    "width": "escaped_value"
+                                },
+                                {
+                                    "slot": "escaped_value",
+                                    "width": "escaped_value"
+                                }
+                            ]
+                        },
+                        "id": "escaped_value",
+                        "instanceName": "escaped_value",
+                        "position": "escaped_value",
+                        "slot": "escaped_value"
+                    },
+                    "scheduleEntries": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayNumber": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "left": "escaped_value",
+                            "number": "escaped_value",
+                            "scheduleEntryNumber": "escaped_value",
+                            "start": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayNumber": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "left": "escaped_value",
+                            "number": "escaped_value",
+                            "scheduleEntryNumber": "escaped_value",
+                            "start": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "activityResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "category": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "progressLabel": "escaped_value",
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "location": "escaped_value",
+                "title": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "activityResponsibles": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ],
+                    "progressLabel": {
+                        "_links": {
+                            "camp": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "id": "escaped_value",
+                        "position": "escaped_value",
+                        "title": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "_links": {
+                            "children": [],
+                            "contentType": {
+                                "href": "escaped_value"
+                            },
+                            "parent": "escaped_value",
+                            "root": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "contentTypeName": "escaped_value",
+                        "data": {
+                            "columns": [
+                                {
+                                    "slot": "escaped_value",
+                                    "width": "escaped_value"
+                                }
+                            ]
+                        },
+                        "id": "escaped_value",
+                        "instanceName": "escaped_value",
+                        "position": "escaped_value",
+                        "slot": "escaped_value"
+                    },
+                    "scheduleEntries": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayNumber": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "left": "escaped_value",
+                            "number": "escaped_value",
+                            "scheduleEntryNumber": "escaped_value",
+                            "start": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "activityResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "category": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "progressLabel": {
+                        "href": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "location": "escaped_value",
+                "title": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set activity_progress_labels__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set activity_progress_labels__1.json
@@ -1,0 +1,78 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "title": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "title": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "title": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "title": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set activity_responsibles__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set activity_responsibles__1.json
@@ -1,0 +1,65 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set camp_collaborations__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set camp_collaborations__1.json
@@ -1,0 +1,973 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": "escaped_value"
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": "escaped_value"
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "name": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set camps__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set camps__1.json
@@ -1,0 +1,164 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "activities": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaborations": {
+                        "href": "escaped_value"
+                    },
+                    "categories": {
+                        "href": "escaped_value"
+                    },
+                    "creator": {
+                        "href": "escaped_value"
+                    },
+                    "materialLists": {
+                        "href": "escaped_value"
+                    },
+                    "periods": {
+                        "href": "escaped_value"
+                    },
+                    "profiles": {
+                        "href": "escaped_value"
+                    },
+                    "progressLabels": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "addressCity": "escaped_value",
+                "addressName": "escaped_value",
+                "addressStreet": "escaped_value",
+                "addressZipcode": "escaped_value",
+                "coachName": "escaped_value",
+                "courseKind": "escaped_value",
+                "courseNumber": "escaped_value",
+                "id": "escaped_value",
+                "isPrototype": "escaped_value",
+                "kind": "escaped_value",
+                "motto": "escaped_value",
+                "name": "escaped_value",
+                "organizer": "escaped_value",
+                "printYSLogoOnPicasso": "escaped_value",
+                "title": "escaped_value",
+                "trainingAdvisorName": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activities": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaborations": {
+                        "href": "escaped_value"
+                    },
+                    "categories": {
+                        "href": "escaped_value"
+                    },
+                    "creator": {
+                        "href": "escaped_value"
+                    },
+                    "materialLists": {
+                        "href": "escaped_value"
+                    },
+                    "periods": {
+                        "href": "escaped_value"
+                    },
+                    "profiles": {
+                        "href": "escaped_value"
+                    },
+                    "progressLabels": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "addressCity": "escaped_value",
+                "addressName": "escaped_value",
+                "addressStreet": "escaped_value",
+                "addressZipcode": "escaped_value",
+                "coachName": "escaped_value",
+                "courseKind": "escaped_value",
+                "courseNumber": "escaped_value",
+                "id": "escaped_value",
+                "isPrototype": "escaped_value",
+                "kind": "escaped_value",
+                "motto": "escaped_value",
+                "name": "escaped_value",
+                "organizer": "escaped_value",
+                "printYSLogoOnPicasso": "escaped_value",
+                "title": "escaped_value",
+                "trainingAdvisorName": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activities": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaborations": {
+                        "href": "escaped_value"
+                    },
+                    "categories": {
+                        "href": "escaped_value"
+                    },
+                    "creator": {
+                        "href": "escaped_value"
+                    },
+                    "materialLists": {
+                        "href": "escaped_value"
+                    },
+                    "periods": {
+                        "href": "escaped_value"
+                    },
+                    "profiles": {
+                        "href": "escaped_value"
+                    },
+                    "progressLabels": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "addressCity": "escaped_value",
+                "addressName": "escaped_value",
+                "addressStreet": "escaped_value",
+                "addressZipcode": "escaped_value",
+                "coachName": "escaped_value",
+                "courseKind": "escaped_value",
+                "courseNumber": "escaped_value",
+                "id": "escaped_value",
+                "isPrototype": "escaped_value",
+                "kind": "escaped_value",
+                "motto": "escaped_value",
+                "name": "escaped_value",
+                "organizer": "escaped_value",
+                "printYSLogoOnPicasso": "escaped_value",
+                "title": "escaped_value",
+                "trainingAdvisorName": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set categories__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set categories__1.json
@@ -1,0 +1,303 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "rootContentNode": {
+                        "_links": {
+                            "children": [],
+                            "contentType": {
+                                "href": "escaped_value"
+                            },
+                            "parent": "escaped_value",
+                            "root": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "contentTypeName": "escaped_value",
+                        "data": {
+                            "columns": [
+                                {
+                                    "slot": "escaped_value",
+                                    "width": "escaped_value"
+                                }
+                            ]
+                        },
+                        "id": "escaped_value",
+                        "instanceName": "escaped_value",
+                        "position": "escaped_value",
+                        "slot": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "preferredContentTypes": {
+                        "href": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value",
+                "numberingStyle": "escaped_value",
+                "short": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "rootContentNode": {
+                        "_links": {
+                            "children": [],
+                            "contentType": {
+                                "href": "escaped_value"
+                            },
+                            "parent": "escaped_value",
+                            "root": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "contentTypeName": "escaped_value",
+                        "data": {
+                            "columns": [
+                                {
+                                    "slot": "escaped_value",
+                                    "width": "escaped_value"
+                                }
+                            ]
+                        },
+                        "id": "escaped_value",
+                        "instanceName": "escaped_value",
+                        "position": "escaped_value",
+                        "slot": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "preferredContentTypes": {
+                        "href": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value",
+                "numberingStyle": "escaped_value",
+                "short": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "rootContentNode": {
+                        "_links": {
+                            "children": [],
+                            "contentType": {
+                                "href": "escaped_value"
+                            },
+                            "parent": "escaped_value",
+                            "root": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "contentTypeName": "escaped_value",
+                        "data": {
+                            "columns": [
+                                {
+                                    "slot": "escaped_value",
+                                    "width": "escaped_value"
+                                }
+                            ]
+                        },
+                        "id": "escaped_value",
+                        "instanceName": "escaped_value",
+                        "position": "escaped_value",
+                        "slot": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "preferredContentTypes": {
+                        "href": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value",
+                "numberingStyle": "escaped_value",
+                "short": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "rootContentNode": {
+                        "_links": {
+                            "children": [],
+                            "contentType": {
+                                "href": "escaped_value"
+                            },
+                            "parent": "escaped_value",
+                            "root": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "contentTypeName": "escaped_value",
+                        "data": {
+                            "columns": [
+                                {
+                                    "slot": "escaped_value",
+                                    "width": "escaped_value"
+                                }
+                            ]
+                        },
+                        "id": "escaped_value",
+                        "instanceName": "escaped_value",
+                        "position": "escaped_value",
+                        "slot": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "preferredContentTypes": {
+                        "href": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value",
+                "numberingStyle": "escaped_value",
+                "short": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "rootContentNode": {
+                        "_links": {
+                            "children": [
+                                {
+                                    "href": "escaped_value"
+                                }
+                            ],
+                            "contentType": {
+                                "href": "escaped_value"
+                            },
+                            "parent": "escaped_value",
+                            "root": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "contentTypeName": "escaped_value",
+                        "data": {
+                            "columns": [
+                                {
+                                    "slot": "escaped_value",
+                                    "width": "escaped_value"
+                                }
+                            ]
+                        },
+                        "id": "escaped_value",
+                        "instanceName": "escaped_value",
+                        "position": "escaped_value",
+                        "slot": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "preferredContentTypes": {
+                        "href": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value",
+                "numberingStyle": "escaped_value",
+                "short": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodecolumn_layouts__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodecolumn_layouts__1.json
@@ -1,0 +1,404 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodematerial_nodes__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodematerial_nodes__1.json
@@ -1,0 +1,97 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "materialItems": []
+                },
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "materialItems": [
+                        {
+                            "_links": {
+                                "materialList": {
+                                    "href": "escaped_value"
+                                },
+                                "materialNode": {
+                                    "href": "escaped_value"
+                                },
+                                "period": "escaped_value",
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "article": "escaped_value",
+                            "id": "escaped_value",
+                            "quantity": "escaped_value",
+                            "unit": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodemulti_selects__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodemulti_selects__1.json
@@ -1,0 +1,81 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        },
+                        "key2": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodes__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodes__1.json
@@ -1,0 +1,714 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "materialItems": []
+                },
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "materialItems": [
+                        {
+                            "_links": {
+                                "materialList": {
+                                    "href": "escaped_value"
+                                },
+                                "materialNode": {
+                                    "href": "escaped_value"
+                                },
+                                "period": "escaped_value",
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "article": "escaped_value",
+                            "id": "escaped_value",
+                            "quantity": "escaped_value",
+                            "unit": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        },
+                        "key2": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ab9740f6-61a4-4cae-b574-a73aeb7c5ea0": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        },
+                        "cb26d76a-9e3b-43f0-a7c4-0f2ad0ea8029": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ea6f1e5d-0ef7-454f-8ae0-1d9b3bfd1177": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodesingle_texts__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodesingle_texts__1.json
@@ -1,0 +1,98 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodestoryboards__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_nodestoryboards__1.json
@@ -1,0 +1,90 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ab9740f6-61a4-4cae-b574-a73aeb7c5ea0": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        },
+                        "cb26d76a-9e3b-43f0-a7c4-0f2ad0ea8029": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ea6f1e5d-0ef7-454f-8ae0-1d9b3bfd1177": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_types__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set content_types__1.json
@@ -1,0 +1,126 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "active": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "active": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "active": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "active": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "active": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "active": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "active": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set day_responsibles__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set day_responsibles__1.json
@@ -1,0 +1,133 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            },
+            {
+                "_links": {
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            },
+            {
+                "_links": {
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            },
+            {
+                "_links": {
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            },
+            {
+                "_links": {
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            },
+            {
+                "_links": {
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            },
+            {
+                "_links": {
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set days__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set days__1.json
@@ -1,0 +1,361 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "dayResponsibles": []
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "dayResponsibles": []
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "dayResponsibles": []
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "dayResponsibles": [
+                        {
+                            "_links": {
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        },
+                        {
+                            "_links": {
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "dayResponsibles": [
+                        {
+                            "_links": {
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "dayResponsibles": [
+                        {
+                            "_links": {
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "dayResponsibles": [
+                        {
+                            "_links": {
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "dayResponsibles": [
+                        {
+                            "_links": {
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "dayResponsibles": [
+                        {
+                            "_links": {
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set material_items__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set material_items__1.json
@@ -1,0 +1,98 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "materialList": {
+                        "href": "escaped_value"
+                    },
+                    "materialNode": "escaped_value",
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "article": "escaped_value",
+                "id": "escaped_value",
+                "quantity": "escaped_value",
+                "unit": "escaped_value"
+            },
+            {
+                "_links": {
+                    "materialList": {
+                        "href": "escaped_value"
+                    },
+                    "materialNode": "escaped_value",
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "article": "escaped_value",
+                "id": "escaped_value",
+                "quantity": "escaped_value",
+                "unit": "escaped_value"
+            },
+            {
+                "_links": {
+                    "materialList": {
+                        "href": "escaped_value"
+                    },
+                    "materialNode": "escaped_value",
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "article": "escaped_value",
+                "id": "escaped_value",
+                "quantity": "escaped_value",
+                "unit": "escaped_value"
+            },
+            {
+                "_links": {
+                    "materialList": {
+                        "href": "escaped_value"
+                    },
+                    "materialNode": {
+                        "href": "escaped_value"
+                    },
+                    "period": "escaped_value",
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "article": "escaped_value",
+                "id": "escaped_value",
+                "quantity": "escaped_value",
+                "unit": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set material_lists__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set material_lists__1.json
@@ -1,0 +1,111 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaboration": "escaped_value",
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaboration": "escaped_value",
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaboration": "escaped_value",
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaboration": "escaped_value",
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "name": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set periods__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set periods__1.json
@@ -1,0 +1,142 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "days": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "description": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "days": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "description": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "days": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "description": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "days": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "description": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "start": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set profiles__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set profiles__1.json
@@ -1,0 +1,114 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "email": "escaped_value",
+                "firstname": "escaped_value",
+                "id": "escaped_value",
+                "language": "escaped_value",
+                "legalName": "escaped_value",
+                "nickname": "escaped_value",
+                "surname": "escaped_value"
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "email": "escaped_value",
+                "firstname": "escaped_value",
+                "id": "escaped_value",
+                "language": "escaped_value",
+                "legalName": "escaped_value",
+                "nickname": "escaped_value",
+                "surname": "escaped_value"
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "email": "escaped_value",
+                "firstname": "escaped_value",
+                "id": "escaped_value",
+                "language": "escaped_value",
+                "legalName": "escaped_value",
+                "nickname": "escaped_value",
+                "surname": "escaped_value"
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "email": "escaped_value",
+                "firstname": "escaped_value",
+                "id": "escaped_value",
+                "language": "escaped_value",
+                "legalName": "escaped_value",
+                "nickname": "escaped_value",
+                "surname": "escaped_value"
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "email": "escaped_value",
+                "firstname": "escaped_value",
+                "id": "escaped_value",
+                "language": "escaped_value",
+                "legalName": "escaped_value",
+                "nickname": "escaped_value",
+                "surname": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set schedule_entries__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set schedule_entries__1.json
@@ -1,0 +1,176 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set activities__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set activities__1.json
@@ -1,0 +1,558 @@
+{
+    "_embedded": {
+        "activityResponsibles": [
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            }
+        ],
+        "category": {
+            "_embedded": {
+                "rootContentNode": {
+                    "_links": {
+                        "children": [
+                            {
+                                "href": "escaped_value"
+                            }
+                        ],
+                        "contentType": {
+                            "href": "escaped_value"
+                        },
+                        "parent": "escaped_value",
+                        "root": {
+                            "href": "escaped_value"
+                        },
+                        "self": {
+                            "href": "escaped_value"
+                        }
+                    },
+                    "contentTypeName": "escaped_value",
+                    "data": {
+                        "columns": [
+                            {
+                                "slot": "escaped_value",
+                                "width": "escaped_value"
+                            }
+                        ]
+                    },
+                    "id": "escaped_value",
+                    "instanceName": "escaped_value",
+                    "position": "escaped_value",
+                    "slot": "escaped_value"
+                }
+            },
+            "_links": {
+                "camp": {
+                    "href": "escaped_value"
+                },
+                "contentNodes": {
+                    "href": "escaped_value"
+                },
+                "preferredContentTypes": {
+                    "href": "escaped_value"
+                },
+                "rootContentNode": {
+                    "href": "escaped_value"
+                },
+                "self": {
+                    "href": "escaped_value"
+                }
+            },
+            "color": "escaped_value",
+            "id": "escaped_value",
+            "name": "escaped_value",
+            "numberingStyle": "escaped_value",
+            "short": "escaped_value"
+        },
+        "contentNodes": [
+            {
+                "_embedded": {
+                    "materialItems": [
+                        {
+                            "_links": {
+                                "materialList": {
+                                    "href": "escaped_value"
+                                },
+                                "materialNode": {
+                                    "href": "escaped_value"
+                                },
+                                "period": "escaped_value",
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "article": "escaped_value",
+                            "id": "escaped_value",
+                            "quantity": "escaped_value",
+                            "unit": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        },
+                        "key2": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ab9740f6-61a4-4cae-b574-a73aeb7c5ea0": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        },
+                        "cb26d76a-9e3b-43f0-a7c4-0f2ad0ea8029": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ea6f1e5d-0ef7-454f-8ae0-1d9b3bfd1177": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        ],
+        "progressLabel": "escaped_value",
+        "rootContentNode": {
+            "_links": {
+                "children": [
+                    {
+                        "href": "escaped_value"
+                    },
+                    {
+                        "href": "escaped_value"
+                    },
+                    {
+                        "href": "escaped_value"
+                    },
+                    {
+                        "href": "escaped_value"
+                    },
+                    {
+                        "href": "escaped_value"
+                    },
+                    {
+                        "href": "escaped_value"
+                    }
+                ],
+                "contentType": {
+                    "href": "escaped_value"
+                },
+                "parent": "escaped_value",
+                "root": {
+                    "href": "escaped_value"
+                },
+                "self": {
+                    "href": "escaped_value"
+                }
+            },
+            "contentTypeName": "escaped_value",
+            "data": {
+                "columns": [
+                    {
+                        "slot": "escaped_value",
+                        "width": "escaped_value"
+                    },
+                    {
+                        "slot": "escaped_value",
+                        "width": "escaped_value"
+                    }
+                ]
+            },
+            "id": "escaped_value",
+            "instanceName": "escaped_value",
+            "position": "escaped_value",
+            "slot": "escaped_value"
+        },
+        "scheduleEntries": [
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "activityResponsibles": {
+            "href": "escaped_value"
+        },
+        "camp": {
+            "href": "escaped_value"
+        },
+        "category": {
+            "href": "escaped_value"
+        },
+        "contentNodes": {
+            "href": "escaped_value"
+        },
+        "progressLabel": "escaped_value",
+        "rootContentNode": {
+            "href": "escaped_value"
+        },
+        "scheduleEntries": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "id": "escaped_value",
+    "location": "escaped_value",
+    "title": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set activity_progress_labels__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set activity_progress_labels__1.json
@@ -1,0 +1,13 @@
+{
+    "_links": {
+        "camp": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "id": "escaped_value",
+    "position": "escaped_value",
+    "title": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set activity_responsibles__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set activity_responsibles__1.json
@@ -1,0 +1,14 @@
+{
+    "_links": {
+        "activity": {
+            "href": "escaped_value"
+        },
+        "campCollaboration": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "id": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set camp_collaborations__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set camp_collaborations__1.json
@@ -1,0 +1,78 @@
+{
+    "_embedded": {
+        "camp": {
+            "_links": {
+                "activities": {
+                    "href": "escaped_value"
+                },
+                "campCollaborations": {
+                    "href": "escaped_value"
+                },
+                "categories": {
+                    "href": "escaped_value"
+                },
+                "creator": {
+                    "href": "escaped_value"
+                },
+                "materialLists": {
+                    "href": "escaped_value"
+                },
+                "periods": {
+                    "href": "escaped_value"
+                },
+                "profiles": {
+                    "href": "escaped_value"
+                },
+                "progressLabels": {
+                    "href": "escaped_value"
+                },
+                "self": {
+                    "href": "escaped_value"
+                }
+            },
+            "addressCity": "escaped_value",
+            "addressName": "escaped_value",
+            "addressStreet": "escaped_value",
+            "addressZipcode": "escaped_value",
+            "coachName": "escaped_value",
+            "courseKind": "escaped_value",
+            "courseNumber": "escaped_value",
+            "id": "escaped_value",
+            "isPrototype": "escaped_value",
+            "kind": "escaped_value",
+            "motto": "escaped_value",
+            "name": "escaped_value",
+            "organizer": "escaped_value",
+            "printYSLogoOnPicasso": "escaped_value",
+            "title": "escaped_value",
+            "trainingAdvisorName": "escaped_value"
+        },
+        "user": {
+            "_links": {
+                "profile": {
+                    "href": "escaped_value"
+                },
+                "self": {
+                    "href": "escaped_value"
+                }
+            },
+            "displayName": "escaped_value",
+            "id": "escaped_value"
+        }
+    },
+    "_links": {
+        "camp": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        },
+        "user": {
+            "href": "escaped_value"
+        }
+    },
+    "id": "escaped_value",
+    "inviteEmail": "escaped_value",
+    "role": "escaped_value",
+    "status": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set camps__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set camps__1.json
@@ -1,0 +1,418 @@
+{
+    "_embedded": {
+        "campCollaborations": [
+            {
+                "_embedded": {
+                    "user": "escaped_value"
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": "escaped_value"
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            }
+        ],
+        "periods": [
+            {
+                "_embedded": {
+                    "days": [
+                        {
+                            "_links": {
+                                "dayResponsibles": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "scheduleEntries": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayOffset": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "number": "escaped_value",
+                            "start": "escaped_value"
+                        },
+                        {
+                            "_links": {
+                                "dayResponsibles": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "scheduleEntries": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayOffset": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "number": "escaped_value",
+                            "start": "escaped_value"
+                        },
+                        {
+                            "_links": {
+                                "dayResponsibles": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "scheduleEntries": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayOffset": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "number": "escaped_value",
+                            "start": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "days": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "description": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "days": [
+                        {
+                            "_links": {
+                                "dayResponsibles": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "scheduleEntries": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayOffset": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "number": "escaped_value",
+                            "start": "escaped_value"
+                        },
+                        {
+                            "_links": {
+                                "dayResponsibles": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "scheduleEntries": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayOffset": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "number": "escaped_value",
+                            "start": "escaped_value"
+                        },
+                        {
+                            "_links": {
+                                "dayResponsibles": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "scheduleEntries": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayOffset": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "number": "escaped_value",
+                            "start": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "days": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "description": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "start": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "activities": {
+            "href": "escaped_value"
+        },
+        "campCollaborations": {
+            "href": "escaped_value"
+        },
+        "categories": {
+            "href": "escaped_value"
+        },
+        "creator": {
+            "href": "escaped_value"
+        },
+        "materialLists": {
+            "href": "escaped_value"
+        },
+        "periods": {
+            "href": "escaped_value"
+        },
+        "profiles": {
+            "href": "escaped_value"
+        },
+        "progressLabels": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "addressCity": "escaped_value",
+    "addressName": "escaped_value",
+    "addressStreet": "escaped_value",
+    "addressZipcode": "escaped_value",
+    "coachName": "escaped_value",
+    "courseKind": "escaped_value",
+    "courseNumber": "escaped_value",
+    "id": "escaped_value",
+    "isPrototype": "escaped_value",
+    "kind": "escaped_value",
+    "motto": "escaped_value",
+    "name": "escaped_value",
+    "organizer": "escaped_value",
+    "printYSLogoOnPicasso": "escaped_value",
+    "title": "escaped_value",
+    "trainingAdvisorName": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set categories__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set categories__1.json
@@ -1,0 +1,137 @@
+{
+    "_embedded": {
+        "contentNodes": [
+            {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        ],
+        "preferredContentTypes": [
+            {
+                "_links": {
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "active": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value"
+            }
+        ],
+        "rootContentNode": {
+            "_links": {
+                "children": [
+                    {
+                        "href": "escaped_value"
+                    }
+                ],
+                "contentType": {
+                    "href": "escaped_value"
+                },
+                "parent": "escaped_value",
+                "root": {
+                    "href": "escaped_value"
+                },
+                "self": {
+                    "href": "escaped_value"
+                }
+            },
+            "contentTypeName": "escaped_value",
+            "data": {
+                "columns": [
+                    {
+                        "slot": "escaped_value",
+                        "width": "escaped_value"
+                    }
+                ]
+            },
+            "id": "escaped_value",
+            "instanceName": "escaped_value",
+            "position": "escaped_value",
+            "slot": "escaped_value"
+        }
+    },
+    "_links": {
+        "camp": {
+            "href": "escaped_value"
+        },
+        "contentNodes": {
+            "href": "escaped_value"
+        },
+        "preferredContentTypes": {
+            "href": "escaped_value"
+        },
+        "rootContentNode": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "color": "escaped_value",
+    "id": "escaped_value",
+    "name": "escaped_value",
+    "numberingStyle": "escaped_value",
+    "short": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_nodecolumn_layouts__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_nodecolumn_layouts__1.json
@@ -1,0 +1,32 @@
+{
+    "_links": {
+        "children": [
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "contentType": {
+            "href": "escaped_value"
+        },
+        "parent": "escaped_value",
+        "root": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "contentTypeName": "escaped_value",
+    "data": {
+        "columns": [
+            {
+                "slot": "escaped_value",
+                "width": "escaped_value"
+            }
+        ]
+    },
+    "id": "escaped_value",
+    "instanceName": "escaped_value",
+    "position": "escaped_value",
+    "slot": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_nodematerial_nodes__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_nodematerial_nodes__1.json
@@ -1,0 +1,29 @@
+{
+    "_embedded": {
+        "materialItems": []
+    },
+    "_links": {
+        "children": [],
+        "contentType": {
+            "href": "escaped_value"
+        },
+        "materialItems": {
+            "href": "escaped_value"
+        },
+        "parent": {
+            "href": "escaped_value"
+        },
+        "root": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "contentTypeName": "escaped_value",
+    "data": "escaped_value",
+    "id": "escaped_value",
+    "instanceName": "escaped_value",
+    "position": "escaped_value",
+    "slot": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_nodemulti_selects__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_nodemulti_selects__1.json
@@ -1,0 +1,32 @@
+{
+    "_links": {
+        "children": [],
+        "contentType": {
+            "href": "escaped_value"
+        },
+        "parent": {
+            "href": "escaped_value"
+        },
+        "root": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "contentTypeName": "escaped_value",
+    "data": {
+        "options": {
+            "key1": {
+                "checked": "escaped_value"
+            },
+            "key2": {
+                "checked": "escaped_value"
+            }
+        }
+    },
+    "id": "escaped_value",
+    "instanceName": "escaped_value",
+    "position": "escaped_value",
+    "slot": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_nodesingle_texts__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_nodesingle_texts__1.json
@@ -1,0 +1,25 @@
+{
+    "_links": {
+        "children": [],
+        "contentType": {
+            "href": "escaped_value"
+        },
+        "parent": {
+            "href": "escaped_value"
+        },
+        "root": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "contentTypeName": "escaped_value",
+    "data": {
+        "html": "escaped_value"
+    },
+    "id": "escaped_value",
+    "instanceName": "escaped_value",
+    "position": "escaped_value",
+    "slot": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_nodestoryboards__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_nodestoryboards__1.json
@@ -1,0 +1,38 @@
+{
+    "_links": {
+        "children": [],
+        "contentType": {
+            "href": "escaped_value"
+        },
+        "parent": {
+            "href": "escaped_value"
+        },
+        "root": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "contentTypeName": "escaped_value",
+    "data": {
+        "sections": {
+            "ab9740f6-61a4-4cae-b574-a73aeb7c5ea0": {
+                "column1": "escaped_value",
+                "column2Html": "escaped_value",
+                "column3": "escaped_value",
+                "position": "escaped_value"
+            },
+            "cb26d76a-9e3b-43f0-a7c4-0f2ad0ea8029": {
+                "column1": "escaped_value",
+                "column2Html": "escaped_value",
+                "column3": "escaped_value",
+                "position": "escaped_value"
+            }
+        }
+    },
+    "id": "escaped_value",
+    "instanceName": "escaped_value",
+    "position": "escaped_value",
+    "slot": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_types__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set content_types__1.json
@@ -1,0 +1,13 @@
+{
+    "_links": {
+        "contentNodes": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "active": "escaped_value",
+    "id": "escaped_value",
+    "name": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set day_responsibles__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set day_responsibles__1.json
@@ -1,0 +1,14 @@
+{
+    "_links": {
+        "campCollaboration": {
+            "href": "escaped_value"
+        },
+        "day": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "id": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set days__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set days__1.json
@@ -1,0 +1,39 @@
+{
+    "_embedded": {
+        "dayResponsibles": [
+            {
+                "_links": {
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "dayResponsibles": {
+            "href": "escaped_value"
+        },
+        "period": {
+            "href": "escaped_value"
+        },
+        "scheduleEntries": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "dayOffset": "escaped_value",
+    "end": "escaped_value",
+    "id": "escaped_value",
+    "number": "escaped_value",
+    "start": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set material_items__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set material_items__1.json
@@ -1,0 +1,18 @@
+{
+    "_links": {
+        "materialList": {
+            "href": "escaped_value"
+        },
+        "materialNode": {
+            "href": "escaped_value"
+        },
+        "period": "escaped_value",
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "article": "escaped_value",
+    "id": "escaped_value",
+    "quantity": "escaped_value",
+    "unit": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set material_lists__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set material_lists__1.json
@@ -1,0 +1,16 @@
+{
+    "_links": {
+        "camp": {
+            "href": "escaped_value"
+        },
+        "campCollaboration": "escaped_value",
+        "materialItems": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "id": "escaped_value",
+    "name": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set periods__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set periods__1.json
@@ -1,0 +1,143 @@
+{
+    "_embedded": {
+        "camp": {
+            "_links": {
+                "activities": {
+                    "href": "escaped_value"
+                },
+                "campCollaborations": {
+                    "href": "escaped_value"
+                },
+                "categories": {
+                    "href": "escaped_value"
+                },
+                "creator": {
+                    "href": "escaped_value"
+                },
+                "materialLists": {
+                    "href": "escaped_value"
+                },
+                "periods": {
+                    "href": "escaped_value"
+                },
+                "profiles": {
+                    "href": "escaped_value"
+                },
+                "progressLabels": {
+                    "href": "escaped_value"
+                },
+                "self": {
+                    "href": "escaped_value"
+                }
+            },
+            "addressCity": "escaped_value",
+            "addressName": "escaped_value",
+            "addressStreet": "escaped_value",
+            "addressZipcode": "escaped_value",
+            "coachName": "escaped_value",
+            "courseKind": "escaped_value",
+            "courseNumber": "escaped_value",
+            "id": "escaped_value",
+            "isPrototype": "escaped_value",
+            "kind": "escaped_value",
+            "motto": "escaped_value",
+            "name": "escaped_value",
+            "organizer": "escaped_value",
+            "printYSLogoOnPicasso": "escaped_value",
+            "title": "escaped_value",
+            "trainingAdvisorName": "escaped_value"
+        },
+        "days": [
+            {
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "camp": {
+            "href": "escaped_value"
+        },
+        "contentNodes": {
+            "href": "escaped_value"
+        },
+        "dayResponsibles": {
+            "href": "escaped_value"
+        },
+        "days": {
+            "href": "escaped_value"
+        },
+        "materialItems": {
+            "href": "escaped_value"
+        },
+        "scheduleEntries": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "description": "escaped_value",
+    "end": "escaped_value",
+    "id": "escaped_value",
+    "start": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set profiles__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set profiles__1.json
@@ -1,0 +1,17 @@
+{
+    "_links": {
+        "self": {
+            "href": "escaped_value"
+        },
+        "user": {
+            "href": "escaped_value"
+        }
+    },
+    "email": "escaped_value",
+    "firstname": "escaped_value",
+    "id": "escaped_value",
+    "language": "escaped_value",
+    "legalName": "escaped_value",
+    "nickname": "escaped_value",
+    "surname": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set schedule_entries__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetItemMatchesStructure with data set schedule_entries__1.json
@@ -1,0 +1,87 @@
+{
+    "_embedded": {
+        "activity": {
+            "_embedded": {
+                "rootContentNode": {
+                    "_links": {
+                        "children": [],
+                        "contentType": {
+                            "href": "escaped_value"
+                        },
+                        "parent": "escaped_value",
+                        "root": {
+                            "href": "escaped_value"
+                        },
+                        "self": {
+                            "href": "escaped_value"
+                        }
+                    },
+                    "contentTypeName": "escaped_value",
+                    "data": {
+                        "columns": [
+                            {
+                                "slot": "escaped_value",
+                                "width": "escaped_value"
+                            }
+                        ]
+                    },
+                    "id": "escaped_value",
+                    "instanceName": "escaped_value",
+                    "position": "escaped_value",
+                    "slot": "escaped_value"
+                }
+            },
+            "_links": {
+                "activityResponsibles": {
+                    "href": "escaped_value"
+                },
+                "camp": {
+                    "href": "escaped_value"
+                },
+                "category": {
+                    "href": "escaped_value"
+                },
+                "contentNodes": {
+                    "href": "escaped_value"
+                },
+                "progressLabel": {
+                    "href": "escaped_value"
+                },
+                "rootContentNode": {
+                    "href": "escaped_value"
+                },
+                "scheduleEntries": {
+                    "href": "escaped_value"
+                },
+                "self": {
+                    "href": "escaped_value"
+                }
+            },
+            "id": "escaped_value",
+            "location": "escaped_value",
+            "title": "escaped_value"
+        }
+    },
+    "_links": {
+        "activity": {
+            "href": "escaped_value"
+        },
+        "day": {
+            "href": "escaped_value"
+        },
+        "period": {
+            "href": "escaped_value"
+        },
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "dayNumber": "escaped_value",
+    "end": "escaped_value",
+    "id": "escaped_value",
+    "left": "escaped_value",
+    "number": "escaped_value",
+    "scheduleEntryNumber": "escaped_value",
+    "start": "escaped_value",
+    "width": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testRootEndpointMatchesSnapshot__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testRootEndpointMatchesSnapshot__1.json
@@ -1,0 +1,118 @@
+{
+    "_links": {
+        "activities": {
+            "href": "\/activities{\/id}{?camp,camp[]}",
+            "templated": true
+        },
+        "activityProgressLabels": {
+            "href": "\/activity_progress_labels{\/id}{?camp,camp[]}",
+            "templated": true
+        },
+        "activityResponsibles": {
+            "href": "\/activity_responsibles{\/id}{?activity,activity[],activity.camp,activity.camp[]}",
+            "templated": true
+        },
+        "campCollaborations": {
+            "href": "\/camp_collaborations{\/id}{\/action}{?camp,camp[],activityResponsibles.activity,activityResponsibles.activity[]}",
+            "templated": true
+        },
+        "camps": {
+            "href": "\/camps{\/id}{?isPrototype,isPrototype[]}",
+            "templated": true
+        },
+        "categories": {
+            "href": "\/categories{\/id}{?camp,camp[]}",
+            "templated": true
+        },
+        "columnLayouts": {
+            "href": "\/content_node\/column_layouts{\/id}{?contentType,contentType[],root,root[],period}",
+            "templated": true
+        },
+        "contentNodes": {
+            "href": "\/content_nodes{?contentType,contentType[],root,root[],period}",
+            "templated": true
+        },
+        "contentTypes": {
+            "href": "\/content_types{\/id}{?categories,categories[]}",
+            "templated": true
+        },
+        "dayResponsibles": {
+            "href": "\/day_responsibles{\/id}{?day,day[],day.period,day.period[]}",
+            "templated": true
+        },
+        "days": {
+            "href": "\/days{\/id}{?period,period[]}",
+            "templated": true
+        },
+        "invitations": {
+            "href": "\/invitations{\/id}{\/action}",
+            "templated": true
+        },
+        "login": {
+            "href": "\/authentication_token"
+        },
+        "materialItems": {
+            "href": "\/material_items{\/id}{?materialList,materialList[],materialNode,materialNode[],period}",
+            "templated": true
+        },
+        "materialLists": {
+            "href": "\/material_lists{\/id}{?camp,camp[]}",
+            "templated": true
+        },
+        "materialNodes": {
+            "href": "\/content_node\/material_nodes{\/id}{?contentType,contentType[],root,root[],period}",
+            "templated": true
+        },
+        "multiSelects": {
+            "href": "\/content_node\/multi_selects{\/id}{?contentType,contentType[],root,root[],period}",
+            "templated": true
+        },
+        "oauthCevidb": {
+            "href": "\/auth\/cevidb{?callback}",
+            "templated": true
+        },
+        "oauthGoogle": {
+            "href": "\/auth\/google{?callback}",
+            "templated": true
+        },
+        "oauthJubladb": {
+            "href": "\/auth\/jubladb{?callback}",
+            "templated": true
+        },
+        "oauthPbsmidata": {
+            "href": "\/auth\/pbsmidata{?callback}",
+            "templated": true
+        },
+        "periods": {
+            "href": "\/periods{\/id}{?camp,camp[]}",
+            "templated": true
+        },
+        "profiles": {
+            "href": "\/profiles{\/id}{?user.collaborations.camp,user.collaborations.camp[]}",
+            "templated": true
+        },
+        "resetPassword": {
+            "href": "\/auth\/reset_password{\/id}",
+            "templated": true
+        },
+        "scheduleEntries": {
+            "href": "\/schedule_entries{\/id}{?period,period[],activity,activity[],start[before],start[strictly_before],start[after],start[strictly_after],end[before],end[strictly_before],end[after],end[strictly_after]}",
+            "templated": true
+        },
+        "self": {
+            "href": "\/"
+        },
+        "singleTexts": {
+            "href": "\/content_node\/single_texts{\/id}{?contentType,contentType[],root,root[],period}",
+            "templated": true
+        },
+        "storyboards": {
+            "href": "\/content_node\/storyboards{\/id}{?contentType,contentType[],root,root[],period}",
+            "templated": true
+        },
+        "users": {
+            "href": "\/users{\/id}{\/action}",
+            "templated": true
+        }
+    }
+}

--- a/api/tests/Api/Users/CreateUserTest.php
+++ b/api/tests/Api/Users/CreateUserTest.php
@@ -7,6 +7,14 @@ use ApiPlatform\Metadata\Post;
 use App\Entity\Profile;
 use App\Entity\User;
 use App\Tests\Api\ECampApiTestCase;
+use App\Tests\Constraints\CompatibleHalResponse;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function PHPUnit\Framework\assertThat;
 
 /**
  * @internal
@@ -786,6 +794,33 @@ class CreateUserTest extends ECampApiTestCase {
             'roles' => ['roles'],
             'user' => ['user'],
         ];
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testCreateResponseStructureMatchesReadResponseStructure() {
+        $client = static::createClientWithCredentials();
+        $client->disableReboot();
+        $createResponse = $client->request(
+            'POST',
+            '/users',
+            [
+                'json' => $this->getExampleWritePayload(),
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $createArray = $createResponse->toArray();
+        $newItemLink = $createArray['_links']['self']['href'];
+        $getItemResponse = $client->request('GET', $newItemLink);
+
+        assertThat($createArray, CompatibleHalResponse::isHalCompatibleWith($getItemResponse->toArray()));
     }
 
     public function getExampleWritePayload($attributes = [], $except = [], $mergeEmbeddedAttributes = []) {

--- a/api/tests/Constraints/CompatibleHalResponse.php
+++ b/api/tests/Constraints/CompatibleHalResponse.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Tests\Constraints;
+
+use PHPUnit\Framework\Constraint\Constraint;
+
+class CompatibleHalResponse extends Constraint {
+    public function __construct(private readonly array $halResponse) {
+    }
+
+    public static function isHalCompatibleWith(array $halResponse): CompatibleHalResponse {
+        return new CompatibleHalResponse($halResponse);
+    }
+
+    public function toString(): string {
+        return 'is hal compatible with '.$this->exporter()->export($this->halResponse);
+    }
+
+    protected function matches($other): bool {
+        if (!is_array($other)) {
+            return false;
+        }
+        $halResponseKeys = array_keys($this->halResponse);
+        sort($halResponseKeys);
+        $halResponseKeysWithoutEmbedded = array_diff($halResponseKeys, ['_embedded']);
+
+        $otherKeys = array_keys($other);
+        sort($otherKeys);
+        $otherKeysWithoutEmbedded = array_diff($otherKeys, ['_embedded']);
+
+        if (join($halResponseKeysWithoutEmbedded) !== join($otherKeysWithoutEmbedded)) {
+            return false;
+        }
+
+        $halResponseLinksKeys = array_keys($this->halResponse['_links'] ?? []);
+        $halResponseEmbeddedKeys = array_keys($this->halResponse['_embedded'] ?? []);
+        $halResponseRelationKeys = array_unique(array_merge($halResponseLinksKeys, $halResponseEmbeddedKeys));
+        sort($halResponseRelationKeys);
+
+        $otherLinksKeys = array_keys($other['_links'] ?? []);
+        $otherEmbeddedKeys = array_keys($other['_embedded'] ?? []);
+        $otherRelationKeys = array_unique(array_merge($otherLinksKeys, $otherEmbeddedKeys));
+        sort($otherRelationKeys);
+
+        if (join($halResponseRelationKeys) !== join($otherRelationKeys)) {
+            return false;
+        }
+
+        foreach ($halResponseRelationKeys as $key) {
+            if (isset($this->halResponse['_embedded'][$key], $other['_embedded'][$key])) {
+                $compatibleHalResponse = new CompatibleHalResponse($this->halResponse['_embedded'][$key]);
+                if (!$compatibleHalResponse->matches($other['_embedded'][$key])) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/api/tests/Constraints/CompatibleHalResponseTest.php
+++ b/api/tests/Constraints/CompatibleHalResponseTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace App\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+
+use function PHPUnit\Framework\assertThat;
+use function PHPUnit\Framework\logicalNot;
+
+/**
+ * @internal
+ */
+class CompatibleHalResponseTest extends TestCase {
+    /**
+     * @dataProvider compatibleArrays
+     */
+    public function testCompatibleArrays(array $array1, array $array2) {
+        assertThat($array1, CompatibleHalResponse::isHalCompatibleWith($array2));
+    }
+
+    /**
+     * @dataProvider compatibleArrays
+     */
+    public function testCompatibleArraysIsCommutative(array $array1, array $array2) {
+        assertThat($array2, CompatibleHalResponse::isHalCompatibleWith($array1));
+    }
+
+    public static function compatibleArrays() {
+        return [
+            'empty' => [[], []],
+            'one_key' => [['one' => 1], ['one' => 1]],
+            'two_keys' => [
+                ['one' => 1, 'two' => 2],
+                ['one' => 1, 'two' => 2],
+            ],
+            'different_values' => [['one' => 1], ['one' => 2]],
+            'one_embedded_one_not' => [
+                [
+                    '_links' => [
+                        'one' => 'value',
+                    ],
+                ],
+                [
+                    '_links' => [
+                        'one' => 'value',
+                    ],
+                    '_embedded' => [
+                        'one' => [
+                            '_links' => [
+                                'self' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'recursive' => [
+                [
+                    '_links' => [
+                        'one' => 'value',
+                    ],
+                    '_embedded' => [
+                        'one' => [
+                            '_links' => [
+                                'self' => 1,
+                            ],
+                            '_embedded' => [
+                                'one' => [
+                                    '_links' => [
+                                        'self' => 1,
+                                    ],
+                                ],
+                                'two' => [
+                                    '_links' => [
+                                        'self' => 1,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'two' => [
+                            '_links' => [
+                                'self' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    '_links' => [
+                        'one' => 'value',
+                    ],
+                    '_embedded' => [
+                        'one' => [
+                            '_links' => [
+                                'self' => 1,
+                            ],
+                            '_embedded' => [
+                                'one' => [
+                                    '_links' => [
+                                        'self' => 1,
+                                    ],
+                                ],
+                                'two' => [
+                                    '_links' => [
+                                        'self' => 1,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'two' => [
+                            '_links' => [
+                                'self' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider notCompatibleArrays
+     */
+    public function testNotCompatibleArrays(array $array1, array $array2) {
+        assertThat($array1, logicalNot(CompatibleHalResponse::isHalCompatibleWith($array2)));
+    }
+
+    /**
+     * @dataProvider notCompatibleArrays
+     */
+    public function testNotCompatibleArraysIsCommutative(array $array1, array $array2) {
+        assertThat($array2, logicalNot(CompatibleHalResponse::isHalCompatibleWith($array1)));
+    }
+
+    public static function notCompatibleArrays() {
+        return [
+            'empty_and_not_empty' => [[], [2]],
+            'one_key' => [['one' => 1], ['two' => 1]],
+            'two_keys' => [
+                ['one' => 1, 'three' => 2],
+                ['one' => 1, 'two' => 2],
+            ],
+            'one_embedded_one_not' => [
+                [
+                    '_links' => [
+                        'two' => 'value',
+                    ],
+                ],
+                [
+                    '_links' => [
+                        'one' => 'value',
+                    ],
+                    '_embedded' => [
+                        'one' => [
+                            '_links' => [
+                                'self' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'recursive' => [
+                [
+                    '_links' => [
+                        'one' => 'value',
+                    ],
+                    '_embedded' => [
+                        'one' => [
+                            '_links' => [
+                                'self' => 1,
+                            ],
+                            '_embedded' => [
+                                'one' => [
+                                    '_links' => [
+                                        'self' => 1,
+                                    ],
+                                ],
+                                'two' => [
+                                    '_links' => [
+                                        'self' => 1,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'two' => [
+                            '_links' => [
+                                'self' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    '_links' => [
+                        'one' => 'value',
+                    ],
+                    '_embedded' => [
+                        'one' => [
+                            '_links' => [
+                                'self' => 1,
+                            ],
+                            '_embedded' => [
+                                'one' => [
+                                    '_links' => [
+                                        'self' => 1,
+                                    ],
+                                ],
+                                'three' => [
+                                    '_links' => [
+                                        'self' => 1,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'two' => [
+                            '_links' => [
+                                'self' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/api/tests/Util/ArrayDeepSortTest.php
+++ b/api/tests/Util/ArrayDeepSortTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Tests\Util;
+
+use App\Util\ArrayDeepSort;
+use PHPUnit\Framework\TestCase;
+use Spatie\Snapshots\MatchesSnapshots;
+
+use function PHPUnit\Framework\assertThat;
+use function PHPUnit\Framework\equalTo;
+
+/**
+ * @internal
+ */
+class ArrayDeepSortTest extends TestCase {
+    use MatchesSnapshots;
+
+    /**
+     * @dataProvider getJsonFiles
+     */
+    public function testSortsJson1AlwaysTheSame(string $jsonFileName) {
+        $json1 = file_get_contents(__DIR__."/Resource/{$jsonFileName}");
+        $array = json_decode($json1, true);
+
+        $sortedArray = ArrayDeepSort::sort($array);
+
+        $this->assertMatchesJsonSnapshot($sortedArray);
+    }
+
+    public static function getJsonFiles() {
+        return [
+            'json_to_sort_1.json' => ['json_to_sort_1.json'],
+            'json_to_sort_2.json' => ['json_to_sort_2.json'],
+            'json_to_sort_3.json' => ['json_to_sort_3.json'],
+        ];
+    }
+
+    public function testSortsAssocArrayByKey() {
+        $sorted = ArrayDeepSort::sort(['z' => 0, 'a' => 1]);
+
+        assertThat($sorted, equalTo(['a' => 1, 'z' => 0]));
+    }
+
+    public function testSortsListByValueWithStringCompare() {
+        $sorted = ArrayDeepSort::sort([1, 'test', 11, 2]);
+
+        assertThat($sorted, equalTo(['test', 1, 11, 2]));
+    }
+
+    public function testSortsNestedArrays() {
+        $sorted = ArrayDeepSort::sort([
+            'totalItems' => 'escaped_value',
+            '_links' => [
+                'items' => [
+                    [
+                        'href' => [
+                            'z',
+                        ],
+                    ],
+                    [
+                        'href' => [
+                            'a',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        assertThat(json_encode($sorted), equalTo(json_encode([
+            '_links' => [
+                'items' => [
+                    [
+                        'href' => [
+                            'a',
+                        ],
+                    ],
+                    [
+                        'href' => [
+                            'z',
+                        ],
+                    ],
+                ],
+            ],
+            'totalItems' => 'escaped_value',
+        ])));
+    }
+}

--- a/api/tests/Util/Resource/json_to_sort_1.json
+++ b/api/tests/Util/Resource/json_to_sort_1.json
@@ -1,0 +1,714 @@
+{
+    "_embedded": {
+        "items": {
+            "6": {
+                "_embedded": {
+                    "materialItems": []
+                },
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "13": {
+                "_embedded": {
+                    "materialItems": [
+                        {
+                            "_links": {
+                                "materialList": {
+                                    "href": "escaped_value"
+                                },
+                                "materialNode": {
+                                    "href": "escaped_value"
+                                },
+                                "period": "escaped_value",
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "article": "escaped_value",
+                            "id": "escaped_value",
+                            "quantity": "escaped_value",
+                            "unit": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "2": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "3": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "4": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "5": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "8": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "19": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "0": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "10": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "14": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "15": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "12": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        },
+                        "key2": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "9": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "16": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ab9740f6-61a4-4cae-b574-a73aeb7c5ea0": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        },
+                        "cb26d76a-9e3b-43f0-a7c4-0f2ad0ea8029": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "11": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ea6f1e5d-0ef7-454f-8ae0-1d9b3bfd1177": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "18": {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "17": {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "1": {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "7": {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        }
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Util/Resource/json_to_sort_2.json
+++ b/api/tests/Util/Resource/json_to_sort_2.json
@@ -1,0 +1,90 @@
+{
+    "_embedded": {
+        "items": {
+            "1": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ab9740f6-61a4-4cae-b574-a73aeb7c5ea0": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        },
+                        "cb26d76a-9e3b-43f0-a7c4-0f2ad0ea8029": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "0": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ea6f1e5d-0ef7-454f-8ae0-1d9b3bfd1177": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        }
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Util/Resource/json_to_sort_3.json
+++ b/api/tests/Util/Resource/json_to_sort_3.json
@@ -1,0 +1,114 @@
+[
+  {
+    "color": "escaped_value",
+    "id": "escaped_value",
+    "name": "escaped_value",
+    "numberingStyle": "escaped_value",
+    "short": "escaped_value",
+    "_links": {
+      "camp": {
+        "href": "escaped_value"
+      },
+      "contentNodes": {
+        "href": "escaped_value"
+      },
+      "preferredContentTypes": {
+        "href": "escaped_value"
+      },
+      "rootContentNode": {
+        "href": "escaped_value"
+      },
+      "self": {
+        "href": "escaped_value"
+      }
+    },
+    "_embedded": {
+      "rootContentNode": {
+        "contentTypeName": "escaped_value",
+        "id": "escaped_value",
+        "instanceName": "escaped_value",
+        "position": "escaped_value",
+        "slot": "escaped_value",
+        "data": {
+          "columns": [
+            {
+              "slot": "escaped_value",
+              "width": "escaped_value"
+            }
+          ]
+        },
+        "_links": {
+          "parent": "escaped_value",
+          "children": [],
+          "contentType": {
+            "href": "escaped_value"
+          },
+          "root": {
+            "href": "escaped_value"
+          },
+          "self": {
+            "href": "escaped_value"
+          }
+        }
+      }
+    }
+  },
+  {
+    "color": "escaped_value",
+    "id": "escaped_value",
+    "name": "escaped_value",
+    "numberingStyle": "escaped_value",
+    "short": "escaped_value",
+    "_links": {
+      "camp": {
+        "href": "escaped_value"
+      },
+      "contentNodes": {
+        "href": "escaped_value"
+      },
+      "preferredContentTypes": {
+        "href": "escaped_value"
+      },
+      "rootContentNode": {
+        "href": "escaped_value"
+      },
+      "self": {
+        "href": "escaped_value"
+      }
+    },
+    "_embedded": {
+      "rootContentNode": {
+        "contentTypeName": "escaped_value",
+        "id": "escaped_value",
+        "instanceName": "escaped_value",
+        "position": "escaped_value",
+        "slot": "escaped_value",
+        "data": {
+          "columns": [
+            {
+              "slot": "escaped_value",
+              "width": "escaped_value"
+            }
+          ]
+        },
+        "_links": {
+          "parent": "escaped_value",
+          "children": [
+            {
+              "href": "escaped_value"
+            }
+          ],
+          "contentType": {
+            "href": "escaped_value"
+          },
+          "root": {
+            "href": "escaped_value"
+          },
+          "self": {
+            "href": "escaped_value"
+          }
+        }
+      }
+    }
+  }
+]

--- a/api/tests/Util/__snapshots__/ArrayDeepSortTest__testSortsJson1AlwaysTheSame with data set json_to_sort_1.json__1.json
+++ b/api/tests/Util/__snapshots__/ArrayDeepSortTest__testSortsJson1AlwaysTheSame with data set json_to_sort_1.json__1.json
@@ -1,0 +1,714 @@
+{
+    "_embedded": {
+        "items": {
+            "6": {
+                "_embedded": {
+                    "materialItems": []
+                },
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "13": {
+                "_embedded": {
+                    "materialItems": [
+                        {
+                            "_links": {
+                                "materialList": {
+                                    "href": "escaped_value"
+                                },
+                                "materialNode": {
+                                    "href": "escaped_value"
+                                },
+                                "period": "escaped_value",
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "article": "escaped_value",
+                            "id": "escaped_value",
+                            "quantity": "escaped_value",
+                            "unit": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "2": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "3": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "4": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "5": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "8": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "19": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "0": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "10": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "14": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "15": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "html": "escaped_value"
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "12": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        },
+                        "key2": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "9": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "16": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ab9740f6-61a4-4cae-b574-a73aeb7c5ea0": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        },
+                        "cb26d76a-9e3b-43f0-a7c4-0f2ad0ea8029": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "11": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ea6f1e5d-0ef7-454f-8ae0-1d9b3bfd1177": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "18": {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "17": {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "1": {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "7": {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": "escaped_value",
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        }
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Util/__snapshots__/ArrayDeepSortTest__testSortsJson1AlwaysTheSame with data set json_to_sort_2.json__1.json
+++ b/api/tests/Util/__snapshots__/ArrayDeepSortTest__testSortsJson1AlwaysTheSame with data set json_to_sort_2.json__1.json
@@ -1,0 +1,90 @@
+{
+    "_embedded": {
+        "items": {
+            "1": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ab9740f6-61a4-4cae-b574-a73aeb7c5ea0": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        },
+                        "cb26d76a-9e3b-43f0-a7c4-0f2ad0ea8029": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            },
+            "0": {
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ea6f1e5d-0ef7-454f-8ae0-1d9b3bfd1177": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        }
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Util/__snapshots__/ArrayDeepSortTest__testSortsJson1AlwaysTheSame with data set json_to_sort_3.json__1.json
+++ b/api/tests/Util/__snapshots__/ArrayDeepSortTest__testSortsJson1AlwaysTheSame with data set json_to_sort_3.json__1.json
@@ -1,0 +1,114 @@
+[
+    {
+        "color": "escaped_value",
+        "id": "escaped_value",
+        "name": "escaped_value",
+        "numberingStyle": "escaped_value",
+        "short": "escaped_value",
+        "_links": {
+            "camp": {
+                "href": "escaped_value"
+            },
+            "contentNodes": {
+                "href": "escaped_value"
+            },
+            "preferredContentTypes": {
+                "href": "escaped_value"
+            },
+            "rootContentNode": {
+                "href": "escaped_value"
+            },
+            "self": {
+                "href": "escaped_value"
+            }
+        },
+        "_embedded": {
+            "rootContentNode": {
+                "contentTypeName": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "parent": "escaped_value",
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "color": "escaped_value",
+        "id": "escaped_value",
+        "name": "escaped_value",
+        "numberingStyle": "escaped_value",
+        "short": "escaped_value",
+        "_links": {
+            "camp": {
+                "href": "escaped_value"
+            },
+            "contentNodes": {
+                "href": "escaped_value"
+            },
+            "preferredContentTypes": {
+                "href": "escaped_value"
+            },
+            "rootContentNode": {
+                "href": "escaped_value"
+            },
+            "self": {
+                "href": "escaped_value"
+            }
+        },
+        "_embedded": {
+            "rootContentNode": {
+                "contentTypeName": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value",
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "parent": "escaped_value",
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                }
+            }
+        }
+    }
+]


### PR DESCRIPTION
That we are sure that we don't accidentally change the interface for the frontend which may lead to n+1 requests.
e.g. when we make performance improvements

This is an example of 2 entities, one of which where all operation responses are snapshoted.
We cannot snapshot the values because
a) The ID's are different each time
b) We use randomly generated data

Other ways we could test that the api response does not change accidentally:

1. Snapshot the openapi spec
This does not work because there the _links are modeled as map, and the _embedded entities don't appear as normal properties.

2. Snapshot the responses of a php instance with the development testdata in the database
- either in php (for that we need the infrastructure to use the development data instead of the test fixtures for these requests
- or with e.g. cypress (there we need a way to make sure the database state is deterministic

There we could even snapshot the output of the symfony profiler and eventually make assertions on the number of db requests or the request duration.

### After finishing the PR:

api: add snapshot tests for the api responses

- test the root endpoint without escaping the values
- test GetCollection endpoints with escaping the values
- test GetItem endpoints with escaping the values
Here using a map to use a fixture per collection endpoint was necessary,
because taking the first item of the collection endpoint would result in a different
item used which may have another structure. (e.g. more children or more related entities)
- test that Patch and GetItem result in the same response
This was not possible for the /profile endpoint because there some properties are present in
_links, in PATCH, but not in _embedded, but they still lead to a compatible response.

api: test that create and readItem responses are hal compatible

Here i could not generalize the tests because
generating valid post bodies dynamically
was not easily possible.

ResponseStructureSnapshotTest: test only for hal compatibility in testPatchResponseMatchesGetItemResponse

This allows to test the /period endpoint too.

#### Current drawbacks:

Currently it increases the runtime for the tests by 5 Minutes....