### PR TITLE
e2e: do not fail tests because of Request aborted error

### DIFF
--- a/e2e/support/index.js
+++ b/e2e/support/index.js
@@ -18,3 +18,5 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+Cypress.on('uncaught:exception', (err) => !err.message.includes('Request aborted'))


### PR DESCRIPTION
If all other methods fail, we can use this to make the tests less flaky.

Related to https://github.com/ecamp/ecamp3/issues/4010