### PR TITLE
frontend: pin remaining dependency eslint-plugin-local-rules in packge.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -86,7 +86,7 @@
         "eslint": "8.53.0",
         "eslint-config-prettier": "9.0.0",
         "eslint-plugin-import": "2.29.0",
-        "eslint-plugin-local-rules": "^2.0.0",
+        "eslint-plugin-local-rules": "2.0.0",
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "5.0.1",
         "eslint-plugin-promise": "6.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,7 +99,7 @@
     "eslint": "8.53.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-import": "2.29.0",
-    "eslint-plugin-local-rules": "^2.0.0",
+    "eslint-plugin-local-rules": "2.0.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "5.0.1",
     "eslint-plugin-promise": "6.1.1",


### PR DESCRIPTION


That the updates don't get hidden in general lock file maintenance PR's.