### PR TITLE
ApiWrapper.vue: fix autosave

### DIFF
--- a/frontend/src/components/form/api/ApiWrapper.vue
+++ b/frontend/src/components/form/api/ApiWrapper.vue
@@ -165,7 +165,7 @@ export default {
       }
     },
     debouncedSave() {
-      return debounce(this.save, this.autoSaveDelay)
+      return debounce(this.save, this.autoSaveDelay).call()
     },
     // reload data from API (doesn't force loading from server if available locally)
     reload() {

--- a/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
@@ -21,7 +21,10 @@ vi.mock('lodash', async (importOriginal) => {
   const lodash = await importOriginal()
   return {
     ...lodash,
-    debounce: (callback) => new Promise((resolve) => (debounce = resolve)).then(callback),
+    debounce: (callback) =>
+      function () {
+        return new Promise((resolve) => (debounce = resolve)).then(callback)
+      },
     set: lodash.set,
     get: lodash.get,
   }


### PR DESCRIPTION
In commit 4e408be the debouncedSave method was moved from computed to the methods, where it seems to belong.
But the lodash debounce function returns a function, which delays the invocation of the func when called, but does not directly schedule the delayed function execution.
The caller has to do that by calling the returned function.
This apparently was done by vue before commit 24dc4bf, because it was a computed property.

closes #3839