### PR TITLE
frontend: load all dayResponsibles in one request in Dashboard.vue

### DIFF
--- a/api/src/Entity/Day.php
+++ b/api/src/Entity/Day.php
@@ -38,7 +38,7 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
     normalizationContext: ['groups' => ['read']],
     order: ['period.start', 'dayOffset']
 )]
-#[ApiFilter(filterClass: SearchFilter::class, properties: ['period'])]
+#[ApiFilter(filterClass: SearchFilter::class, properties: ['period', 'period.camp'])]
 #[UniqueEntity(fields: ['period', 'dayOffset'])]
 #[ORM\Entity(repositoryClass: DayRepository::class)]
 #[ORM\UniqueConstraint(name: 'offset_period_idx', columns: ['periodId', 'dayOffset'])]

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
@@ -21467,6 +21467,32 @@ paths:
           allowReserved: false
           deprecated: false
           description: ''
+          explode: false
+          in: query
+          name: period.camp
+          required: false
+          schema:
+            type: string
+          style: form
+        -
+          allowEmptyValue: true
+          allowReserved: false
+          deprecated: false
+          description: ''
+          explode: true
+          in: query
+          name: 'period.camp[]'
+          required: false
+          schema:
+            items:
+              type: string
+            type: array
+          style: form
+        -
+          allowEmptyValue: true
+          allowReserved: false
+          deprecated: false
+          description: ''
           explode: true
           in: query
           name: 'period[]'

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testRootEndpointMatchesSnapshot__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testRootEndpointMatchesSnapshot__1.json
@@ -41,7 +41,7 @@
             "templated": true
         },
         "days": {
-            "href": "\/days{\/id}{?period,period[]}",
+            "href": "\/days{\/id}{?period,period[],period.camp,period.camp[]}",
             "templated": true
         },
         "invitations": {

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -404,6 +404,13 @@ export default {
 
     const { categories, periods, collaborators, progressLabels } =
       await loadAndProcessCollections(this.camp())
+    await Promise.all(
+      this.camp()
+        .periods()
+        .items.map((period) => period._meta.self)
+        .map((periodHref) => this.api.get().days({ period: periodHref }))
+    )
+
     const queryFilters = processRouteQuery(this.$route.query)
     const { period, responsible, category, progressLabel } = {
       ...this.filter,

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -404,12 +404,7 @@ export default {
 
     const { categories, periods, collaborators, progressLabels } =
       await loadAndProcessCollections(this.camp())
-    await Promise.all(
-      this.camp()
-        .periods()
-        .items.map((period) => period._meta.self)
-        .map((periodHref) => this.api.get().days({ period: periodHref }))
-    )
+    await this.api.get().days({ 'period.camp': this.camp()._meta.self })
 
     const queryFilters = processRouteQuery(this.$route.query)
     const { period, responsible, category, progressLabel } = {


### PR DESCRIPTION
1.
frontend: load all dayResponsibles in one request per period Dashboard.vue

By loading the days in one request per period which embed the dayResponsibles.
When loading the dayResponsibles directly, there was still
a request per day for the dayResponsibles.
This makes the loading of Dashboard.vue faster.
It also may reduce the e2e test failures of the firefox tests due to:
"Request aborted" errors after the test is finished.
(The test did not wait for the dayResponsibles to be loaded and then
aborted the load which lead to the requests being aborted.)

2.
frontend/api: add camp filter on days for Dashboard.vue

That it's possible to load all days of a camp in one request.

Related to #4010