### PR TITLE
Limit renovate schedule to preset daily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "schedule:daily"
   ],
   "force": {
     "constraints": {


### PR DESCRIPTION
To prevent renovate to jam the runners queue use the [daily preset](https://docs.renovatebot.com/presets-schedule/#scheduledaily) by renovate to limit renovate bot execution.