### PR TITLE
deployment-pr.yml: do not deploy the same PR at the same time

### DIFF
--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, reopened, labeled, synchronize]
 
+concurrency:
+  group: ${{ github.workflow}}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     if: contains(github.event.pull_request.labels.*.name, 'deploy!')


### PR DESCRIPTION
Else the second deployment fails if you push to fast to the same PR.

See https://github.com/ecamp/ecamp3/pull/4068 to see the effect


![grafik](https://github.com/ecamp/ecamp3/assets/1506818/0ae9ba9f-4b63-43d2-85bb-e0a626cd04a9)
https://github.com/ecamp/ecamp3/actions/runs/6834522334
![grafik](https://github.com/ecamp/ecamp3/assets/1506818/20e8adcb-4187-4532-905c-773766926a0a)
