### PR TITLE
CI: remove electron browser from e2e test runs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -315,7 +315,6 @@ jobs:
       fail-fast: false
       matrix:
         browser:
-          - electron
           - chrome
           - firefox
           - edge

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -17,18 +17,19 @@ xhost local:root
 
 ### Run all e2e tests
 ```shell
-docker compose --profile e2e run --rm e2e
+docker compose --profile e2e run --rm e2e --browser chrome
 ```
 
 ### Run a specific e2e test
 ```shell
-docker compose --profile e2e run --rm e2e --spec specs/login.cy.js
+docker compose --profile e2e run --rm e2e  --browser chrome --spec specs/login.cy.js
 ```
 
 ### Run tests using a specific browser
 Supported browsers: `chrome`, `edge`, `electron` (default), `firefox`
+Electron is currently not stable on the CI.
 ```shell
-docker compose --profile e2e run --rm e2e --browser chrome
+docker compose --profile e2e run --rm e2e --browser firefox
 ```
 
 ### Open the cypress UI and visually see the tests run


### PR DESCRIPTION
Because it is unstable currently and most people
don't use electron for ecamp3.