### PR TITLE
print/nuxt.config.js: optimize dayjs deps to avoid console error in dev mode

### DIFF
--- a/print/nuxt.config.js
+++ b/print/nuxt.config.js
@@ -76,6 +76,23 @@ export default defineNuxtConfig({
 
   telemetry: false,
 
+  vite: {
+    optimizeDeps: {
+      include: [
+        'dayjs',
+        'dayjs/locale/de',
+        'dayjs/locale/de-ch',
+        'dayjs/locale/fr',
+        'dayjs/locale/it',
+        'dayjs/plugin/customParseFormat',
+        'dayjs/plugin/duration',
+        'dayjs/plugin/isBetween',
+        'dayjs/plugin/localizedFormat',
+        'dayjs/plugin/utc',
+      ],
+    },
+  },
+
   vue: {
     compilerOptions: {
       whitespace: 'preserve',


### PR DESCRIPTION
Dayjs seems to be distributed as commonjs module.
This is no problem in production mode and production preview. But in dev mode, the modules are not transformed by vite and the browser cannot work with the commonjs modules. This fixes the following console error for customParseFormat (and the corresponding erros for the other dayjs plugins): '/print/_nuxt/node_modules/dayjs/plugin/customParseFormat.js?v=6041f242' does not provide an export named 'default'