### PR TITLE
Fix warnings in frontend tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -194,7 +194,7 @@
       "^.+\\.jsx?$": "babel-jest"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(vuetify|vee-validate|axios))"
+      "node_modules/(?!(vuetify|vee-validate|axios|url-template))"
     ],
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/src/$1"

--- a/frontend/src/views/camp/Admin.vue
+++ b/frontend/src/views/camp/Admin.vue
@@ -45,10 +45,12 @@ import CampActivityProgressLabels from '@/components/campAdmin/CampActivityProgr
 import ContentCard from '@/components/layout/ContentCard.vue'
 import CampDangerZone from '@/components/campAdmin/CampDangerZone.vue'
 import { campRoleMixin } from '@/mixins/campRoleMixin'
+import CampConditionalFields from '@/components/campAdmin/CampConditionalFields.vue'
 
 export default {
   name: 'Admin',
   components: {
+    CampConditionalFields,
     CampDangerZone,
     ContentCard,
     CampSettings,

--- a/frontend/src/views/camp/Invitation.vue
+++ b/frontend/src/views/camp/Invitation.vue
@@ -22,7 +22,7 @@
           <span class="subtitle-2 font-weight-bold">{{
             $tc('views.camp.invitation.title')
           }}</span>
-          <span v-if="!invite?._meta.loading">{{ invite?.campTitle }}</span>
+          <span v-if="ready">{{ invite.campTitle }}</span>
         </template>
         <span v-else-if="variant === 'rejected'">{{
           $tc('views.camp.invitation.successfullyRejected')
@@ -38,7 +38,7 @@
       >
         <div v-if="authUser">
           <v-alert
-            v-if="invite?.userAlreadyInCamp"
+            v-if="invite.userAlreadyInCamp"
             border="left"
             colored-border
             color="primary"
@@ -79,7 +79,7 @@
             {{ $tc('views.camp.invitation.register') }}
           </v-btn>
         </div>
-        <v-btn dark text :small="invite?.userAlreadyInCamp" @click="rejectInvitation">
+        <v-btn dark text :small="invite.userAlreadyInCamp" @click="rejectInvitation">
           {{ $tc('views.camp.invitation.reject') }}
         </v-btn>
       </div>

--- a/frontend/src/views/camp/__tests__/Admin.spec.js
+++ b/frontend/src/views/camp/__tests__/Admin.spec.js
@@ -108,7 +108,7 @@ const USER = {
 }
 
 function createCampWithRole(role) {
-  return () => ({
+  const camp = {
     campCollaborations: () => ({
       items: [
         {
@@ -122,6 +122,9 @@ function createCampWithRole(role) {
     }),
     materialLists: () => {},
     progressLabels: () => {},
-    _meta: { load: Promise.resolve() },
-  })
+  }
+  camp._meta = {
+    load: Promise.resolve(camp),
+  }
+  return () => camp
 }


### PR DESCRIPTION
Invitation.vue: do not use optional chaining in template

The transformation jest uses cannot collect coverage for optional chaining (?.).
Failed to collect coverage from /home/runner/work/ecamp3/ecamp3/frontend/src/views/camp/Invitation.vue
ERROR: Unexpected token (1:1001)
STACK: SyntaxError: Unexpected token (1:1001)
    at Parser.pp$4.raise (/home/runner/work/ecamp3/ecamp3/frontend/node_modules/vue-template-es2015-compiler/buble.js:2757:13)
    at Parser.pp.unexpected (/home/runner/work/ecamp3/ecamp3/frontend/node_modules/vue-template-es2015-compiler/buble.js:647:8)
    at Parser.pp$3.parseExprAtom (/home/runner/work/ecamp3/ecamp3/frontend/node_modules/vue-template-es2015-compiler/buble.js:2196:10)



frontend: transform package url-template in jest tests

Else jest complains:
Jest encountered an unexpected token
...
/home/runner/work/ecamp3/ecamp3/frontend/node_modules/url-template/lib/url-template.js:97
      export function parseTemplate(template) {
      ^^^^^^


Admin.vue: register CampConditionalFields component

Else jest complains that the component is not registered.
Also fix Admin.spec.js, was broken in 020ffab.
