### PR TITLE
api: upgrade api-platform/core to 3.2.1

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -5,7 +5,7 @@
         "php": ">=8.1.0",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "api-platform/core": "3.1.20",
+        "api-platform/core": "3.2.1",
         "composer/package-versions-deprecated": "1.11.99",
         "cweagans/composer-patches": "1.7.3",
         "doctrine/doctrine-bundle": "2.10.2",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1aaaebb030f235c8115806eaa53a857e",
+    "content-hash": "e125cd96e471a137ddcafb682725cd2f",
     "packages": [
         {
             "name": "api-platform/core",
-            "version": "v3.1.20",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/api-platform/core.git",
-                "reference": "0fb35cd1424ca1100194ab0b76103547068513f3"
+                "reference": "13aa25cd319ee5d45ce28d1e98e43b01f6132499"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/api-platform/core/zipball/0fb35cd1424ca1100194ab0b76103547068513f3",
-                "reference": "0fb35cd1424ca1100194ab0b76103547068513f3",
+                "url": "https://api.github.com/repos/api-platform/core/zipball/13aa25cd319ee5d45ce28d1e98e43b01f6132499",
+                "reference": "13aa25cd319ee5d45ce28d1e98e43b01f6132499",
                 "shasum": ""
             },
             "require": {
@@ -41,7 +41,7 @@
                 "doctrine/mongodb-odm": "<2.4",
                 "doctrine/orm": "<2.14.0",
                 "doctrine/persistence": "<1.3",
-                "elasticsearch/elasticsearch": ">=8.0",
+                "elasticsearch/elasticsearch": ">=8.0,<8.4",
                 "phpspec/prophecy": "<1.15",
                 "phpunit/phpunit": "<9.5",
                 "symfony/var-exporter": "<6.1.1"
@@ -56,7 +56,7 @@
                 "doctrine/mongodb-odm": "^2.2",
                 "doctrine/mongodb-odm-bundle": "^4.0",
                 "doctrine/orm": "^2.14",
-                "elasticsearch/elasticsearch": "^7.11.0",
+                "elasticsearch/elasticsearch": "^7.11 || ^8.4",
                 "friends-of-behat/mink-browserkit-driver": "^1.3.1",
                 "friends-of-behat/mink-extension": "^2.2",
                 "friends-of-behat/symfony-extension": "^2.1",
@@ -99,6 +99,7 @@
                 "symfony/routing": "^6.1",
                 "symfony/security-bundle": "^6.1",
                 "symfony/security-core": "^6.1",
+                "symfony/stopwatch": "^6.1",
                 "symfony/twig-bundle": "^6.1",
                 "symfony/uid": "^6.1",
                 "symfony/validator": "^6.1",
@@ -165,9 +166,9 @@
             ],
             "support": {
                 "issues": "https://github.com/api-platform/core/issues",
-                "source": "https://github.com/api-platform/core/tree/v3.1.20"
+                "source": "https://github.com/api-platform/core/tree/v3.2.1"
             },
-            "time": "2023-10-11T15:29:22+00:00"
+            "time": "2023-10-18T07:46:05+00:00"
         },
         {
             "name": "behat/transliterator",

--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -12,6 +12,12 @@ api_platform:
         jsonapi: [ 'application/vnd.api+json' ]
         json: [ 'application/json' ]
         html: [ 'text/html' ]
+    docs_formats:
+        jsonhal: [ 'application/hal+json' ]
+        jsonld: [ 'application/ld+json' ]
+        jsonapi: [ 'application/vnd.api+json' ]
+        jsonopenapi: ['application/vnd.openapi+json']
+        html: [ 'text/html' ]
     patch_formats:
         json: [ 'application/merge-patch+json' ]
     error_formats:

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -75,7 +75,7 @@ services:
     App\Serializer\Normalizer\TranslationConstraintViolationListNormalizer:
         arguments:
             - '@api_platform.hydra.normalizer.constraint_violation_list'
-            - '@api_platform.problem.normalizer.constraint_violation_list'
+            - '@api_platform.hal.normalizer.constraint_violation_list'
 
     App\Serializer\SerializerContextBuilder:
         decorates: 'api_platform.serializer.context_builder'

--- a/api/patch/api-plattform-allow-null-links.patch
+++ b/api/patch/api-plattform-allow-null-links.patch
@@ -5,24 +5,20 @@ Subject: [PATCH] hal allow null links
 
 ---
  src/Hal/Serializer/ItemNormalizer.php | 9 ++++-----
- 1 file changed, 4 insertions(+), 5 deletions(-)
+ 1 file changed, 4 insertions(+), 6 deletions(-)
 
 diff --git a/src/Hal/Serializer/ItemNormalizer.php b/src/Hal/Serializer/ItemNormalizer.php
 index a6e485d178..824679ee6b 100644
 --- a/src/Hal/Serializer/ItemNormalizer.php
 +++ b/src/Hal/Serializer/ItemNormalizer.php
-@@ -189,9 +189,6 @@ private function populateRelation(array $data, $object, ?string $format, array $
-             }
+@@ -244,14 +244,12 @@ final class ItemNormalizer extends AbstractItemNormalizer
  
-             $attributeValue = $this->getAttributeValue($object, $relation['name'], $format, $context);
+             $attributeValue = $this->getAttributeValue($object, $relation['name'], $format, $childContext);
+ 
 -            if (empty($attributeValue)) {
 -                continue;
 -            }
- 
-             $relationName = $relation['name'];
-             if ($this->nameConverter) {
-@@ -200,8 +197,10 @@ private function populateRelation(array $data, $object, ?string $format, array $
- 
+-
              if ('one' === $relation['cardinality']) {
                  if ('links' === $type) {
 -                    $data[$key][$relationName]['href'] = $this->getRelationIri($attributeValue);

--- a/api/src/Doctrine/Filter/ContentNodePeriodFilter.php
+++ b/api/src/Doctrine/Filter/ContentNodePeriodFilter.php
@@ -2,9 +2,9 @@
 
 namespace App\Doctrine\Filter;
 
-use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Operation;
 use App\Entity\Activity;
 use App\Entity\ContentNode;

--- a/api/src/Doctrine/Filter/MaterialItemPeriodFilter.php
+++ b/api/src/Doctrine/Filter/MaterialItemPeriodFilter.php
@@ -2,9 +2,9 @@
 
 namespace App\Doctrine\Filter;
 
-use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Operation;
 use App\Entity\Activity;
 use App\Entity\ContentNode\MaterialNode;

--- a/api/src/EventListener/JWTCreatedListener.php
+++ b/api/src/EventListener/JWTCreatedListener.php
@@ -2,7 +2,7 @@
 
 namespace App\EventListener;
 
-use ApiPlatform\Api\IriConverterInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
 use Symfony\Bundle\SecurityBundle\Security;
 

--- a/api/src/Metadata/Resource/Factory/UriTemplateFactory.php
+++ b/api/src/Metadata/Resource/Factory/UriTemplateFactory.php
@@ -2,12 +2,12 @@
 
 namespace App\Metadata\Resource\Factory;
 
-use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;

--- a/api/src/Serializer/Normalizer/CircularReferenceDetectingHalItemNormalizer.php
+++ b/api/src/Serializer/Normalizer/CircularReferenceDetectingHalItemNormalizer.php
@@ -2,8 +2,8 @@
 
 namespace App\Serializer\Normalizer;
 
-use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Api\ResourceClassResolverInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;

--- a/api/src/Serializer/Normalizer/ContentTypeNormalizer.php
+++ b/api/src/Serializer/Normalizer/ContentTypeNormalizer.php
@@ -2,7 +2,7 @@
 
 namespace App\Serializer\Normalizer;
 
-use ApiPlatform\Api\IriConverterInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use App\Entity\ContentType;
 use App\Metadata\Resource\Factory\UriTemplateFactory;
 use Rize\UriTemplate;

--- a/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
+++ b/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
@@ -3,20 +3,21 @@
 namespace App\Serializer\Normalizer;
 
 use ApiPlatform\Api\FilterInterface;
-use ApiPlatform\Api\IriConverterInterface;
-use ApiPlatform\Api\UrlGeneratorInterface;
 use ApiPlatform\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\UrlGeneratorInterface;
 use App\Entity\BaseEntity;
 use App\Metadata\Resource\Factory\UriTemplateFactory;
 use App\Metadata\Resource\OperationHelper;
 use App\Util\ClassInfoTrait;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
-use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Rize\UriTemplate;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -89,9 +90,9 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
         private UriTemplateFactory $uriTemplateFactory,
         private RouterInterface $router,
         private IriConverterInterface $iriConverter,
-        private ManagerRegistry $managerRegistry,
+        private readonly EntityManagerInterface $entityManager,
         private ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory,
-        private PropertyAccessorInterface $propertyAccessor
+        private PropertyAccessorInterface $propertyAccessor,
     ) {}
 
     public function supportsNormalization($data, $format = null, array $context = []): bool {
@@ -226,8 +227,8 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
         return $param;
     }
 
-    protected function getManagerRegistry(): ManagerRegistry {
-        return $this->managerRegistry;
+    protected function getClassMetadata(string $resourceClass): ClassMetadata {
+        return $this->entityManager->getClassMetadata($resourceClass);
     }
 
     /**

--- a/api/src/Serializer/Normalizer/TranslationConstraintViolationListNormalizer.php
+++ b/api/src/Serializer/Normalizer/TranslationConstraintViolationListNormalizer.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 class TranslationConstraintViolationListNormalizer implements NormalizerInterface {
     public function __construct(
         private readonly AbstractConstraintViolationListNormalizer $hydraNormalizer,
-        private readonly AbstractConstraintViolationListNormalizer $problemNormalizer,
+        private readonly AbstractConstraintViolationListNormalizer $halNormalizer,
         private readonly TranslationInfoOfConstraintViolation $translationInfoOfConstraintViolation,
         private readonly TranslateToAllLocalesService $translateToAllLocalesService
     ) {}
@@ -33,7 +33,7 @@ class TranslationConstraintViolationListNormalizer implements NormalizerInterfac
 
         /** @var ConstraintViolationList $object */
         foreach ($object as $violation) {
-            foreach ($result['violations'] as &$resultItem) {
+            foreach ($result as &$resultItem) {
                 $code = $resultItem['code'] ?? null;
                 $propertyPath = $resultItem['propertyPath'];
                 $message = $resultItem['message'] ?? null;
@@ -80,6 +80,6 @@ class TranslationConstraintViolationListNormalizer implements NormalizerInterfac
     }
 
     private function getNormalizerCollection(): ArrayCollection {
-        return new ArrayCollection([$this->hydraNormalizer, $this->problemNormalizer]);
+        return new ArrayCollection([$this->hydraNormalizer, $this->halNormalizer]);
     }
 }

--- a/api/src/Serializer/Normalizer/UriTemplateNormalizer.php
+++ b/api/src/Serializer/Normalizer/UriTemplateNormalizer.php
@@ -2,7 +2,7 @@
 
 namespace App\Serializer\Normalizer;
 
-use ApiPlatform\Api\UrlGeneratorInterface;
+use ApiPlatform\Metadata\UrlGeneratorInterface;
 use App\Metadata\Resource\Factory\UriTemplateFactory;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\String\Inflector\EnglishInflector;

--- a/api/src/Serializer/PreventAutomaticEmbeddingPropertyMetadataFactory.php
+++ b/api/src/Serializer/PreventAutomaticEmbeddingPropertyMetadataFactory.php
@@ -85,6 +85,7 @@ final class PreventAutomaticEmbeddingPropertyMetadataFactory implements Property
             $apiProperty->isInitializable(),
             $apiProperty->getIris(),
             $apiProperty->getGenId(),
+            $apiProperty->getUriTemplate(),
             $apiProperty->getExtraProperties()
         );
     }

--- a/api/tests/Api/ECampApiTestCase.php
+++ b/api/tests/Api/ECampApiTestCase.php
@@ -2,11 +2,11 @@
 
 namespace App\Tests\Api;
 
-use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;

--- a/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
+++ b/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
@@ -47,10 +47,10 @@ class ResponseSnapshotTest extends ECampApiTestCase {
         $response = static::createClientWithCredentials()
             ->request(
                 'GET',
-                '/docs.json',
+                '/docs.jsonopenapi',
                 [
                     'headers' => [
-                        'accept' => 'application/json',
+                        'accept' => 'application/vnd.openapi+json',
                     ],
                 ]
             )

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
@@ -20,6 +20,7 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
@@ -28,6 +29,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -52,14 +54,17 @@ components:
           description: 'The current assigned ProgressLabel.'
           example: /progress_labels/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout-read'
           description: |-
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           description: "The list of points in time when this activity's programme will be carried out."
@@ -97,6 +102,7 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
@@ -105,6 +111,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -129,7 +136,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/ActivityProgressLabel-read_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout-read_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries'
@@ -137,6 +146,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           items:
@@ -168,13 +178,16 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
           anyOf:
             -
               $ref: '#/components/schemas/Category-read_Activity.Category_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries_Activity.ContentNodes'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -199,7 +212,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/ActivityProgressLabel-read_Activity.Category_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries_Activity.ContentNodes'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout-read_Activity.Category_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries_Activity.ContentNodes'
@@ -207,6 +222,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           items:
@@ -240,6 +256,7 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
@@ -248,6 +265,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -272,14 +290,17 @@ components:
           description: 'The current assigned ProgressLabel.'
           example: /progress_labels/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout-read_ScheduleEntry.Activity'
           description: |-
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           description: "The list of points in time when this activity's programme will be carried out."
@@ -314,6 +335,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         location:
           description: "The physical location where this activity's programme will be carried out."
@@ -324,8 +346,10 @@ components:
           description: 'The current assigned ProgressLabel.'
           example: /progress_labels/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         title:
           description: 'The title of this activity that is shown in the picasso.'
           example: Sportolympiade
@@ -346,6 +370,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         location:
           description: "The physical location where this activity's programme will be carried out."
@@ -356,8 +381,10 @@ components:
           description: 'The current assigned ProgressLabel.'
           example: /progress_labels/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         scheduleEntries:
           description: "The list of points in time when this activity's programme will be carried out."
           example:
@@ -366,8 +393,7 @@ components:
               period: /periods/1a2b3c4a
               start: '2023-05-01T15:00:00+00:00'
           items:
-            format: iri-reference
-            type: string
+            $ref: '#/components/schemas/ScheduleEntry-write_create'
           minItems: 1
           type: array
         title:
@@ -405,6 +431,7 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
@@ -413,6 +440,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -437,14 +465,17 @@ components:
           description: 'The current assigned ProgressLabel.'
           example: /progress_labels/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout.jsonhal-read'
           description: |-
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           description: "The list of points in time when this activity's programme will be carried out."
@@ -491,6 +522,7 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
@@ -499,6 +531,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -523,7 +556,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/ActivityProgressLabel.jsonhal-read_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout.jsonhal-read_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries'
@@ -531,6 +566,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           items:
@@ -571,13 +607,16 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
           anyOf:
             -
               $ref: '#/components/schemas/Category.jsonhal-read_Activity.Category_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries_Activity.ContentNodes'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -602,7 +641,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/ActivityProgressLabel.jsonhal-read_Activity.Category_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries_Activity.ContentNodes'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout.jsonhal-read_Activity.Category_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries_Activity.ContentNodes'
@@ -610,6 +651,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           items:
@@ -632,15 +674,6 @@ components:
       deprecated: false
       description: 'A piece of programme that will be carried out once or multiple times in a camp.'
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         activityResponsibles:
           description: 'The list of people that are responsible for planning or carrying out this activity.'
           items:
@@ -652,6 +685,7 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
@@ -660,6 +694,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -684,14 +719,17 @@ components:
           description: 'The current assigned ProgressLabel.'
           example: /progress_labels/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout.jsonhal-read_ScheduleEntry.Activity'
           description: |-
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           description: "The list of points in time when this activity's programme will be carried out."
@@ -735,6 +773,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         location:
           description: "The physical location where this activity's programme will be carried out."
@@ -745,8 +784,10 @@ components:
           description: 'The current assigned ProgressLabel.'
           example: /progress_labels/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         scheduleEntries:
           description: "The list of points in time when this activity's programme will be carried out."
           example:
@@ -755,8 +796,7 @@ components:
               period: /periods/1a2b3c4a
               start: '2023-05-01T15:00:00+00:00'
           items:
-            format: iri-reference
-            type: string
+            $ref: '#/components/schemas/ScheduleEntry.jsonhal-write_create'
           minItems: 1
           type: array
         title:
@@ -808,6 +848,7 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
@@ -816,6 +857,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -840,14 +882,17 @@ components:
           description: 'The current assigned ProgressLabel.'
           example: /progress_labels/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout.jsonld-read'
           description: |-
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           description: "The list of points in time when this activity's programme will be carried out."
@@ -891,6 +936,7 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
@@ -899,6 +945,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -923,7 +970,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/ActivityProgressLabel.jsonld-read_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout.jsonld-read_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries'
@@ -931,6 +980,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           items:
@@ -985,13 +1035,16 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
           anyOf:
             -
               $ref: '#/components/schemas/Category.jsonld-read_Activity.Category_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries_Activity.ContentNodes'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -1016,7 +1069,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/ActivityProgressLabel.jsonld-read_Activity.Category_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries_Activity.ContentNodes'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout.jsonld-read_Activity.Category_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries_Activity.ContentNodes'
@@ -1024,6 +1079,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           items:
@@ -1046,29 +1102,6 @@ components:
       deprecated: false
       description: 'A piece of programme that will be carried out once or multiple times in a camp.'
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         activityResponsibles:
           description: 'The list of people that are responsible for planning or carrying out this activity.'
           items:
@@ -1080,6 +1113,7 @@ components:
           description: 'The camp to which this activity belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         category:
@@ -1088,6 +1122,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
@@ -1112,14 +1147,17 @@ components:
           description: 'The current assigned ProgressLabel.'
           example: /progress_labels/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         rootContentNode:
           $ref: '#/components/schemas/ColumnLayout.jsonld-read_ScheduleEntry.Activity'
           description: |-
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         scheduleEntries:
           description: "The list of points in time when this activity's programme will be carried out."
@@ -1154,6 +1192,7 @@ components:
             of the activity, and is used for marking similar activities. Must be in the same camp as the activity.
           example: /categories/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         location:
           description: "The physical location where this activity's programme will be carried out."
@@ -1164,8 +1203,10 @@ components:
           description: 'The current assigned ProgressLabel.'
           example: /progress_labels/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         scheduleEntries:
           description: "The list of points in time when this activity's programme will be carried out."
           example:
@@ -1174,8 +1215,7 @@ components:
               period: /periods/1a2b3c4a
               start: '2023-05-01T15:00:00+00:00'
           items:
-            format: iri-reference
-            type: string
+            $ref: '#/components/schemas/ScheduleEntry.jsonld-write_create'
           minItems: 1
           type: array
         title:
@@ -1199,6 +1239,7 @@ components:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1229,6 +1270,7 @@ components:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1259,6 +1301,7 @@ components:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1307,6 +1350,7 @@ components:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         position:
           default: -1
@@ -1340,6 +1384,7 @@ components:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1366,19 +1411,11 @@ components:
         Progress labels in a camp.
         To each activity one label can be assigned.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         camp:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1405,19 +1442,11 @@ components:
         Progress labels in a camp.
         To each activity one label can be assigned.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         camp:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1457,6 +1486,7 @@ components:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         position:
           default: -1
@@ -1504,6 +1534,7 @@ components:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1530,33 +1561,11 @@ components:
         Progress labels in a camp.
         To each activity one label can be assigned.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         camp:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1583,33 +1592,11 @@ components:
         Progress labels in a camp.
         To each activity one label can be assigned.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         camp:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1640,6 +1627,7 @@ components:
           description: 'The camp to which this label belongs.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         position:
           default: -1
@@ -1662,11 +1650,13 @@ components:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1686,11 +1676,13 @@ components:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1710,11 +1702,13 @@ components:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1734,11 +1728,13 @@ components:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       required:
         - activity
@@ -1761,11 +1757,13 @@ components:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1781,24 +1779,17 @@ components:
       deprecated: false
       description: 'A person that is responsible for planning or carrying out an activity.'
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         activity:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1814,24 +1805,17 @@ components:
       deprecated: false
       description: 'A person that is responsible for planning or carrying out an activity.'
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         activity:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1860,11 +1844,13 @@ components:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       required:
         - activity
@@ -1901,11 +1887,13 @@ components:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1921,38 +1909,17 @@ components:
       deprecated: false
       description: 'A person that is responsible for planning or carrying out an activity.'
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         activity:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -1968,38 +1935,17 @@ components:
       deprecated: false
       description: 'A person that is responsible for planning or carrying out an activity.'
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         activity:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -2019,11 +1965,13 @@ components:
           description: 'The activity that the person is responsible for.'
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The person that is responsible. Must be a collaborator in the same camp as the activity.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       required:
         - activity
@@ -2049,26 +1997,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           items:
             format: iri-reference
@@ -2086,25 +2038,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -2122,8 +2078,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -2138,8 +2095,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -2149,8 +2107,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -2191,8 +2150,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -2224,26 +2184,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           description: |-
             The people working on planning and carrying out the camp. Only collaborators have access
@@ -2264,25 +2228,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -2300,8 +2268,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -2316,8 +2285,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -2327,8 +2297,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           items:
             $ref: '#/components/schemas/Period-read_Camp.Periods_Period.Days_Camp.CampCollaborations_CampCollaboration.User'
@@ -2363,8 +2334,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -2396,26 +2368,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           items:
             format: iri-reference
@@ -2433,25 +2409,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -2469,8 +2449,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -2485,8 +2466,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -2496,8 +2478,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -2538,8 +2521,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -2571,26 +2555,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           items:
             format: iri-reference
@@ -2608,25 +2596,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -2644,8 +2636,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -2660,8 +2653,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -2671,8 +2665,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -2713,8 +2708,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -2736,62 +2732,73 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campPrototype:
           description: 'The prototype camp that will be used as a template to create this camp.'
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
           writeOnly: true
         coachName:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         kind:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         motto:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -2801,8 +2808,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -2811,8 +2819,7 @@ components:
               end: '2022-01-08'
               start: '2022-01-01'
           items:
-            format: iri-reference
-            type: string
+            $ref: '#/components/schemas/Period-write_create'
           minItems: 1
           type: array
         printYSLogoOnPicasso:
@@ -2828,8 +2835,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - name
         - periods
@@ -2846,56 +2854,65 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         coachName:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         kind:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         motto:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -2905,8 +2922,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         printYSLogoOnPicasso:
           description: 'Whether the Y+S logo should be printed on the picasso of this camp.'
           example: true
@@ -2920,8 +2938,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - name
         - printYSLogoOnPicasso
@@ -2956,26 +2975,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           items:
             format: iri-reference
@@ -2993,25 +3016,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -3029,8 +3056,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -3045,8 +3073,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -3056,8 +3085,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -3098,8 +3128,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -3140,26 +3171,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           description: |-
             The people working on planning and carrying out the camp. Only collaborators have access
@@ -3180,25 +3215,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -3216,8 +3255,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -3232,8 +3272,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -3243,8 +3284,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           items:
             $ref: '#/components/schemas/Period.jsonhal-read_Camp.Periods_Period.Days_Camp.CampCollaborations_CampCollaboration.User'
@@ -3279,8 +3321,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -3298,15 +3341,6 @@ components:
         The main entity that eCamp is designed to manage. Contains programme which may be
         distributed across multiple time periods.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         activities:
           description: |-
             All the programme that will be carried out during the camp. An activity may be carried out
@@ -3321,26 +3355,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           items:
             format: iri-reference
@@ -3358,25 +3396,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -3394,8 +3436,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -3410,8 +3453,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -3421,8 +3465,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -3463,8 +3508,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -3482,15 +3528,6 @@ components:
         The main entity that eCamp is designed to manage. Contains programme which may be
         distributed across multiple time periods.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         activities:
           description: |-
             All the programme that will be carried out during the camp. An activity may be carried out
@@ -3505,26 +3542,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           items:
             format: iri-reference
@@ -3542,25 +3583,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -3578,8 +3623,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -3594,8 +3640,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -3605,8 +3652,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -3647,8 +3695,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -3679,62 +3728,73 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campPrototype:
           description: 'The prototype camp that will be used as a template to create this camp.'
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
           writeOnly: true
         coachName:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         kind:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         motto:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -3744,8 +3804,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -3754,8 +3815,7 @@ components:
               end: '2022-01-08'
               start: '2022-01-01'
           items:
-            format: iri-reference
-            type: string
+            $ref: '#/components/schemas/Period.jsonhal-write_create'
           minItems: 1
           type: array
         printYSLogoOnPicasso:
@@ -3771,8 +3831,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - name
         - periods
@@ -3822,26 +3883,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           items:
             format: iri-reference
@@ -3859,25 +3924,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -3895,8 +3964,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -3911,8 +3981,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -3922,8 +3993,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -3964,8 +4036,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -4020,26 +4093,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           description: |-
             The people working on planning and carrying out the camp. Only collaborators have access
@@ -4060,25 +4137,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -4096,8 +4177,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -4112,8 +4194,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -4123,8 +4206,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           items:
             $ref: '#/components/schemas/Period.jsonld-read_Camp.Periods_Period.Days_Camp.CampCollaborations_CampCollaboration.User'
@@ -4159,8 +4243,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -4178,29 +4263,6 @@ components:
         The main entity that eCamp is designed to manage. Contains programme which may be
         distributed across multiple time periods.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         activities:
           description: |-
             All the programme that will be carried out during the camp. An activity may be carried out
@@ -4215,26 +4277,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           items:
             format: iri-reference
@@ -4252,25 +4318,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -4288,8 +4358,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -4304,8 +4375,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -4315,8 +4387,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -4357,8 +4430,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -4376,29 +4450,6 @@ components:
         The main entity that eCamp is designed to manage. Contains programme which may be
         distributed across multiple time periods.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         activities:
           description: |-
             All the programme that will be carried out during the camp. An activity may be carried out
@@ -4413,26 +4464,30 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campCollaborations:
           items:
             format: iri-reference
@@ -4450,25 +4505,29 @@ components:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         creator:
           description: |-
             The person that created the camp. This value never changes, even when the person
             leaves the camp.
           format: iri-reference
+          'owl:maxCardinality': 1
           readOnly: true
           type: string
         id:
@@ -4486,8 +4545,9 @@ components:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialLists:
           description: |-
             Lists for collecting the required materials needed for carrying out the programme. Each collaborator
@@ -4502,8 +4562,9 @@ components:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -4513,8 +4574,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -4555,8 +4617,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - activities
         - campCollaborations
@@ -4578,62 +4641,73 @@ components:
           description: 'The name of the town where the camp will take place.'
           example: Hintertüpfingen
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressName:
           description: 'A textual description of the location of the camp.'
           example: 'Wiese hinter der alten Mühle'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressStreet:
           description: 'The street name and number (if any) of the location of the camp.'
           example: 'Schönriedweg 23'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         addressZipcode:
           description: 'The zipcode of the location of the camp.'
           example: '1234'
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         campPrototype:
           description: 'The prototype camp that will be used as a template to create this camp.'
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
           writeOnly: true
         coachName:
           description: 'The name of the Y+S coach who is in charge of the camp.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseKind:
           description: 'The official name for the type of this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         courseNumber:
           description: 'The official course number, identifying this course.'
           example: 'PBS AG 123-23'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         kind:
           description: 'Rough categorization of the camp (house, tent, traveling, summer, autumn).'
           example: Zeltlager
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         motto:
           description: "The thematic topic (if any) of the camp's programme and storyline."
           example: Piraten
           maxLength: 128
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         name:
           description: 'A short name for the camp.'
           example: 'SoLa 2022'
@@ -4643,8 +4717,9 @@ components:
           description: 'The name of the organization which plans and carries out the camp.'
           example: 'Pfadi Luftig'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         periods:
           description: 'The time periods of the camp, there must be at least one. Periods in a camp may not overlap.'
           example:
@@ -4653,8 +4728,7 @@ components:
               end: '2022-01-08'
               start: '2022-01-01'
           items:
-            format: iri-reference
-            type: string
+            $ref: '#/components/schemas/Period.jsonld-write_create'
           minItems: 1
           type: array
         printYSLogoOnPicasso:
@@ -4670,8 +4744,9 @@ components:
           description: 'The name of the training advisor who is in charge of the course.'
           example: 'Albert Anderegg'
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - name
         - periods
@@ -4686,6 +4761,7 @@ components:
           description: 'The camp that the collaborator is part of. Cannot be changed once the campCollaboration is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -4703,8 +4779,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -4730,8 +4807,10 @@ components:
           description: 'The person that is collaborating in the camp. Cannot be changed once the campCollaboration is established.'
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - role
@@ -4745,6 +4824,7 @@ components:
           description: 'The camp that the collaborator is part of. Cannot be changed once the campCollaboration is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -4762,8 +4842,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -4789,7 +4870,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/User-read_Camp.Periods_Period.Days_Camp.CampCollaborations_CampCollaboration.User'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
       required:
         - camp
@@ -4804,7 +4887,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/Camp-read_CampCollaboration.Camp_CampCollaboration.User'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -4822,8 +4907,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -4849,7 +4935,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/User-read_CampCollaboration.Camp_CampCollaboration.User'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
       required:
         - camp
@@ -4868,6 +4956,7 @@ components:
           description: 'The camp that the collaborator is part of. Cannot be changed once the campCollaboration is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         inviteEmail:
           description: |-
@@ -4879,8 +4968,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -4896,8 +4986,10 @@ components:
           description: 'The person that is collaborating in the camp. Cannot be changed once the campCollaboration is established.'
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - role
@@ -4948,6 +5040,7 @@ components:
           description: 'The camp that the collaborator is part of. Cannot be changed once the campCollaboration is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -4965,8 +5058,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -4992,8 +5086,10 @@ components:
           description: 'The person that is collaborating in the camp. Cannot be changed once the campCollaboration is established.'
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - role
@@ -5003,19 +5099,11 @@ components:
       deprecated: false
       description: 'A user participating in some way in the planning or realization of a camp.'
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         camp:
           description: 'The camp that the collaborator is part of. Cannot be changed once the campCollaboration is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -5033,8 +5121,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -5060,7 +5149,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/User.jsonhal-read_Camp.Periods_Period.Days_Camp.CampCollaborations_CampCollaboration.User'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
       required:
         - camp
@@ -5084,7 +5175,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/Camp.jsonhal-read_CampCollaboration.Camp_CampCollaboration.User'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -5102,8 +5195,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -5129,7 +5223,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/User.jsonhal-read_CampCollaboration.Camp_CampCollaboration.User'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
       required:
         - camp
@@ -5153,6 +5249,7 @@ components:
           description: 'The camp that the collaborator is part of. Cannot be changed once the campCollaboration is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         inviteEmail:
           description: |-
@@ -5164,8 +5261,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -5181,8 +5279,10 @@ components:
           description: 'The person that is collaborating in the camp. Cannot be changed once the campCollaboration is established.'
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - role
@@ -5218,6 +5318,7 @@ components:
           description: 'The camp that the collaborator is part of. Cannot be changed once the campCollaboration is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -5235,8 +5336,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -5262,8 +5364,10 @@ components:
           description: 'The person that is collaborating in the camp. Cannot be changed once the campCollaboration is established.'
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - role
@@ -5273,33 +5377,11 @@ components:
       deprecated: false
       description: 'A user participating in some way in the planning or realization of a camp.'
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         camp:
           description: 'The camp that the collaborator is part of. Cannot be changed once the campCollaboration is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -5317,8 +5399,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -5344,7 +5427,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/User.jsonld-read_Camp.Periods_Period.Days_Camp.CampCollaborations_CampCollaboration.User'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
       required:
         - camp
@@ -5382,7 +5467,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/Camp.jsonld-read_CampCollaboration.Camp_CampCollaboration.User'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -5400,8 +5487,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -5427,7 +5515,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/User.jsonld-read_CampCollaboration.Camp_CampCollaboration.User'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
       required:
         - camp
@@ -5442,6 +5532,7 @@ components:
           description: 'The camp that the collaborator is part of. Cannot be changed once the campCollaboration is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         inviteEmail:
           description: |-
@@ -5453,8 +5544,9 @@ components:
           format: email
           maxLength: 128
           minLength: 1
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         role:
           description: |-
             The role that this person has in the camp. Depending on the role, the collaborator might have
@@ -5470,8 +5562,10 @@ components:
           description: 'The person that is collaborating in the camp. Cannot be changed once the campCollaboration is established.'
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - role
@@ -5488,6 +5582,7 @@ components:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -5541,6 +5636,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         short:
           description: |-
@@ -5569,6 +5665,7 @@ components:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -5622,6 +5719,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         short:
           description: |-
@@ -5650,6 +5748,7 @@ components:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -5701,6 +5800,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         short:
           description: |-
@@ -5729,6 +5829,7 @@ components:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -5852,6 +5953,7 @@ components:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -5905,6 +6007,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         short:
           description: |-
@@ -5929,19 +6032,11 @@ components:
         "similar" activities. A category may contain some skeleton programme which is used as a blueprint
         when creating a new activity in the category.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         camp:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -5995,6 +6090,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         short:
           description: |-
@@ -6032,6 +6128,7 @@ components:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -6083,6 +6180,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         short:
           description: |-
@@ -6120,6 +6218,7 @@ components:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -6203,6 +6302,7 @@ components:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -6256,6 +6356,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         short:
           description: |-
@@ -6280,33 +6381,11 @@ components:
         "similar" activities. A category may contain some skeleton programme which is used as a blueprint
         when creating a new activity in the category.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         camp:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -6360,6 +6439,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         short:
           description: |-
@@ -6411,6 +6491,7 @@ components:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -6462,6 +6543,7 @@ components:
             The programme contents, organized as a tree of content nodes. The root content node cannot be
             exchanged, but all the contents attached to it can.
           example: /content_nodes/1a2b3c4d
+          'owl:maxCardinality': 1
           readOnly: true
         short:
           description: |-
@@ -6490,6 +6572,7 @@ components:
           description: 'The camp to which this category belongs. May not be changed once the category is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         color:
           description: 'The color of the activities in this category, as a hex color string.'
@@ -6557,6 +6640,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -6575,8 +6659,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -6589,8 +6674,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -6598,8 +6684,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -6613,17 +6701,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -6649,6 +6740,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -6667,8 +6759,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -6681,8 +6774,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -6690,8 +6784,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -6705,17 +6801,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -6741,6 +6840,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -6759,8 +6859,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -6773,8 +6874,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -6782,8 +6884,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -6797,17 +6901,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -6833,6 +6940,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -6851,8 +6959,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -6865,8 +6974,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -6874,8 +6984,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -6889,17 +7001,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -6925,6 +7040,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -6943,8 +7059,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -6957,8 +7074,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -6966,8 +7084,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -6981,17 +7101,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -7009,6 +7132,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           default: '{"columns":[{"slot":"1","width":6},{"slot":"2","width":6}]}'
@@ -7022,16 +7146,18 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -7039,8 +7165,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -7054,8 +7182,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - data
@@ -7078,16 +7207,18 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -7095,8 +7226,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -7110,8 +7243,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - data
         - position
@@ -7144,6 +7278,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -7162,8 +7297,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -7176,8 +7312,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -7185,8 +7322,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -7200,17 +7339,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -7221,15 +7363,6 @@ components:
       deprecated: false
       description: ''
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -7245,6 +7378,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -7263,8 +7397,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -7277,8 +7412,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -7286,8 +7422,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -7301,17 +7439,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -7322,15 +7463,6 @@ components:
       deprecated: false
       description: ''
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -7346,6 +7478,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -7364,8 +7497,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -7378,8 +7512,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -7387,8 +7522,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -7402,17 +7539,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -7423,15 +7563,6 @@ components:
       deprecated: false
       description: ''
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -7447,6 +7578,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -7465,8 +7597,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -7479,8 +7612,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -7488,8 +7622,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -7503,17 +7639,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -7524,15 +7663,6 @@ components:
       deprecated: false
       description: ''
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -7548,6 +7678,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -7566,8 +7697,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -7580,8 +7712,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -7589,8 +7722,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -7604,17 +7739,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -7641,6 +7779,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           default: '{"columns":[{"slot":"1","width":6},{"slot":"2","width":6}]}'
@@ -7654,16 +7793,18 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -7671,8 +7812,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -7686,8 +7829,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - data
@@ -7736,6 +7880,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -7754,8 +7899,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -7768,8 +7914,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -7777,8 +7924,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -7792,17 +7941,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -7813,29 +7965,6 @@ components:
       deprecated: false
       description: ''
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -7851,6 +7980,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -7869,8 +7999,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -7883,8 +8014,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -7892,8 +8024,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -7907,17 +8041,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -7928,29 +8065,6 @@ components:
       deprecated: false
       description: ''
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -7966,6 +8080,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -7984,8 +8099,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -7998,8 +8114,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8007,8 +8124,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8022,17 +8141,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -8043,29 +8165,6 @@ components:
       deprecated: false
       description: ''
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -8081,6 +8180,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -8099,8 +8199,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -8113,8 +8214,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8122,8 +8224,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8137,17 +8241,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -8158,29 +8265,6 @@ components:
       deprecated: false
       description: ''
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -8196,6 +8280,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -8214,8 +8299,9 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -8228,8 +8314,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8237,8 +8324,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8252,17 +8341,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -8280,6 +8372,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           default: '{"columns":[{"slot":"1","width":6},{"slot":"2","width":6}]}'
@@ -8293,16 +8386,18 @@ components:
                 width: 12
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8310,8 +8405,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8325,8 +8422,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - data
@@ -8357,6 +8455,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -8369,8 +8468,9 @@ components:
             text: 'dummy text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -8383,8 +8483,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8392,8 +8493,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8407,17 +8510,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -8447,6 +8553,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -8459,8 +8566,9 @@ components:
             text: 'dummy text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -8473,8 +8581,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8482,8 +8591,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8497,17 +8608,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -8537,6 +8651,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -8549,8 +8664,9 @@ components:
             text: 'dummy text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -8563,8 +8679,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8572,8 +8689,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8587,17 +8706,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -8636,6 +8758,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -8648,8 +8771,9 @@ components:
             text: 'dummy text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -8662,8 +8786,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8671,8 +8796,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8686,17 +8813,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -8711,15 +8841,6 @@ components:
         content nodes may be inserted. In return, a content node may be nested inside a slot in a parent
         container content node. This way, a tree of content nodes makes up a complete programme.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -8735,6 +8856,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -8747,8 +8869,9 @@ components:
             text: 'dummy text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -8761,8 +8884,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8770,8 +8894,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8785,17 +8911,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -8810,15 +8939,6 @@ components:
         content nodes may be inserted. In return, a content node may be nested inside a slot in a parent
         container content node. This way, a tree of content nodes makes up a complete programme.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -8834,6 +8954,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -8846,8 +8967,9 @@ components:
             text: 'dummy text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -8860,8 +8982,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8869,8 +8992,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8884,17 +9009,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -8930,6 +9058,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -8942,8 +9071,9 @@ components:
             text: 'dummy text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -8956,8 +9086,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -8965,8 +9096,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -8980,17 +9113,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -9005,29 +9141,6 @@ components:
         content nodes may be inserted. In return, a content node may be nested inside a slot in a parent
         container content node. This way, a tree of content nodes makes up a complete programme.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -9043,6 +9156,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -9055,8 +9169,9 @@ components:
             text: 'dummy text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -9069,8 +9184,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -9078,8 +9194,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -9093,17 +9211,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -9118,29 +9239,6 @@ components:
         content nodes may be inserted. In return, a content node may be nested inside a slot in a parent
         container content node. This way, a tree of content nodes makes up a complete programme.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         children:
           description: 'All content nodes that are direct children of this content node.'
           example: '["/content_nodes/1a2b3c4d"]'
@@ -9156,6 +9254,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -9168,8 +9267,9 @@ components:
             text: 'dummy text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -9182,8 +9282,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -9191,8 +9292,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -9206,17 +9309,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -9355,15 +9461,6 @@ components:
         determines what data can be stored in content nodes of this type, as well as validation,
         available slots and jsonConfig settings.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         active:
           default: true
           description: 'Whether this content type is still maintained and recommended for use in new camps.'
@@ -9465,29 +9562,6 @@ components:
         determines what data can be stored in content nodes of this type, as well as validation,
         available slots and jsonConfig settings.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         active:
           default: true
           description: 'Whether this content type is still maintained and recommended for use in new camps.'
@@ -9554,9 +9628,10 @@ components:
           description: 'The end date and time of the day. This is a read-only convenience property.'
           example: '2022-01-03T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -9572,6 +9647,7 @@ components:
           description: 'The time period that this day belongs to.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntries:
           description: "All scheduleEntries in this day's period which overlap with this day (using midnight as cutoff)."
@@ -9585,9 +9661,10 @@ components:
           description: 'The start date and time of the day. This is a read-only convenience property.'
           example: '2022-01-02T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - dayOffset
         - dayResponsibles
@@ -9615,9 +9692,10 @@ components:
           description: 'The end date and time of the day. This is a read-only convenience property.'
           example: '2022-01-03T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -9633,6 +9711,7 @@ components:
           description: 'The time period that this day belongs to.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntries:
           description: "All scheduleEntries in this day's period which overlap with this day (using midnight as cutoff)."
@@ -9646,9 +9725,10 @@ components:
           description: 'The start date and time of the day. This is a read-only convenience property.'
           example: '2022-01-02T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - dayOffset
         - dayResponsibles
@@ -9679,9 +9759,10 @@ components:
           description: 'The end date and time of the day. This is a read-only convenience property.'
           example: '2022-01-03T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -9697,6 +9778,7 @@ components:
           description: 'The time period that this day belongs to.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntries:
           description: "All scheduleEntries in this day's period which overlap with this day (using midnight as cutoff)."
@@ -9710,9 +9792,10 @@ components:
           description: 'The start date and time of the day. This is a read-only convenience property.'
           example: '2022-01-02T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - dayOffset
         - dayResponsibles
@@ -9726,15 +9809,6 @@ components:
         easier to move the whole periods to different dates. Days are created automatically when
         creating or updating periods, and are not writable through the API directly.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         dayOffset:
           description: "The 0-based offset in days from the period's start date when this day starts."
           example: '1'
@@ -9752,9 +9826,10 @@ components:
           description: 'The end date and time of the day. This is a read-only convenience property.'
           example: '2022-01-03T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -9770,6 +9845,7 @@ components:
           description: 'The time period that this day belongs to.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntries:
           description: "All scheduleEntries in this day's period which overlap with this day (using midnight as cutoff)."
@@ -9783,9 +9859,10 @@ components:
           description: 'The start date and time of the day. This is a read-only convenience property.'
           example: '2022-01-02T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - dayOffset
         - dayResponsibles
@@ -9822,9 +9899,10 @@ components:
           description: 'The end date and time of the day. This is a read-only convenience property.'
           example: '2022-01-03T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -9840,6 +9918,7 @@ components:
           description: 'The time period that this day belongs to.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntries:
           description: "All scheduleEntries in this day's period which overlap with this day (using midnight as cutoff)."
@@ -9853,9 +9932,10 @@ components:
           description: 'The start date and time of the day. This is a read-only convenience property.'
           example: '2022-01-02T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - dayOffset
         - dayResponsibles
@@ -9869,15 +9949,6 @@ components:
         easier to move the whole periods to different dates. Days are created automatically when
         creating or updating periods, and are not writable through the API directly.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         dayOffset:
           description: "The 0-based offset in days from the period's start date when this day starts."
           example: '1'
@@ -9895,9 +9966,10 @@ components:
           description: 'The end date and time of the day. This is a read-only convenience property.'
           example: '2022-01-03T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -9913,6 +9985,7 @@ components:
           description: 'The time period that this day belongs to.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntries:
           description: "All scheduleEntries in this day's period which overlap with this day (using midnight as cutoff)."
@@ -9926,9 +9999,10 @@ components:
           description: 'The start date and time of the day. This is a read-only convenience property.'
           example: '2022-01-02T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - dayOffset
         - dayResponsibles
@@ -9942,29 +10016,6 @@ components:
         easier to move the whole periods to different dates. Days are created automatically when
         creating or updating periods, and are not writable through the API directly.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         dayOffset:
           description: "The 0-based offset in days from the period's start date when this day starts."
           example: '1'
@@ -9982,9 +10033,10 @@ components:
           description: 'The end date and time of the day. This is a read-only convenience property.'
           example: '2022-01-03T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -10000,6 +10052,7 @@ components:
           description: 'The time period that this day belongs to.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntries:
           description: "All scheduleEntries in this day's period which overlap with this day (using midnight as cutoff)."
@@ -10013,9 +10066,10 @@ components:
           description: 'The start date and time of the day. This is a read-only convenience property.'
           example: '2022-01-02T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - dayOffset
         - dayResponsibles
@@ -10066,9 +10120,10 @@ components:
           description: 'The end date and time of the day. This is a read-only convenience property.'
           example: '2022-01-03T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -10084,6 +10139,7 @@ components:
           description: 'The time period that this day belongs to.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntries:
           description: "All scheduleEntries in this day's period which overlap with this day (using midnight as cutoff)."
@@ -10097,9 +10153,10 @@ components:
           description: 'The start date and time of the day. This is a read-only convenience property.'
           example: '2022-01-02T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - dayOffset
         - dayResponsibles
@@ -10113,29 +10170,6 @@ components:
         easier to move the whole periods to different dates. Days are created automatically when
         creating or updating periods, and are not writable through the API directly.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         dayOffset:
           description: "The 0-based offset in days from the period's start date when this day starts."
           example: '1'
@@ -10153,9 +10187,10 @@ components:
           description: 'The end date and time of the day. This is a read-only convenience property.'
           example: '2022-01-03T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -10171,6 +10206,7 @@ components:
           description: 'The time period that this day belongs to.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntries:
           description: "All scheduleEntries in this day's period which overlap with this day (using midnight as cutoff)."
@@ -10184,9 +10220,10 @@ components:
           description: 'The start date and time of the day. This is a read-only convenience property.'
           example: '2022-01-02T00:00:00+00:00'
           format: date
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - dayOffset
         - dayResponsibles
@@ -10200,11 +10237,13 @@ components:
           description: "The person that is responsible. Must belong to the same camp as the day's period."
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which the person is responsible.'
           example: /days/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -10224,11 +10263,13 @@ components:
           description: "The person that is responsible. Must belong to the same camp as the day's period."
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which the person is responsible.'
           example: /days/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -10248,11 +10289,13 @@ components:
           description: "The person that is responsible. Must belong to the same camp as the day's period."
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which the person is responsible.'
           example: /days/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       required:
         - campCollaboration
@@ -10275,11 +10318,13 @@ components:
           description: "The person that is responsible. Must belong to the same camp as the day's period."
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which the person is responsible.'
           example: /days/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -10295,24 +10340,17 @@ components:
       deprecated: false
       description: 'A person that has some whole-day responsibility on a day in the camp.'
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         campCollaboration:
           description: "The person that is responsible. Must belong to the same camp as the day's period."
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which the person is responsible.'
           example: /days/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -10341,11 +10379,13 @@ components:
           description: "The person that is responsible. Must belong to the same camp as the day's period."
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which the person is responsible.'
           example: /days/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       required:
         - campCollaboration
@@ -10382,11 +10422,13 @@ components:
           description: "The person that is responsible. Must belong to the same camp as the day's period."
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which the person is responsible.'
           example: /days/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -10402,38 +10444,17 @@ components:
       deprecated: false
       description: 'A person that has some whole-day responsibility on a day in the camp.'
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         campCollaboration:
           description: "The person that is responsible. Must belong to the same camp as the day's period."
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which the person is responsible.'
           example: /days/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
@@ -10453,11 +10474,13 @@ components:
           description: "The person that is responsible. Must belong to the same camp as the day's period."
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which the person is responsible.'
           example: /days/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       required:
         - campCollaboration
@@ -10485,15 +10508,17 @@ components:
           description: |-
             Indicates whether the logged in user is already collaborating in the camp, and
             can therefore not accept the invitation.
-          nullable: true
-          type: boolean
+          type:
+            - boolean
+            - 'null'
         userDisplayName:
           description: |-
             The display name of the user that is invited. May be null in case the user does
             not already have an account.
           example: 'Robert Baden-Powell'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       type: object
     Invitation-read:
       deprecated: false
@@ -10517,15 +10542,17 @@ components:
           description: |-
             Indicates whether the logged in user is already collaborating in the camp, and
             can therefore not accept the invitation.
-          nullable: true
-          type: boolean
+          type:
+            - boolean
+            - 'null'
         userDisplayName:
           description: |-
             The display name of the user that is invited. May be null in case the user does
             not already have an account.
           example: 'Robert Baden-Powell'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       type: object
     Invitation-write:
       deprecated: false
@@ -10564,15 +10591,17 @@ components:
           description: |-
             Indicates whether the logged in user is already collaborating in the camp, and
             can therefore not accept the invitation.
-          nullable: true
-          type: boolean
+          type:
+            - boolean
+            - 'null'
         userDisplayName:
           description: |-
             The display name of the user that is invited. May be null in case the user does
             not already have an account.
           example: 'Robert Baden-Powell'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       type: object
     Invitation.jsonhal-read:
       deprecated: false
@@ -10605,15 +10634,17 @@ components:
           description: |-
             Indicates whether the logged in user is already collaborating in the camp, and
             can therefore not accept the invitation.
-          nullable: true
-          type: boolean
+          type:
+            - boolean
+            - 'null'
         userDisplayName:
           description: |-
             The display name of the user that is invited. May be null in case the user does
             not already have an account.
           example: 'Robert Baden-Powell'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       type: object
     Invitation.jsonld:
       deprecated: false
@@ -10643,15 +10674,17 @@ components:
           description: |-
             Indicates whether the logged in user is already collaborating in the camp, and
             can therefore not accept the invitation.
-          nullable: true
-          type: boolean
+          type:
+            - boolean
+            - 'null'
         userDisplayName:
           description: |-
             The display name of the user that is invited. May be null in case the user does
             not already have an account.
           example: 'Robert Baden-Powell'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       type: object
     Invitation.jsonld-read:
       deprecated: false
@@ -10698,15 +10731,17 @@ components:
           description: |-
             Indicates whether the logged in user is already collaborating in the camp, and
             can therefore not accept the invitation.
-          nullable: true
-          type: boolean
+          type:
+            - boolean
+            - 'null'
         userDisplayName:
           description: |-
             The display name of the user that is invited. May be null in case the user does
             not already have an account.
           example: 'Robert Baden-Powell'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       type: object
     MaterialItem-read:
       deprecated: false
@@ -10729,30 +10764,37 @@ components:
             responsible to prepare and bring the item to the camp.
           example: /material_lists/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         materialNode:
           description: 'The content node to which this item belongs, if it does not belong to a period.'
           example: /content_node/material_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         period:
           description: 'The period to which this item belongs, if it does not belong to a content node.'
           example: /periods/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         quantity:
           description: 'The number of items or the amount in the unit of items that are required.'
           example: 1.5
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         unit:
           description: 'An optional unit for measuring the amount of items required.'
           example: kg
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - article
         - materialList
@@ -10771,29 +10813,36 @@ components:
             responsible to prepare and bring the item to the camp.
           example: /material_lists/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         materialNode:
           description: 'The content node to which this item belongs, if it does not belong to a period.'
           example: /content_node/material_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         period:
           description: 'The period to which this item belongs, if it does not belong to a content node.'
           example: /periods/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         quantity:
           description: 'The number of items or the amount in the unit of items that are required.'
           example: 1.5
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         unit:
           description: 'An optional unit for measuring the amount of items required.'
           example: kg
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       type: object
     MaterialItem.jsonhal-read:
       deprecated: false
@@ -10825,30 +10874,37 @@ components:
             responsible to prepare and bring the item to the camp.
           example: /material_lists/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         materialNode:
           description: 'The content node to which this item belongs, if it does not belong to a period.'
           example: /content_node/material_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         period:
           description: 'The period to which this item belongs, if it does not belong to a content node.'
           example: /periods/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         quantity:
           description: 'The number of items or the amount in the unit of items that are required.'
           example: 1.5
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         unit:
           description: 'An optional unit for measuring the amount of items required.'
           example: kg
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - article
         - materialList
@@ -10877,30 +10933,37 @@ components:
             responsible to prepare and bring the item to the camp.
           example: /material_lists/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         materialNode:
           description: 'The content node to which this item belongs, if it does not belong to a period.'
           example: /content_node/material_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         period:
           description: 'The period to which this item belongs, if it does not belong to a content node.'
           example: /periods/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         quantity:
           description: 'The number of items or the amount in the unit of items that are required.'
           example: 1.5
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         unit:
           description: 'An optional unit for measuring the amount of items required.'
           example: kg
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - article
         - materialList
@@ -10949,30 +11012,37 @@ components:
             responsible to prepare and bring the item to the camp.
           example: /material_lists/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         materialNode:
           description: 'The content node to which this item belongs, if it does not belong to a period.'
           example: /content_node/material_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         period:
           description: 'The period to which this item belongs, if it does not belong to a content node.'
           example: /periods/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         quantity:
           description: 'The number of items or the amount in the unit of items that are required.'
           example: 1.5
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         unit:
           description: 'An optional unit for measuring the amount of items required.'
           example: kg
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - article
         - materialList
@@ -10992,30 +11062,37 @@ components:
             responsible to prepare and bring the item to the camp.
           example: /material_lists/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         materialNode:
           description: 'The content node to which this item belongs, if it does not belong to a period.'
           example: /content_node/material_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         period:
           description: 'The period to which this item belongs, if it does not belong to a content node.'
           example: /periods/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         quantity:
           description: 'The number of items or the amount in the unit of items that are required.'
           example: 1.5
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         unit:
           description: 'An optional unit for measuring the amount of items required.'
           example: kg
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - article
         - materialList
@@ -11030,14 +11107,17 @@ components:
           description: 'The camp this material list belongs to.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The campCollaboration this material list belongs to.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -11060,8 +11140,9 @@ components:
           description: 'The human readable name of the material list.'
           example: Lebensmittel
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - materialItems
@@ -11077,8 +11158,9 @@ components:
           description: 'The human readable name of the material list.'
           example: Lebensmittel
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - name
       type: object
@@ -11092,13 +11174,15 @@ components:
           description: 'The camp this material list belongs to.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         name:
           description: 'The human readable name of the material list.'
           example: Lebensmittel
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - name
@@ -11122,14 +11206,17 @@ components:
           description: 'The camp this material list belongs to.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The campCollaboration this material list belongs to.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -11152,8 +11239,9 @@ components:
           description: 'The human readable name of the material list.'
           example: Lebensmittel
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - materialItems
@@ -11178,13 +11266,15 @@ components:
           description: 'The camp this material list belongs to.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         name:
           description: 'The human readable name of the material list.'
           example: Lebensmittel
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - name
@@ -11222,14 +11312,17 @@ components:
           description: 'The camp this material list belongs to.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         campCollaboration:
           description: 'The campCollaboration this material list belongs to.'
           example: /camp_collaborations/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -11252,8 +11345,9 @@ components:
           description: 'The human readable name of the material list.'
           example: Lebensmittel
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - materialItems
@@ -11269,13 +11363,15 @@ components:
           description: 'The camp this material list belongs to.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         name:
           description: 'The human readable name of the material list.'
           example: Lebensmittel
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - camp
         - name
@@ -11299,6 +11395,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -11311,8 +11408,9 @@ components:
             (overridden from abstract class in order to add specific validation).
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -11325,8 +11423,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialItems:
           items:
             $ref: '#/components/schemas/MaterialItem-read'
@@ -11338,8 +11437,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -11353,17 +11454,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -11381,6 +11485,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           description: |-
@@ -11388,16 +11493,18 @@ components:
             (overridden from abstract class in order to add specific validation).
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -11405,8 +11512,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -11420,8 +11529,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - parent
@@ -11437,16 +11547,18 @@ components:
             (overridden from abstract class in order to add specific validation).
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -11454,8 +11566,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -11469,8 +11583,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - position
       type: object
@@ -11502,6 +11617,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -11514,8 +11630,9 @@ components:
             (overridden from abstract class in order to add specific validation).
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -11528,8 +11645,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialItems:
           items:
             $ref: '#/components/schemas/MaterialItem.jsonhal-read'
@@ -11541,8 +11659,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -11556,17 +11676,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -11593,6 +11716,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           description: |-
@@ -11600,16 +11724,18 @@ components:
             (overridden from abstract class in order to add specific validation).
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -11617,8 +11743,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -11632,8 +11760,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - parent
@@ -11681,6 +11810,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -11693,8 +11823,9 @@ components:
             (overridden from abstract class in order to add specific validation).
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -11707,8 +11838,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         materialItems:
           items:
             $ref: '#/components/schemas/MaterialItem.jsonld-read'
@@ -11720,8 +11852,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -11735,17 +11869,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -11763,6 +11900,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           description: |-
@@ -11770,16 +11908,18 @@ components:
             (overridden from abstract class in order to add specific validation).
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -11787,8 +11927,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -11802,8 +11944,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - parent
@@ -11828,6 +11971,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -11846,8 +11990,9 @@ components:
                 checked: false
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -11860,8 +12005,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -11869,8 +12015,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -11884,17 +12032,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -11911,6 +12062,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           description: |-
@@ -11924,16 +12076,18 @@ components:
                 checked: false
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -11941,8 +12095,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -11956,8 +12112,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - parent
@@ -11979,16 +12136,18 @@ components:
                 checked: false
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -11996,8 +12155,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -12011,8 +12172,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - data
         - position
@@ -12045,6 +12207,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -12063,8 +12226,9 @@ components:
                 checked: false
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -12077,8 +12241,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -12086,8 +12251,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -12101,17 +12268,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -12137,6 +12307,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           description: |-
@@ -12150,16 +12321,18 @@ components:
                 checked: false
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -12167,8 +12340,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -12182,8 +12357,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - parent
@@ -12231,6 +12407,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -12249,8 +12426,9 @@ components:
                 checked: false
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -12263,8 +12441,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -12272,8 +12451,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -12287,17 +12468,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -12314,6 +12498,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           description: |-
@@ -12327,16 +12512,18 @@ components:
                 checked: false
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -12344,8 +12531,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -12359,8 +12548,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - parent
@@ -12376,6 +12566,7 @@ components:
           description: 'The camp that this time period belongs to. Cannot be changed once the period is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes used in some activity which is carried out (has a schedule entry) in this period.'
@@ -12405,8 +12596,9 @@ components:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -12464,6 +12656,7 @@ components:
           description: 'The camp that this time period belongs to. Cannot be changed once the period is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes used in some activity which is carried out (has a schedule entry) in this period.'
@@ -12490,8 +12683,9 @@ components:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -12549,7 +12743,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/Camp-read_Period.Camp_Period.Days'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         contentNodes:
           description: 'All the content nodes used in some activity which is carried out (has a schedule entry) in this period.'
@@ -12576,8 +12772,9 @@ components:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -12635,8 +12832,9 @@ components:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -12672,13 +12870,15 @@ components:
           description: 'The camp that this time period belongs to. Cannot be changed once the period is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         description:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -12724,6 +12924,7 @@ components:
           description: 'The camp that this time period belongs to. Cannot be changed once the period is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes used in some activity which is carried out (has a schedule entry) in this period.'
@@ -12753,8 +12954,9 @@ components:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -12808,19 +13010,11 @@ components:
         A time period in which the programme of a camp will take place. There may be multiple
         periods in a camp, but they may not overlap. A period is made up of one or more full days.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         camp:
           description: 'The camp that this time period belongs to. Cannot be changed once the period is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes used in some activity which is carried out (has a schedule entry) in this period.'
@@ -12847,8 +13041,9 @@ components:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -12915,7 +13110,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/Camp.jsonhal-read_Period.Camp_Period.Days'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         contentNodes:
           description: 'All the content nodes used in some activity which is carried out (has a schedule entry) in this period.'
@@ -12942,8 +13139,9 @@ components:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -13010,13 +13208,15 @@ components:
           description: 'The camp that this time period belongs to. Cannot be changed once the period is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         description:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -13076,6 +13276,7 @@ components:
           description: 'The camp that this time period belongs to. Cannot be changed once the period is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes used in some activity which is carried out (has a schedule entry) in this period.'
@@ -13105,8 +13306,9 @@ components:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -13160,33 +13362,11 @@ components:
         A time period in which the programme of a camp will take place. There may be multiple
         periods in a camp, but they may not overlap. A period is made up of one or more full days.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         camp:
           description: 'The camp that this time period belongs to. Cannot be changed once the period is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentNodes:
           description: 'All the content nodes used in some activity which is carried out (has a schedule entry) in this period.'
@@ -13213,8 +13393,9 @@ components:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -13295,7 +13476,9 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/Camp.jsonld-read_Period.Camp_Period.Days'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         contentNodes:
           description: 'All the content nodes used in some activity which is carried out (has a schedule entry) in this period.'
@@ -13322,8 +13505,9 @@ components:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -13381,13 +13565,15 @@ components:
           description: 'The camp that this time period belongs to. Cannot be changed once the period is created.'
           example: /camps/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         description:
           description: 'A free text name for the period. Useful to distinguish multiple periods in the same camp.'
           example: Hauptlager
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         end:
           description: |-
             The (inclusive) day at the end of which the period ends, as an ISO date string. Should
@@ -13433,8 +13619,9 @@ components:
           description: "The user's (optional) first name."
           example: Robert
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -13454,34 +13641,40 @@ components:
             - it-CH-scout
           example: en
           maxLength: 20
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         legalName:
           description: |-
             The legal name of the user, for printing on legally relevant
             documents. Falls back to the nickname if not complete.
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         nickname:
           description: "The user's (optional) nickname or scout name."
           example: Bi-Pi
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         surname:
           description: "The user's (optional) last name."
           example: Baden-Powell
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         user:
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - email
       type: object
@@ -13504,8 +13697,9 @@ components:
           description: "The user's (optional) first name."
           example: Robert
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -13525,34 +13719,104 @@ components:
             - it-CH-scout
           example: en
           maxLength: 20
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         legalName:
           description: |-
             The legal name of the user, for printing on legally relevant
             documents. Falls back to the nickname if not complete.
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         nickname:
           description: "The user's (optional) nickname or scout name."
           example: Bi-Pi
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         surname:
           description: "The user's (optional) last name."
           example: Baden-Powell
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         user:
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
+          type:
+            - 'null'
+            - string
+      required:
+        - email
+      type: object
+    Profile-write_create:
+      deprecated: false
+      description: |-
+        The profile of a person using eCamp.
+        The properties available to related eCamp users are here.
+        Related means that they were or are collaborators in the same camp.
+      properties:
+        email:
+          description: 'Unique email of the user.'
+          example: bi-pi@example.com
+          externalDocs:
+            url: 'https://schema.org/email'
+          format: email
+          maxLength: 64
           type: string
+        firstname:
+          description: "The user's (optional) first name."
+          example: Robert
+          maxLength: 64
+          type:
+            - 'null'
+            - string
+        language:
+          description: 'The optional preferred language of the user, as an ICU language code.'
+          enum:
+            - de
+            - de-CH-scout
+            - en
+            - en-CH-scout
+            - fr
+            - fr-CH-scout
+            - it
+            - it-CH-scout
+          example: en
+          maxLength: 20
+          type:
+            - 'null'
+            - string
+        newEmail:
+          description: 'New email.'
+          example: bi-pi@example.com
+          externalDocs:
+            url: 'https://schema.org/email'
+          format: email
+          type:
+            - 'null'
+            - string
+        nickname:
+          description: "The user's (optional) nickname or scout name."
+          example: Bi-Pi
+          maxLength: 32
+          type:
+            - 'null'
+            - string
+        surname:
+          description: "The user's (optional) last name."
+          example: Baden-Powell
+          maxLength: 64
+          type:
+            - 'null'
+            - string
       required:
         - email
       type: object
@@ -13567,8 +13831,9 @@ components:
           description: "The user's (optional) first name."
           example: Robert
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         language:
           description: 'The optional preferred language of the user, as an ICU language code.'
           enum:
@@ -13582,32 +13847,37 @@ components:
             - it-CH-scout
           example: en
           maxLength: 20
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         newEmail:
           description: 'New email.'
           example: bi-pi@example.com
           externalDocs:
             url: 'https://schema.org/email'
           format: email
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         nickname:
           description: "The user's (optional) nickname or scout name."
           example: Bi-Pi
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         surname:
           description: "The user's (optional) last name."
           example: Baden-Powell
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         untrustedEmailKey:
           description: 'User input for email verification.'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       type: object
     Profile.jsonhal-read:
@@ -13638,8 +13908,9 @@ components:
           description: "The user's (optional) first name."
           example: Robert
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -13659,34 +13930,40 @@ components:
             - it-CH-scout
           example: en
           maxLength: 20
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         legalName:
           description: |-
             The legal name of the user, for printing on legally relevant
             documents. Falls back to the nickname if not complete.
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         nickname:
           description: "The user's (optional) nickname or scout name."
           example: Bi-Pi
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         surname:
           description: "The user's (optional) last name."
           example: Baden-Powell
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         user:
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - email
       type: object
@@ -13697,15 +13974,6 @@ components:
         The properties available to related eCamp users are here.
         Related means that they were or are collaborators in the same camp.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         email:
           description: 'Unique email of the user.'
           example: bi-pi@example.com
@@ -13718,8 +13986,9 @@ components:
           description: "The user's (optional) first name."
           example: Robert
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -13739,34 +14008,104 @@ components:
             - it-CH-scout
           example: en
           maxLength: 20
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         legalName:
           description: |-
             The legal name of the user, for printing on legally relevant
             documents. Falls back to the nickname if not complete.
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         nickname:
           description: "The user's (optional) nickname or scout name."
           example: Bi-Pi
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         surname:
           description: "The user's (optional) last name."
           example: Baden-Powell
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         user:
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
+          type:
+            - 'null'
+            - string
+      required:
+        - email
+      type: object
+    Profile.jsonhal-write_create:
+      deprecated: false
+      description: |-
+        The profile of a person using eCamp.
+        The properties available to related eCamp users are here.
+        Related means that they were or are collaborators in the same camp.
+      properties:
+        email:
+          description: 'Unique email of the user.'
+          example: bi-pi@example.com
+          externalDocs:
+            url: 'https://schema.org/email'
+          format: email
+          maxLength: 64
           type: string
+        firstname:
+          description: "The user's (optional) first name."
+          example: Robert
+          maxLength: 64
+          type:
+            - 'null'
+            - string
+        language:
+          description: 'The optional preferred language of the user, as an ICU language code.'
+          enum:
+            - de
+            - de-CH-scout
+            - en
+            - en-CH-scout
+            - fr
+            - fr-CH-scout
+            - it
+            - it-CH-scout
+          example: en
+          maxLength: 20
+          type:
+            - 'null'
+            - string
+        newEmail:
+          description: 'New email.'
+          example: bi-pi@example.com
+          externalDocs:
+            url: 'https://schema.org/email'
+          format: email
+          type:
+            - 'null'
+            - string
+        nickname:
+          description: "The user's (optional) nickname or scout name."
+          example: Bi-Pi
+          maxLength: 32
+          type:
+            - 'null'
+            - string
+        surname:
+          description: "The user's (optional) last name."
+          example: Baden-Powell
+          maxLength: 64
+          type:
+            - 'null'
+            - string
       required:
         - email
       type: object
@@ -13812,8 +14151,9 @@ components:
           description: "The user's (optional) first name."
           example: Robert
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -13833,34 +14173,40 @@ components:
             - it-CH-scout
           example: en
           maxLength: 20
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         legalName:
           description: |-
             The legal name of the user, for printing on legally relevant
             documents. Falls back to the nickname if not complete.
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         nickname:
           description: "The user's (optional) nickname or scout name."
           example: Bi-Pi
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         surname:
           description: "The user's (optional) last name."
           example: Baden-Powell
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         user:
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - email
       type: object
@@ -13871,29 +14217,6 @@ components:
         The properties available to related eCamp users are here.
         Related means that they were or are collaborators in the same camp.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         email:
           description: 'Unique email of the user.'
           example: bi-pi@example.com
@@ -13906,8 +14229,9 @@ components:
           description: "The user's (optional) first name."
           example: Robert
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -13927,34 +14251,104 @@ components:
             - it-CH-scout
           example: en
           maxLength: 20
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         legalName:
           description: |-
             The legal name of the user, for printing on legally relevant
             documents. Falls back to the nickname if not complete.
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         nickname:
           description: "The user's (optional) nickname or scout name."
           example: Bi-Pi
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         surname:
           description: "The user's (optional) last name."
           example: Baden-Powell
           maxLength: 64
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         user:
           example: /users/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
+          type:
+            - 'null'
+            - string
+      required:
+        - email
+      type: object
+    Profile.jsonld-write_create:
+      deprecated: false
+      description: |-
+        The profile of a person using eCamp.
+        The properties available to related eCamp users are here.
+        Related means that they were or are collaborators in the same camp.
+      properties:
+        email:
+          description: 'Unique email of the user.'
+          example: bi-pi@example.com
+          externalDocs:
+            url: 'https://schema.org/email'
+          format: email
+          maxLength: 64
           type: string
+        firstname:
+          description: "The user's (optional) first name."
+          example: Robert
+          maxLength: 64
+          type:
+            - 'null'
+            - string
+        language:
+          description: 'The optional preferred language of the user, as an ICU language code.'
+          enum:
+            - de
+            - de-CH-scout
+            - en
+            - en-CH-scout
+            - fr
+            - fr-CH-scout
+            - it
+            - it-CH-scout
+          example: en
+          maxLength: 20
+          type:
+            - 'null'
+            - string
+        newEmail:
+          description: 'New email.'
+          example: bi-pi@example.com
+          externalDocs:
+            url: 'https://schema.org/email'
+          format: email
+          type:
+            - 'null'
+            - string
+        nickname:
+          description: "The user's (optional) nickname or scout name."
+          example: Bi-Pi
+          maxLength: 32
+          type:
+            - 'null'
+            - string
+        surname:
+          description: "The user's (optional) last name."
+          example: Baden-Powell
+          maxLength: 64
+          type:
+            - 'null'
+            - string
       required:
         - email
       type: object
@@ -13963,22 +14357,26 @@ components:
       description: ''
       properties:
         email:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: "$id: base64_encode($email . '#' . $resetKey)."
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         password:
           maxLength: 128
           minLength: 12
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
         recaptchaToken:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       type: object
     ResetPassword-create:
@@ -13986,11 +14384,13 @@ components:
       description: ''
       properties:
         email:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         recaptchaToken:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       type: object
     ResetPassword-update:
@@ -14000,12 +14400,14 @@ components:
         password:
           maxLength: 128
           minLength: 12
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
         recaptchaToken:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       type: object
     ResetPassword.jsonhal:
@@ -14022,22 +14424,26 @@ components:
               type: object
           type: object
         email:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: "$id: base64_encode($email . '#' . $resetKey)."
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         password:
           maxLength: 128
           minLength: 12
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
         recaptchaToken:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       type: object
     ResetPassword.jsonhal-create:
@@ -14054,11 +14460,13 @@ components:
               type: object
           type: object
         email:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         recaptchaToken:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       type: object
     ResetPassword.jsonld:
@@ -14089,22 +14497,26 @@ components:
           readOnly: true
           type: string
         email:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: "$id: base64_encode($email . '#' . $resetKey)."
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         password:
           maxLength: 128
           minLength: 12
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
         recaptchaToken:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       type: object
     ResetPassword.jsonld-create:
@@ -14112,11 +14524,13 @@ components:
       description: ''
       properties:
         email:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         recaptchaToken:
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       type: object
     ScheduleEntry-read:
@@ -14131,14 +14545,17 @@ components:
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -14162,8 +14579,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -14176,6 +14594,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -14191,15 +14610,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - end
         - start
@@ -14216,14 +14636,17 @@ components:
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -14248,8 +14671,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -14262,6 +14686,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -14277,15 +14702,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - activity
         - end
@@ -14303,14 +14729,17 @@ components:
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -14335,8 +14764,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -14349,6 +14779,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -14364,15 +14795,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - activity
         - end
@@ -14388,15 +14820,19 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/Activity-read_ScheduleEntry.Activity'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -14421,8 +14857,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -14435,6 +14872,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -14450,15 +14888,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - activity
         - end
@@ -14483,12 +14922,14 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         period:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         start:
           description: 'Start date and time of the schedule entry.'
@@ -14496,15 +14937,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - end
         - start
@@ -14521,6 +14963,7 @@ components:
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         end:
           description: 'End date and time of the schedule entry.'
@@ -14535,12 +14978,14 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         period:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         start:
           description: 'Start date and time of the schedule entry.'
@@ -14548,16 +14993,18 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
+        - activity
         - end
         - start
       type: object
@@ -14582,14 +15029,17 @@ components:
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -14613,8 +15063,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -14627,6 +15078,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -14642,15 +15094,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - end
         - start
@@ -14661,29 +15114,23 @@ components:
         A calendar event in a period of the camp, at which some activity will take place. The start time
         is specified as an offset in minutes from the period's start time.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         activity:
           description: |-
             The activity that will take place at the time defined by this schedule entry. Can not be changed
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -14708,8 +15155,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -14722,6 +15170,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -14737,15 +15186,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - activity
         - end
@@ -14757,29 +15207,23 @@ components:
         A calendar event in a period of the camp, at which some activity will take place. The start time
         is specified as an offset in minutes from the period's start time.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         activity:
           description: |-
             The activity that will take place at the time defined by this schedule entry. Can not be changed
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -14804,8 +15248,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -14818,6 +15263,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -14833,15 +15279,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - activity
         - end
@@ -14866,15 +15313,19 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/Activity.jsonhal-read_ScheduleEntry.Activity'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -14899,8 +15350,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -14913,6 +15365,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -14928,15 +15381,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - activity
         - end
@@ -14963,6 +15417,7 @@ components:
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         end:
           description: 'End date and time of the schedule entry.'
@@ -14977,12 +15432,14 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         period:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         start:
           description: 'Start date and time of the schedule entry.'
@@ -14990,16 +15447,18 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
+        - activity
         - end
         - start
       type: object
@@ -15038,14 +15497,17 @@ components:
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -15069,8 +15531,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -15083,6 +15546,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -15098,15 +15562,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - end
         - start
@@ -15117,43 +15582,23 @@ components:
         A calendar event in a period of the camp, at which some activity will take place. The start time
         is specified as an offset in minutes from the period's start time.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         activity:
           description: |-
             The activity that will take place at the time defined by this schedule entry. Can not be changed
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -15178,8 +15623,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -15192,6 +15638,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -15207,15 +15654,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - activity
         - end
@@ -15227,43 +15675,23 @@ components:
         A calendar event in a period of the camp, at which some activity will take place. The start time
         is specified as an offset in minutes from the period's start time.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         activity:
           description: |-
             The activity that will take place at the time defined by this schedule entry. Can not be changed
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -15288,8 +15716,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -15302,6 +15731,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -15317,15 +15747,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - activity
         - end
@@ -15364,15 +15795,19 @@ components:
           anyOf:
             -
               $ref: '#/components/schemas/Activity.jsonld-read_ScheduleEntry.Activity'
-          nullable: true
+            -
+              type: 'null'
+          'owl:maxCardinality': 1
           readOnly: true
         day:
           description: 'The day on which this schedule entry starts.'
           example: /days/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         dayNumber:
           description: 'The day number of the day on which this schedule entry starts.'
           example: '1'
@@ -15397,8 +15832,9 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         number:
           description: |-
             Uniquely identifies this schedule entry in the period. This uses the day number, followed
@@ -15411,6 +15847,7 @@ components:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         scheduleEntryNumber:
           description: |-
@@ -15426,15 +15863,16 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
         - activity
         - end
@@ -15452,6 +15890,7 @@ components:
             once the schedule entry is created.
           example: /activities/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         end:
           description: 'End date and time of the schedule entry.'
@@ -15466,12 +15905,14 @@ components:
             visible. Should be a decimal number between 0 and 1, and left+width should not exceed 1, but the
             API currently does not enforce this.
           example: 0.6
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
         period:
           description: 'The time period which this schedule entry is part of. Must belong to the same camp as the activity.'
           example: /periods/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         start:
           description: 'Start date and time of the schedule entry.'
@@ -15479,16 +15920,18 @@ components:
           format: date-time
           type: string
         width:
-          default: 1.0
+          default: 1
           description: |-
             When rendering a period in a calendar view: Specifies how wide the rendered calendar event should
             be, as a fractional amount of the width of the whole day. This is useful to arrange multiple
             overlapping schedule entries such that all of them are visible. Should be a decimal number
             between 0 and 1, and left+width should not exceed 1, but the API currently does not enforce this.
           example: 0.4
-          nullable: true
-          type: number
+          type:
+            - 'null'
+            - number
       required:
+        - activity
         - end
         - start
       type: object
@@ -15511,6 +15954,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -15526,8 +15970,9 @@ components:
             html: 'my example text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -15540,8 +15985,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -15549,8 +15995,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -15564,17 +16012,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -15592,6 +16043,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           default: '{"html":""}'
@@ -15602,16 +16054,18 @@ components:
             html: 'my example text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -15619,8 +16073,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -15634,8 +16090,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - data
@@ -15655,16 +16112,18 @@ components:
             html: 'my example text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -15672,8 +16131,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -15687,8 +16148,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - data
         - position
@@ -15721,6 +16183,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -15736,8 +16199,9 @@ components:
             html: 'my example text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -15750,8 +16214,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -15759,8 +16224,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -15774,17 +16241,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -15811,6 +16281,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           default: '{"html":""}'
@@ -15821,16 +16292,18 @@ components:
             html: 'my example text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -15838,8 +16311,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -15853,8 +16328,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - data
@@ -15903,6 +16379,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -15918,8 +16395,9 @@ components:
             html: 'my example text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -15932,8 +16410,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -15941,8 +16420,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -15956,17 +16437,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -15984,6 +16468,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           default: '{"html":""}'
@@ -15994,16 +16479,18 @@ components:
             html: 'my example text'
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -16011,8 +16498,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -16026,8 +16515,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - data
@@ -16053,6 +16543,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -16072,8 +16563,9 @@ components:
                 position: 0
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16086,8 +16578,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -16095,8 +16588,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -16110,17 +16605,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -16137,6 +16635,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           description: |-
@@ -16151,16 +16650,18 @@ components:
                 position: 0
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -16168,8 +16669,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -16183,8 +16686,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - parent
@@ -16207,16 +16711,18 @@ components:
                 position: 0
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -16224,8 +16730,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -16239,8 +16747,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - data
         - position
@@ -16273,6 +16782,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -16292,8 +16802,9 @@ components:
                 position: 0
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16306,8 +16817,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -16315,8 +16827,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -16330,17 +16844,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -16366,6 +16883,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           description: |-
@@ -16380,16 +16898,18 @@ components:
                 position: 0
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -16397,8 +16917,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -16412,8 +16934,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - parent
@@ -16461,6 +16984,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         contentTypeName:
           description: 'The name of the content type of this content node. Read-only, for convenience.'
@@ -16480,8 +17004,9 @@ components:
                 position: 0
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16494,8 +17019,9 @@ components:
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -16503,8 +17029,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -16518,17 +17046,20 @@ components:
             content node is the root.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
+          'owl:maxCardinality': 1
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         slot:
           description: |-
             The name of the slot in the parent in which this content node resides. The valid slot names
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - children
         - contentType
@@ -16545,6 +17076,7 @@ components:
             in a content node. The content type may not be changed once the content node is created.
           example: /content_types/1a2b3c4d
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
         data:
           description: |-
@@ -16559,16 +17091,18 @@ components:
                 position: 0
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - 'null'
         instanceName:
           description: |-
             An optional name for this content node. This is useful when planning e.g. an alternative
             version of the programme suited for bad weather, in addition to the normal version.
           example: Schlechtwetterprogramm
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
         parent:
           description: |-
             The parent to which this content node belongs. Is null in case this content node is the
@@ -16576,8 +17110,10 @@ components:
             as the new parent is in the same camp as the old one.
           example: /content_nodes/1a2b3c4d
           format: iri-reference
-          nullable: true
-          type: string
+          'owl:maxCardinality': 1
+          type:
+            - 'null'
+            - string
         position:
           default: -1
           description: |-
@@ -16591,8 +17127,9 @@ components:
             are defined by the content type of the parent.
           example: '1'
           maxLength: 32
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
       required:
         - contentType
         - parent
@@ -16606,8 +17143,9 @@ components:
       properties:
         activationKey:
           description: 'User-Input for activation.'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       type: object
     User-read:
@@ -16619,9 +17157,10 @@ components:
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16636,6 +17175,7 @@ components:
             nickname: Bi-Pi
             surname: Baden-Powell
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       type: object
     User-read_Camp.Periods_Period.Days_Camp.CampCollaborations_CampCollaboration.User:
@@ -16647,9 +17187,10 @@ components:
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16664,6 +17205,7 @@ components:
             nickname: Bi-Pi
             surname: Baden-Powell
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       type: object
     User-read_CampCollaboration.Camp_CampCollaboration.User:
@@ -16675,9 +17217,10 @@ components:
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16692,6 +17235,7 @@ components:
             nickname: Bi-Pi
             surname: Baden-Powell
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       type: object
     User-read_User.create:
@@ -16703,9 +17247,10 @@ components:
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16714,6 +17259,7 @@ components:
           type: string
         profile:
           $ref: '#/components/schemas/Profile-read_User.create'
+          'owl:maxCardinality': 1
           readOnly: true
       required:
         - profile
@@ -16732,8 +17278,9 @@ components:
           example: learning-by-doing-101
           maxLength: 128
           minLength: 12
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       type: object
     User-write_create:
@@ -16750,22 +17297,24 @@ components:
           example: learning-by-doing-101
           maxLength: 128
           minLength: 12
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
         profile:
+          $ref: '#/components/schemas/Profile-write_create'
           example:
             email: bi-pi@example.com
             firstname: Robert
             language: en
             nickname: Bi-Pi
             surname: Baden-Powell
-          format: iri-reference
-          type: string
+          'owl:maxCardinality': 1
         recaptchaToken:
           description: 'ReCaptchaToken used on Register-View.'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       required:
         - password
@@ -16789,9 +17338,10 @@ components:
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16806,6 +17356,7 @@ components:
             nickname: Bi-Pi
             surname: Baden-Powell
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       type: object
     User.jsonhal-read_Camp.Periods_Period.Days_Camp.CampCollaborations_CampCollaboration.User:
@@ -16814,21 +17365,13 @@ components:
         A person using eCamp.
         The properties available for all other eCamp users are here.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16843,6 +17386,7 @@ components:
             nickname: Bi-Pi
             surname: Baden-Powell
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       type: object
     User.jsonhal-read_CampCollaboration.Camp_CampCollaboration.User:
@@ -16851,21 +17395,13 @@ components:
         A person using eCamp.
         The properties available for all other eCamp users are here.
       properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16880,6 +17416,7 @@ components:
             nickname: Bi-Pi
             surname: Baden-Powell
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       type: object
     User.jsonhal-read_User.create:
@@ -16900,9 +17437,10 @@ components:
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -16911,6 +17449,7 @@ components:
           type: string
         profile:
           $ref: '#/components/schemas/Profile.jsonhal-read_User.create'
+          'owl:maxCardinality': 1
           readOnly: true
       required:
         - profile
@@ -16938,22 +17477,24 @@ components:
           example: learning-by-doing-101
           maxLength: 128
           minLength: 12
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
         profile:
+          $ref: '#/components/schemas/Profile.jsonhal-write_create'
           example:
             email: bi-pi@example.com
             firstname: Robert
             language: en
             nickname: Bi-Pi
             surname: Baden-Powell
-          format: iri-reference
-          type: string
+          'owl:maxCardinality': 1
         recaptchaToken:
           description: 'ReCaptchaToken used on Register-View.'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       required:
         - password
@@ -16991,9 +17532,10 @@ components:
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -17008,6 +17550,7 @@ components:
             nickname: Bi-Pi
             surname: Baden-Powell
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       type: object
     User.jsonld-read_Camp.Periods_Period.Days_Camp.CampCollaborations_CampCollaboration.User:
@@ -17016,35 +17559,13 @@ components:
         A person using eCamp.
         The properties available for all other eCamp users are here.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -17059,6 +17580,7 @@ components:
             nickname: Bi-Pi
             surname: Baden-Powell
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       type: object
     User.jsonld-read_CampCollaboration.Camp_CampCollaboration.User:
@@ -17067,35 +17589,13 @@ components:
         A person using eCamp.
         The properties available for all other eCamp users are here.
       properties:
-        '@context':
-          oneOf:
-            -
-              additionalProperties: true
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-                  type: string
-              required:
-                - '@vocab'
-                - hydra
-              type: object
-            -
-              type: string
-          readOnly: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -17110,6 +17610,7 @@ components:
             nickname: Bi-Pi
             surname: Baden-Powell
           format: iri-reference
+          'owl:maxCardinality': 1
           type: string
       type: object
     User.jsonld-read_User.create:
@@ -17144,9 +17645,10 @@ components:
         displayName:
           description: 'A displayable name of the user.'
           example: 'Robert Baden-Powell'
-          nullable: true
           readOnly: true
-          type: string
+          type:
+            - 'null'
+            - string
         id:
           description: 'An internal, unique, randomly generated identifier of this entity.'
           example: 1a2b3c4d
@@ -17155,6 +17657,7 @@ components:
           type: string
         profile:
           $ref: '#/components/schemas/Profile.jsonld-read_User.create'
+          'owl:maxCardinality': 1
           readOnly: true
       required:
         - profile
@@ -17173,22 +17676,24 @@ components:
           example: learning-by-doing-101
           maxLength: 128
           minLength: 12
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
         profile:
+          $ref: '#/components/schemas/Profile.jsonld-write_create'
           example:
             email: bi-pi@example.com
             firstname: Robert
             language: en
             nickname: Bi-Pi
             surname: Baden-Powell
-          format: iri-reference
-          type: string
+          'owl:maxCardinality': 1
         recaptchaToken:
           description: 'ReCaptchaToken used on Register-View.'
-          nullable: true
-          type: string
+          type:
+            - 'null'
+            - string
           writeOnly: true
       required:
         - password
@@ -17199,7 +17704,7 @@ info:
   description: ''
   title: 'eCamp v3'
   version: 1.0.0
-openapi: 3.0.0
+openapi: 3.1.0
 paths:
   /activities:
     get:
@@ -17256,7 +17761,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/Activity.jsonld-read_Activity.ActivityProgressLabel_Activity.ActivityResponsibles_Activity.ScheduleEntries' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -17507,7 +18012,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/ActivityProgressLabel.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -17784,7 +18289,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/ActivityResponsible.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -18284,7 +18789,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/CampCollaboration.jsonld-read_CampCollaboration.Camp_CampCollaboration.User' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -18593,7 +19098,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/Camp.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -18844,7 +19349,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/Category.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -19133,7 +19638,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/ColumnLayout.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -19422,7 +19927,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/MaterialNode.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -19711,7 +20216,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/MultiSelect.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -20000,7 +20505,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/SingleText.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -20289,7 +20794,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/Storyboard.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -20578,7 +21083,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/ContentNode.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -20654,7 +21159,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/ContentType.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -20799,7 +21304,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/DayResponsible.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -20994,7 +21499,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/Day.jsonld-read_Day.DayResponsibles' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -21087,7 +21592,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/Invitation.jsonld' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -21360,7 +21865,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/MaterialItem.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -21611,7 +22116,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/MaterialList.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -21862,7 +22367,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/Period.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -22113,7 +22618,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/Profile.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -22410,7 +22915,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/ScheduleEntry.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:
@@ -22635,7 +23140,7 @@ paths:
               schema:
                 properties:
                   'hydra:member': { items: { $ref: '#/components/schemas/User.jsonld-read' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { nullable: true, type: string }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
                   'hydra:totalItems': { minimum: 0, type: integer }
                   'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
                 required:

--- a/api/tests/Doctrine/Filter/ContentNodePeriodFilterTest.php
+++ b/api/tests/Doctrine/Filter/ContentNodePeriodFilterTest.php
@@ -2,8 +2,8 @@
 
 namespace App\Tests\Doctrine\Filter;
 
-use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use App\Doctrine\Filter\ContentNodePeriodFilter;
 use App\Entity\ContentNode;
 use App\Entity\Period;

--- a/api/tests/Doctrine/Filter/MaterialItemPeriodFilterTest.php
+++ b/api/tests/Doctrine/Filter/MaterialItemPeriodFilterTest.php
@@ -2,8 +2,8 @@
 
 namespace App\Tests\Doctrine\Filter;
 
-use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use App\Doctrine\Filter\MaterialItemPeriodFilter;
 use App\Entity\MaterialItem;
 use App\Entity\Period;

--- a/api/tests/EventListener/JWTCreatedListenerTest.php
+++ b/api/tests/EventListener/JWTCreatedListenerTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests\EventListener;
 
-use ApiPlatform\Api\IriConverterInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use App\Entity\User;
 use App\EventListener\JWTCreatedListener;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;

--- a/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
+++ b/api/tests/Integration/Serializer/Normalizer/TranslationConstraintViolationListNormalizerIntegrationTest.php
@@ -2,8 +2,8 @@
 
 namespace App\Tests\Integration\Serializer\Normalizer;
 
+use ApiPlatform\Hal\Serializer\ConstraintViolationListNormalizer as HalConstraintViolationListNormalizer;
 use ApiPlatform\Hydra\Serializer\ConstraintViolationListNormalizer as HydraConstraintViolationListNormalizer;
-use ApiPlatform\Problem\Serializer\ConstraintViolationListNormalizer as JsonProblemConstraintViolationListNormalizer;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestAssertionsTrait;
 use App\Entity\CampCollaboration;
 use App\Serializer\Normalizer\TranslationConstraintViolationListNormalizer;
@@ -51,7 +51,7 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
             []
         );
 
-        self::assertArraySubset(['violations' => [
+        self::assertArraySubset([
             [
                 'i18n' => [
                     'key' => 'app.validator.allowtransition.assertallowtransitions',
@@ -81,7 +81,7 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
                     'parameters' => [],
                 ],
             ],
-        ]], $result);
+        ], $result);
     }
 
     /**
@@ -99,7 +99,7 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
             []
         );
 
-        self::assertArraySubset(['violations' => [
+        self::assertArraySubset([
             [
                 'i18n' => [
                     'translations' => [
@@ -144,12 +144,12 @@ class TranslationConstraintViolationListNormalizerIntegrationTest extends Kernel
                     ],
                 ],
             ],
-        ]], $result);
+        ], $result);
     }
 
     public static function getFormats() {
         $hydra = HydraConstraintViolationListNormalizer::FORMAT;
-        $problem = JsonProblemConstraintViolationListNormalizer::FORMAT;
+        $problem = HalConstraintViolationListNormalizer::FORMAT;
 
         return [
             $hydra => [$hydra],

--- a/api/tests/Metadata/Resource/Factory/UriTemplateFactoryTest.php
+++ b/api/tests/Metadata/Resource/Factory/UriTemplateFactoryTest.php
@@ -3,10 +3,10 @@
 namespace App\Tests\Metadata\Resource\Factory;
 
 use ApiPlatform\Api\FilterInterface;
-use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;

--- a/api/tests/Serializer/Normalizer/CircularReferenceDetectingHalItemNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/CircularReferenceDetectingHalItemNormalizerTest.php
@@ -2,10 +2,10 @@
 
 namespace App\Tests\Serializer\Normalizer;
 
-use ApiPlatform\Api\IriConverterInterface;
-use ApiPlatform\Api\ResourceClassResolverInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use App\Serializer\Normalizer\CircularReferenceDetectingHalItemNormalizer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/api/tests/Serializer/Normalizer/ContentTypeNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/ContentTypeNormalizerTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests\Serializer\Normalizer;
 
-use ApiPlatform\Api\IriConverterInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use App\Entity\ContentType;
 use App\Metadata\Resource\Factory\UriTemplateFactory;
 use App\Serializer\Normalizer\ContentTypeNormalizer;

--- a/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
@@ -3,12 +3,12 @@
 namespace App\Tests\Serializer\Normalizer;
 
 use ApiPlatform\Api\FilterInterface;
-use ApiPlatform\Api\IriConverterInterface;
 use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
@@ -47,6 +47,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
     private ManagerRegistry|MockObject $managerRegistryMock;
     private MockObject|ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactoryMock;
     private MockObject|PropertyAccessorInterface $propertyAccessor;
+    private MockObject|EntityManagerInterface $entityManager;
 
     private ?FilterInterface $filterInstance;
 
@@ -68,6 +69,8 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
 
         $this->iriConverterMock->method('getIriFromResource')->willReturn('/iri');
 
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
         $this->normalizer = new RelatedCollectionLinkNormalizer(
             $this->decoratedMock,
             $this->filterLocatorMock,
@@ -76,7 +79,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
             $this->uriTemplateFactory,
             $this->routerMock,
             $this->iriConverterMock,
-            $this->managerRegistryMock,
+            $this->entityManager,
             $this->resourceMetadataCollectionFactoryMock,
             $this->propertyAccessor,
         );
@@ -321,9 +324,8 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
 
         $classMetadata = $this->createMock(ORM\ClassMetadata::class);
         $classMetadata->method('getAssociationMapping')->willThrowException(new ORM\MappingException('test exception'));
-        $manager = $this->createMock(EntityManagerInterface::class);
-        $manager->method('getClassMetadata')->willReturn($classMetadata);
-        $this->managerRegistryMock->method('getManagerForClass')->willReturn($manager);
+        $this->entityManager->method('getClassMetadata')->willReturn($classMetadata);
+        $this->managerRegistryMock->method('getManagerForClass')->willReturn($this->entityManager);
 
         $this->mockRelatedResourceMetadata(['filters' => ['attribute_filter_something_something']]);
         $this->mockRelatedFilterDescription(['parent' => ['strategy' => 'exact']]);
@@ -425,10 +427,8 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $classMetadata->method('getAssociationMapping')->willReturn($relationMetadata);
         $classMetadata->method('hasAssociation')->willReturn(true);
 
-        $manager = $this->createMock(EntityManagerInterface::class);
-        $manager->method('getClassMetadata')->willReturn($classMetadata);
-
-        $this->managerRegistryMock->method('getManagerForClass')->willReturn($manager);
+        $this->entityManager->method('getClassMetadata')->willReturn($classMetadata);
+        $this->managerRegistryMock->method('getManagerForClass')->willReturn($this->entityManager);
     }
 
     protected function mockRelatedResourceMetadata($collectionOperationMetadata) {

--- a/api/tests/Serializer/PreventAutomaticEmbeddingPropertyMetadataFactoryTest.php
+++ b/api/tests/Serializer/PreventAutomaticEmbeddingPropertyMetadataFactoryTest.php
@@ -39,6 +39,7 @@ class PreventAutomaticEmbeddingPropertyMetadataFactoryTest extends TestCase {
             true,
             [],
             true,
+            '',
             []
         );
         $decorated->expects($this->once())


### PR DESCRIPTION
Fixes #3933
update api-plattform-allow-null-links.patch because of whitespace changes: create a file ...._old.php with the repository version of the file

then: git diff --no-index api/vendor/api-platform/core/src/Hal/Serializer/ItemNormalizer_old.php api/vendor/api-platform/core/src/Hal/Serializer/ItemNormalizer.php

Add docs_formats because this must now be configured separately to enable hal.
Do not support json as docs format, because this renders an error. (It returns a 200 response, but the returned json contains a stacktrace).