### PR TITLE
Fix linebreaks in client print

### DIFF
--- a/pdf/src/campPrint/RichText.vue
+++ b/pdf/src/campPrint/RichText.vue
@@ -32,8 +32,7 @@ const rules = [
   },
   {
     shouldProcessNode: (node) => node.type === 'tag' && node.name === 'br',
-    processNode: (_) =>
-      h('Text', {}, () => [visit({ type: 'text', content: '\n' }, null)]),
+    processNode: (_) => h('Text', {}, '\n'),
   },
   {
     shouldProcessNode: (node) =>


### PR DESCRIPTION
Fixes #3571

Looks like I was a little too quick cleaning up some things, and made the RichText renderer too complicated.