### PR TITLE
frontend/vitest.config.ts: exclude src/pdf folder from coverage measurement

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,7 @@ import * as path from 'path'
 import { VuetifyResolver } from 'unplugin-vue-components/resolvers'
 import Components from 'unplugin-vue-components/vite'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
+import { configDefaults } from 'vitest/config'
 
 const plugins = [
   comlink(), // must be first
@@ -151,6 +152,7 @@ export default defineConfig(({ mode }) => ({
     setupFiles: './tests/setup.js',
     coverage: {
       all: true,
+      exclude: [...configDefaults.coverage.exclude, '**/src/pdf/**'],
       reporter: ['text', 'lcov', 'html'],
       reportsDirectory: './data/coverage',
     },


### PR DESCRIPTION
There are files with a lot of lines we should not cover with our tests. This commit should improve that.

![image](https://github.com/ecamp/ecamp3/assets/1506818/7e0a8409-d834-475c-9c89-f6ac79571e09)
