### PR TITLE
Implement paper and widescreen display size for activity

### DIFF
--- a/frontend/src/assets/icons/BigScreen.svg
+++ b/frontend/src/assets/icons/BigScreen.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 28 24">
+	<path fill="currentColor" d="M25 2H3a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h9v2h-2v2h8v-2h-2v-2h9a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2Zm0 14H3V4h22v12Z"/>
+	<path fill="currentColor" d="M9 12.8 6.4 10 9 7.2 7.8 6 4 10l3.8 4L9 12.8Zm10-5.6 2.6 2.8-2.6 2.8 1.2 1.2 3.8-4-3.8-4L19 7.2Z"/>
+</svg>

--- a/frontend/src/assets/icons/PaperSize.svg
+++ b/frontend/src/assets/icons/PaperSize.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 28 24">
+	<path fill="currentColor" d="M27 14.8 24.4 12 27 9.2 25.8 8 22 12l3.8 4 1.2-1.2ZM15 2H9a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8l-6-6Zm4 18H9V4h5v5h5v11ZM1 9.2 3.6 12 1 14.8 2.2 16 6 12 2.2 8 1 9.2Z"/>
+</svg>

--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -93,12 +93,32 @@ Displays a single scheduleEntry
         <template v-else>{{ $tc('global.button.back') }}</template>
       </v-btn>
 
-      <v-btn text icon class="d-none d-md-block" @click="toggleDisplaySize">
-        <v-icon v-if="isPaperDisplaySize" class="resize-icon"
-          >$vuetify.icons.bigScreen</v-icon
-        >
-        <v-icon v-else class="resize-icon">$vuetify.icons.paperSize</v-icon>
-      </v-btn>
+      <v-tooltip bottom>
+        <template #activator="{ on }">
+          <v-btn
+            text
+            icon
+            class="d-none d-md-block"
+            :aria-label="
+              isPaperDisplaySize
+                ? $tc('components.activity.scheduleEntry.switchToFullSize')
+                : $tc('components.activity.scheduleEntry.switchToPaperSize')
+            "
+            @click="toggleDisplaySize"
+            v-on="on"
+          >
+            <v-icon v-if="isPaperDisplaySize" class="resize-icon"
+              >$vuetify.icons.bigScreen</v-icon
+            >
+            <v-icon v-else class="resize-icon">$vuetify.icons.paperSize</v-icon>
+          </v-btn>
+        </template>
+        {{
+          isPaperDisplaySize
+            ? $tc('components.activity.scheduleEntry.switchToFullSize')
+            : $tc('components.activity.scheduleEntry.switchToPaperSize')
+        }}
+      </v-tooltip>
       <!-- hamburger menu -->
       <v-menu v-if="!layoutMode" offset-y>
         <template #activator="{ on, attrs }">

--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -93,7 +93,7 @@ Displays a single scheduleEntry
         <template v-else>{{ $tc('global.button.back') }}</template>
       </v-btn>
 
-      <v-btn text icon class="d-hidden d-md-block" @click="togglePaperSize">
+      <v-btn text icon class="d-none d-md-block" @click="togglePaperSize">
         <v-icon v-if="displaySize === 'paper'" class="resize-icon"
           >$vuetify.icons.bigScreen</v-icon
         >

--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -8,7 +8,7 @@ Displays a single scheduleEntry
     toolbar
     back
     :loaded="!scheduleEntry()._meta.loading && !activity.camp()._meta.loading"
-    :max-width="displaySize === 'paper' ? '25cm' : ''"
+    :max-width="isPaperDisplaySize ? '944px' : ''"
   >
     <template #title>
       <v-toolbar-title class="font-weight-bold">
@@ -93,13 +93,11 @@ Displays a single scheduleEntry
         <template v-else>{{ $tc('global.button.back') }}</template>
       </v-btn>
 
-      <v-btn text icon class="d-none d-md-block" @click="togglePaperSize">
-        <v-icon v-if="displaySize === 'paper'" class="resize-icon"
+      <v-btn text icon class="d-none d-md-block" @click="toggleDisplaySize">
+        <v-icon v-if="isPaperDisplaySize" class="resize-icon"
           >$vuetify.icons.bigScreen</v-icon
         >
