### PR TITLE
CI: detect flaky tests in ci

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -368,113 +368,14 @@ jobs:
           COVERALLS_FLAG_NAME: pdf
 
   e2e-tests-build:
-    name: 'Tests: End-to-end (build job)'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      # build API (using cache; provide image to docker compose)
-      - name: Build docker image (API/PHP)
-        uses: docker/build-push-action@v5
-        with:
-          file: api/Dockerfile
-          context: './api'
-          push: false
-          load: true
-          target: api_platform_php_dev
-          builder: ${{ steps.buildx.outputs.name }}
-          tags: ecamp/ecamp3-dev-api-php
-          cache-from: type=gha,scope=api
-          cache-to: type=gha,scope=api,mode=max
-          outputs: type=docker,dest=/tmp/ecamp3-dev-api-php.tar
-
-      # build caddy (using cache; provide image to docker compose)
-      - name: Build docker image (Caddy)
-        uses: docker/build-push-action@v5
-        with:
-          file: api/Dockerfile
-          context: './api'
-          push: false
-          load: true
-          target: api_platform_caddy
-          builder: ${{ steps.buildx.outputs.name }}
-          tags: ecamp/ecamp3-dev-api-caddy
-          cache-from: type=gha,scope=caddy
-          cache-to: type=gha,scope=caddy,mode=max
-          outputs: type=docker,dest=/tmp/ecamp3-dev-api-caddy.tar
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: e2e-tests-images
-          path: /tmp/ecamp3-dev-*.tar
+    name: 'Tests: End-to-end build'
+    uses: ./.github/workflows/reusable-e2e-tests-build.yml
 
   e2e-tests-run:
-    name: 'Tests: End-to-end'
-    runs-on: ubuntu-latest
-    needs: e2e-tests-build
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        browser:
-          - chrome
-          - firefox
-          - edge
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-      - run: cp .env.ci .env
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Restore tmp folder
-        uses: actions/download-artifact@v4
-        with:
-          name: e2e-tests-images
-          path: /tmp
-
-      - name: Load images
-        run: |
-          docker load --input /tmp/ecamp3-dev-api-php.tar
-          docker load --input /tmp/ecamp3-dev-api-caddy.tar
-          docker image ls -a --digests
-
-      - name: Restore cache volumes (npm, composer)
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
-        with:
-          path: .cache
-          key: docker-compose-${{ hashFiles('frontend/package-lock.json', 'print/package-lock.json', 'api/composer.lock') }}-${{ matrix.browser }}
-          restore-keys: |
-            docker-compose-
-
-      # start necessary containers
-      - run: docker compose up -d php caddy frontend pdf print browserless database docker-host
-
-      - uses: cypress-io/github-action@v5
-        with:
-          working-directory: e2e
-          browser: ${{ matrix.browser }}
-          wait-on: 'http://localhost:3000, http://localhost:3000/api, http://localhost:3000/print/health'
-          wait-on-timeout: 300
-
-      # store screenshots and videos on GitHub as artifacts, for downloading and debugging in case of problems
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: cypress-output-${{ matrix.browser }}
-          path: |
-            e2e/data/**/*
-
-      # print docker container logs (good for debugging; can be disabled again later on)
-      - run: docker compose logs --tail="all"
-        if: always()
+    name: 'Tests: End-to-end run'
+    needs:
+      - e2e-tests-build
+    uses: ./.github/workflows/reusable-e2e-tests-run.yml
 
   coveralls-finished:
     name: 'Finish coveralls report'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,59 @@
+name: "Tests: End to End to detect flaky tests"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        type: number
+        description: |
+          Number of times the tests should run
+        required: true
+        default: 10
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+  schedule:
+    - cron: '42 4 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  create-array:
+    name: 'Create large array for matrix'
+    if: contains(github.event.pull_request.labels.*.name, 'test-flaky-e2e!') || github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      array: ${{ steps.array.outputs.result }}
+
+    steps:
+      - name: Create large array
+        uses: actions/github-script@v6
+        id: array
+        with:
+          script: |
+            function range(start, stop) {
+              return Array(stop - start)
+              .fill(start)
+              .map((value, index) => value + index);
+            }
+            return range(0, ${{ inputs.pr_number != null && inputs.pr_number || 10 }})
+
+  e2e-tests-build:
+    name: 'Tests: End-to-end build to detect flaky tests'
+    needs:
+      - create-array
+    uses: ./.github/workflows/reusable-e2e-tests-build.yml
+  
+  e2e-tests-run:
+    name: 'Tests: End-to-end run to detect flaky tests'
+    needs:
+      - create-array
+      - e2e-tests-build
+    uses: ./.github/workflows/reusable-e2e-tests-run.yml
+    with:
+      run-identifier: ${{ matrix.array }}
+    strategy:
+      fail-fast: false
+      matrix:
+        array: ${{ fromJSON(needs.create-array.outputs.array) }}

