### PR TITLE
frontend: fix mobile view of materialLists

### DIFF
--- a/frontend/src/components/material/MaterialLists.vue
+++ b/frontend/src/components/material/MaterialLists.vue
@@ -1,6 +1,6 @@
 <template>
   <v-list>
-    <v-list-item :to="materialListRoute(camp(), false, { isDetail: true })" exact-path>
+    <v-list-item :to="materialListRoute(camp(), '/all', { isDetail: true })" exact-path>
       <v-list-item-content>
         {{ $tc('components.material.materialLists.overview') }}
       </v-list-item-content>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -429,6 +429,9 @@
       "activity": {
         "title": "Aktivitätseinstellungen"
       },
+      "adminMaterialLists": {
+        "title": "Materiallisten"
+      },
       "collaborators": {
         "email": "E-Mail-Adresse",
         "inactiveCollaborators": "Inaktiv",
@@ -438,9 +441,6 @@
       },
       "info": {
         "title": "Lagerinfos"
-      },
-      "materialLists": {
-        "title": "Materiallisten"
       },
       "print": {
         "title": "Lager drucken"
@@ -604,6 +604,9 @@
       "title": "Meine Lager"
     },
     "material": {
+      "materialLists": {
+        "title": "Materiallisten"
+      },
       "materialOverview": {
         "createNewList": "Materialliste erstellen",
         "download": "Übersicht herunterladen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -429,6 +429,9 @@
       "activity": {
         "title": "Activity settings"
       },
+      "adminMaterialLists": {
+        "title": "Material lists"
+      },
       "collaborators": {
         "email": "Email address",
         "inactiveCollaborators": "Inactive",
@@ -438,9 +441,6 @@
       },
       "info": {
         "title": "Camp infos"
-      },
-      "materialLists": {
-        "title": "Material lists"
       },
       "print": {
         "title": "Print camp"
@@ -604,6 +604,9 @@
       "title": "My Camps"
     },
     "material": {
+      "materialLists": {
+        "title": "Material lists"
+      },
       "materialOverview": {
         "createNewList": "Create material list",
         "download": "Download overview",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -429,6 +429,9 @@
       "activity": {
         "title": "Paramètres d'activité"
       },
+      "adminMaterialLists": {
+        "title": "Liste de matériel"
+      },
       "collaborators": {
         "email": "Adresse e-mail",
         "inactiveCollaborators": "Inactif",
@@ -438,9 +441,6 @@
       },
       "info": {
         "title": "Infos sur le camp"
-      },
-      "materialLists": {
-        "title": "Liste de matériel"
       },
       "print": {
         "title": "Imprimer un camp"
@@ -604,6 +604,9 @@
       "title": "Mes camps"
     },
     "material": {
+      "materialLists": {
+        "title": "Liste de matériel"
+      },
       "materialOverview": {
         "createNewList": "Créer une liste de matériel",
         "download": "Télécharger l'aperçu",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -429,6 +429,9 @@
       "activity": {
         "title": "Impostazioni dell'attività"
       },
+      "adminMaterialLists": {
+        "title": "Liste di materiali"
+      },
       "collaborators": {
         "email": "Indirizzo e-mail",
         "inactiveCollaborators": "Inattivo",
@@ -438,9 +441,6 @@
       },
       "info": {
         "title": "Info sul campo"
-      },
-      "materialLists": {
-        "title": "Liste di materiali"
       },
       "print": {
         "title": "Stampa il campo"
@@ -604,6 +604,9 @@
       "title": "I miei campi"
     },
     "material": {
+      "materialLists": {
+        "title": "Liste di materiali"
+      },
       "materialOverview": {
         "createNewList": "Creare un elenco di materiali",
         "download": "Scarica la panoramica",

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -263,7 +263,7 @@ export default new Router({
       },
     },
     {
-      name: 'material/lists',
+      name: 'material/lists', // Only used on mobile
       path: '/camps/:campId/:campTitle?/material/lists',
       components: {
         navigation: NavigationCamp,

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -246,7 +246,7 @@ export default new Router({
       ],
     },
     {
-      name: 'material/overview',
+      name: 'material/all',
       path: '/camps/:campId/:campTitle?/material/all',
       components: {
         navigation: NavigationCamp,
@@ -257,6 +257,21 @@ export default new Router({
       props: {
         navigation: (route) => ({ camp: campFromRoute(route) }),
         aside: (route) => ({ camp: campFromRoute(route) }),
+        default: (route) => ({
+          camp: campFromRoute(route),
+        }),
+      },
+    },
+    {
+      name: 'material/lists',
+      path: '/camps/:campId/:campTitle?/material/lists',
+      components: {
+        navigation: NavigationCamp,
+        default: () => import('./views/material/MaterialLists.vue'),
+      },
+      beforeEnter: all([requireAuth, requireCamp]),
+      props: {
+        navigation: (route) => ({ camp: campFromRoute(route) }),
         default: (route) => ({
           camp: campFromRoute(route),
         }),
@@ -324,7 +339,7 @@ export default new Router({
         {
           path: 'material',
           name: 'admin/material',
-          component: () => import('./views/admin/MaterialLists.vue'),
+          component: () => import('./views/admin/AdminMaterialLists.vue'),
         },
         {
           path: 'print',
@@ -518,25 +533,26 @@ export function campRoute(camp, subroute = 'dashboard', query = {}) {
 
 /**
  * @param camp
- * @param materialList
+ * @param materialListOrRoute { '/all', '/lists', object }
  * @param query
  */
-export function materialListRoute(camp, materialList = false, query = {}) {
-  if (materialList === false) {
+export function materialListRoute(camp, materialListOrRoute = '/all', query = {}) {
+  if (camp._meta.loading) return {}
+  if (typeof materialListOrRoute === 'string') {
     return {
-      name: 'material/overview',
+      name: `material${materialListOrRoute}`,
       params: { campId: camp.id, campTitle: slugify(camp.title) },
       query,
     }
   }
-  if (!materialList?._meta || materialList.meta?.loading) return {}
+  if (!materialListOrRoute?._meta || materialListOrRoute.meta?.loading) return {}
   return {
     name: 'material/detail',
     params: {
       campId: camp.id,
       campTitle: slugify(camp.title),
-      materialId: materialList.id,
-      materialName: slugify(materialList.name),
+      materialId: materialListOrRoute.id,
+      materialName: slugify(materialListOrRoute.name),
     },
     query,
   }

--- a/frontend/src/views/admin/AdminMaterialLists.vue
+++ b/frontend/src/views/admin/AdminMaterialLists.vue
@@ -3,7 +3,7 @@ Show all material lists for a camp on mobile
 -->
 
 <template>
-  <content-card :title="$tc('views.admin.materialLists.title')" toolbar>
+  <content-card :title="$tc('views.admin.adminMaterialLists.title')" toolbar>
     <template v-if="!isGuest" #title-actions>
       <DialogMaterialListCreate :camp="camp()">
         <template #activator="{ on }">

--- a/frontend/src/views/camp/navigation/mobile/NavBottombar.vue
+++ b/frontend/src/views/camp/navigation/mobile/NavBottombar.vue
@@ -12,7 +12,7 @@
       <span>{{ camp().name }}</span>
       <v-icon large>mdi-tent</v-icon>
     </v-btn>
-    <v-btn :to="campRoute(camp(), 'material')">
+    <v-btn :to="materialListRoute(camp(), '/lists')">
       <span>{{ $tc('views.camp.navigation.mobile.navBottombar.material') }}</span>
       <v-icon>mdi-package-variant</v-icon>
     </v-btn>
@@ -24,7 +24,7 @@
 </template>
 
 <script>
-import { campRoute } from '@/router'
+import { campRoute, materialListRoute } from '@/router'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -43,6 +43,7 @@ export default {
     }),
   },
   methods: {
+    materialListRoute,
     campRoute,
   },
 }

--- a/frontend/src/views/material/MaterialLists.vue
+++ b/frontend/src/views/material/MaterialLists.vue
@@ -1,0 +1,50 @@
+<!--
+Show all material lists for a camp on mobile
+-->
+
+<template>
+  <content-card :title="$tc('views.material.materialLists.title')" toolbar>
+    <template v-if="!isGuest" #title-actions>
+      <DialogMaterialListCreate :camp="camp()">
+        <template #activator="{ on }">
+          <ButtonAdd class="mr-n2" height="32" v-on="on"
+            >{{ $tc('global.button.create') }}
+          </ButtonAdd>
+        </template>
+      </DialogMaterialListCreate>
+    </template>
+    <MaterialLists :camp="camp" />
+  </content-card>
+</template>
+
+<script>
+import ContentCard from '@/components/layout/ContentCard.vue'
+import { campRoleMixin } from '@/mixins/campRoleMixin'
+import ButtonAdd from '@/components/buttons/ButtonAdd.vue'
+import DialogMaterialListCreate from '@/components/campAdmin/DialogMaterialListCreate.vue'
+import MaterialLists from '@/components/material/MaterialLists.vue'
+
+export default {
+  name: 'MaterialLists',
+  components: {
+    MaterialLists,
+    DialogMaterialListCreate,
+    ButtonAdd,
+    ContentCard,
+  },
+  mixins: [campRoleMixin],
+  props: {
+    camp: { type: Function, required: true },
+  },
+  computed: {
+    materialLists() {
+      return this.camp().materialLists()
+    },
+  },
+  mounted() {
+    this.materialLists.$loadItems()
+  },
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
Fixes #3899
Navigate to the list of materiallists in the NavBottombar. Add new view for the list of materiallists
to navigate to the details of one materiallist.
Rename the views/admin/(,Admin)MaterialLists component to avoid name clash with the new component.
Add quick way to differentiate the target routes in the materialListRoute helper for the NavBottombar and NavTopbar.
May have been introduced in #3841.

Also add guard if camp is not loaded to materialListRoute.