### PR TITLE
fix: coveralls BC on workflow re-run

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -179,8 +179,7 @@ jobs:
                                   --json_path api/build/logs/coveralls-upload.json
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_SERVICE_NAME: github
-          COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
+          CI_JOB_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           CI_PULL_REQUEST: ${{ github.event.number }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: api
@@ -380,8 +379,10 @@ jobs:
       - frontend-tests
       - print-tests
     runs-on: ubuntu-latest
+    env:
+      COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -179,6 +179,9 @@ jobs:
                                   --json_path api/build/logs/coveralls-upload.json
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_SERVICE_NAME: github
+          COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
+          CI_PULL_REQUEST: ${{ github.event.number }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: api
 
@@ -215,7 +218,7 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: github
-          COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}
+          COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
           CI_PULL_REQUEST: ${{ github.event.number }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: frontend
@@ -255,7 +258,7 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: github
-          COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}
+          COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
           CI_PULL_REQUEST: ${{ github.event.number }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: print


### PR DESCRIPTION
BC on coveralls side

Trying to fix as per these comments:
https://github.com/lemurheavy/coveralls-public/issues/1716#issuecomment-1594019773

### Initial workflow run
https://github.com/ecamp/ecamp3/actions/runs/5562284229/attempts/1
https://coveralls.io/builds/61365243

Workflow runs successfully. However, coverage only includes API (no frontend, no print).

### Second workflow run
https://github.com/ecamp/ecamp3/actions/runs/5562284229/attempts/2


