### PR TITLE
.helm: also delete hook resources before-hook-creation

### DIFF
--- a/.helm/ecamp3/templates/hook_db_create.yaml
+++ b/.helm/ecamp3/templates/hook_db_create.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
   template:
     metadata:

--- a/.helm/ecamp3/templates/hook_db_drop.yaml
+++ b/.helm/ecamp3/templates/hook_db_drop.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
   template:
     metadata:

--- a/.helm/ecamp3/templates/hook_db_migrate.yaml
+++ b/.helm/ecamp3/templates/hook_db_migrate.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "app.commonLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
   template:
     metadata:

--- a/.helm/ecamp3/templates/hook_secrets.yaml
+++ b/.helm/ecamp3/templates/hook_secrets.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,post-delete
     "helm.sh/hook-weight": "-6"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 type: Opaque
 data:
   admin-database-url: {{ .Values.postgresql.adminUrl | default .Values.postgresql.url | b64enc | quote }}


### PR DESCRIPTION
That you don't have to manually delete the resources before you retry the deployment with the updated configuration. Worked very good for the hook_db_restore resources.

Else the deployment fails with the message:
 UPGRADE FAILED: post-upgrade hooks failed: warning: Hook post-upgrade ecamp3/templates/hook_db_migrate.yaml failed: 1 error occurred:
	* jobs.batch "ecamp3-dev-db-migrate" already exists