--- a/.github/workflows/reusable-e2e-tests-build.yml
+++ b/.github/workflows/reusable-e2e-tests-build.yml
@@ -1,0 +1,51 @@
+name: '[reusable only] e2e tests build'
+
+on:
+  workflow_call:
+
+jobs:
+  e2e-tests-build:
+    name: 'Tests: End-to-end (build job)'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      # build API (using cache; provide image to docker compose)
+      - name: Build docker image (API/PHP)
+        uses: docker/build-push-action@v5
+        with:
+          file: api/Dockerfile
+          context: './api'
+          push: false
+          load: true
+          target: api_platform_php_dev
+          builder: ${{ steps.buildx.outputs.name }}
+          tags: ecamp/ecamp3-dev-api-php
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,scope=api,mode=max
+          outputs: type=docker,dest=/tmp/ecamp3-dev-api-php.tar
+
+      # build caddy (using cache; provide image to docker compose)
+      - name: Build docker image (Caddy)
+        uses: docker/build-push-action@v5
+        with:
+          file: api/Dockerfile
+          context: './api'
+          push: false
+          load: true
+          target: api_platform_caddy
+          builder: ${{ steps.buildx.outputs.name }}
+          tags: ecamp/ecamp3-dev-api-caddy
+          cache-from: type=gha,scope=caddy
+          cache-to: type=gha,scope=caddy,mode=max
+          outputs: type=docker,dest=/tmp/ecamp3-dev-api-caddy.tar
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: e2e-tests-images
+          path: /tmp/ecamp3-dev-*.tar

--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -2,6 +2,10 @@ name: '[reusable only] e2e tests run'
 
 on:
   workflow_call:
+    inputs:
+      run-identifier:
+        required: false
+        type: string
 
 jobs:
   e2e-tests-run:
@@ -58,7 +62,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-output-${{ matrix.browser }}
+          name: cypress-output-${{ matrix.browser }}${{ inputs.run-identifier != null && format('-{0}', inputs.run-identifier) }}
           path: |
             e2e/data/**/*
 

--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -1,0 +1,67 @@
+name: '[reusable only] e2e tests run'
+
+on:
+  workflow_call:
+
+jobs:
+  e2e-tests-run:
+    name: 'Tests: End-to-end'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        browser:
+          - chrome
+          - firefox
+          - edge
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
+      - run: cp .env.ci .env
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore tmp folder
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-tests-images
+          path: /tmp
+
+      - name: Load images
+        run: |
+          docker load --input /tmp/ecamp3-dev-api-php.tar
+          docker load --input /tmp/ecamp3-dev-api-caddy.tar
+          docker image ls -a --digests
+
+      - name: Restore cache volumes (npm, composer)
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
+        with:
+          path: .cache
+          key: docker-compose-${{ hashFiles('frontend/package-lock.json', 'print/package-lock.json', 'api/composer.lock') }}-${{ matrix.browser }}
+          restore-keys: |
+            docker-compose-
+
+      # start necessary containers
+      - run: docker compose up -d php caddy frontend pdf print browserless database docker-host
+
+      - uses: cypress-io/github-action@v5
+        with:
+          working-directory: e2e
+          browser: ${{ matrix.browser }}
+          wait-on: 'http://localhost:3000, http://localhost:3000/api, http://localhost:3000/print/health'
+          wait-on-timeout: 300
+
+      # store screenshots and videos on GitHub as artifacts, for downloading and debugging in case of problems
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cypress-output-${{ matrix.browser }}
+          path: |
+            e2e/data/**/*
+
+      # print docker container logs (good for debugging; can be disabled again later on)
+      - run: docker compose logs --tail="all"
+        if: always()


### PR DESCRIPTION
Run the e2e tests 10 times on a schedule in the night to detect if they are flaky.
You can also add the label `test-flaky-e2e!` to run the tests on a PR you think might make the e2e tests flaky.

Related to #4010 