### PR TITLE
api: enable savepoints for transactions

### DIFF
--- a/api/config/packages/doctrine.yaml
+++ b/api/config/packages/doctrine.yaml
@@ -5,6 +5,7 @@ doctrine:
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)
         server_version: '15.0'
+        use_savepoints: true
         types:
             datetime: App\Types\Doctrine\UTCDateTimeType
             date: App\Types\Doctrine\UTCDateType

--- a/api/tests/Api/Activities/ListActivitiesTest.php
+++ b/api/tests/Api/Activities/ListActivitiesTest.php
@@ -94,6 +94,6 @@ class ListActivitiesTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/activities');
 
-        $this->assertSqlQueryCount($client, 19);
+        $this->assertSqlQueryCount($client, 21);
     }
 }

--- a/api/tests/Api/Activities/ReadActivityTest.php
+++ b/api/tests/Api/Activities/ReadActivityTest.php
@@ -141,6 +141,6 @@ class ReadActivityTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/activities/'.$activity->getId());
 
-        $this->assertSqlQueryCount($client, 29);
+        $this->assertSqlQueryCount($client, 31);
     }
 }

--- a/api/tests/Api/ActivityProgressLabel/ListActivityProgressLabelTest.php
+++ b/api/tests/Api/ActivityProgressLabel/ListActivityProgressLabelTest.php
@@ -82,6 +82,6 @@ class ListActivityProgressLabelTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/activity_progress_labels');
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }

--- a/api/tests/Api/ActivityProgressLabel/ReadActivityProgressLabelTest.php
+++ b/api/tests/Api/ActivityProgressLabel/ReadActivityProgressLabelTest.php
@@ -101,6 +101,6 @@ class ReadActivityProgressLabelTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/activity_progress_labels/'.$activityProgressLabel->getId());
 
-        $this->assertSqlQueryCount($client, 5);
+        $this->assertSqlQueryCount($client, 7);
     }
 }

--- a/api/tests/Api/ActivityResponsibles/ListActivityResponsiblesTest.php
+++ b/api/tests/Api/ActivityResponsibles/ListActivityResponsiblesTest.php
@@ -141,6 +141,6 @@ class ListActivityResponsiblesTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/activity_responsibles');
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }

--- a/api/tests/Api/ActivityResponsibles/ReadActivityResponsibleTest.php
+++ b/api/tests/Api/ActivityResponsibles/ReadActivityResponsibleTest.php
@@ -114,6 +114,6 @@ class ReadActivityResponsibleTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/activity_responsibles/'.$activityResponsible->getId());
 
-        $this->assertSqlQueryCount($client, 6);
+        $this->assertSqlQueryCount($client, 8);
     }
 }

--- a/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
+++ b/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
@@ -114,6 +114,6 @@ class ListCampCollaborationsTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/camp_collaborations');
 
-        $this->assertSqlQueryCount($client, 23);
+        $this->assertSqlQueryCount($client, 25);
     }
 }

--- a/api/tests/Api/CampCollaborations/ReadCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/ReadCampCollaborationTest.php
@@ -126,6 +126,6 @@ class ReadCampCollaborationTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/camp_collaborations/'.$campCollaboration->getId());
 
-        $this->assertSqlQueryCount($client, 13);
+        $this->assertSqlQueryCount($client, 15);
     }
 }

--- a/api/tests/Api/Camps/ListCampsTest.php
+++ b/api/tests/Api/Camps/ListCampsTest.php
@@ -77,6 +77,6 @@ class ListCampsTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/camps');
 
-        $this->assertSqlQueryCount($client, 27);
+        $this->assertSqlQueryCount($client, 29);
     }
 }

--- a/api/tests/Api/Camps/ReadCampTest.php
+++ b/api/tests/Api/Camps/ReadCampTest.php
@@ -220,6 +220,6 @@ class ReadCampTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/camps/'.$camp->getId());
 
-        $this->assertSqlQueryCount($client, 26);
+        $this->assertSqlQueryCount($client, 28);
     }
 }

--- a/api/tests/Api/Categories/ListCategoriesTest.php
+++ b/api/tests/Api/Categories/ListCategoriesTest.php
@@ -102,6 +102,6 @@ class ListCategoriesTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/categories');
 
-        $this->assertSqlQueryCount($client, 9);
+        $this->assertSqlQueryCount($client, 11);
     }
 }

--- a/api/tests/Api/Categories/ReadCategoryTest.php
+++ b/api/tests/Api/Categories/ReadCategoryTest.php
@@ -137,6 +137,6 @@ class ReadCategoryTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/categories/'.$category->getId());
 
-        $this->assertSqlQueryCount($client, 7);
+        $this->assertSqlQueryCount($client, 9);
     }
 }

--- a/api/tests/Api/ContentTypes/ListContentTypesTest.php
+++ b/api/tests/Api/ContentTypes/ListContentTypesTest.php
@@ -44,6 +44,6 @@ class ListContentTypesTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/content_types');
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }

--- a/api/tests/Api/ContentTypes/ReadContentTypeTest.php
+++ b/api/tests/Api/ContentTypes/ReadContentTypeTest.php
@@ -51,6 +51,6 @@ class ReadContentTypeTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/content_types/'.$contentType->getId());
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }

--- a/api/tests/Api/DayResponsibles/ListDayResponsiblesTest.php
+++ b/api/tests/Api/DayResponsibles/ListDayResponsiblesTest.php
@@ -107,6 +107,6 @@ class ListDayResponsiblesTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/day_responsibles');
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }

