### PR TITLE
print/vitest.config.ts: exclude .nuxt folder from coverage measurement

### DIFF
--- a/print/vitest.config.ts
+++ b/print/vitest.config.ts
@@ -1,10 +1,11 @@
 // vitest.config.ts
-import { defineConfig } from 'vitest/config'
+import { defineConfig, configDefaults } from 'vitest/config'
 
 export default defineConfig({
   test: {
     coverage: {
       all: true,
+      exclude: [...(configDefaults.coverage.exclude || []), '**/.nuxt/**'],
       reporter: ['text', 'lcov', 'html'],
       reportsDirectory: './coverage',
     },


### PR DESCRIPTION
There are files with a lot of lines we should not cover with our tests. This leads to a repository coverage value of 7%.
This commit should improve that.

![image](https://github.com/ecamp/ecamp3/assets/1506818/50a57499-eb14-4742-b0cb-d38065f32932)
