### PR TITLE
Category layout editing should be full width

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -483,6 +483,7 @@ function getContentLayout(route) {
   switch (route.name) {
     case 'camp/period/program':
     case 'admin/print':
+    case 'admin/activity/category':
       return 'full'
     case 'camp/print':
     case 'camp/material':


### PR DESCRIPTION
Before:
![Screenshot from 2023-10-21 15-00-41](https://github.com/ecamp/ecamp3/assets/7566995/a5e69547-f4bf-4316-8f8e-8904ed2fc04f)

After:
![Screenshot from 2023-10-21 15-01-03](https://github.com/ecamp/ecamp3/assets/7566995/7de205df-59ff-4e4c-a3a9-46b3acfc2202)