--- a/api/tests/Api/DayResponsibles/ReadDayResponsibleTest.php
+++ b/api/tests/Api/DayResponsibles/ReadDayResponsibleTest.php
@@ -114,6 +114,6 @@ class ReadDayResponsibleTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/day_responsibles/'.$dayResponsible->getId());
 
-        $this->assertSqlQueryCount($client, 7);
+        $this->assertSqlQueryCount($client, 9);
     }
 }

--- a/api/tests/Api/Days/ListDaysTest.php
+++ b/api/tests/Api/Days/ListDaysTest.php
@@ -128,6 +128,6 @@ class ListDaysTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/days');
 
-        $this->assertSqlQueryCount($client, 15);
+        $this->assertSqlQueryCount($client, 17);
     }
 }

--- a/api/tests/Api/Days/ReadDayTest.php
+++ b/api/tests/Api/Days/ReadDayTest.php
@@ -174,6 +174,6 @@ class ReadDayTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/days/'.$day->getId());
 
-        $this->assertSqlQueryCount($client, 9);
+        $this->assertSqlQueryCount($client, 11);
     }
 }

--- a/api/tests/Api/MaterialItems/ListMaterialItemsTest.php
+++ b/api/tests/Api/MaterialItems/ListMaterialItemsTest.php
@@ -170,6 +170,6 @@ class ListMaterialItemsTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/material_items');
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }

--- a/api/tests/Api/MaterialItems/ReadMaterialItemTest.php
+++ b/api/tests/Api/MaterialItems/ReadMaterialItemTest.php
@@ -130,6 +130,6 @@ class ReadMaterialItemTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/material_items/'.$materialItem->getId());
 
-        $this->assertSqlQueryCount($client, 6);
+        $this->assertSqlQueryCount($client, 8);
     }
 }

--- a/api/tests/Api/MaterialLists/ListMaterialListsTest.php
+++ b/api/tests/Api/MaterialLists/ListMaterialListsTest.php
@@ -108,6 +108,6 @@ class ListMaterialListsTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/material_lists');
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }

--- a/api/tests/Api/MaterialLists/ReadMaterialListTest.php
+++ b/api/tests/Api/MaterialLists/ReadMaterialListTest.php
@@ -118,6 +118,6 @@ class ReadMaterialListTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/material_lists/'.$materialList->getId());
 
-        $this->assertSqlQueryCount($client, 5);
+        $this->assertSqlQueryCount($client, 7);
     }
 }

--- a/api/tests/Api/Periods/ListPeriodsTest.php
+++ b/api/tests/Api/Periods/ListPeriodsTest.php
@@ -100,6 +100,6 @@ class ListPeriodsTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/periods');
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }

--- a/api/tests/Api/Periods/ReadPeriodTest.php
+++ b/api/tests/Api/Periods/ReadPeriodTest.php
@@ -140,6 +140,6 @@ class ReadPeriodTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/periods/'.$period->getId());
 
-        $this->assertSqlQueryCount($client, 17);
+        $this->assertSqlQueryCount($client, 19);
     }
 }

--- a/api/tests/Api/Profiles/ListProfilesTest.php
+++ b/api/tests/Api/Profiles/ListProfilesTest.php
@@ -117,6 +117,6 @@ class ListProfilesTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/profiles');
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }

--- a/api/tests/Api/Profiles/ReadProfileTest.php
+++ b/api/tests/Api/Profiles/ReadProfileTest.php
@@ -103,6 +103,6 @@ class ReadProfileTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/profiles/'.$profile->getId());
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }

--- a/api/tests/Api/ScheduleEntries/ListScheduleEntriesTest.php
+++ b/api/tests/Api/ScheduleEntries/ListScheduleEntriesTest.php
@@ -381,6 +381,6 @@ class ListScheduleEntriesTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/schedule_entries');
 
-        $this->assertSqlQueryCount($client, 21);
+        $this->assertSqlQueryCount($client, 23);
     }
 }

--- a/api/tests/Api/ScheduleEntries/ReadScheduleEntryTest.php
+++ b/api/tests/Api/ScheduleEntries/ReadScheduleEntryTest.php
@@ -151,6 +151,6 @@ class ReadScheduleEntryTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/schedule_entries/'.$scheduleEntry->getId());
 
-        $this->assertSqlQueryCount($client, 17);
+        $this->assertSqlQueryCount($client, 19);
     }
 }

--- a/api/tests/Api/Users/ListUsersTest.php
+++ b/api/tests/Api/Users/ListUsersTest.php
@@ -27,6 +27,6 @@ class ListUsersTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/users');
 
-        $this->assertSqlQueryCount($client, 20);
+        $this->assertSqlQueryCount($client, 22);
     }
 }

--- a/api/tests/Api/Users/ReadUserTest.php
+++ b/api/tests/Api/Users/ReadUserTest.php
@@ -95,6 +95,6 @@ class ReadUserTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/users/'.$user->getId());
 
-        $this->assertSqlQueryCount($client, 4);
+        $this->assertSqlQueryCount($client, 6);
     }
 }


### PR DESCRIPTION
We use nested transactions in our tests to roll back the changes made in the tests.
Doing this without enabling savepoints is deprecated and will be removed in doctrine/orm 3.0.

This adds 2 queries to every request in the tests:
- SAVEPOINT DOCTRINE2_SAVEPOINT_2
- RELEASE SAVEPOINT DOCTRINE2_SAVEPOINT_2

closes #3741