### PR TITLE
Improve frontend startup without pdf service running

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - CI=${CI}
     working_dir: /app
     command: ./docker-setup.sh
+    depends_on:
+      - pdf
 
   php:
     image: ecamp/ecamp3-dev-api-php

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,12 +1,10 @@
 {
-  "name": "e2e",
-  "version": "1.0.0",
+  "name": "@ecamp3/e2e",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "e2e",
-      "version": "1.0.0",
+      "name": "@ecamp3/e2e",
       "devDependencies": {
         "cypress": "13.2.0",
         "eslint-config-prettier": "9.0.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "e2e",
-  "version": "1.0.0",
+  "name": "@ecamp3/e2e",
+  "private": true,
   "scripts": {
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/frontend/docker-setup.sh
+++ b/frontend/docker-setup.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+BASEDIR=$(dirname "$0")
+PDF_DIST=$BASEDIR"/src/pdf"
+
+if [ ! -f "$PDF_DIST/pdf.mjs" ] || [ ! -f "$PDF_DIST/prepareInMainThread.mjs" ]; then
+    # Copy dummy versions of the pdf build outputs, to make sure there is always something to import
+    cp "$PDF_DIST/pdf.mjs.dist" "$PDF_DIST/pdf.mjs"
+    cp "$PDF_DIST/prepareInMainThread.mjs.dist" "$PDF_DIST/prepareInMainThread.mjs"
+fi
+
 if [ "$CI" = 'true' ] ; then
   npm ci --verbose
   npm run build

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,10 @@
 {
-  "name": "frontend",
-  "version": "0.1.0",
+  "name": "@ecamp3/frontend",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend",
-      "version": "0.1.0",
+      "name": "@ecamp3/frontend",
       "hasInstallScript": true,
       "dependencies": {
         "@intlify/core": "9.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "frontend",
-  "version": "0.1.0",
+  "name": "@ecamp3/frontend",
   "private": true,
   "scripts": {
     "serve": "vite --host 0.0.0.0",

--- a/pdf/dist/pdf.mjs.dist
+++ b/pdf/dist/pdf.mjs.dist
@@ -1,0 +1,10 @@
+// This file will be replaced with generated code by the pdf build service.
+
+const prepare = false;
+const render = (props = {}) => {
+  throw new Error('Clientside PDF generation code is not ready yet. Please ensure that @ecamp3/client-pdf has been built without any compiler errors.');
+};
+export {
+  prepare,
+  render
+};

--- a/pdf/dist/prepareInMainThread.mjs.dist
+++ b/pdf/dist/prepareInMainThread.mjs.dist
@@ -1,0 +1,8 @@
+// This file will be replaced with generated code by the pdf build service.
+
+async function prepareInMainThread(config) {
+  throw new Error('Clientside PDF generation code is not ready yet. Please ensure that @ecamp3/client-pdf has been built without any compiler errors.');
+}
+export {
+  prepareInMainThread
+};

--- a/pdf/package-lock.json
+++ b/pdf/package-lock.json
@@ -1,12 +1,10 @@
 {
-  "name": "pdf",
-  "version": "0.1.0",
+  "name": "@ecamp3/client-pdf",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pdf",
-      "version": "0.1.0",
+      "name": "@ecamp3/client-pdf",
       "dependencies": {
         "@vue/runtime-core": "3.3.4",
         "html-entities": "2.4.0",

--- a/pdf/package.json
+++ b/pdf/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "pdf",
-  "version": "0.1.0",
+  "name": "@ecamp3/client-pdf",
   "description": "Create pdfs for eCamp, using Vue components",
   "main": "src/index.js",
   "private": true,

--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -1,12 +1,10 @@
 {
-  "name": "print",
-  "version": "1.0.0",
+  "name": "@ecamp3/backend-print",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "print",
-      "version": "1.0.0",
+      "name": "@ecamp3/backend-print",
       "dependencies": {
         "@mdi/js": "7.2.96",
         "@nuxtjs/axios": "5.13.6",

--- a/print/package.json
+++ b/print/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "print",
-  "version": "1.0.0",
+  "name": "@ecamp3/backend-print",
   "private": true,
   "scripts": {
     "dev": "nuxt dev",

--- a/translation/package-lock.json
+++ b/translation/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "translation",
+  "name": "@ecamp3/translations",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "@ecamp3/translations",
       "dependencies": {
         "deepl-node": "1.10.2"
       }

--- a/translation/package.json
+++ b/translation/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "@ecamp3/translations",
+  "private": true,
   "dependencies": {
     "deepl-node": "1.10.2"
   },


### PR DESCRIPTION
I had the following errors:
```
✘ [ERROR] ENOENT: no such file or directory, open '/home/ecamp3/frontend/src/pdf/prepareInMainThread.mjs' [plugin vite:dep-scan]

    src/components/print/print-client/generatePdf.js:1:36:
      1 │ import { prepareInMainThread } from '@/pdf/prepareInMainThread.mjs'
```

```error
✘ [ERROR] ENOENT: no such file or directory, open '/app/src/pdf/pdf.mjs' [plugin vite:dep-scan]

   src/components/print/print-client/renderPdf.js:3:32:
     3 │ import { render, prepare } from '@/pdf/pdf.mjs'
```

The missing files, `pdf.mjs` and `prepareInMainThread.mjs`, caused the problem due to a new repository installation where I forgot to run the client-side pdf service.

To help beginners, I have created a placeholder that gives a helpful suggestion instead of generating a vite error, and it is now possible to run the frontend without having to build the client-side pdf code.

To guide beginners to the correct package, all package.json names have been made consistent. Also the version field has been removed as it is not used and is unmaintained. Additionally they have been marked private.