### PR TITLE
chore(api): use pcov for code coverage

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           php-version: '8.2.12'
           tools: composer:2.6.0
-          coverage: xdebug
+          coverage: none
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -196,7 +196,7 @@ jobs:
           php-version: '8.2.12'
           extensions: intl-73.1
           tools: composer:2.6.0
-          coverage: xdebug
+          coverage: pcov
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -129,7 +129,10 @@ COPY --link docker/php/conf.d/api-platform.dev.ini $PHP_INI_DIR/conf.d/
 # renovate: datasource=github-tags depName=xdebug/xdebug
 ARG XDEBUG_VERSION=3.2.2
 RUN set -eux; \
-	install-php-extensions xdebug-$XDEBUG_VERSION
+	install-php-extensions \
+	xdebug-$XDEBUG_VERSION \
+	pcov \
+	;
 
 # "caddy" stage
 # depends on the "php" stage above


### PR DESCRIPTION
API tests run 2-3x faster compared to coverage by xdebug

On my fork:
- Previously 20min: https://github.com/usu/ecamp3/actions/runs/6840001833/job/18598812518
- Afterwards 7min: https://github.com/usu/ecamp3/actions/runs/6841887010/job/18602758800