### PR TITLE
renovate.json: remove print package rules for nuxt2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -108,36 +108,6 @@
         "postgres"
       ],
       "allowedVersions": "15-alpine"
-    },
-    {
-      "matchPackageNames": [
-        "@nuxtjs/eslint-module"
-      ],
-      "allowedVersions": "^3"
-    },
-    {
-      "matchPackageNames": [
-        "@nuxtjs/stylelint-module"
-      ],
-      "allowedVersions": "^4"
-    },
-    {
-      "matchFileNames": [
-        "print/package.json"
-      ],
-      "matchPackageNames": [
-        "prettier"
-      ],
-      "allowedVersions": "^2"
-    },
-    {
-      "matchFileNames": [
-        "print/package.json"
-      ],
-      "matchPackageNames": [
-        "eslint-plugin-prettier"
-      ],
-      "allowedVersions": "^4"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
Now we have nuxt3 and can hopefully update these dependencies.