### PR TITLE
api: fix phpstan errors

### DIFF
--- a/api/src/State/ContentNode/ContentNodePersistProcessor.php
+++ b/api/src/State/ContentNode/ContentNodePersistProcessor.php
@@ -17,6 +17,7 @@ class ContentNodePersistProcessor extends AbstractPersistProcessor {
      * @param T $data
      */
     public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []): ContentNode {
+        /** @var ContentNode $data */
         $data = parent::onBefore($data, $operation, $uriVariables, $context);
 
         if ($operation instanceof Post) {

--- a/api/src/State/Util/AbstractPersistProcessor.php
+++ b/api/src/State/Util/AbstractPersistProcessor.php
@@ -4,7 +4,6 @@ namespace App\State\Util;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Entity\BaseEntity;
 
 /**
  * @template T
@@ -69,7 +68,7 @@ abstract class AbstractPersistProcessor implements ProcessorInterface {
      *
      * @return T
      */
-    public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []): BaseEntity {
+    public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []) {
         return $data;
     }
 


### PR DESCRIPTION
After fixing the psalm errors and an update of phpstan, we have now phpstan errors.

This fixes the following errors:
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------
  Line   State/ContentNode/ContentNodePersistProcessor.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------
  24     Access to an undefined property App\Entity\BaseEntity::$parent.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  25     Access to an undefined property App\Entity\BaseEntity::$parent.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  28     Method App\State\ContentNode\ContentNodePersistProcessor::onBefore() should return T of App\Entity\ContentNode but returns App\Entity\BaseEntity.
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------

 ------ -------------------------------------------------------------------------------------
  Line   State/Util/AbstractPersistProcessor.php
 ------ -------------------------------------------------------------------------------------
  72     PHPDoc tag @return with type T is not subtype of native type App\Entity\BaseEntity.
         💡 Write @template T of App\Entity\BaseEntity to fix this.
 ------ -------------------------------------------------------------------------------------