### PR TITLE
ETimePicker: fix times between 01:00 and 09:59 cannot be typed 

### DIFF
--- a/frontend/src/components/form/base/ETimePicker.vue
+++ b/frontend/src/components/form/base/ETimePicker.vue
@@ -118,10 +118,8 @@ export default {
      */
     parse(val) {
       if (val) {
-        const parsedDateTime = this.$date(val, 'LT')
-        const formatted = parsedDateTime.format('LT')
-        const valIgnoringLeadingZero = val.replace(/^0([1-9].+)/, '$1')
-        if (parsedDateTime.isValid() && formatted === valIgnoringLeadingZero) {
+        const parsedDateTime = this.$date.utc(val, 'LT')
+        if (parsedDateTime.isValid() && parsedDateTime.format('LT') === val) {
           const newValue = this.setTimeOnValue(parsedDateTime)
           return Promise.resolve(newValue)
         } else {

--- a/frontend/src/components/form/base/ETimePicker.vue
+++ b/frontend/src/components/form/base/ETimePicker.vue
@@ -72,7 +72,7 @@ export default {
       let valueDateTime = this.getValueAsDateTime(this.value)
 
       // override time
-      if (valueDateTime && valueDateTime.isValid()) {
+      if (valueDateTime) {
         valueDateTime = valueDateTime
           .hour(time.hour())
           .minute(time.minute())
@@ -118,8 +118,13 @@ export default {
      */
     parse(val) {
       if (val) {
-        const parsedDateTime = this.$date.utc(val, 'LT')
-        if (parsedDateTime.isValid() && parsedDateTime.format('LT') === val) {
+        let valIgnoringLeadingZero = val.replace(/^0*?([\d]{1,2}):/, '$1:')
+        const parsedDateTime = this.$date.utc(valIgnoringLeadingZero, 'LT')
+        const formatted = parsedDateTime.format('LT')
+        if (!formatted.startsWith('0') && valIgnoringLeadingZero.match(/^0\d/)) {
+          valIgnoringLeadingZero = valIgnoringLeadingZero.slice(1)
+        }
+        if (parsedDateTime.isValid() && formatted === valIgnoringLeadingZero) {
           const newValue = this.setTimeOnValue(parsedDateTime)
           return Promise.resolve(newValue)
         } else {

--- a/frontend/src/components/form/base/__tests__/ETimePicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/ETimePicker.spec.js
@@ -224,6 +224,10 @@ describe('An ETimePicker', () => {
           from: time1Config,
           to: time2Config,
         },
+        {
+          from: time2Config,
+          to: time1Config,
+        },
       ])(
         `from $from.localizedTime to $to.localizedTime`,
         async ({

--- a/frontend/src/components/form/base/__tests__/ETimePicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/ETimePicker.spec.js
@@ -210,33 +210,54 @@ describe('An ETimePicker', () => {
       ).rejects.toThrow(/Received element is visible/)
     })
 
-    it('updates v-model when the input field is changed', async () => {
-      // given
-      const { emitted } = render(ETimePicker, {
-        props: { value: TIME1_ISO, name: 'test' },
-      })
-      const inputField = await screen.findByDisplayValue(data.time1)
+    describe('updates v-model when the input field is changed', async () => {
+      const time1Config = {
+        iso: TIME1_ISO,
+        localizedTime: data.time1,
+      }
+      const time2Config = {
+        iso: TIME2_ISO,
+        localizedTime: data.time2,
+      }
+      it.each([
+        {
+          from: time1Config,
+          to: time2Config,
+        },
+      ])(
+        `from $from.localizedTime to $to.localizedTime`,
+        async ({
+          from: { iso: fromIso, localizedTime: fromLocalizedTime },
+          to: { iso: toIso, localizedTime: toLocalizedTime },
+        }) => {
+          // given
+          const { emitted } = render(ETimePicker, {
+            props: { value: fromIso, name: 'test' },
+          })
+          const inputField = await screen.findByDisplayValue(fromLocalizedTime)
 
-      // when
-      await user.clear(inputField)
-      await user.keyboard(data.time2)
+          // when
+          await user.clear(inputField)
+          await user.keyboard(toLocalizedTime)
 
-      // then
-      await waitFor(async () => {
-        const events = emitted().input
-        // some input events were fired
-        expect(events.length).toBeGreaterThan(0)
-        // the last one included the parsed version of our entered time
-        expect(events[events.length - 1]).toEqual([TIME2_ISO])
-      })
-      // Our entered time should be visible...
-      screen.getByDisplayValue(data.time2)
-      // ...and stay visible
-      await expect(
-        waitFor(() => {
-          expect(screen.getByDisplayValue(data.time2)).not.toBeVisible()
-        })
-      ).rejects.toThrow(/Received element is visible/)
+          // then
+          await waitFor(async () => {
+            const events = emitted().input
+            // some input events were fired
+            expect(events.length).toBeGreaterThan(0)
+            // the last one included the parsed version of our entered time
+            expect(events[events.length - 1]).toEqual([toIso])
+          })
+          // Our entered time should be visible...
+          screen.getByDisplayValue(toLocalizedTime)
+          // ...and stay visible
+          await expect(
+            waitFor(() => {
+              expect(screen.getByDisplayValue(toLocalizedTime)).not.toBeVisible()
+            })
+          ).rejects.toThrow(/Received element is visible/)
+        }
+      )
     })
 
     it('updates v-model when a new time is selected in the picker', async () => {

--- a/frontend/src/components/form/base/__tests__/ETimePicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/ETimePicker.spec.js
@@ -211,28 +211,82 @@ describe('An ETimePicker', () => {
     })
 
     describe('updates v-model when the input field is changed', async () => {
-      const time1Config = {
+      const timeConfig1 = {
         iso: TIME1_ISO,
         localizedTime: data.time1,
+        textInput: data.time1,
       }
-      const time2Config = {
+      const timeConfig2 = {
         iso: TIME2_ISO,
         localizedTime: data.time2,
+        textInput: data.time2,
+      }
+      const timeConfig3 = {
+        iso: TIME3_ISO,
+        localizedTime: data.time3,
+        textInput: data.time3,
       }
       it.each([
         {
-          from: time1Config,
-          to: time2Config,
+          from: timeConfig1,
+          to: timeConfig2,
         },
         {
-          from: time2Config,
-          to: time1Config,
+          from: timeConfig2,
+          to: timeConfig1,
+        },
+        {
+          from: timeConfig1,
+          to: timeConfig3,
+        },
+        //with leading zero
+        {
+          from: timeConfig1,
+          to: {
+            ...timeConfig2,
+            textInput: '0' + timeConfig2.localizedTime,
+          },
+        },
+        {
+          from: timeConfig1,
+          to: {
+            ...timeConfig2,
+            textInput: '0000' + timeConfig2.localizedTime,
+          },
+        },
+        {
+          from: timeConfig2,
+          to: {
+            ...timeConfig1,
+            textInput: '0' + timeConfig1.localizedTime,
+          },
+        },
+        {
+          from: timeConfig2,
+          to: {
+            ...timeConfig1,
+            textInput: '00000' + timeConfig1.localizedTime,
+          },
+        },
+        {
+          from: timeConfig1,
+          to: {
+            ...timeConfig3,
+            textInput: '0' + timeConfig3.localizedTime,
+          },
+        },
+        {
+          from: timeConfig1,
+          to: {
+            ...timeConfig3,
+            textInput: '00000' + timeConfig3.localizedTime,
+          },
         },
       ])(
-        `from $from.localizedTime to $to.localizedTime`,
+        `from $from.localizedTime to $to.textInput`,
         async ({
           from: { iso: fromIso, localizedTime: fromLocalizedTime },
-          to: { iso: toIso, localizedTime: toLocalizedTime },
+          to: { iso: toIso, localizedTime: toLocalizedTime, textInput },
         }) => {
           // given
           const { emitted } = render(ETimePicker, {
@@ -242,7 +296,7 @@ describe('An ETimePicker', () => {
 
           // when
           await user.clear(inputField)
-          await user.keyboard(toLocalizedTime)
+          await user.keyboard(textInput)
 
           // then
           await waitFor(async () => {
@@ -303,19 +357,26 @@ describe('An ETimePicker', () => {
       ).rejects.toThrow(/Received element is visible/)
     })
 
-    it('validates the input', async () => {
-      // given
-      render(ETimePicker, {
-        props: { value: TIME1_ISO, name: 'test' },
+    describe('validates the input', async () => {
+      it.each([
+        data.timeInWrongLocale,
+        'a' + data.time1,
+        data.time2 + 'a',
+        '0000:a' + data.time3,
+      ])('%s', async (textInput) => {
+        // given
+        render(ETimePicker, {
+          props: { value: TIME1_ISO, name: 'test' },
+        })
+        const inputField = await screen.findByDisplayValue(data.time1)
+
+        // when
+        await user.clear(inputField)
+        await user.keyboard(textInput)
+
+        // then
+        await screen.findByText(data.validationMessage)
       })
-      const inputField = await screen.findByDisplayValue(data.time1)
-
-      // when
-      await user.clear(inputField)
-      await user.keyboard(data.timeInWrongLocale)
-
-      // then
-      await screen.findByText(data.validationMessage)
     })
 
     it('works with invalid initialization', async () => {


### PR DESCRIPTION
And allow leading 0.

1.
 ETimePicker.spec.js: make 'updates v-model when the input field is ch…

…anged' parametrized

That we can easily add more cases.

2.
 ETimePicker: fix times between 01:00 and 09:59 cannot be typed 

3.
ETimePicker: also allow leading 0 


closes #3920 

@carlobeltrame was your goal to allow leading 0 in 272ec2c?