### PR TITLE
CategoryCreateProcessor: set timestampable properties manually

### DIFF
--- a/api/src/Entity/ContentNode/ColumnLayout.php
+++ b/api/src/Entity/ContentNode/ColumnLayout.php
@@ -138,4 +138,12 @@ class ColumnLayout extends ContentNode implements SupportsContentNodeChildren {
 
         return $columns->map(fn (array $element) => $element['slot'])->getValues();
     }
+
+    public function updateCreateTime(): void {
+        $this->createTime = new \DateTime();
+    }
+
+    public function updateUpdateTime(): void {
+        $this->updateTime = new \DateTime();
+    }
 }

--- a/api/src/State/CategoryCreateProcessor.php
+++ b/api/src/State/CategoryCreateProcessor.php
@@ -30,6 +30,14 @@ class CategoryCreateProcessor extends AbstractPersistProcessor {
             ->findOneBy(['name' => 'ColumnLayout'])
         ;
         $rootContentNode->data = ['columns' => [['slot' => '1', 'width' => 12]]];
+        /*
+         * Set the timestampable properties here by hand, because only in production
+         * this does not work.
+         * Remove this again as soon as https://github.com/ecamp/ecamp3/issues/3662 is really fixed.
+         */
+        $rootContentNode->updateCreateTime();
+        $rootContentNode->updateUpdateTime();
+
         $data->setRootContentNode($rootContentNode);
 
         return $data;


### PR DESCRIPTION
In production this does not work in this case now.
Because reproduction and fix may be hard, we use this quickfix here.
This allows us to release and deploy in the meantime.
Use a method name which does not match the naming conventions for
the setters and getters, else the fields are null when creating a ColumnLayout directly.

Issue: #3662