-        <v-icon v-else-if="displaySize === 'widescreen'" class="resize-icon"
-          >$vuetify.icons.paperSize</v-icon
-        >
+        <v-icon v-else class="resize-icon">$vuetify.icons.paperSize</v-icon>
       </v-btn>
       <!-- hamburger menu -->
       <v-menu v-if="!layoutMode" offset-y>
@@ -278,7 +276,7 @@ export default {
       editActivityTitle: false,
       categoryChangeState: null,
       loading: true,
-      displaySize: 'paper',
+      isPaperDisplaySize: true,
     }
   },
   computed: {
@@ -327,10 +325,8 @@ export default {
 
   // reload data every time user navigates to Activity view
   async mounted() {
-    const localDisplaySize = localStorage.getItem('activityDisplaySize')
-    this.displaySize = ['paper', 'widescreen'].includes(localDisplaySize)
-      ? localDisplaySize
-      : 'paper'
+    this.isPaperDisplaySize =
+      localStorage.getItem('activityIsPaperDisplaySize') !== 'false'
     this.loading = true
     await this.scheduleEntry().activity()._meta.load // wait if activity is being loaded as part of a collection
     this.loading = false
@@ -367,9 +363,9 @@ export default {
       // redirect to Picasso
       this.$router.push(periodRoute(this.scheduleEntry().period()))
     },
-    togglePaperSize() {
-      this.displaySize = this.displaySize === 'paper' ? 'widescreen' : 'paper'
-      localStorage.setItem('activityDisplaySize', this.displaySize)
+    toggleDisplaySize() {
+      this.isPaperDisplaySize = !this.isPaperDisplaySize
+      localStorage.setItem('activityIsPaperDisplaySize', this.isPaperDisplaySize)
     },
   },
 }

--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -4,9 +4,11 @@ Displays a single scheduleEntry
 
 <template>
   <content-card
+    class="ec-schedule-entry"
     toolbar
     back
     :loaded="!scheduleEntry()._meta.loading && !activity.camp()._meta.loading"
+    :max-width="displaySize === 'paper' ? '25cm' : ''"
   >
     <template #title>
       <v-toolbar-title class="font-weight-bold">
@@ -91,6 +93,14 @@ Displays a single scheduleEntry
         <template v-else>{{ $tc('global.button.back') }}</template>
       </v-btn>
 
+      <v-btn text icon class="d-hidden d-md-block" @click="togglePaperSize">
+        <v-icon v-if="displaySize === 'paper'" class="resize-icon"
+          >$vuetify.icons.bigScreen</v-icon
+        >
+        <v-icon v-else-if="displaySize === 'widescreen'" class="resize-icon"
+          >$vuetify.icons.paperSize</v-icon
+        >
+      </v-btn>
       <!-- hamburger menu -->
       <v-menu v-if="!layoutMode" offset-y>
         <template #activator="{ on, attrs }">
@@ -268,6 +278,7 @@ export default {
       editActivityTitle: false,
       categoryChangeState: null,
       loading: true,
+      displaySize: 'paper',
     }
   },
   computed: {
@@ -316,6 +327,10 @@ export default {
 
   // reload data every time user navigates to Activity view
   async mounted() {
+    const localDisplaySize = localStorage.getItem('activityDisplaySize')
+    this.displaySize = ['paper', 'widescreen'].includes(localDisplaySize)
+      ? localDisplaySize
+      : 'paper'
     this.loading = true
     await this.scheduleEntry().activity()._meta.load // wait if activity is being loaded as part of a collection
     this.loading = false
@@ -352,6 +367,10 @@ export default {
       // redirect to Picasso
       this.$router.push(periodRoute(this.scheduleEntry().period()))
     },
+    togglePaperSize() {
+      this.displaySize = this.displaySize === 'paper' ? 'widescreen' : 'paper'
+      localStorage.setItem('activityDisplaySize', this.displaySize)
+    },
   },
 }
 </script>
@@ -365,5 +384,14 @@ export default {
 
 .e-category-chip-save-icon {
   font-size: 18px;
+}
+
+.ec-schedule-entry {
+  transition: max-width 0.7s ease;
+}
+
+.resize-icon,
+.resize-icon ::v-deep svg {
+  width: 28px !important;
 }
 </style>

--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -391,7 +391,7 @@ export default {
 }
 
 .resize-icon,
-.resize-icon ::v-deep svg {
+.resize-icon :deep(svg) {
   width: 28px !important;
 }
 </style>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -23,7 +23,9 @@
       "scheduleEntry": {
         "backToContents": "Zurück zum Bearbeiten des Inhalts",
         "changeLayout": "Layout ändern",
-        "deleteWarning": "Möchtest du diese Aktivität wirklich löschen? Der komplette Inhalt dieser Aktivität wird gelöscht."
+        "deleteWarning": "Möchtest du diese Aktivität wirklich löschen? Der komplette Inhalt dieser Aktivität wird gelöscht.",
+        "switchToFullSize": "Zum Breitformat umschalten",
+        "switchToPaperSize": "Zum Papierformat umschalten"
       }
     },
     "camp": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -23,7 +23,9 @@
       "scheduleEntry": {
         "backToContents": "Back to editing content",
         "changeLayout": "Change layout",
-        "deleteWarning": "Do you really want to delete this activity? All content of this activity will be removed."
+        "deleteWarning": "Do you really want to delete this activity? All content of this activity will be removed.",
+        "switchToFullSize": "Switch to full size",
+        "switchToPaperSize": "Switch to paper size"
       }
     },
     "camp": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -23,7 +23,9 @@
       "scheduleEntry": {
         "backToContents": "Retour à l'édition du contenu",
         "changeLayout": "Changer la mise en page",
-        "deleteWarning": "Veux-tu vraiment supprimer cette activité ? Tout le contenu de cette activité sera supprimé."
+        "deleteWarning": "Veux-tu vraiment supprimer cette activité ? Tout le contenu de cette activité sera supprimé.",
+        "switchToFullSize": "Passer au format large",
+        "switchToPaperSize": "Passer au format papier"
       }
     },
     "camp": {

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -23,7 +23,9 @@
       "scheduleEntry": {
         "backToContents": "Torna alla modifica dei contenuti",
         "changeLayout": "Cambia il layout",
-        "deleteWarning": "Vuoi davvero cancellare questa attività? Tutti i contenuti di questa attività saranno rimossi."
+        "deleteWarning": "Vuoi davvero cancellare questa attività? Tutti i contenuti di questa attività saranno rimossi.",
+        "switchToFullSize": "Passare al formato largo",
+        "switchToPaperSize": "Passare al formato carta"
       }
     },
     "camp": {

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -8,6 +8,8 @@ import eCampLogo from '@/assets/eCampLogo.svg'
 import CeviLogo from '@/assets/CeviLogo.svg'
 import JublaLogo from '@/assets/JublaLogo.svg'
 import TentDay from '@/assets/tents/TentDay.svg'
+import PaperSize from '@/assets/icons/PaperSize.svg'
+import BigScreen from '@/assets/icons/BigScreen.svg'
 import i18n from '@/plugins/i18n'
 import colors from 'vuetify/lib/util/colors'
 
@@ -27,6 +29,8 @@ class VuetifyLoaderPlugin {
           cevi: { component: CeviLogo },
           jubla: { component: JublaLogo },
           tentDay: { component: TentDay },
+          paperSize: { component: PaperSize },
+          bigScreen: { component: BigScreen },
         },
       },
       theme: {


### PR DESCRIPTION
With this feature it could suggest how the layout looks like in print. The value is stored in the localStorage.

![Bildschirmfoto 2023-10-24 um 20 56 52](https://github.com/ecamp/ecamp3/assets/3001985/90f06b1e-24e0-4942-a463-c2f0fe0d4060)
![Bildschirmfoto 2023-10-24 um 20 56 57](https://github.com/ecamp/ecamp3/assets/3001985/e5928fe3-8073-4fbe-8423-d196ce79b8be)
