### PR TITLE
fix ApiPlatform deprecations

### DIFF
--- a/api/src/Serializer/Denormalizer/InputFilterDenormalizer.php
+++ b/api/src/Serializer/Denormalizer/InputFilterDenormalizer.php
@@ -6,6 +6,7 @@ use App\Entity\BaseEntity;
 use App\InputFilter\FilterAttribute;
 use App\InputFilter\InputFilter;
 use App\InputFilter\UnexpectedValueException;
+use App\Serializer\NoCachingSupportTrait;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
@@ -17,6 +18,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
  */
 class InputFilterDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface {
     use DenormalizerAwareTrait;
+    use NoCachingSupportTrait;
 
     private const ALREADY_CALLED = 'INPUT_FILTER_DENORMALIZER_ALREADY_CALLED';
 

--- a/api/src/Serializer/Denormalizer/MaterialItemDenormalizer.php
+++ b/api/src/Serializer/Denormalizer/MaterialItemDenormalizer.php
@@ -4,6 +4,7 @@ namespace App\Serializer\Denormalizer;
 
 use ApiPlatform\Metadata\Post;
 use App\Entity\MaterialItem;
+use App\Serializer\NoCachingSupportTrait;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
@@ -15,6 +16,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
  */
 class MaterialItemDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface {
     use DenormalizerAwareTrait;
+    use NoCachingSupportTrait;
 
     private const ALREADY_CALLED = 'MATERIAL_ITEM_DENORMALIZER_ALREADY_CALLED';
 

--- a/api/src/Serializer/NoCachingSupportTrait.php
+++ b/api/src/Serializer/NoCachingSupportTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Serializer;
+
+trait NoCachingSupportTrait {
+    /**
+     * We dont want to cache if this type is supported, because it should only be called once.
+     *
+     * @see DenormalizerInterface::getSupportedTypes
+     */
+    public function getSupportedTypes(?string $format): array {
+        return ['*' => false];
+    }
+}

--- a/api/src/Serializer/Normalizer/CollectionItemsNormalizer.php
+++ b/api/src/Serializer/Normalizer/CollectionItemsNormalizer.php
@@ -36,6 +36,14 @@ class CollectionItemsNormalizer implements NormalizerInterface, NormalizerAwareI
         return $data;
     }
 
+    public function getSupportedTypes(?string $format): array {
+        if (method_exists($this->decorated, 'getSupportedTypes')) {
+            return $this->decorated->getSupportedTypes($format);
+        }
+
+        return ['*' => false];
+    }
+
     public function setNormalizer(NormalizerInterface $normalizer): void {
         if ($this->decorated instanceof NormalizerAwareInterface) {
             $this->decorated->setNormalizer($normalizer);

--- a/api/src/Serializer/Normalizer/ContentTypeNormalizer.php
+++ b/api/src/Serializer/Normalizer/ContentTypeNormalizer.php
@@ -44,6 +44,14 @@ class ContentTypeNormalizer implements NormalizerInterface, SerializerAwareInter
         return $data;
     }
 
+    public function getSupportedTypes(?string $format): array {
+        if (method_exists($this->decorated, 'getSupportedTypes')) {
+            return $this->decorated->getSupportedTypes($format);
+        }
+
+        return ['*' => false];
+    }
+
     public function setSerializer(SerializerInterface $serializer): void {
         if ($this->decorated instanceof SerializerAwareInterface) {
             $this->decorated->setSerializer($serializer);

--- a/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
+++ b/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
@@ -123,6 +123,14 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
         return $data;
     }
 
+    public function getSupportedTypes(?string $format): array {
+        if (method_exists($this->decorated, 'getSupportedTypes')) {
+            return $this->decorated->getSupportedTypes($format);
+        }
+
+        return ['*' => false];
+    }
+
     public function setSerializer(SerializerInterface $serializer): void {
         if ($this->decorated instanceof SerializerAwareInterface) {
             $this->decorated->setSerializer($serializer);

--- a/api/src/Serializer/Normalizer/TranslationConstraintViolationListNormalizer.php
+++ b/api/src/Serializer/Normalizer/TranslationConstraintViolationListNormalizer.php
@@ -8,12 +8,11 @@ use ApiPlatform\Serializer\AbstractConstraintViolationListNormalizer;
 use App\Serializer\Normalizer\Error\TranslationInfoOfConstraintViolation;
 use App\Service\TranslateToAllLocalesService;
 use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 
-class TranslationConstraintViolationListNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface {
+class TranslationConstraintViolationListNormalizer implements NormalizerInterface {
     public function __construct(
         private readonly AbstractConstraintViolationListNormalizer $hydraNormalizer,
         private readonly AbstractConstraintViolationListNormalizer $problemNormalizer,
@@ -72,10 +71,18 @@ class TranslationConstraintViolationListNormalizer implements NormalizerInterfac
         return $result;
     }
 
-    public function hasCacheableSupportsMethod(): bool {
-        return $this->getNormalizerCollection()->forAll(fn ($_, $elem) => $elem->hasCacheableSupportsMethod());
+    public function getSupportedTypes(?string $format): array {
+        return $this->getNormalizerCollection()
+            ->map(function (AbstractConstraintViolationListNormalizer $normalizer) use ($format) {
+                return $normalizer->getSupportedTypes($format);
+            })
+            ->reduce(fn (array|null $left, array $right) => array_merge($left ?? [], $right), [])
+        ;
     }
 
+    /**
+     * @return ArrayCollection<int<0, 1>, AbstractConstraintViolationListNormalizer>
+     */
     private function getNormalizerCollection(): ArrayCollection {
         return new ArrayCollection([$this->hydraNormalizer, $this->problemNormalizer]);
     }

--- a/api/src/Serializer/Normalizer/UriTemplateNormalizer.php
+++ b/api/src/Serializer/Normalizer/UriTemplateNormalizer.php
@@ -4,7 +4,6 @@ namespace App\Serializer\Normalizer;
 
 use ApiPlatform\Api\UrlGeneratorInterface;
 use App\Metadata\Resource\Factory\UriTemplateFactory;
-use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\String\Inflector\EnglishInflector;
 
@@ -12,7 +11,7 @@ use Symfony\Component\String\Inflector\EnglishInflector;
  * This class modifies the API entrypoint when retrieved in HAL JSON format (/index.jsonhal) to include URI templates, and additionally
  * makes sure that the relation names of the _links are in plural rather than the default singular of API platform.
  */
-class UriTemplateNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface {
+class UriTemplateNormalizer implements NormalizerInterface {
     public function __construct(
         private NormalizerInterface $decorated,
         private EnglishInflector $inflector,
@@ -58,11 +57,11 @@ class UriTemplateNormalizer implements NormalizerInterface, CacheableSupportsMet
         return $result;
     }
 
-    public function hasCacheableSupportsMethod(): bool {
-        if (!$this->decorated instanceof CacheableSupportsMethodInterface) {
-            return false;
+    public function getSupportedTypes(?string $format): array {
+        if (method_exists($this->decorated, 'getSupportedTypes')) {
+            return $this->decorated->getSupportedTypes($format);
         }
 
-        return $this->decorated->hasCacheableSupportsMethod();
+        return ['*' => false];
     }
 }


### PR DESCRIPTION
TranslationConstraintViolationListNormalizer: switch to getSupportedTypes

CacheableSupportsMethodInterface is deprecated.

fixes:
   1x: Class "App\Serializer\Normalizer\TranslationConstraintViolationListNormalizer" should implement method "Symfony\Component\Serializer\Normalizer\NormalizerInterface::getSupportedTypes(?string $format): array".
    1x in CreateActivityTest::testCreateActivityIsDeniedForAnonymousUser from App\Tests\Api\Activities


UriTemplateNormalizer: switch to getSupportedTypes

CacheableSupportsMethodInterface is deprecated.

fixes:
   1x: Class "App\Serializer\Normalizer\UriTemplateNormalizer" should implement method "Symfony\Component\Serializer\Normalizer\NormalizerInterface::getSupportedTypes(?string $format): array".
    1x in CreateActivityTest::testCreateActivityIsDeniedForAnonymousUser from App\Tests\Api\Activities

  1x: The "App\Serializer\Normalizer\UriTemplateNormalizer" class implements "Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface" that is deprecated since Symfony 6.3, implement "getSupportedTypes(?string $format)" instead.
    1x in CreateActivityTest::testCreateActivityIsDeniedForAnonymousUser from App\Tests\Api\Activities


api/Denormalizer: implement getSupportedTypes

Because we want to call these Denormalizers only ones per request,
we cannot cache the result of supportsDenormalization.

fixes:
  1x: Class "App\Serializer\Denormalizer\InputFilterDenormalizer" should implement method "Symfony\Component\Serializer\Normalizer\DenormalizerInterface::getSupportedTypes(?string $format): array".
    1x in CreateActivityTest::testCreateActivityIsDeniedForAnonymousUser from App\Tests\Api\Activities

  1x: Class "App\Serializer\Denormalizer\MaterialItemDenormalizer" should implement method "Symfony\Component\Serializer\Normalizer\DenormalizerInterface::getSupportedTypes(?string $format): array".
    1x in CreateActivityTest::testCreateActivityIsDeniedForAnonymousUser from App\Tests\Api\Activities


api/Normalizer: implement getSupportedTypes

These Normalizers did not implement the CacheableSupportsMethodInterface
but decorate Normalizers which might support caching the
result of supportsNormalization.
Because the method implementation is not yet enforced,
we have to check if the method exists on the decorated Normalizer.

fixes:
  1x: Class "App\Serializer\Normalizer\CollectionItemsNormalizer" should implement method "Symfony\Component\Serializer\Normalizer\NormalizerInterface::getSupportedTypes(?string $format): array".
    1x in CreateActivityTest::testCreateActivityIsDeniedForAnonymousUser from App\Tests\Api\Activities

  1x: Class "App\Serializer\Normalizer\ContentTypeNormalizer" should implement method "Symfony\Component\Serializer\Normalizer\NormalizerInterface::getSupportedTypes(?string $format): array".
    1x in CreateActivityTest::testCreateActivityIsDeniedForAnonymousUser from App\Tests\Api\Activities

  1x: Class "App\Serializer\Normalizer\RelatedCollectionLinkNormalizer" should implement method "Symfony\Component\Serializer\Normalizer\NormalizerInterface::getSupportedTypes(?string $format): array".
    1x in CreateActivityTest::testCreateActivityIsDeniedForAnonymousUser from App\Tests\Api\Activities