### PR TITLE
Add the possibility to set the login text key in dev and feature branch deployments

### DIFF
--- a/.github/workflows/reusable-dev-deployment.yml
+++ b/.github/workflows/reusable-dev-deployment.yml
@@ -125,6 +125,7 @@ jobs:
             --set deployedVersion="$(git rev-parse --short '${{ inputs.sha }}')" \
             --set recaptcha.siteKey='${{ secrets.RECAPTCHA_SITE_KEY }}' \
             --set recaptcha.secret='${{ secrets.RECAPTCHA_SECRET }}' \
+            --set frontend.loginInfoTextKey=${{ vars.LOGIN_INFO_TEXT_KEY }} \
             --set featureToggle.developer=true
 
       - name: Finish the GitHub deployment


### PR DESCRIPTION
Previously "dev" was the default for this value, but we changed it to "prod" for the go live. Dev and feature branch deployments haven't had the need to specify this value, but now they do.