### PR TITLE
frontend: set timezone for tests

### DIFF
--- a/frontend/src/helpers/__tests__/vCalendarDragAndDrop.spec.js
+++ b/frontend/src/helpers/__tests__/vCalendarDragAndDrop.spec.js
@@ -22,7 +22,7 @@ describe('toTime', () => {
         present: false,
         future: true,
       },
-      1683555180000,
+      1683508380000,
     ],
     [
       {
@@ -40,7 +40,7 @@ describe('toTime', () => {
         present: false,
         future: true,
       },
-      1683454800000,
+      1683408000000,
     ],
     [
       {
@@ -58,7 +58,7 @@ describe('toTime', () => {
         present: false,
         future: true,
       },
-      1649197320000,
+      1649150520000,
     ],
   ])('maps %p to %p', (input, expected) => {
     expect(toTime(input)).toEqual(expected)

--- a/frontend/tests/globalSetup.js
+++ b/frontend/tests/globalSetup.js
@@ -1,0 +1,3 @@
+export function setup() {
+  process.env.TZ = 'UTC'
+}

--- a/frontend/tests/globalSetup.js
+++ b/frontend/tests/globalSetup.js
@@ -1,3 +1,3 @@
 export function setup() {
-  process.env.TZ = 'UTC'
+  process.env.TZ = 'Pacific/Tongatapu'
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -147,6 +147,7 @@ export default defineConfig(({ mode }) => ({
     globals: true,
     environment: 'jsdom',
     alias: [{ find: /^vue$/, replacement: 'vue/dist/vue.runtime.common.js' }],
+    globalSetup: './tests/globalSetup.js',
     setupFiles: './tests/setup.js',
     coverage: {
       all: true,


### PR DESCRIPTION
Else frontend/src/helpers/__tests__/vCalendarDragAndDrop.spec.js toTime test fails if the timezone is not set to UTC.
Taken from https://github.com/vitest-dev/vitest/issues/1575#issuecomment-1439286286