### PR TITLE
api/migrations/prod-data: delete code to truncate database

### DIFF
--- a/api/migrations/prod-data/Version202210081114PM.php
+++ b/api/migrations/prod-data/Version202210081114PM.php
@@ -16,7 +16,6 @@ final class Version202210081114PMPMPM extends AbstractMigration {
 
     public function up(Schema $schema): void {
         // START PHP CODE
-        // $this->addSql(createTruncateDatabaseCommand());
 
         $statements = getStatementsForMigrationFile();
         foreach ($statements as $statement) {

--- a/api/migrations/prod-data/helpers.php
+++ b/api/migrations/prod-data/helpers.php
@@ -5,25 +5,6 @@ namespace DataMigrations;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statements\InsertStatement;
 
-function createTruncateDatabaseCommand(): string {
-    return "
-            DO $$ DECLARE
-                r RECORD;
-            BEGIN
-                FOR r IN (
-                    SELECT tablename 
-                    FROM pg_tables 
-                    WHERE 
-                        schemaname = current_schema() 
-                        AND tablename != 'doctrine_migration_versions'
-                        AND tablename != 'content_type') 
-                LOOP
-                    EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' CASCADE';
-                END LOOP;
-            END $$;
-        ";
-}
-
 function getStatementsForMigrationFile(): array {
     $dump_file = __DIR__.'/data.sql';
     $sql = file_get_contents($dump_file);


### PR DESCRIPTION
We never want to delete the data in prod.
And if we want to, we can copy the code from the dev-data directory.