### PR TITLE
api: set report_fields_where_declared:true in doctrine.yaml for doctr…

### DIFF
--- a/api/config/packages/doctrine.yaml
+++ b/api/config/packages/doctrine.yaml
@@ -14,6 +14,7 @@ doctrine:
         enable_lazy_ghost_objects: true
         naming_strategy: App\Util\CamelPascalNamingStrategy
         auto_mapping: true
+        report_fields_where_declared: true
         mappings:
             App:
                 is_bundle: false

--- a/api/src/Entity/ContentNode.php
+++ b/api/src/Entity/ContentNode.php
@@ -89,11 +89,6 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
     #[ORM\OneToMany(targetEntity: ContentNode::class, mappedBy: 'parent', cascade: ['persist'])]
     public Collection $children;
 
-    /**
-     * Holds the actual data of the content node.
-     */
-    #[ApiProperty(example: ['text' => 'dummy text'])]
-    #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'json', nullable: true, options: ['jsonb' => true])]
     public ?array $data = null;
 
@@ -173,6 +168,11 @@ abstract class ContentNode extends BaseEntity implements BelongsToContentNodeTre
         return $this->root;
     }
 
+    /**
+     * Holds the actual data of the content node.
+     */
+    #[ApiProperty(example: ['text' => 'dummy text'])]
+    #[Groups(['read', 'write'])]
     public function getData(): ?array {
         return $this->data;
     }

--- a/api/src/Entity/ContentNode/ColumnLayout.php
+++ b/api/src/Entity/ContentNode/ColumnLayout.php
@@ -79,20 +79,7 @@ class ColumnLayout extends ContentNode implements SupportsContentNodeChildren {
         ],
     ];
 
-    /**
-     * Holds the actual data of the content node
-     * (overridden from abstract class in order to add specific validation).
-     */
-    #[ApiProperty(example: ['columns' => [['slot' => '1', 'width' => 12]]])]
-    #[Groups(['read', 'write'])]
-    #[ORM\Column(type: 'json', nullable: true, options: ['jsonb' => true])]
-    #[Assert\Sequentially(constraints: [
-        new AssertJsonSchema(schema: self::JSON_SCHEMA),
-        new AssertColumWidthsSumTo12(),
-        new AssertNoOrphanChildren(),
-    ])]
-    #[Assert\NotNull]
-    public ?array $data = ['columns' => [['slot' => '1', 'width' => 6], ['slot' => '2', 'width' => 6]]];
+    public const DATA_DEFAULT = '{"columns":[{"slot":"1","width":6},{"slot":"2","width":6}]}';
 
     /**
      * All content nodes that are part of this content node tree.
@@ -104,6 +91,26 @@ class ColumnLayout extends ContentNode implements SupportsContentNodeChildren {
     public function __construct() {
         parent::__construct();
         $this->rootDescendants = new ArrayCollection();
+        $this->data = json_decode(self::DATA_DEFAULT, true);
+    }
+
+    /**
+     * Holds the actual data of the content node
+     * (overridden from abstract class in order to add specific validation).
+     */
+    #[ApiProperty(
+        default: self::DATA_DEFAULT,
+        example: ['columns' => [['slot' => '1', 'width' => 12]]]
+    )]
+    #[Groups(['read', 'write'])]
+    #[Assert\Sequentially(constraints: [
+        new AssertJsonSchema(schema: self::JSON_SCHEMA),
+        new AssertColumWidthsSumTo12(),
+        new AssertNoOrphanChildren(),
+    ])]
+    #[Assert\NotNull]
+    public function getData(): ?array {
+        return parent::getData();
     }
 
     /**

--- a/api/src/Entity/ContentNode/MaterialNode.php
+++ b/api/src/Entity/ContentNode/MaterialNode.php
@@ -50,16 +50,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 #[ORM\Entity(repositoryClass: MaterialNodeRepository::class)]
 class MaterialNode extends ContentNode {
-    /**
-     * Holds the actual data of the content node
-     * (overridden from abstract class in order to add specific validation).
-     */
-    #[ApiProperty(example: null)]
-    #[Groups(['read', 'write'])]
-    #[ORM\Column(type: 'json', nullable: true, options: ['jsonb' => true])]
-    #[Assert\IsNull]
-    public ?array $data = null;
-
     #[ApiProperty(readableLink: true, writableLink: false)]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: MaterialItem::class, mappedBy: 'materialNode', orphanRemoval: true, cascade: ['persist', 'remove'])]
