### PR TITLE
TranslationConstraintViolationListNormalizer: remove type annotation …

### DIFF
--- a/api/src/Serializer/Normalizer/TranslationConstraintViolationListNormalizer.php
+++ b/api/src/Serializer/Normalizer/TranslationConstraintViolationListNormalizer.php
@@ -80,9 +80,6 @@ class TranslationConstraintViolationListNormalizer implements NormalizerInterfac
         ;
     }
 
-    /**
-     * @return ArrayCollection<int<0, 1>, AbstractConstraintViolationListNormalizer>
-     */
     private function getNormalizerCollection(): ArrayCollection {
         return new ArrayCollection([$this->hydraNormalizer, $this->problemNormalizer]);
     }


### PR DESCRIPTION
…of getNormalizerCollection

Psalm and phpstan don't aggree on the type, psalm is a little stricter and considers the number of elements in the collection. /**
* @phpstan-return  ArrayCollection<int, AbstractConstraintViolationListNormalizer> *
* @psalm-return ArrayCollection<int<0, 1>, AbstractConstraintViolationListNormalizer> */

I would say it leads to less maintenance if we remove the type annotation, and both phpstan and psalm can infer the type.