### PR TITLE
Revert "CategoryCreateProcessor: set timestampable properties manually"

### DIFF
--- a/api/src/Entity/ContentNode/ColumnLayout.php
+++ b/api/src/Entity/ContentNode/ColumnLayout.php
@@ -138,12 +138,4 @@ class ColumnLayout extends ContentNode implements SupportsContentNodeChildren {
 
         return $columns->map(fn (array $element) => $element['slot'])->getValues();
     }
-
-    public function updateCreateTime(): void {
-        $this->createTime = new \DateTime();
-    }
-
-    public function updateUpdateTime(): void {
-        $this->updateTime = new \DateTime();
-    }
 }

--- a/api/src/State/CategoryCreateProcessor.php
+++ b/api/src/State/CategoryCreateProcessor.php
@@ -33,14 +33,6 @@ class CategoryCreateProcessor extends AbstractPersistProcessor {
             ->findOneBy(['name' => 'ColumnLayout'])
         ;
         $rootContentNode->data = ['columns' => [['slot' => '1', 'width' => 12]]];
-        /*
-         * Set the timestampable properties here by hand, because only in production
-         * this does not work.
-         * Remove this again as soon as https://github.com/ecamp/ecamp3/issues/3662 is really fixed.
-         */
-        $rootContentNode->updateCreateTime();
-        $rootContentNode->updateUpdateTime();
-
         $data->setRootContentNode($rootContentNode);
 
         return $data;


### PR DESCRIPTION
This reverts commit 410c96c.
After the release of https://github.com/doctrine-extensions/DoctrineExtensions/releases/tag/v3.13.0 and the update in 071a776, we can revert the change now.

closes #3662.