@@ -70,6 +60,17 @@ class MaterialNode extends ContentNode {
         $this->materialItems = new ArrayCollection();
 
         parent::__construct();
+    }
+
+    /**
+     * Holds the actual data of the content node
+     * (overridden from abstract class in order to add specific validation).
+     */
+    #[ApiProperty(example: null)]
+    #[Groups(['read', 'write'])]
+    #[Assert\IsNull]
+    public function getData(): ?array {
+        return $this->data;
     }
 
     /**

--- a/api/src/Entity/ContentNode/MultiSelect.php
+++ b/api/src/Entity/ContentNode/MultiSelect.php
@@ -81,9 +81,10 @@ class MultiSelect extends ContentNode {
         'natureAndEnvironment' => ['checked' => true],
     ]])]
     #[Groups(['read', 'write'])]
-    #[ORM\Column(type: 'json', nullable: true, options: ['jsonb' => true])]
     #[Assert\IsNull(groups: ['create'])] // create with empty data; default value is populated by data persister
     #[Assert\NotNull(groups: ['update'])]
     #[AssertJsonSchema(schema: self::JSON_SCHEMA, groups: ['update'])]
-    public ?array $data = null;
+    public function getData(): ?array {
+        return $this->data;
+    }
 }

--- a/api/src/Entity/ContentNode/SingleText.php
+++ b/api/src/Entity/ContentNode/SingleText.php
@@ -58,14 +58,25 @@ class SingleText extends ContentNode {
         ],
     ];
 
+    public const DATA_DEFAULT = '{"html":""}';
+
+    public function __construct() {
+        parent::__construct();
+        $this->data = json_decode(self::DATA_DEFAULT, true);
+    }
+
     /**
      * Holds the actual data of the content node
      * (overridden from abstract class in order to add specific validation).
      */
-    #[ApiProperty(example: ['html' => 'my example text'])]
+    #[ApiProperty(
+        default: self::DATA_DEFAULT,
+        example: ['html' => 'my example text']
+    )]
     #[Groups(['read', 'write'])]
-    #[ORM\Column(type: 'json', nullable: true, options: ['jsonb' => true])]
     #[AssertJsonSchema(schema: self::JSON_SCHEMA)]
     #[Assert\NotNull]
-    public ?array $data = ['html' => ''];
+    public function getData(): ?array {
+        return $this->data;
+    }
 }

--- a/api/src/Entity/ContentNode/Storyboard.php
+++ b/api/src/Entity/ContentNode/Storyboard.php
@@ -99,8 +99,9 @@ class Storyboard extends ContentNode {
             'column3' => '',
             'position' => 0, ], ]])]
     #[Groups(['read', 'write'])]
-    #[ORM\Column(type: 'json', nullable: true, options: ['jsonb' => true])]
     #[AssertJsonSchema(schema: self::JSON_SCHEMA)]
     #[Assert\NotNull(groups: ['update'])] // if created with empty data, then default value is populated in data persister
-    public ?array $data = null;
+    public function getData(): ?array {
+        return $this->data;
+    }
 }


### PR DESCRIPTION
…ine/orm 3

And don't overwrite the doctrine definition for the same field again with the same values.
Now we define the Constraints on the getter,
because api-platform only allows to define constraints on a getter. Move the example on ContentNode::data to the getter, because then this example was used for all children for the data property instead of the example on the getter.
~~Now the comment for the property still overwrites the comments for the getters, but this is ok as the inheritance is an implementation detail, and must not be exposed in the api.~~ Edit by @BacLuc: This was wrong

closes #3740