### PR TITLE
ETextField: Input component refactor for $listeners

### DIFF
--- a/frontend/src/components/form/api/ApiTextField.vue
+++ b/frontend/src/components/form/api/ApiTextField.vue
@@ -48,10 +48,13 @@ export default {
     },
     parse(input) {
       if (
-        (this.$attrs.inputmode === 'numeric' || this.$attrs.type === 'number') &&
-        !Number.isNaN(Number(input))
+        this.$attrs.inputmode === 'numeric' ||
+        this.$attrs.inputmode === 'decimal' ||
+        this.$attrs.type === 'number'
+        //!Number.isNaN(Number(input))
       ) {
-        return Number(input)
+        const dotInput = typeof input === 'string' ? input.replace(',', '.') : input
+        return Number(dotInput)
       } else {
         return input
       }

--- a/frontend/src/components/form/base/ENumberField.vue
+++ b/frontend/src/components/form/base/ENumberField.vue
@@ -1,0 +1,93 @@
+<template>
+  <ValidationProvider
+    v-slot="{ errors: veeErrors }"
+    ref="validationProvider"
+    tag="div"
+    :name="name"
+    :vid="veeId"
+    :rules="veeRules"
+    :required="required"
+    :mode="eagerIfChanged"
+    class="e-form-container"
+  >
+    <v-text-field
+      ref="textField"
+      v-model="formattedValue"
+      v-bind="$attrs"
+      :filled="filled"
+      :required="required"
+      :hide-details="hideDetails"
+      :error-messages="veeErrors.concat(errorMessages)"
+      :label="label || name"
+      type="text"
+      :class="[inputClass]"
+      :hide-spin-buttons="true"
+      v-on="{ ...$listeners, input: undefined }"
+    >
+      <!-- passing through all slots -->
+      <slot v-for="(_, name) in $slots" :slot="name" :name="name" />
+      <template v-for="(_, name) in $scopedSlots" :slot="name" slot-scope="slotData">
+        <slot :name="name" v-bind="slotData" />
+      </template>
+    </v-text-field>
+  </ValidationProvider>
+</template>
+
+<script>
+import { ValidationProvider } from 'vee-validate'
+import { formComponentPropsMixin } from '@/mixins/formComponentPropsMixin.js'
+import { formComponentMixin } from '@/mixins/formComponentMixin.js'
+import { eagerIfChanged } from '@/helpers/veeValidateCustomInteractionMode'
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'ENumberField',
+  components: { ValidationProvider },
+  mixins: [formComponentPropsMixin, formComponentMixin],
+  props: {
+    value: {
+      type: Number,
+      required: true,
+    },
+  },
+  emits: ['input'],
+  computed: {
+    formattedValue: {
+      get: function () {
+        return this.$n(this.value, 'decimal')
+      },
+      set: function (newNumber) {
+        let newValueAsNumber = newNumber
+        if (typeof newNumber !== 'number') {
+          newValueAsNumber = parseFloat(
+            newNumber
+              .replace(' ', '')
+              .replace(',', '.')
+              .replace(/[^\d,.-]/g, '')
+          )
+        }
+
+        this.$emit('input', newValueAsNumber)
+      },
+    },
+  },
+  mounted() {},
+  methods: {
+    eagerIfChanged,
+    focus() {
+      this.$refs.textField.focus()
+    },
+  },
+}
+</script>
+
+<style scoped>
+[required]:deep(label::after) {
+  content: '\a0*';
+  font-size: 12px;
+  color: #d32f2f;
+}
+[required]:deep(.v-input--is-label-active label::after) {
+  color: gray;
+}
+</style>

--- a/frontend/src/components/form/base/ENumberField.vue
+++ b/frontend/src/components/form/base/ENumberField.vue
@@ -38,8 +38,6 @@ import { ValidationProvider } from 'vee-validate'
 import { formComponentPropsMixin } from '@/mixins/formComponentPropsMixin.js'
 import { formComponentMixin } from '@/mixins/formComponentMixin.js'
 import { eagerIfChanged } from '@/helpers/veeValidateCustomInteractionMode'
