### PR TITLE
edit lint config to prevent overwriting linebreaks

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "semi": false,
   "bracketSameLine": false,
   "bracketSpacing": true,
-  "printWidth": 90
+  "printWidth": 90,
+  "endOfLine": "auto"
 }

--- a/frontend/eslint-local-rules/index.js
+++ b/frontend/eslint-local-rules/index.js
@@ -5,4 +5,5 @@ const matchingTranslationKeys = require('../src/common/eslint-local-rules/matchi
 
 module.exports = {
   'matching-translation-keys': matchingTranslationKeys(path, utils, fs),
+  'linebreak-style':'windows'
 }


### PR DESCRIPTION
I noticed an issue (at least on my machine: IntelliJ, windows, wsl) when running  `docker compose exec frontend npm run lint`
It changes the linebreak to LF and that makes all the files show up as changed.
Most of the Project uses CRLF with [some exceptions](https://github.com/ecamp/ecamp3/blob/devel/.gitattributes).
I assume this doesn't happen when formatting using the IDEA instead of running the command.
Prettier allows for [linebreak auto](https://prettier.io/docs/en/options.html#end-of-line) so no file will be overwritten.
ESLint allows only LF or CRLF [afaik](https://eslint.org/docs/latest/rules/linebreak-style), I changed it to CRLF and it did not overwrite any linebreaks so I don't think this should be a problem.

I assume the current behaviour is reproducible and unintended so I did not create an issue or anything for this.
