### PR TITLE
Remove empty GetCollection entry from HTML serialization without removing hal endpoint

### DIFF
--- a/api/src/DTO/Invitation.php
+++ b/api/src/DTO/Invitation.php
@@ -48,6 +48,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         new GetCollection(
             provider: InvitationProvider::class,
             security: 'false',
+            openapi: false,
             openapiContext: ['description' => 'Not implemented. Only needed that we can show this endpoint in /index.jsonhal.']
         ),
     ],

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
@@ -10486,40 +10486,6 @@ components:
         - campCollaboration
         - day
       type: object
-    Invitation:
-      deprecated: false
-      description: |-
-        An invitation for a person to collaborate in a camp. The person may or may not
-        already have an account.
-      properties:
-        campId:
-          description: |-
-            The id of the camp for which this invitation is valid. This is useful for
-            redirecting the user to the correct place after they accept.
-          example: 1a2b3c4d
-          type: string
-        campTitle:
-          description: |-
-            The full title of the camp for which this invitation is valid. This should help
-            the user to decide whether to accept or reject the invitation.
-          example: 'Abteilungs-Sommerlager 2022'
-          type: string
-        userAlreadyInCamp:
-          description: |-
-            Indicates whether the logged in user is already collaborating in the camp, and
-            can therefore not accept the invitation.
-          type:
-            - boolean
-            - 'null'
-        userDisplayName:
-          description: |-
-            The display name of the user that is invited. May be null in case the user does
-            not already have an account.
-          example: 'Robert Baden-Powell'
-          type:
-            - 'null'
-            - string
-      type: object
     Invitation-read:
       deprecated: false
       description: |-
@@ -10560,49 +10526,6 @@ components:
         An invitation for a person to collaborate in a camp. The person may or may not
         already have an account.
       type: object
-    Invitation.jsonhal:
-      deprecated: false
-      description: |-
-        An invitation for a person to collaborate in a camp. The person may or may not
-        already have an account.
-      properties:
-        _links:
-          properties:
-            self:
-              properties:
-                href:
-                  format: iri-reference
-                  type: string
-              type: object
-          type: object
-        campId:
-          description: |-
-            The id of the camp for which this invitation is valid. This is useful for
-            redirecting the user to the correct place after they accept.
-          example: 1a2b3c4d
-          type: string
-        campTitle:
-          description: |-
-            The full title of the camp for which this invitation is valid. This should help
-            the user to decide whether to accept or reject the invitation.
-          example: 'Abteilungs-Sommerlager 2022'
-          type: string
-        userAlreadyInCamp:
-          description: |-
-            Indicates whether the logged in user is already collaborating in the camp, and
-            can therefore not accept the invitation.
-          type:
-            - boolean
-            - 'null'
-        userDisplayName:
-          description: |-
-            The display name of the user that is invited. May be null in case the user does
-            not already have an account.
-          example: 'Robert Baden-Powell'
-          type:
-            - 'null'
-            - string
-      type: object
     Invitation.jsonhal-read:
       deprecated: false
       description: |-
@@ -10618,46 +10541,6 @@ components:
                   type: string
               type: object
           type: object
-        campId:
-          description: |-
-            The id of the camp for which this invitation is valid. This is useful for
-            redirecting the user to the correct place after they accept.
-          example: 1a2b3c4d
-          type: string
-        campTitle:
-          description: |-
-            The full title of the camp for which this invitation is valid. This should help
-            the user to decide whether to accept or reject the invitation.
-          example: 'Abteilungs-Sommerlager 2022'
-          type: string
-        userAlreadyInCamp:
-          description: |-
-            Indicates whether the logged in user is already collaborating in the camp, and
-            can therefore not accept the invitation.
-          type:
-            - boolean
-            - 'null'
-        userDisplayName:
-          description: |-
-            The display name of the user that is invited. May be null in case the user does
-            not already have an account.
-          example: 'Robert Baden-Powell'
-          type:
-            - 'null'
-            - string
-      type: object
-    Invitation.jsonld:
-      deprecated: false
-      description: |-
-        An invitation for a person to collaborate in a camp. The person may or may not
-        already have an account.
-      properties:
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
         campId:
           description: |-
             The id of the camp for which this invitation is valid. This is useful for
@@ -21562,56 +21445,6 @@ paths:
       summary: 'Retrieves a Day resource.'
       tags:
         - Day
-    parameters: []
-  /invitations:
-    get:
-      deprecated: false
-      description: 'Not implemented. Only needed that we can show this endpoint in /index.jsonhal.'
-      operationId: api_invitations_get_collection
-      parameters: []
-      responses:
-        200:
-          content:
-            application/hal+json:
-              schema:
-                properties:
-                  _embedded: { items: { $ref: '#/components/schemas/Invitation.jsonhal' }, type: array }
-                  _links: { properties: { first: { properties: { href: { format: iri-reference, type: string } }, type: object }, last: { properties: { href: { format: iri-reference, type: string } }, type: object }, next: { properties: { href: { format: iri-reference, type: string } }, type: object }, previous: { properties: { href: { format: iri-reference, type: string } }, type: object }, self: { properties: { href: { format: iri-reference, type: string } }, type: object } }, type: object }
-                  itemsPerPage: { minimum: 0, type: integer }
-                  totalItems: { minimum: 0, type: integer }
-                required:
-                  - _embedded
-                  - _links
-                type: object
-            application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/Invitation'
-                type: array
-            application/ld+json:
-              schema:
-                properties:
-                  'hydra:member': { items: { $ref: '#/components/schemas/Invitation.jsonld' }, type: array }
-                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
-                  'hydra:totalItems': { minimum: 0, type: integer }
-                  'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
-                required:
-                  - 'hydra:member'
-                type: object
-            application/vnd.api+json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/Invitation'
-                type: array
-            text/html:
-              schema:
-                items:
-                  $ref: '#/components/schemas/Invitation'
-                type: array
-          description: 'Invitation collection'
-      summary: 'Retrieves the collection of Invitation resources.'
-      tags:
-        - Invitation
     parameters: []
   '/invitations/{inviteKey}/accept':
     parameters: []


### PR DESCRIPTION
before: ![before with get on invitation (non existing)](https://github.com/ecamp/ecamp3/assets/3001985/c91cbb9a-60d0-4daa-b982-0680f122127d)

after: ![Bildschirmfoto 2023-11-10 um 21 35 30](https://github.com/ecamp/ecamp3/assets/3001985/b2abecff-2043-4597-ae05-312ac8169adb)
