### PR TITLE
Organize admin views

### DIFF
--- a/e2e/specs/clientPrint.cy.js
+++ b/e2e/specs/clientPrint.cy.js
@@ -9,6 +9,7 @@ describe('Client print test', () => {
 
     cy.visit('/camps')
     cy.get('a:contains("GRGR")').click()
+    cy.get('a:contains("Admin")').click()
     cy.get('a:contains("Drucken")').click()
     cy.get('button:contains("PDF herunterladen (Layout #2)")').click()
 

--- a/e2e/specs/nuxtPrint.cy.js
+++ b/e2e/specs/nuxtPrint.cy.js
@@ -42,6 +42,7 @@ describe('Nuxt print test', () => {
 
     cy.visit('/camps')
     cy.get('a:contains("GRGR")').click()
+    cy.get('a:contains("Admin")').click()
     cy.get('a:contains("Drucken")').click()
     cy.get('button:contains("PDF herunterladen (Layout #1)")').click()
 

--- a/frontend/src/components/campAdmin/CampConditionalFields.vue
+++ b/frontend/src/components/campAdmin/CampConditionalFields.vue
@@ -3,81 +3,85 @@ Displays fields which don't apply to all camps, but are required for some
 -->
 
 <template>
-  <v-expansion-panels v-model="openPanels" class="mb-8 mt-2" multiple>
-    <v-expansion-panel>
-      <v-expansion-panel-header>
-        <div class="subtitle-1 conditional-group-title">
-          {{ $tc('components.campAdmin.campConditionalFields.ysCamp.title') }}
-        </div>
-      </v-expansion-panel-header>
-      <v-expansion-panel-content>
-        <v-skeleton-loader v-if="camp()._meta.loading" type="article" />
-        <div v-else class="mt-3">
-          <api-form :entity="camp()">
-            <api-text-field
-              fieldname="organizer"
-              :name="$tc('entity.camp.fields.organizer')"
-              :disabled="disabled"
-            />
-            <api-text-field
-              fieldname="kind"
-              :name="$tc('entity.camp.fields.kind')"
-              :disabled="disabled"
-            />
-            <api-text-field
-              fieldname="coachName"
-              :name="$tc('entity.camp.fields.coachName')"
-              :disabled="disabled"
-            />
-          </api-form>
-        </div>
-      </v-expansion-panel-content>
-    </v-expansion-panel>
-    <v-expansion-panel>
-      <v-expansion-panel-header>
-        <div class="subtitle-1 conditional-group-title">
-          {{ $tc('components.campAdmin.campConditionalFields.course.title') }}
-        </div>
-      </v-expansion-panel-header>
-      <v-expansion-panel-content>
-        <v-skeleton-loader v-if="camp()._meta.loading" type="article" />
-        <div v-else class="mt-3">
-          <api-form :entity="camp()">
-            <api-text-field
-              fieldname="courseNumber"
-              :name="$tc('entity.camp.fields.courseNumber')"
-              :disabled="disabled"
-            />
-            <api-text-field
-              fieldname="courseKind"
-              :name="$tc('entity.camp.fields.courseKind')"
-              :disabled="disabled"
-            />
-            <api-text-field
-              fieldname="trainingAdvisorName"
-              :name="$tc('entity.camp.fields.trainingAdvisorName')"
-              :disabled="disabled"
-            />
-            <api-checkbox
-              fieldname="printYSLogoOnPicasso"
-              :name="$tc('entity.camp.fields.printYSLogoOnPicasso')"
-              :disabled="disabled"
-            />
-          </api-form>
-        </div>
-      </v-expansion-panel-content>
-    </v-expansion-panel>
-  </v-expansion-panels>
+  <v-expansion-panel>
+    <v-expansion-panel-header>
+      <h2 class="subtitle-1 font-weight-bold">
+        {{ $tc('components.campAdmin.campConditionalFields.title') }}
+      </h2>
+    </v-expansion-panel-header>
+    <v-expansion-panel-content>
+      <v-row class="pb-6">
+        <v-col cols="12" md="6" class="pb-0">
+          <content-group
+            :title="$tc('components.campAdmin.campConditionalFields.ysCamp.title')"
+          >
+            <v-skeleton-loader v-if="camp()._meta.loading" type="article" />
+            <div v-else class="mt-3">
+              <api-form :entity="camp()">
+                <api-text-field
+                  fieldname="organizer"
+                  :name="$tc('entity.camp.fields.organizer')"
+                  :disabled="disabled"
+                />
+                <api-text-field
+                  fieldname="kind"
+                  :name="$tc('entity.camp.fields.kind')"
+                  :disabled="disabled"
+                />
+                <api-text-field
+                  fieldname="coachName"
+                  :name="$tc('entity.camp.fields.coachName')"
+                  :disabled="disabled"
+                />
+              </api-form>
+            </div>
+          </content-group>
+        </v-col>
+        <v-col cols="12" md="6" class="pb-0">
+          <content-group
+            :title="$tc('components.campAdmin.campConditionalFields.course.title')"
+          >
+            <v-skeleton-loader v-if="camp()._meta.loading" type="article" />
+            <div v-else class="mt-3">
+              <api-form :entity="camp()">
+                <api-text-field
+                  fieldname="courseNumber"
+                  :name="$tc('entity.camp.fields.courseNumber')"
+                  :disabled="disabled"
+                />
+                <api-text-field
+                  fieldname="courseKind"
+                  :name="$tc('entity.camp.fields.courseKind')"
+                  :disabled="disabled"
+                />
+                <api-text-field
+                  fieldname="trainingAdvisorName"
+                  :name="$tc('entity.camp.fields.trainingAdvisorName')"
+                  :disabled="disabled"
+                />
+                <api-checkbox
+                  fieldname="printYSLogoOnPicasso"
+                  :name="$tc('entity.camp.fields.printYSLogoOnPicasso')"
+                  :disabled="disabled"
+                />
+              </api-form>
+            </div>
+          </content-group>
+        </v-col>
+      </v-row>
+    </v-expansion-panel-content>
+  </v-expansion-panel>
 </template>
 
 <script>
 import ApiTextField from '@/components/form/api/ApiTextField.vue'
 import ApiForm from '@/components/form/api/ApiForm.vue'
 import ApiCheckbox from '../form/api/ApiCheckbox.vue'
+import ContentGroup from '@/components/layout/ContentGroup.vue'
 
 export default {
   name: 'CampConditionalFields',
-  components: { ApiTextField, ApiCheckbox, ApiForm },
+  components: { ContentGroup, ApiTextField, ApiCheckbox, ApiForm },
   props: {
     camp: {
       type: Function,
@@ -88,24 +92,5 @@ export default {
       default: false,
     },
   },
-  data: () => ({
-    openPanels: [],
-  }),
-  mounted() {
-    this.camp()._meta.load.then((camp) => {
-      if (camp.organizer || camp.kind || camp.coachName) {
-        this.openPanels.push(0)
-      }
-      if (camp.courseNumber || camp.courseKind || camp.trainingAdvisorName) {
-        this.openPanels.push(1)
-      }
-    })
-  },
 }
 </script>
-
-<style scoped>
-.conditional-group-title {
-  font-size: 1rem !important;
-}
-</style>

--- a/frontend/src/components/campAdmin/CampDangerZone.vue
+++ b/frontend/src/components/campAdmin/CampDangerZone.vue
@@ -3,70 +3,80 @@ Critical operations on camp
 -->
 
 <template>
-  <content-group :title="$tc('components.campAdmin.campDangerZone.title')">
-    <v-skeleton-loader v-if="camp()._meta.loading" type="article" />
-    <div v-else>
-      <v-list>
-        <v-list-item class="px-0" three-line>
-          <v-list-item-content>
-            <v-list-item-title>
-              {{ $tc('components.campAdmin.campDangerZone.deleteCamp.title') }}
-            </v-list-item-title>
-            <v-list-item-subtitle>
-              {{ $tc('components.campAdmin.campDangerZone.deleteCamp.description') }}
-            </v-list-item-subtitle>
-          </v-list-item-content>
-          <v-list-item-action>
-            <dialog-entity-delete
-              :entity="camp()"
-              :submit-enabled="promptText === camp().name"
-              icon="mdi-bomb"
-              @submit="$router.push({ name: 'camps' })"
-            >
-              <template #activator="{ on }">
-                <button-delete
-                  icon="mdi-bomb"
-                  :text="false"
-                  dark
-                  outlined
-                  color="blue-grey"
-                  @click.prevent="on.click"
-                >
-                  {{ $tc('global.button.delete') }}
-                </button-delete>
-              </template>
-              <p class="body-1">
-                {{
-                  $tc('components.campAdmin.campDangerZone.deleteCamp.explanation', 0, {
-                    campName: camp().name,
-                  })
-                }}
-              </p>
-              <label>
-                {{
-                  $tc('components.campAdmin.campDangerZone.deleteCamp.label', 0, {
-                    campName: camp().name,
-                  })
-                }}
-                <e-text-field v-model="promptText" />
-              </label>
-            </dialog-entity-delete>
-          </v-list-item-action>
-        </v-list-item>
-      </v-list>
-    </div>
-  </content-group>
+  <v-expansion-panel active-class="red lighten-5 red--text text--darken-4">
+    <v-expansion-panel-header>
+      <h2 class="subtitle-1 font-weight-bold">
+        {{ $tc('components.campAdmin.campDangerZone.title') }}
+      </h2>
+    </v-expansion-panel-header>
+    <v-expansion-panel-content>
+      <v-skeleton-loader v-if="camp()._meta.loading" type="article" />
+      <div v-else>
+        <v-list class="py-0" color="transparent">
+          <v-list-item class="px-0">
+            <v-list-item-content>
+              <v-list-item-title>
+                {{ $tc('components.campAdmin.campDangerZone.deleteCamp.title') }}
+              </v-list-item-title>
+              <div class="body-2 grey--text text--darken-3">
+                {{ $tc('components.campAdmin.campDangerZone.deleteCamp.description') }}
+              </div>
+            </v-list-item-content>
+            <v-list-item-action>
+              <dialog-entity-delete
+                :entity="camp()"
+                :submit-enabled="promptText === camp().name"
+                icon="mdi-bomb"
+                @submit="$router.push({ name: 'camps' })"
+              >
+                <template #activator="{ on }">
+                  <button-delete
+                    icon="mdi-bomb"
+                    :text="false"
+                    dark
+                    outlined
+                    color="blue-grey"
+                    @click.prevent="on.click"
+                  >
+                    {{ $tc('global.button.delete') }}
+                  </button-delete>
+                </template>
+                <p class="body-1">
+                  {{
+                    $tc('components.campAdmin.campDangerZone.deleteCamp.explanation', 0, {
+                      campName: camp().name,
+                    })
+                  }}
+                </p>
+                <label>
+                  {{
+                    $tc('components.campAdmin.campDangerZone.deleteCamp.label', 0, {
+                      campName: camp().name,
+                    })
+                  }}
+                  <e-text-field v-model="promptText" />
+                </label>
+              </dialog-entity-delete>
+            </v-list-item-action>
+          </v-list-item>
+        </v-list>
+      </div>
+    </v-expansion-panel-content>
+  </v-expansion-panel>
 </template>
 
 <script>
-import ContentGroup from '@/components/layout/ContentGroup.vue'
 import ButtonDelete from '@/components/buttons/ButtonDelete.vue'
 import DialogEntityDelete from '@/components/dialog/DialogEntityDelete.vue'
 import ETextField from '@/components/form/base/ETextField.vue'
 
 export default {
   name: 'CampDangerZone',
-  components: { ETextField, DialogEntityDelete, ButtonDelete, ContentGroup },
+  components: {
+    ETextField,
+    DialogEntityDelete,
+    ButtonDelete,
+  },
   props: {
     camp: {
       type: Function,

--- a/frontend/src/components/campAdmin/DialogMaterialListEdit.vue
+++ b/frontend/src/components/campAdmin/DialogMaterialListEdit.vue
@@ -4,13 +4,21 @@
     :loading="loading"
     :error="error"
     icon="mdi-package-variant"
-    :title="materialList.name"
+    :title="$tc('components.campAdmin.dialogMaterialListEdit.title')"
     :submit-action="update"
     submit-color="success"
     :cancel-action="close"
   >
     <template #activator="scope">
       <slot name="activator" v-bind="scope" />
+    </template>
+    <template #moreActions>
+      <PromptEntityDelete
+        :entity="entityUri"
+        :warning-text-entity="materialList.name"
+        position="top"
+        align="left"
+      />
     </template>
     <dialog-material-list-form :material-list="entityData" />
   </dialog-form>
@@ -20,10 +28,11 @@
 import DialogBase from '@/components/dialog/DialogBase.vue'
 import DialogForm from '@/components/dialog/DialogForm.vue'
 import DialogMaterialListForm from './DialogMaterialListForm.vue'
+import PromptEntityDelete from '@/components/prompt/PromptEntityDelete.vue'
 
 export default {
   name: 'DialogMaterialListEdit',
-  components: { DialogForm, DialogMaterialListForm },
+  components: { PromptEntityDelete, DialogForm, DialogMaterialListForm },
   extends: DialogBase,
   props: {
     materialList: { type: Object, required: true },

--- a/frontend/src/components/generic/GenericPage.vue
+++ b/frontend/src/components/generic/GenericPage.vue
@@ -1,7 +1,3 @@
-<!--
-Displays several tabs with details on a single camp.
--->
-
 <template>
   <v-container fluid :style="layoutStyle">
     <router-view v-bind="$attrs" />
@@ -10,7 +6,7 @@ Displays several tabs with details on a single camp.
 
 <script>
 export default {
-  name: 'Camp',
+  name: 'GenericPage',
   props: {
     layout: { type: String, required: false, default: 'full' },
   },

--- a/frontend/src/components/layout/ContentGroup.vue
+++ b/frontend/src/components/layout/ContentGroup.vue
@@ -3,7 +3,7 @@ Displays the content wrapped inside a card.
 -->
 
 <template>
-  <v-sheet class="ec-content-group mb-8 mt-2">
+  <v-sheet class="ec-content-group mt-2">
     <slot name="title">
       <component
         :is="titleTag"
@@ -39,5 +39,9 @@ export default {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+}
+
+.ec-content-group + .ec-content-group {
+  margin-top: 32px !important;
 }
 </style>

--- a/frontend/src/components/layout/SidebarListItem.vue
+++ b/frontend/src/components/layout/SidebarListItem.vue
@@ -1,17 +1,17 @@
 <template>
   <v-list-item link :to="to" @click="$emit('click', $event)">
     <slot name="pre">
-      <v-list-item-avatar v-if="!hideAvatar">
+      <v-list-item-icon v-if="!hideAvatar">
         <v-icon v-if="icon">{{ icon }}</v-icon>
-      </v-list-item-avatar>
+      </v-list-item-icon>
     </slot>
     <v-list-item-content>
       <v-list-item-title>{{ title }}</v-list-item-title>
       <v-list-item-subtitle v-if="subtitle">{{ subtitle }}</v-list-item-subtitle>
     </v-list-item-content>
-    <v-list-item-action v-if="!hideChevron">
-      <v-icon>mdi-chevron-right</v-icon>
-    </v-list-item-action>
+    <v-list-item-icon v-if="!hideChevron">
+      <v-icon style="opacity: 0.6">mdi-chevron-right</v-icon>
+    </v-list-item-icon>
   </v-list-item>
 </template>
 

--- a/frontend/src/components/material/MaterialListsEdit.vue
+++ b/frontend/src/components/material/MaterialListsEdit.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-list>
+    <v-skeleton-loader v-if="materialLists._meta.loading" type="list-item@3" />
+    <DialogMaterialListEdit
+      v-for="materialList in materialLists.allItems"
+      :key="materialList._meta.self"
+      :material-list="materialList"
+    >
+      <template #activator="{ on }">
+        <v-list-item exact-path v-on="on">
+          <v-list-item-content>
+            <v-list-item-title>{{ materialList.name }}</v-list-item-title>
+          </v-list-item-content>
+          <v-list-item-action class="e-collaborator-item__actions ml-2">
+            <ButtonEdit color="primary--text" text class="my-n1 v-btn--has-bg" />
+          </v-list-item-action>
+        </v-list-item>
+      </template>
+    </DialogMaterialListEdit>
+  </v-list>
+</template>
+<script>
+import ButtonEdit from '@/components/buttons/ButtonEdit.vue'
+import DialogMaterialListEdit from '@/components/campAdmin/DialogMaterialListEdit.vue'
+
+export default {
+  name: 'MaterialListsEdit',
+  components: { ButtonEdit, DialogMaterialListEdit },
+  props: {
+    materialLists: {
+      type: Object,
+      required: true,
+    },
+  },
+}
+</script>

--- a/frontend/src/components/navigation/SideBar.vue
+++ b/frontend/src/components/navigation/SideBar.vue
@@ -8,38 +8,61 @@
     :temporary="!mini && !$vuetify.breakpoint.mdAndUp"
     :mini-variant.sync="mini"
     mini-variant-width="40"
-    color="blue-grey lighten-4"
+    :width="$vuetify.breakpoint.xl || (!mini && !$vuetify.breakpoint.mdAndUp) ? 350 : 256"
+    :color="!title || mini ? 'blue-grey lighten-4' : null"
   >
-    <v-btn
-      v-if="mini"
-      icon
-      class="ec-drawer-open mr-1"
-      @click.stop="overrideExpanded = true"
-    >
-      <v-icon>mdi-format-list-bulleted-type</v-icon>
-    </v-btn>
-    <v-spacer />
-    <v-btn
-      v-if="!mini"
-      icon
-      fixed
-      class="ec-drawer-collapse mr-1"
-      style="z-index: 10"
-      right
-      @click.stop="overrideExpanded = false"
-    >
-      <v-icon>mdi-chevron-left</v-icon>
-    </v-btn>
+    <template v-if="title">
+      <v-list class="py-0">
+        <v-list-item v-if="mini" class="py-1" @click.stop="overrideExpanded = true">
+          <v-icon>{{ icon }}</v-icon>
+        </v-list-item>
+        <v-list-item v-else class="py-1 pr-2">
+          <v-list-item-title class="subtitle-1 font-weight-bold">
+            {{ title }}
+          </v-list-item-title>
+          <v-btn icon @click.stop="overrideExpanded = false">
+            <v-icon>mdi-chevron-left</v-icon>
+          </v-btn>
+        </v-list-item>
+      </v-list>
+      <v-divider />
+      <slot v-if="!mini" />
+    </template>
+    <template v-else>
+      <v-btn
+        v-if="mini"
+        icon
+        class="ec-drawer-open mr-1"
+        @click.stop="overrideExpanded = true"
+      >
+        <v-icon>mdi-format-list-bulleted-type</v-icon>
+      </v-btn>
+      <v-spacer />
+      <v-btn
+        v-if="!mini"
+        icon
+        fixed
+        class="ec-drawer-collapse mr-1"
+        style="z-index: 10"
+        right
+        @click.stop="overrideExpanded = false"
+      >
+        <v-icon>mdi-chevron-left</v-icon>
+      </v-btn>
 
-    <v-divider />
-
-    <slot v-if="!mini" />
+      <v-divider />
+      <slot v-if="!mini" />
+    </template>
   </v-navigation-drawer>
 </template>
 
 <script>
 export default {
   name: 'SideBar',
+  props: {
+    title: { type: String, default: null },
+    icon: { type: String, default: 'mdi-format-list-bulleted-type' },
+  },
   data() {
     return {
       drawer: false,

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -55,10 +55,11 @@
       },
       "campConditionalFields": {
         "course": {
-          "title": "Weitere Felder für Kurse"
+          "title": "Kurse"
         },
+        "title": "Einstellungen für J+S",
         "ysCamp": {
-          "title": "Weitere Felder für J+S-Lager"
+          "title": "Lager"
         }
       },
       "campDangerZone": {
@@ -91,7 +92,7 @@
         "periodChangeStart": "Zu Begin Tage hinzufügen/entfernen"
       },
       "campSettings": {
-        "title": "Einstellungen"
+        "title": "Beschreibung"
       },
       "createCampPeriods": {
         "add": "Weiteren Lagerabschnitt hinzufügen"
@@ -104,6 +105,9 @@
       },
       "dialogMaterialListCreate": {
         "title": "Materialliste erstellen"
+      },
+      "dialogMaterialListEdit": {
+        "title": "Materialliste bearbeiten"
       },
       "dialogPeriodCreate": {
         "title": "Lagerabschnitt erstellen"
@@ -199,7 +203,7 @@
         "addNewItem": "Eintrag hinzufügen",
         "noItems": "Keine Einträge gefunden",
         "periodOnly": "Filter: Lagerabschnitt",
-        "reference": "Aktivität\u00a0/ Abschnitt"
+        "reference": "Aktivität / Abschnitt"
       },
       "useMaterialViewHelper": {
         "detail": "Materialliste",
@@ -241,6 +245,21 @@
       "localPdfDownloadButton": {
         "error": "Etwas hat nicht geklappt. Probiere es nochmals, oder lade die Seite neu."
       },
+      "printClient": {
+        "downloadClientPdfButton": {
+          "label": "PDF herunterladen (Layout #2)"
+        },
+        "downloadClientPdfListItem": {
+          "label": "PDF herunterladen (Layout #2)"
+        },
+        "generatePdfMixin": {
+          "error": "Etwas hat nicht geklappt. Probiere es nochmals, oder lade die Seite neu."
+        },
+        "printPreviewClient": {
+          "previewError": "Etwas hat nicht geklappt. Probiere es nochmals mit anderen Druckeinstellungen, oder lade die Seite neu.",
+          "previewIframeTitle": "Druckvorschau"
+        }
+      },
       "printConfigurator": {
         "add": "Inhalt hinzufügen",
         "config": {
@@ -265,21 +284,6 @@
         },
         "printPreviewNuxt": {
           "openPreview": "Vorschau in neuem Fenster öffnen",
-          "previewError": "Etwas hat nicht geklappt. Probiere es nochmals mit anderen Druckeinstellungen, oder lade die Seite neu.",
-          "previewIframeTitle": "Druckvorschau"
-        }
-      },
-      "printClient": {
-        "downloadClientPdfButton": {
-          "label": "PDF herunterladen (Layout #2)"
-        },
-        "downloadClientPdfListItem": {
-          "label": "PDF herunterladen (Layout #2)"
-        },
-        "generatePdfMixin": {
-          "error": "Etwas hat nicht geklappt. Probiere es nochmals, oder lade die Seite neu."
-        },
-        "printPreviewClient": {
           "previewError": "Etwas hat nicht geklappt. Probiere es nochmals mit anderen Druckeinstellungen, oder lade die Seite neu.",
           "previewIframeTitle": "Druckvorschau"
         }
@@ -392,6 +396,11 @@
     "language": "Deutsch",
     "loading": "Laden …",
     "lokaliseMessage": "Übersetzungen unterstützt durch lokalise.com",
+    "navigation": {
+      "admin": {
+        "title": "Admin"
+      }
+    },
     "serverError": {
       "409": "Uuuups... Diese Aktion hat zu einem Fehler auf dem Server geführt.",
       "short": "Serverfehler"
@@ -415,6 +424,36 @@
       "sideBarProgram": {
         "title": "Tagesübersicht"
       }
+    },
+    "admin": {
+      "activity": {
+        "title": "Aktivitätseinstellungen"
+      },
+      "collaborators": {
+        "email": "E-Mail-Adresse",
+        "inactiveCollaborators": "Inaktiv",
+        "members": "Mitarbeitende",
+        "openInvitations": "Offene Einladungen",
+        "title": "Team"
+      },
+      "info": {
+        "title": "Lagerinfos"
+      },
+      "materialLists": {
+        "title": "Materiallisten"
+      },
+      "print": {
+        "title": "Lager drucken"
+      },
+      "sideBarAdmin": {
+        "itemActivity": "Aktivitäten",
+        "itemActivitySubtitle": "Kategorie, Vorlagen & Status",
+        "itemCollaborators": "Team",
+        "itemInfos": "Lagerinfos",
+        "itemMaterialLists": "Materiallisten",
+        "itemPrint": "PDF / Drucken"
+      },
+      "title": "Admin"
     },
     "auth": {
       "activate": {
@@ -476,21 +515,10 @@
       }
     },
     "camp": {
-      "admin": {
-        "collaborators": "Team verwalten",
-        "title": "Admin"
-      },
       "campProgram": {
         "reminderLockedCreate": "Ziehen zum Erstellen ist nur im entsperrten Modus möglich.",
         "reminderLockedMove": "Ziehen zum Verschieben ist nur im entsperrten Modus möglich.",
         "title": "Grobprogramm"
-      },
-      "collaborators": {
-        "email": "E-Mail-Adresse",
-        "inactiveCollaborators": "Inaktiv",
-        "members": "Mitarbeitende",
-        "openInvitations": "Offene Einladungen",
-        "title": "Team"
       },
       "dashboard": {
         "activities": "Aktivitäten",
@@ -525,9 +553,6 @@
         "useOtherAuth": "Ausloggen und einen anderen Account benutzen",
         "userAlreadyInCamp": "Du arbeitest schon an diesem Lager mit"
       },
-      "material": {
-        "title": "Materiallisten"
-      },
       "navigation": {
         "desktop": {
           "navTopbar": {
@@ -548,16 +573,16 @@
             "story": "Geschichte"
           },
           "navSidebar": {
-            "itemCampAdmin": "Lagereinstellungen",
+            "itemActivity": "Aktivitäten",
+            "itemActivitySubtitle": "Kategorie, Vorlagen & Status",
             "itemCamps": "Meine Lager",
             "itemClose": "Menü schliessen",
             "itemCollaborators": "Team",
+            "itemInfos": "Lagerinfos",
+            "itemMaterialLists": "Materiallisten",
             "itemPrinting": "PDF / Drucken"
           }
         }
-      },
-      "print": {
-        "title": "Lager drucken"
       },
       "story": {
         "title": "Geschichte"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -55,10 +55,11 @@
       },
       "campConditionalFields": {
         "course": {
-          "title": "Additional fields for courses"
+          "title": "Courses"
         },
+        "title": "Settings for Y+S",
         "ysCamp": {
-          "title": "Additional fields for Y+S camps"
+          "title": "Camps"
         }
       },
       "campDangerZone": {
@@ -104,6 +105,9 @@
       },
       "dialogMaterialListCreate": {
         "title": "Create material list"
+      },
+      "dialogMaterialListEdit": {
+        "title": "Edit material list"
       },
       "dialogPeriodCreate": {
         "title": "Create period"
@@ -199,7 +203,7 @@
         "addNewItem": "Add new item",
         "noItems": "No material items found",
         "periodOnly": "Filter: Period",
-        "reference": "Activity\u00a0/ Period"
+        "reference": "Activity / Period"
       },
       "useMaterialViewHelper": {
         "detail": "Material list",
@@ -241,6 +245,21 @@
       "localPdfDownloadButton": {
         "error": "Something didn't work. Try again, or reload the page."
       },
+      "printClient": {
+        "downloadClientPdfButton": {
+          "label": "Download PDF (layout #2)"
+        },
+        "downloadClientPdfListItem": {
+          "label": "Download PDF (layout #2)"
+        },
+        "generatePdfMixin": {
+          "error": "Something did not work. Please try again, or try reloading the page."
+        },
+        "printPreviewClient": {
+          "previewError": "Something did not work. Please try again with different printing settings, or reload the page.",
+          "previewIframeTitle": "Print preview"
+        }
+      },
       "printConfigurator": {
         "add": "Add content",
         "config": {
@@ -265,21 +284,6 @@
         },
         "printPreviewNuxt": {
           "openPreview": "Open preview in new window",
-          "previewError": "Something did not work. Please try again with different printing settings, or reload the page.",
-          "previewIframeTitle": "Print preview"
-        }
-      },
-      "printClient": {
-        "downloadClientPdfButton": {
-          "label": "Download PDF (layout #2)"
-        },
-        "downloadClientPdfListItem": {
-          "label": "Download PDF (layout #2)"
-        },
-        "generatePdfMixin": {
-          "error": "Something did not work. Please try again, or try reloading the page."
-        },
-        "printPreviewClient": {
           "previewError": "Something did not work. Please try again with different printing settings, or reload the page.",
           "previewIframeTitle": "Print preview"
         }
@@ -370,8 +374,8 @@
       "logout": "Logout",
       "move": "Move",
       "ok": "OK",
-      "rename": "Rename",
       "open": "Open",
+      "rename": "Rename",
       "save": "Save",
       "saving": "Saving",
       "search": "Search",
@@ -392,6 +396,11 @@
     "language": "English",
     "loading": "Loading …",
     "lokaliseMessage": "Language switching powered by lokalise.com",
+    "navigation": {
+      "admin": {
+        "title": "Admin"
+      }
+    },
     "serverError": {
       "409": "Uuuups... This action caused an server-side error.",
       "short": "Server error"
@@ -415,6 +424,36 @@
       "sideBarProgram": {
         "title": "Activities on this day"
       }
+    },
+    "admin": {
+      "activity": {
+        "title": "Activity settings"
+      },
+      "collaborators": {
+        "email": "Email address",
+        "inactiveCollaborators": "Inactive",
+        "members": "Members",
+        "openInvitations": "Open invitations",
+        "title": "Team"
+      },
+      "info": {
+        "title": "Camp infos"
+      },
+      "materialLists": {
+        "title": "Material lists"
+      },
+      "print": {
+        "title": "Print camp"
+      },
+      "sideBarAdmin": {
+        "itemActivity": "Activities",
+        "itemActivitySubtitle": "Category, templates & status",
+        "itemCollaborators": "Team",
+        "itemInfos": "Camp infos",
+        "itemMaterialLists": "Material lists",
+        "itemPrint": "PDF / Print"
+      },
+      "title": "Admin"
     },
     "auth": {
       "activate": {
@@ -476,21 +515,10 @@
       }
     },
     "camp": {
-      "admin": {
-        "collaborators": "Manage Team",
-        "title": "Admin"
-      },
       "campProgram": {
         "reminderLockedCreate": "Drag to create is only possible in unlocked mode.",
         "reminderLockedMove": "Drag to move is only possible in unlocked mode.",
         "title": "Picasso"
-      },
-      "collaborators": {
-        "email": "Email address",
-        "inactiveCollaborators": "Inactive",
-        "members": "Members",
-        "openInvitations": "Open invitations",
-        "title": "Team"
       },
       "dashboard": {
         "activities": "Activities",
@@ -525,9 +553,6 @@
         "useOtherAuth": "Logout & use another account",
         "userAlreadyInCamp": "You are already participating in this camp"
       },
-      "material": {
-        "title": "Material lists"
-      },
       "navigation": {
         "desktop": {
           "navTopbar": {
@@ -548,16 +573,16 @@
             "story": "Story"
           },
           "navSidebar": {
-            "itemCampAdmin": "Camp settings",
+            "itemActivity": "Activities",
+            "itemActivitySubtitle": "Category, templates & status",
             "itemCamps": "My Camps",
             "itemClose": "Close menu",
             "itemCollaborators": "Team",
+            "itemInfos": "Camp infos",
+            "itemMaterialLists": "Material lists",
             "itemPrinting": "PDF / Print"
           }
         }
-      },
-      "print": {
-        "title": "Print camp"
       },
       "story": {
         "title": "Story"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -55,10 +55,11 @@
       },
       "campConditionalFields": {
         "course": {
-          "title": "Autres champs pour les cours"
+          "title": "Cours"
         },
+        "title": "Paramètres pour J+S",
         "ysCamp": {
-          "title": "Autres champs pour les camps J+S"
+          "title": "Camps"
         }
       },
       "campDangerZone": {
@@ -104,6 +105,9 @@
       },
       "dialogMaterialListCreate": {
         "title": "Créer une liste de matériel"
+      },
+      "dialogMaterialListEdit": {
+        "title": "Modifier la liste de matériel"
       },
       "dialogPeriodCreate": {
         "title": "Créer une période"
@@ -199,7 +203,7 @@
         "addNewItem": "Ajoute un nouvel élément",
         "noItems": "Aucun élément matériel trouvé",
         "periodOnly": "Filtre : Période",
-        "reference": "Activité\u00a0/ Période"
+        "reference": "Activité / Période"
       },
       "useMaterialViewHelper": {
         "detail": "Liste de matériel",
@@ -241,6 +245,21 @@
       "localPdfDownloadButton": {
         "error": "Une erreur est survenue. Essaie à nouveau, ou recharge la page."
       },
+      "printClient": {
+        "downloadClientPdfButton": {
+          "label": "Télécharger le PDF (mise en page #2)"
+        },
+        "downloadClientPdfListItem": {
+          "label": "Télécharger le PDF (mise en page #2)"
+        },
+        "generatePdfMixin": {
+          "error": "Une erreur est survenue. Essaie à nouveau, ou recharge la page."
+        },
+        "printPreviewClient": {
+          "previewError": "Une erreur est survenue. Veuillez réessayer avec des paramètres d'impression différents, ou recharger la page.",
+          "previewIframeTitle": "Aperçu avant impression"
+        }
+      },
       "printConfigurator": {
         "add": "Ajouter du contenu",
         "config": {
@@ -265,21 +284,6 @@
         },
         "printPreviewNuxt": {
           "openPreview": "Ouvrir l'aperçu dans une nouvelle fenêtre",
-          "previewError": "Une erreur est survenue. Veuillez réessayer avec des paramètres d'impression différents, ou recharger la page.",
-          "previewIframeTitle": "Aperçu avant impression"
-        }
-      },
-      "printClient": {
-        "downloadClientPdfButton": {
-          "label": "Télécharger le PDF (mise en page #2)"
-        },
-        "downloadClientPdfListItem": {
-          "label": "Télécharger le PDF (mise en page #2)"
-        },
-        "generatePdfMixin": {
-          "error": "Une erreur est survenue. Essaie à nouveau, ou recharge la page."
-        },
-        "printPreviewClient": {
           "previewError": "Une erreur est survenue. Veuillez réessayer avec des paramètres d'impression différents, ou recharger la page.",
           "previewIframeTitle": "Aperçu avant impression"
         }
@@ -370,8 +374,8 @@
       "logout": "Déconnexion",
       "move": "Déplacer",
       "ok": "OK",
-      "rename": "Renommer",
       "open": "Ouvrir",
+      "rename": "Renommer",
       "save": "Sauvegarder",
       "saving": "En cours de sauvegarde",
       "search": "Rechercher",
@@ -392,6 +396,11 @@
     "language": "Français",
     "loading": "Chargement ...",
     "lokaliseMessage": "Changement de langue grâce à lokalise.com",
+    "navigation": {
+      "admin": {
+        "title": "Admin"
+      }
+    },
     "serverError": {
       "409": "Oooops... Cette action a provoqué une erreur côté serveur.",
       "short": "erreur de serveur"
@@ -415,6 +424,36 @@
       "sideBarProgram": {
         "title": "Activités du jour"
       }
+    },
+    "admin": {
+      "activity": {
+        "title": "Paramètres d'activité"
+      },
+      "collaborators": {
+        "email": "Adresse e-mail",
+        "inactiveCollaborators": "Inactif",
+        "members": "Membres",
+        "openInvitations": "Invitations ouvertes",
+        "title": "Team"
+      },
+      "info": {
+        "title": "Infos sur le camp"
+      },
+      "materialLists": {
+        "title": "Liste de matériel"
+      },
+      "print": {
+        "title": "Imprimer un camp"
+      },
+      "sideBarAdmin": {
+        "itemActivity": "Activités",
+        "itemActivitySubtitle": "Catégorie, modèle & statut",
+        "itemCollaborators": "Team",
+        "itemInfos": "Infos sur le camp",
+        "itemMaterialLists": "Liste de matériel",
+        "itemPrint": "PDF / Imprimer"
+      },
+      "title": "Admin"
     },
     "auth": {
       "activate": {
@@ -476,21 +515,10 @@
       }
     },
     "camp": {
-      "admin": {
-        "collaborators": "Gérer l'équipe",
-        "title": "Admin"
-      },
       "campProgram": {
         "reminderLockedCreate": "Glisser pour créer n'est possible qu'en mode déverrouillé.",
         "reminderLockedMove": "Glisser pour déplacer n'est possible qu'en mode déverrouillé.",
         "title": "Programme général"
-      },
-      "collaborators": {
-        "email": "Adresse e-mail",
-        "inactiveCollaborators": "Inactif",
-        "members": "Membres",
-        "openInvitations": "Invitations ouvertes",
-        "title": "Team"
       },
       "dashboard": {
         "activities": "Activités",
@@ -525,9 +553,6 @@
         "useOtherAuth": "Déconnecte-toi et utilise un autre compte",
         "userAlreadyInCamp": "Tu participes déjà à ce camp"
       },
-      "material": {
-        "title": "Liste de matériel"
-      },
       "navigation": {
         "desktop": {
           "navTopbar": {
@@ -548,16 +573,16 @@
             "story": "Histoire"
           },
           "navSidebar": {
-            "itemCampAdmin": "Configuration du camp",
+            "itemActivity": "Activités",
+            "itemActivitySubtitle": "Catégorie, modèle & statut",
             "itemCamps": "Mes Camps",
             "itemClose": "Fermer le menu",
             "itemCollaborators": "Team",
+            "itemInfos": "Infos sur le camp",
+            "itemMaterialLists": "Liste de matériel",
             "itemPrinting": "PDF / Imprimer"
           }
         }
-      },
-      "print": {
-        "title": "Imprimer un camp"
       },
       "story": {
         "title": "Histoire"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -55,10 +55,11 @@
       },
       "campConditionalFields": {
         "course": {
-          "title": "Altri campi per i corsi"
+          "title": "Corsi"
         },
+        "title": "Impostazioni per G+S",
         "ysCamp": {
-          "title": "Altri campi per i campi G+S"
+          "title": "Campi"
         }
       },
       "campDangerZone": {
@@ -104,6 +105,9 @@
       },
       "dialogMaterialListCreate": {
         "title": "Crea l'elenco dei materiali"
+      },
+      "dialogMaterialListEdit": {
+        "title": "Modifica elenco materiali"
       },
       "dialogPeriodCreate": {
         "title": "Creare il periodo"
@@ -199,7 +203,7 @@
         "addNewItem": "Aggiungi un nuovo elemento",
         "noItems": "Nessun oggetto materiale trovato",
         "periodOnly": "Filtro: Periodo",
-        "reference": "Attività\u00a0/ Periodo"
+        "reference": "Attività / Periodo"
       },
       "useMaterialViewHelper": {
         "detail": "Liste di materiali",
@@ -241,6 +245,21 @@
       "localPdfDownloadButton": {
         "error": "Qualcosa non ha funzionato. Riprova o ricarica la pagina."
       },
+      "printClient": {
+        "downloadClientPdfButton": {
+          "label": "Scarica il PDF (layout #2)"
+        },
+        "downloadClientPdfListItem": {
+          "label": "Scarica il PDF (layout #2)"
+        },
+        "generatePdfMixin": {
+          "error": "Qualcosa non ha funzionato. Riprova o ricarica la pagina."
+        },
+        "printPreviewClient": {
+          "previewError": "Qualcosa non ha funzionato. Riprova con altre impostazioni di stampa o ricarica la pagina.",
+          "previewIframeTitle": "Anteprima di stampa"
+        }
+      },
       "printConfigurator": {
         "add": "Aggiungi contenuti",
         "config": {
@@ -265,21 +284,6 @@
         },
         "printPreviewNuxt": {
           "openPreview": "Apri l'anteprima in una nuova finestra",
-          "previewError": "Qualcosa non ha funzionato. Riprova con altre impostazioni di stampa o ricarica la pagina.",
-          "previewIframeTitle": "Anteprima di stampa"
-        }
-      },
-      "printClient": {
-        "downloadClientPdfButton": {
-          "label": "Scarica il PDF (layout #2)"
-        },
-        "downloadClientPdfListItem": {
-          "label": "Scarica il PDF (layout #2)"
-        },
-        "generatePdfMixin": {
-          "error": "Qualcosa non ha funzionato. Riprova o ricarica la pagina."
-        },
-        "printPreviewClient": {
           "previewError": "Qualcosa non ha funzionato. Riprova con altre impostazioni di stampa o ricarica la pagina.",
           "previewIframeTitle": "Anteprima di stampa"
         }
@@ -370,8 +374,8 @@
       "logout": "Disconnessione",
       "move": "Spostamento",
       "ok": "Bene",
-      "rename": "Rinominare",
       "open": "Aprire",
+      "rename": "Rinominare",
       "save": "Salvare",
       "saving": "Salvataggio",
       "search": "Ricerca",
@@ -392,6 +396,11 @@
     "language": "Italiano",
     "loading": "Caricamento ...",
     "lokaliseMessage": "Cambio di lingua alimentato da lokalise.com",
+    "navigation": {
+      "admin": {
+        "title": "Admin"
+      }
+    },
     "serverError": {
       "409": "Oooops... Questa azione ha causato un errore sul lato server.",
       "short": "Errore del server"
@@ -415,6 +424,36 @@
       "sideBarProgram": {
         "title": "Attività in questo giorno"
       }
+    },
+    "admin": {
+      "activity": {
+        "title": "Impostazioni dell'attività"
+      },
+      "collaborators": {
+        "email": "Indirizzo e-mail",
+        "inactiveCollaborators": "Inattivo",
+        "members": "Membri",
+        "openInvitations": "Inviti aperti",
+        "title": "Team"
+      },
+      "info": {
+        "title": "Info sul campo"
+      },
+      "materialLists": {
+        "title": "Liste di materiali"
+      },
+      "print": {
+        "title": "Stampa il campo"
+      },
+      "sideBarAdmin": {
+        "itemActivity": "Attività",
+        "itemActivitySubtitle": "Categoria, modello, stati",
+        "itemCollaborators": "Team",
+        "itemInfos": "Info sul campo",
+        "itemMaterialLists": "Liste di materiali",
+        "itemPrint": "PDF / Stampa"
+      },
+      "title": "Admin"
     },
     "auth": {
       "activate": {
@@ -476,21 +515,10 @@
       }
     },
     "camp": {
-      "admin": {
-        "collaborators": "Gestire il team",
-        "title": "Admin"
-      },
       "campProgram": {
         "reminderLockedCreate": "Trascinare per creare è possibile solo in modalità sbloccata.",
         "reminderLockedMove": "Trascinare per spostarsi è possibile solo in modalità sbloccata.",
         "title": "Picasso"
-      },
-      "collaborators": {
-        "email": "Indirizzo e-mail",
-        "inactiveCollaborators": "Inattivo",
-        "members": "Membri",
-        "openInvitations": "Inviti aperti",
-        "title": "Team"
       },
       "dashboard": {
         "activities": "Attività",
@@ -525,9 +553,6 @@
         "useOtherAuth": "Esci e usa un altro account",
         "userAlreadyInCamp": "Stai già partecipando a questo campo"
       },
-      "material": {
-        "title": "Liste di materiali"
-      },
       "navigation": {
         "desktop": {
           "navTopbar": {
@@ -548,16 +573,16 @@
             "story": "Storia"
           },
           "navSidebar": {
-            "itemCampAdmin": "Configurazione del campo",
+            "itemActivity": "Attività",
+            "itemActivitySubtitle": "Categoria, modello, stati",
             "itemCamps": "I miei campi",
             "itemClose": "Chiudere il menu",
             "itemCollaborators": "Team",
+            "itemInfos": "Info sul campo",
+            "itemMaterialLists": "Liste di materiali",
             "itemPrinting": "PDF / Stampa"
           }
         }
-      },
-      "print": {
-        "title": "Stampa il campo"
       },
       "story": {
         "title": "Storia"

--- a/frontend/src/views/admin/Activity.vue
+++ b/frontend/src/views/admin/Activity.vue
@@ -1,0 +1,34 @@
+<template>
+  <content-card :title="$tc('views.admin.activity.title')" toolbar>
+    <v-container fluid class="px-4 pb-8">
+      <v-row>
+        <v-col cols="12" lg="6" class="pb-0 pr-lg-6">
+          <CampCategories :camp="camp" :disabled="!isManager" />
+        </v-col>
+        <v-col cols="12" lg="6" class="pb-0 pr-lg-6">
+          <CampActivityProgressLabels :camp="camp" :disabled="!isManager" />
+        </v-col>
+      </v-row>
+    </v-container>
+  </content-card>
+</template>
+
+<script>
+import ContentCard from '@/components/layout/ContentCard.vue'
+import CampCategories from '@/components/campAdmin/CampCategories.vue'
+import CampActivityProgressLabels from '@/components/campAdmin/CampActivityProgressLabels.vue'
+import { campRoleMixin } from '@/mixins/campRoleMixin.js'
+
+export default {
+  name: 'AdminActivity',
+  components: {
+    CampActivityProgressLabels,
+    CampCategories,
+    ContentCard,
+  },
+  mixins: [campRoleMixin],
+  props: {
+    camp: { type: Function, required: true },
+  },
+}
+</script>

--- a/frontend/src/views/admin/Collaborators.vue
+++ b/frontend/src/views/admin/Collaborators.vue
@@ -2,9 +2,9 @@
 Displays collaborators of a single camp.
 -->
 <template>
-  <content-card :title="$tc('views.camp.collaborators.title')" toolbar>
+  <content-card :title="$tc('views.admin.collaborators.title')" toolbar>
     <v-card-text>
-      <ContentGroup :title="$tc('views.camp.collaborators.members')">
+      <ContentGroup :title="$tc('views.admin.collaborators.members')">
         <template #title-actions>
           <CollaboratorCreate v-if="isManager" :camp="camp()" />
         </template>
@@ -13,14 +13,14 @@ Displays collaborators of a single camp.
 
       <ContentGroup
         v-if="invited.length > 0"
-        :title="$tc('views.camp.collaborators.openInvitations')"
+        :title="$tc('views.admin.collaborators.openInvitations')"
       >
         <CollaboratorList :collaborators="invited" :is-manager="isManager" />
       </ContentGroup>
 
       <ContentGroup
         v-if="inactive.length > 0"
-        :title="$tc('views.camp.collaborators.inactiveCollaborators')"
+        :title="$tc('views.admin.collaborators.inactiveCollaborators')"
       >
         <CollaboratorList :collaborators="inactive" :is-manager="isManager" inactive />
       </ContentGroup>
@@ -35,7 +35,7 @@ import { campRoleMixin } from '@/mixins/campRoleMixin'
 import CollaboratorList from '@/components/collaborator/CollaboratorList.vue'
 
 export default {
-  name: 'Collaborators',
+  name: 'AdminCollaborators',
   components: {
     CollaboratorList,
     CollaboratorCreate,

--- a/frontend/src/views/admin/Info.vue
+++ b/frontend/src/views/admin/Info.vue
@@ -1,0 +1,66 @@
+<template>
+  <content-card :title="$tc('views.admin.info.title')" toolbar>
+    <v-container fluid class="px-4 pb-8">
+      <v-row>
+        <v-col cols="12" md="6" class="pb-0">
+          <CampSettings :camp="camp" :disabled="!isManager" />
+        </v-col>
+        <v-col cols="12" md="6" class="pb-0">
+          <CampPeriods :camp="camp" :disabled="!isManager" />
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="12" md="6" class="pb-0">
+          <CampAddress :camp="camp" :disabled="!isManager" />
+        </v-col>
+      </v-row>
+    </v-container>
+    <v-expansion-panels v-model="openPanels" flat accordion multiple>
+      <CampConditionalFields :camp="camp" :disabled="!isManager" />
+      <CampDangerZone v-if="isManager" :camp="camp" />
+    </v-expansion-panels>
+  </content-card>
+</template>
+
+<script>
+import ContentCard from '@/components/layout/ContentCard.vue'
+import CampAddress from '@/components/campAdmin/CampAddress.vue'
+import CampSettings from '@/components/campAdmin/CampSettings.vue'
+import CampConditionalFields from '@/components/campAdmin/CampConditionalFields.vue'
+import { campRoleMixin } from '@/mixins/campRoleMixin.js'
+import CampPeriods from '@/components/campAdmin/CampPeriods.vue'
+import CampDangerZone from '@/components/campAdmin/CampDangerZone.vue'
+
+export default {
+  name: 'AdminInfo',
+  components: {
+    CampDangerZone,
+    CampPeriods,
+    CampConditionalFields,
+    CampSettings,
+    CampAddress,
+    ContentCard,
+  },
+  mixins: [campRoleMixin],
+  props: {
+    camp: { type: Function, required: true },
+  },
+  data: () => ({
+    openPanels: [],
+  }),
+  mounted() {
+    this.camp()._meta.load.then((camp) => {
+      if (
+        camp?.organizer ||
+        camp?.kind ||
+        camp?.coachName ||
+        camp?.courseNumber ||
+        camp?.courseKind ||
+        camp?.trainingAdvisorName
+      ) {
+        this.openPanels.push(0)
+      }
+    })
+  },
+}
+</script>

--- a/frontend/src/views/admin/MaterialLists.vue
+++ b/frontend/src/views/admin/MaterialLists.vue
@@ -3,39 +3,52 @@ Show all material lists for a camp on mobile
 -->
 
 <template>
-  <content-card :title="$tc('views.camp.material.title')" toolbar>
+  <content-card :title="$tc('views.admin.materialLists.title')" toolbar>
     <template v-if="!isGuest" #title-actions>
       <DialogMaterialListCreate :camp="camp()">
         <template #activator="{ on }">
-          <ButtonAdd class="mr-n2" height="32" v-on="on">{{
-            $tc('global.button.create')
-          }}</ButtonAdd>
+          <ButtonAdd class="mr-n2" height="32" v-on="on"
+            >{{ $tc('global.button.create') }}
+          </ButtonAdd>
         </template>
       </DialogMaterialListCreate>
     </template>
-    <MaterialLists :camp="camp" />
+    <MaterialListsEdit v-if="!isGuest" :material-lists="materialLists" />
+    <MaterialLists v-else :camp="camp" />
   </content-card>
 </template>
 
 <script>
 import ContentCard from '@/components/layout/ContentCard.vue'
-import MaterialLists from '@/components/material/MaterialLists.vue'
 import { campRoleMixin } from '@/mixins/campRoleMixin'
 import ButtonAdd from '@/components/buttons/ButtonAdd.vue'
 import DialogMaterialListCreate from '@/components/campAdmin/DialogMaterialListCreate.vue'
+import { materialListRoute } from '@/router.js'
+import MaterialLists from '@/components/material/MaterialLists.vue'
+import MaterialListsEdit from '@/components/material/MaterialListsEdit.vue'
 
 export default {
-  name: 'Material',
+  name: 'AdminMaterialLists',
   components: {
+    MaterialListsEdit,
+    MaterialLists,
     DialogMaterialListCreate,
     ButtonAdd,
-    MaterialLists,
     ContentCard,
   },
   mixins: [campRoleMixin],
   props: {
     camp: { type: Function, required: true },
   },
+  computed: {
+    materialLists() {
+      return this.camp().materialLists()
+    },
+  },
+  mounted() {
+    this.materialLists.$loadItems()
+  },
+  methods: { materialListRoute },
 }
 </script>
 

--- a/frontend/src/views/admin/Print.vue
+++ b/frontend/src/views/admin/Print.vue
@@ -3,7 +3,7 @@ Basic layout for print preview
 -->
 
 <template>
-  <content-card :title="$tc('views.camp.print.title')" toolbar>
+  <content-card :title="$tc('views.admin.print.title')" toolbar>
     <print-configurator :camp="camp" />
   </content-card>
 </template>
@@ -13,7 +13,7 @@ import ContentCard from '@/components/layout/ContentCard.vue'
 import PrintConfigurator from '@/components/print/PrintConfigurator.vue'
 
 export default {
-  name: 'Print',
+  name: 'AdminPrint',
   components: {
     ContentCard,
     PrintConfigurator,

--- a/frontend/src/views/admin/SideBarAdmin.vue
+++ b/frontend/src/views/admin/SideBarAdmin.vue
@@ -1,0 +1,54 @@
+<template>
+  <side-bar :title="$tc('global.navigation.admin.title')" icon="mdi-menu">
+    <v-list class="py-0">
+      <SidebarListItem
+        :to="adminRoute(camp(), 'info')"
+        :title="$tc('views.admin.sideBarAdmin.itemInfos')"
+        icon="mdi-tent"
+      />
+      <SidebarListItem
+        :to="adminRoute(camp(), 'activity')"
+        :title="$tc('views.admin.sideBarAdmin.itemActivity')"
+        :subtitle="$tc('views.admin.sideBarAdmin.itemActivitySubtitle')"
+        icon="mdi-view-dashboard-outline"
+      />
+      <SidebarListItem
+        :to="adminRoute(camp(), 'collaborators')"
+        :title="$tc('views.admin.sideBarAdmin.itemCollaborators')"
+        icon="mdi-account-group-outline"
+      />
+      <SidebarListItem
+        :to="adminRoute(camp(), 'material')"
+        :title="$tc('views.admin.sideBarAdmin.itemMaterialLists')"
+        icon="mdi-package-variant-closed"
+      />
+      <SidebarListItem
+        :to="adminRoute(camp(), 'print')"
+        :title="$tc('views.admin.sideBarAdmin.itemPrint')"
+        icon="mdi-file-outline"
+      />
+    </v-list>
+  </side-bar>
+</template>
+
+<script>
+import SideBar from '@/components/navigation/SideBar.vue'
+import { adminRoute, campRoute } from '@/router.js'
+import { campRoleMixin } from '@/mixins/campRoleMixin.js'
+import SidebarListItem from '@/components/layout/SidebarListItem.vue'
+
+export default {
+  name: 'SideBarAdmin',
+  components: { SidebarListItem, SideBar },
+  mixins: [campRoleMixin],
+  props: {
+    camp: {
+      type: Function,
+      required: true,
+    },
+  },
+  methods: { adminRoute, campRoute },
+}
+</script>
+
+<style scoped></style>

--- a/frontend/src/views/admin/__tests__/Admin.spec.js
+++ b/frontend/src/views/admin/__tests__/Admin.spec.js
@@ -1,5 +1,7 @@
+import Vue from 'vue'
+import { fireEvent } from '@testing-library/vue'
 import { render } from '@/test/renderWithVuetify.js'
-import Admin from '../Admin.vue'
+import Admin from '../Info.vue'
 import flushPromises from 'flush-promises'
 
 describe('Admin view', () => {
@@ -19,7 +21,11 @@ describe('Admin view', () => {
 
     await flushPromises()
 
-    expect(getByText('Gefahrenzone')).toBeInTheDocument()
+    const dangerZone = getByText('Gefahrenzone')
+
+    expect(dangerZone).toBeInTheDocument()
+    await fireEvent.click(dangerZone)
+    await Vue.nextTick()
     expect(getByText('Lager löschen')).toBeInTheDocument()
   })
 

--- a/frontend/src/views/camp/navigation/desktop/NavTopbar.vue
+++ b/frontend/src/views/camp/navigation/desktop/NavTopbar.vue
@@ -22,28 +22,16 @@
           $tc('views.camp.navigation.desktop.navTopbar.story')
         }}</span>
       </v-btn>
-      <v-btn :to="campRoute(camp(), 'collaborators')" text>
-        <v-icon :left="$vuetify.breakpoint.mdAndUp">mdi-account-group</v-icon>
-        <span class="sr-only-sm-and-down">{{
-          $tc('views.camp.navigation.desktop.navTopbar.team')
-        }}</span>
-      </v-btn>
       <v-btn :to="materialListRoute(camp())" text>
         <v-icon :left="$vuetify.breakpoint.mdAndUp"> mdi-package-variant </v-icon>
         <span class="sr-only-sm-and-down">{{
           $tc('views.camp.navigation.desktop.navTopbar.material')
         }}</span>
       </v-btn>
-      <v-btn :to="campRoute(camp(), 'print')" text>
-        <v-icon :left="$vuetify.breakpoint.mdAndUp">mdi-printer</v-icon>
-        <span class="sr-only-sm-and-down">{{
-          $tc('views.camp.navigation.desktop.navTopbar.print')
-        }}</span>
-      </v-btn>
       <v-btn :to="campRoute(camp(), 'admin')" text>
-        <v-icon :left="$vuetify.breakpoint.mdAndUp">mdi-cogs</v-icon>
+        <v-icon :left="$vuetify.breakpoint.mdAndUp"> mdi-cogs </v-icon>
         <span class="sr-only-sm-and-down">{{
-          $tc('views.camp.navigation.desktop.navTopbar.admin')
+          $tc('global.navigation.admin.title')
         }}</span>
       </v-btn>
     </v-toolbar-items>
@@ -57,6 +45,7 @@ import UserMeta from '@/components/navigation/UserMeta.vue'
 import Logo from '@/components/navigation/Logo.vue'
 import { campRoute, materialListRoute } from '@/router.js'
 import { mapGetters } from 'vuex'
+import { campRoleMixin } from '@/mixins/campRoleMixin.js'
 
 export default {
   name: 'NavTopbar',
@@ -64,6 +53,7 @@ export default {
     UserMeta,
     Logo,
   },
+  mixins: [campRoleMixin],
   props: {
     camp: { type: Function, required: true },
   },

--- a/frontend/src/views/camp/navigation/mobile/NavSidebar.vue
+++ b/frontend/src/views/camp/navigation/mobile/NavSidebar.vue
@@ -16,7 +16,10 @@
         <SidebarListItem
           v-if="user && !user._meta.loading"
           :title="user.displayName"
-          :subtitle="user.profile().firstname + ' ' + user.profile().surname"
+          :subtitle="
+            user.profile().nickname &&
+            user.profile().firstname + ' ' + user.profile().surname
+          "
           :to="{ name: 'profile', query: { isDetail: true } }"
         >
           <template #pre>
@@ -44,21 +47,34 @@
         />
         <v-divider inset i />
         <SidebarListItem
-          :title="$tc('views.camp.navigation.mobile.navSidebar.itemCampAdmin')"
+          :to="adminRoute(camp(), 'info')"
+          :title="$tc('views.camp.navigation.mobile.navSidebar.itemInfos')"
           icon="mdi-cogs"
-          :to="campRoute(camp(), 'admin', { isDetail: true })"
+        />
+        <v-divider inset />
+        <SidebarListItem
+          :to="adminRoute(camp(), 'activity')"
+          :title="$tc('views.camp.navigation.mobile.navSidebar.itemActivity')"
+          :subtitle="$tc('views.camp.navigation.mobile.navSidebar.itemActivitySubtitle')"
+          icon="mdi-view-dashboard"
         />
         <v-divider inset />
         <SidebarListItem
           :title="$tc('views.camp.navigation.mobile.navSidebar.itemCollaborators')"
           icon="mdi-account-group"
-          :to="campRoute(camp(), 'collaborators', { isDetail: true })"
+          :to="adminRoute(camp(), 'collaborators')"
+        />
+        <v-divider inset />
+        <SidebarListItem
+          :to="adminRoute(camp(), 'material')"
+          :title="$tc('views.camp.navigation.mobile.navSidebar.itemMaterialLists')"
+          icon="mdi-package-variant"
         />
         <v-divider inset />
         <SidebarListItem
           :title="$tc('views.camp.navigation.mobile.navSidebar.itemPrinting')"
-          icon="mdi-file-outline"
-          :to="campRoute(camp(), 'print', { isDetail: true })"
+          icon="mdi-file"
+          :to="adminRoute(camp(), 'print')"
         />
       </v-list>
       <div class="mt-auto">
@@ -80,7 +96,7 @@
 </template>
 
 <script>
-import { campRoute } from '@/router'
+import { campRoute, adminRoute } from '@/router'
 import UserAvatar from '@/components/user/UserAvatar.vue'
 import SidebarListItem from '@/components/layout/SidebarListItem.vue'
 import { mapGetters } from 'vuex'
@@ -101,6 +117,7 @@ export default {
     }),
   },
   methods: {
+    adminRoute,
     campRoute,
   },
 }

--- a/frontend/src/views/material/MaterialDetail.vue
+++ b/frontend/src/views/material/MaterialDetail.vue
@@ -16,7 +16,7 @@
                     <v-icon>mdi-pencil</v-icon>
                   </v-list-item-icon>
                   <v-list-item-content>{{
-                    $tc('global.button.rename')
+                    $tc('global.button.edit')
                   }}</v-list-item-content>
                 </v-list-item>
               </template>


### PR DESCRIPTION
The goal of this PR is to reorganize the admin views. Also provide better wording for non-managers on the admin/info page. This will make the experience more consistent across devices.

Member view:
![Admin page with TopNavbarItem "Infos"](https://github.com/ecamp/ecamp3/assets/3001985/01907f92-4da2-420a-8e46-7a3ae7a3b544)

Manager view:
![Admin page with TopNavbarItem "Admin"](https://github.com/ecamp/ecamp3/assets/3001985/a682316e-8461-4e33-a22c-cb2726cc6ec3)

In a next PR, I would like to change the api-input prop `disabled` to `readonly` and remove the outlined style of the api-input if it is readonly. 
![Bildschirmfoto 2023-09-25 um 12 59 20](https://github.com/ecamp/ecamp3/assets/3001985/17ee7764-ea82-4169-980b-10cbae9d6521)


FYI: Material lists would be a new view with renaming capabilities. This was not implemented in this draft as it is blocked by #3797. 