-import { mapGetters } from 'vuex'
-
 export default {
   name: 'ENumberField',
   components: { ValidationProvider },

--- a/frontend/src/components/form/base/ETextField.vue
+++ b/frontend/src/components/form/base/ETextField.vue
@@ -20,7 +20,7 @@
       :label="label || name"
       :class="[inputClass]"
       :type="type"
-      :hide-spin-buttons="true"
+      :hide-spin-buttons="type === 'number'"
       v-on="$listeners"
     >
       <!-- passing through all slots -->

--- a/frontend/src/components/form/base/ETextField.vue
+++ b/frontend/src/components/form/base/ETextField.vue
@@ -7,6 +7,7 @@
     :vid="veeId"
     :rules="dynamicRules"
     :required="required"
+    :mode="eagerIfChanged"
     class="e-form-container"
   >
     <v-text-field
@@ -20,6 +21,7 @@
       :class="[inputClass]"
       :type="type"
       :hide-spin-buttons="true"
+      data-vv-validate-on="input"
       v-on="$listeners"
     >
       <!-- passing through all slots -->
@@ -35,6 +37,7 @@
 import { ValidationProvider } from 'vee-validate'
 import { formComponentPropsMixin } from '@/mixins/formComponentPropsMixin.js'
 import { formComponentMixin } from '@/mixins/formComponentMixin.js'
+import { eagerIfChanged } from '@/helpers/veeValidateCustomInteractionMode'
 
 export default {
   name: 'ETextField',
@@ -54,13 +57,15 @@ export default {
           this.$attrs.inputmode === 'decimal'
             ? { double: { separator: 'comma' } }
             : { numeric: true }
-        return { ...rule, ...this.veeRules }
+        // if there is an existing rule, don't overwrite
+        return { ...this.veeRules, ...rule }
       }
       const rule = this.$attrs.inputmode === 'decimal' ? 'double:0comma' : 'numeric'
       return `${this.veeRules}${this.veeRules?.length === 0 ? '' : '|'}${rule}`
     },
   },
   methods: {
+    eagerIfChanged,
     focus() {
       this.$refs.textField.focus()
     },

--- a/frontend/src/components/form/base/ETextField.vue
+++ b/frontend/src/components/form/base/ETextField.vue
@@ -21,7 +21,6 @@
       :class="[inputClass]"
       :type="type"
       :hide-spin-buttons="true"
-      data-vv-validate-on="input"
       v-on="$listeners"
     >
       <!-- passing through all slots -->

--- a/frontend/src/components/material/DialogMaterialItemForm.vue
+++ b/frontend/src/components/material/DialogMaterialItemForm.vue
@@ -1,11 +1,10 @@
 <template>
   <div>
     <e-text-field
-      :value="localMaterialItem.quantity"
+      v-model.number="localMaterialItem.quantity"
       :name="$tc('entity.materialItem.fields.quantity')"
       inputmode="decimal"
       autofocus
-      @input="localMaterialItem.quantity = Number($event)"
     />
     <e-text-field
       v-model="localMaterialItem.unit"

--- a/frontend/src/components/material/DialogMaterialItemForm.vue
+++ b/frontend/src/components/material/DialogMaterialItemForm.vue
@@ -1,10 +1,11 @@
 <template>
   <div>
     <e-text-field
-      v-model.number="localMaterialItem.quantity"
+      :value="localMaterialItem.quantity"
       :name="$tc('entity.materialItem.fields.quantity')"
-      inputmode="numeric"
+      inputmode="decimal"
       autofocus
+      @input="localMaterialItem.quantity = Number($event)"
     />
     <e-text-field
       v-model="localMaterialItem.unit"

--- a/frontend/src/components/material/MaterialCreateItem.vue
+++ b/frontend/src/components/material/MaterialCreateItem.vue
@@ -9,12 +9,11 @@
     <td class="pt-1">
       <e-text-field
         ref="quantity"
-        :value="materialItem.quantity"
+        v-model.number="materialItem.quantity"
         dense
         inputmode="decimal"
         :name="$tc('entity.materialItem.fields.quantity')"
         fieldname="quantity"
-        @input="materialItem.quantity = Number($event)"
       />
     </td>
     <td class="pt-1">

--- a/frontend/src/components/material/MaterialCreateItem.vue
+++ b/frontend/src/components/material/MaterialCreateItem.vue
@@ -9,11 +9,12 @@
     <td class="pt-1">
       <e-text-field
         ref="quantity"
-        v-model.number="materialItem.quantity"
+        :value="materialItem.quantity"
         dense
-        inputmode="numeric"
+        inputmode="decimal"
         :name="$tc('entity.materialItem.fields.quantity')"
         fieldname="quantity"
+        @input="materialItem.quantity = Number($event)"
       />
     </td>
     <td class="pt-1">

--- a/frontend/src/helpers/veeValidateCustomInteractionMode.js
+++ b/frontend/src/helpers/veeValidateCustomInteractionMode.js
@@ -1,9 +1,8 @@
 const eagerIfChanged = ({ errors, flags }) => {
-  const debounce = 350 /// 350 ms for debounce
   if (flags.pristine) {
     return {
       on: ['input'],
-      debounce,
+      debounce: 1000, // 1 sec debounce,
     }
   }
 
@@ -15,7 +14,7 @@ const eagerIfChanged = ({ errors, flags }) => {
 
   return {
     on: ['change', 'blur'],
-    debounce
+    debounce: 500,
   }
 }
 export { eagerIfChanged }

--- a/frontend/src/helpers/veeValidateCustomInteractionMode.js
+++ b/frontend/src/helpers/veeValidateCustomInteractionMode.js
@@ -1,7 +1,9 @@
 const eagerIfChanged = ({ errors, flags }) => {
+  const debounce = 350 /// 350 ms for debounce
   if (flags.pristine) {
     return {
       on: ['input'],
+      debounce,
     }
   }
 
@@ -13,6 +15,7 @@ const eagerIfChanged = ({ errors, flags }) => {
 
   return {
     on: ['change', 'blur'],
+    debounce
   }
 }
 export { eagerIfChanged }

--- a/frontend/src/helpers/veeValidateCustomInteractionMode.js
+++ b/frontend/src/helpers/veeValidateCustomInteractionMode.js
@@ -1,8 +1,11 @@
+import { apiPropsMixin } from '@/mixins/apiPropsMixin'
+
 const eagerIfChanged = ({ errors, flags }) => {
+  const debounce = apiPropsMixin.props.autoSaveDelay.default
   if (flags.pristine) {
     return {
       on: ['input'],
-      debounce: 1000, // 1 sec debounce,
+      debounce,
     }
   }
 
@@ -14,7 +17,7 @@ const eagerIfChanged = ({ errors, flags }) => {
 
   return {
     on: ['change', 'blur'],
-    debounce: 500,
+    debounce,
   }
 }
 export { eagerIfChanged }

--- a/frontend/src/helpers/veeValidateCustomInteractionMode.js
+++ b/frontend/src/helpers/veeValidateCustomInteractionMode.js
@@ -1,0 +1,18 @@
+const eagerIfChanged = ({ errors, flags }) => {
+  if (flags.pristine) {
+    return {
+      on: ['input'],
+    }
+  }
+
+  if (errors.length) {
+    return {
+      on: ['input', 'change'],
+    }
+  }
+
+  return {
+    on: ['change', 'blur'],
+  }
+}
+export { eagerIfChanged }

--- a/frontend/src/plugins/i18n/index.js
+++ b/frontend/src/plugins/i18n/index.js
@@ -29,6 +29,7 @@ import vuetifyEn from 'vuetify/lib/locale/en'
 import vuetifyDe from 'vuetify/lib/locale/de'
 import vuetifyFr from 'vuetify/lib/locale/fr'
 import vuetifyIt from 'vuetify/lib/locale/it'
+import { numberFormats } from '@/plugins/i18n/numberLocalization'
 
 Vue.use(VueI18n)
 
@@ -94,6 +95,7 @@ const i18n = new VueI18n({
     },
   ]),
   silentTranslationWarn: true,
+  numberFormats,
 })
 
 Object.defineProperty(i18n, 'browserPreferredLocale', {

--- a/frontend/src/plugins/i18n/numberLocalization.js
+++ b/frontend/src/plugins/i18n/numberLocalization.js
@@ -1,0 +1,26 @@
+export const numberFormats = {
+  en: {
+    decimal: {
+      style: 'decimal',
+      useGrouping: false,
+    },
+  },
+  de: {
+    decimal: {
+      style: 'decimal',
+      useGrouping: false,
+    },
+  },
+  fr: {
+    decimal: {
+      style: 'decimal',
+      useGrouping: false,
+    },
+  },
+  it: {
+    decimal: {
+      style: 'decimal',
+      useGrouping: false,
+    },
+  },
+}

--- a/frontend/src/views/dev/Controls.vue
+++ b/frontend/src/views/dev/Controls.vue
@@ -119,6 +119,7 @@ export default {
     hint: 'Dummy hint',
 
     textfieldValue: 'FFFFFFFFFF',
+    decimalTextFieldValue: 3.2,
     textareaValue: 'FFFFFFFFFF',
     richtextValue: '<p>FFFFFFFFFF</p>',
     checkboxValue: false,
@@ -157,6 +158,18 @@ export default {
             inputmode: 'numeric',
             fieldname: 'quantity',
             uri: this.materialUri,
+          },
+        },
+        {
+          id: 'text-field.decimal',
+          component: (type) => `${type}-text-field`,
+          props: {
+            value: this.decimalTextFieldValue,
+            'v-on:input': 'this.decimalTextFieldValue = Number($event)',
+            placeholder: this.placeholder,
+            inputmode: 'decimal',
+            fieldname: 'quantity',
+            uri: this.materialItemUri,
           },
         },
         {
@@ -263,6 +276,9 @@ export default {
     },
     scheduleEntryUri() {
       return '/api/schedule_entries/b6668dffbb2b' // Harry Potter - LA Lagerbau
+    },
+    materialItemUri() {
+      return '/material_items/c585366c8675' // Lorem-ipsum - Gesamtübersicht
     },
     availableLocales() {
       return VueI18n.availableLocales.map((l) => ({

--- a/frontend/src/views/dev/Controls.vue
+++ b/frontend/src/views/dev/Controls.vue
@@ -278,7 +278,7 @@ export default {
       return '/api/schedule_entries/b6668dffbb2b' // Harry Potter - LA Lagerbau
     },
     materialItemUri() {
-      return '/material_items/c585366c8675' // Lorem-ipsum - Gesamtübersicht
+      return '/material_items/470c48009755'
     },
     availableLocales() {
       return VueI18n.availableLocales.map((l) => ({


### PR DESCRIPTION
fixes #3893

I managed to fix the 'dont-autofocus-on-blur-if-autofocus'-issue with a custom VeeValidate interactionmode:
[Code here](frontend/src/helpers/veeValidateCustomInteractionMode.js)

https://github.com/ecamp/ecamp3/assets/57986114/6469be7c-cf50-498a-8ed6-21ccd3136a1c

i changed inputmode namings based on the [HTML specs](https://html.spec.whatwg.org/multipage/interaction.html#attr-inputmode) they now match the VeeValidate rules of [decimal](https://vee-validate.logaretm.com/v2/guide/rules.html#decimal) or [numeric](https://vee-validate.logaretm.com/v2/guide/rules.html#numeric)

I implemented a "," to "." replace on the API wrapper: decimal inputs can be entered with "," but will be loaded as "." this works somewhat:
The write-to-object part works excellent, but the update from the store is not working at all - I have no idea why

https://github.com/ecamp/ecamp3/assets/57986114/c94b84af-10a4-4346-a516-0bc97c8a791d

the model modifier [number](https://vuejs.org/guide/essentials/forms.html#number) doesn't support values like `324,33` if the value is not parseFloat() compatible it uses the string value. the "," support doesn't seem to work. 

I also decided to [hide the spin buttons](https://v2.vuetifyjs.com/en/api/v-text-field/#props-hide-spin-buttons) since they would require a step value to be effective.

@manuelmeister what is the current goal for ETextField decimal/numeric support?

@ecampcore is the autofocus-validation-solution okey?

I haven't started with the tests since I don't think this is the final fix, code review is welcome tho.
I don't understand why the ApiTextField doesn't update from the store.