### PR TITLE
TranslationInfoOfConstraintViolation: add type hint for $key in remov…

### DIFF
--- a/api/src/Serializer/Normalizer/Error/TranslationInfoOfConstraintViolation.php
+++ b/api/src/Serializer/Normalizer/Error/TranslationInfoOfConstraintViolation.php
@@ -18,6 +18,7 @@ class TranslationInfoOfConstraintViolation {
     public static function removeCurlyBraces(array $parameters): array {
         $paramsWithoutCurlyBraces = [];
         foreach ($parameters as $key => $value) {
+            /** @var int|string $key */
             $key = str_replace('{{ ', '', $key);
             $key = str_replace(' }}', '', $key);
             $paramsWithoutCurlyBraces[$key] = $value;


### PR DESCRIPTION
…eCurlyBraces

Else psalm fails with:
ERROR: InvalidReturnType - src/Serializer/Normalizer/Error/TranslationInfoOfConstraintViolation.php:20:21 - The declared return type 'array<string, mixed>' for App\Serializer\Normalizer\Error\TranslationInfoOfConstraintViolation::removeCurlyBraces is incorrect, got 'array<array<array-key, string>|string, mixed>' (see https://psalm.dev/011)
    * @psalm-return array<string, mixed>