### PR TITLE
Richtext popup: show list formatting ability and improve design

### DIFF
--- a/frontend/src/components/form/tiptap/TiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/TiptapEditor.vue
@@ -5,7 +5,7 @@
       :editor="editor"
       :tippy-options="{ maxWidth: 'none' }"
     >
-      <v-toolbar short>
+      <v-toolbar class="ec-tiptap-toolbar" dense>
         <!-- headings currently disabled (see issue #2657) -->
         <!--
         <v-item-group class="v-btn-toggle v-btn-toggle--dense">
@@ -42,39 +42,64 @@
         </v-item-group>
         <div class="mx-1" />
         -->
-        <v-item-group class="v-btn-toggle v-btn-toggle--dense" multiple>
-          <v-btn
-            :class="editor.isActive('bold') ? 'v-item--active v-btn--active' : ''"
-            @click="editor.chain().focus().toggleBold().run()"
-          >
-            <v-icon dense>mdi-format-bold</v-icon>
-          </v-btn>
-          <v-btn
-            :class="editor.isActive('italic') ? 'v-item--active v-btn--active' : ''"
-            @click="editor.chain().focus().toggleItalic().run()"
-          >
-            <v-icon dense>mdi-format-italic</v-icon>
-          </v-btn>
-          <v-btn
-            :class="editor.isActive('underline') ? 'v-item--active v-btn--active' : ''"
-            @click="editor.chain().focus().toggleUnderline().run()"
-          >
-            <v-icon dense>mdi-format-underline</v-icon>
-          </v-btn>
-          <v-btn
-            :class="editor.isActive('strike') ? 'v-item--active v-btn--active' : ''"
-            @click="editor.chain().focus().toggleStrike().run()"
-          >
-            <v-icon dense>mdi-format-strikethrough</v-icon>
-          </v-btn>
-        </v-item-group>
+        <TiptapToolbarButton
+          icon="mdi-format-bold"
+          :class="editor.isActive('bold') ? 'v-item--active v-btn--active' : ''"
+          @click="editor.chain().focus().toggleBold().run()"
+        />
+        <TiptapToolbarButton
+          icon="mdi-format-italic"
+          :class="editor.isActive('italic') ? 'v-item--active v-btn--active' : ''"
+          @click="editor.chain().focus().toggleItalic().run()"
+        />
+        <TiptapToolbarButton
+          icon="mdi-format-underline"
+          :class="editor.isActive('underline') ? 'v-item--active v-btn--active' : ''"
+          @click="editor.chain().focus().toggleUnderline().run()"
+        />
+        <TiptapToolbarButton
+          icon="mdi-format-strikethrough"
+          :class="editor.isActive('strike') ? 'v-item--active v-btn--active' : ''"
+          @click="editor.chain().focus().toggleStrike().run()"
+        />
+
+        <v-divider vertical class="mx-1" />
+
+        <TiptapToolbarButton
+          icon="mdi-format-list-bulleted"
+          :class="editor.isActive('bulletList') ? 'v-item--active v-btn--active' : ''"
+          @click="editor.chain().focus().toggleBulletList().run()"
+        />
+        <TiptapToolbarButton
+          icon="mdi-format-list-numbered"
+          :class="editor.isActive('orderedList') ? 'v-item--active v-btn--active' : ''"
+          @click="editor.chain().focus().toggleOrderedList().run()"
+        />
+
+        <template
+          v-if="
+            editor.can().sinkListItem('listItem') || editor.can().liftListItem('listItem')
+          "
+        >
+          <v-divider vertical class="mx-1" />
+          <TiptapToolbarButton
+            icon="mdi-format-indent-decrease"
+            :disabled="!editor.can().liftListItem('listItem')"
+            @click="editor.chain().focus().liftListItem('listItem').run()"
+          />
+          <TiptapToolbarButton
+            icon="mdi-format-indent-increase"
+            :disabled="!editor.can().sinkListItem('listItem')"
+            @click="editor.chain().focus().sinkListItem('listItem').run()"
+          />
+        </template>
       </v-toolbar>
     </bubble-menu>
     <editor-content class="editor__content" :editor="editor" />
   </div>
 </template>
 <script>
-import { Editor, EditorContent, BubbleMenu } from '@tiptap/vue-2'
+import { BubbleMenu, Editor, EditorContent } from '@tiptap/vue-2'
 import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
@@ -89,10 +114,12 @@ import Strike from '@tiptap/extension-strike'
 import Underline from '@tiptap/extension-underline'
 import History from '@tiptap/extension-history'
 import Placeholder from '@tiptap/extension-placeholder'
+import TiptapToolbarButton from '@/components/form/tiptap/TiptapToolbarButton.vue'
 
 export default {
   name: 'TiptapEditor',
   components: {
+    TiptapToolbarButton,
     EditorContent,
     BubbleMenu,
   },
@@ -211,6 +238,14 @@ div.editor {
   max-width: 100%;
   min-width: 0;
   width: 100%;
+}
+
+div.editor:deep(.ec-tiptap-toolbar) {
+  border-radius: 6px;
+}
+
+div.editor:deep(.ec-tiptap-toolbar .v-toolbar__content) {
+  gap: 2px;
 }
 
 div.editor:deep(.editor__content) {

--- a/frontend/src/components/form/tiptap/TiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/TiptapEditor.vue
@@ -6,42 +6,6 @@
       :tippy-options="{ maxWidth: 'none' }"
     >
       <v-toolbar class="ec-tiptap-toolbar" dense>
-        <!-- headings currently disabled (see issue #2657) -->
-        <!--
-        <v-item-group class="v-btn-toggle v-btn-toggle--dense">
-          <v-btn
-            :class="
-              editor.isActive('heading', { level: 1 })
-                ? 'v-item--active v-btn--active'
-                : ''
-            "
-            @click="editor.chain().focus().toggleHeading({ level: 1 }).run()"
-          >
-            <v-icon>mdi-format-header-1</v-icon>
-          </v-btn>
-          <v-btn
-            :class="
-              editor.isActive('heading', { level: 2 })
-                ? 'v-item--active v-btn--active'
-                : ''
-            "
-            @click="editor.chain().focus().toggleHeading({ level: 2 }).run()"
-          >
-            <v-icon>mdi-format-header-2</v-icon>
-          </v-btn>
-          <v-btn
-            :class="
-              editor.isActive('heading', { level: 3 })
-                ? 'v-item--active v-btn--active'
-                : ''
-            "
-            @click="editor.chain().focus().toggleHeading({ level: 3 }).run()"
-          >
-            <v-icon>mdi-format-header-3</v-icon>
-          </v-btn>
-        </v-item-group>
-        <div class="mx-1" />
-        -->
         <TiptapToolbarButton
           icon="mdi-format-bold"
           :class="editor.isActive('bold') ? 'v-item--active v-btn--active' : ''"
@@ -105,7 +69,6 @@ import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import BulletList from '@tiptap/extension-bullet-list'
 import HardBreak from '@tiptap/extension-hard-break'
-// import Heading from '@tiptap/extension-heading'
 import ListItem from '@tiptap/extension-list-item'
 import OrderedList from '@tiptap/extension-ordered-list'
 import Bold from '@tiptap/extension-bold'
@@ -165,7 +128,6 @@ export default {
           BulletList,
           OrderedList,
           // headings currently disabled (see issue #2657)
-          // Heading.configure({ levels: [1, 2, 3] }),
           HardBreak,
         ]
       )

--- a/frontend/src/components/form/tiptap/TiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/TiptapEditor.vue
@@ -257,10 +257,13 @@ div.editor:deep(.ec-tiptap-toolbar) {
   }
 }
 
+div.editor:deep(.ec-tiptap-toolbar .v-toolbar:not(.ec-tiptap-toolbar--second) .v-toolbar__content) {
+  justify-content: space-between;
+}
+
 div.editor:deep(.ec-tiptap-toolbar .v-toolbar__content) {
   gap: 2px;
   padding: 0 4px;
-  justify-content: space-between;
   .v-btn {
     margin: 0;
   }

--- a/frontend/src/components/form/tiptap/TiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/TiptapEditor.vue
@@ -6,7 +6,7 @@
       :tippy-options="{ maxWidth: 'none' }"
     >
       <div class="elevation-4 ec-tiptap-toolbar white">
-        <v-toolbar class="elevation-0" dense color="transparent">
+        <v-toolbar class="elevation-0 ec-tiptap-toolbar--first" dense color="transparent">
           <TiptapToolbarButton
             icon="mdi-format-bold"
             :class="editor.isActive('bold') ? 'v-item--active v-btn--active' : ''"
@@ -257,7 +257,7 @@ div.editor:deep(.ec-tiptap-toolbar) {
   }
 }
 
-div.editor:deep(.ec-tiptap-toolbar .v-toolbar:not(.ec-tiptap-toolbar--second) .v-toolbar__content) {
+div.editor:deep(.ec-tiptap-toolbar--first .v-toolbar__content) {
   justify-content: space-between;
 }
 

--- a/frontend/src/components/form/tiptap/TiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/TiptapEditor.vue
@@ -5,59 +5,102 @@
       :editor="editor"
       :tippy-options="{ maxWidth: 'none' }"
     >
-      <v-toolbar class="ec-tiptap-toolbar" dense>
-        <TiptapToolbarButton
-          icon="mdi-format-bold"
-          :class="editor.isActive('bold') ? 'v-item--active v-btn--active' : ''"
-          @click="editor.chain().focus().toggleBold().run()"
-        />
-        <TiptapToolbarButton
-          icon="mdi-format-italic"
-          :class="editor.isActive('italic') ? 'v-item--active v-btn--active' : ''"
-          @click="editor.chain().focus().toggleItalic().run()"
-        />
-        <TiptapToolbarButton
-          icon="mdi-format-underline"
-          :class="editor.isActive('underline') ? 'v-item--active v-btn--active' : ''"
-          @click="editor.chain().focus().toggleUnderline().run()"
-        />
-        <TiptapToolbarButton
-          icon="mdi-format-strikethrough"
-          :class="editor.isActive('strike') ? 'v-item--active v-btn--active' : ''"
-          @click="editor.chain().focus().toggleStrike().run()"
-        />
+      <div class="elevation-4 ec-tiptap-toolbar white">
+        <v-toolbar class="elevation-0" dense color="transparent">
+          <TiptapToolbarButton
+            icon="mdi-format-bold"
+            :class="editor.isActive('bold') ? 'v-item--active v-btn--active' : ''"
+            @click="editor.chain().focus().toggleBold().run()"
+          />
+          <TiptapToolbarButton
+            icon="mdi-format-italic"
+            :class="editor.isActive('italic') ? 'v-item--active v-btn--active' : ''"
+            @click="editor.chain().focus().toggleItalic().run()"
+          />
+          <TiptapToolbarButton
+            icon="mdi-format-underline"
+            :class="editor.isActive('underline') ? 'v-item--active v-btn--active' : ''"
+            @click="editor.chain().focus().toggleUnderline().run()"
+          />
+          <TiptapToolbarButton
+            icon="mdi-format-strikethrough"
+            :class="editor.isActive('strike') ? 'v-item--active v-btn--active' : ''"
+            @click="editor.chain().focus().toggleStrike().run()"
+          />
 
-        <v-divider vertical class="mx-1" />
+          <div class="d-none d-sm-contents">
+            <v-divider vertical class="mx-1" />
 
-        <TiptapToolbarButton
-          icon="mdi-format-list-bulleted"
-          :class="editor.isActive('bulletList') ? 'v-item--active v-btn--active' : ''"
-          @click="editor.chain().focus().toggleBulletList().run()"
-        />
-        <TiptapToolbarButton
-          icon="mdi-format-list-numbered"
-          :class="editor.isActive('orderedList') ? 'v-item--active v-btn--active' : ''"
-          @click="editor.chain().focus().toggleOrderedList().run()"
-        />
+            <TiptapToolbarButton
+              icon="mdi-format-list-bulleted"
+              :class="editor.isActive('bulletList') ? 'v-item--active v-btn--active' : ''"
+              @click="editor.chain().focus().toggleBulletList().run()"
+            />
+            <TiptapToolbarButton
+              icon="mdi-format-list-numbered"
+              :class="
+                editor.isActive('orderedList') ? 'v-item--active v-btn--active' : ''
+              "
+              @click="editor.chain().focus().toggleOrderedList().run()"
+            />
 
-        <template
-          v-if="
-            editor.can().sinkListItem('listItem') || editor.can().liftListItem('listItem')
-          "
+            <template
+              v-if="
+                editor.can().sinkListItem('listItem') ||
+                editor.can().liftListItem('listItem')
+              "
+            >
+              <v-divider vertical class="mx-1" />
+              <TiptapToolbarButton
+                icon="mdi-format-indent-decrease"
+                :disabled="!editor.can().liftListItem('listItem')"
+                @click="editor.chain().focus().liftListItem('listItem').run()"
+              />
+              <TiptapToolbarButton
+                icon="mdi-format-indent-increase"
+                :disabled="!editor.can().sinkListItem('listItem')"
+                @click="editor.chain().focus().sinkListItem('listItem').run()"
+              />
+            </template>
+          </div>
+        </v-toolbar>
+        <v-divider class="ec-tiptap-toolbar__mobile-divider" />
+        <v-toolbar
+          class="elevation-0 ec-tiptap-toolbar--second"
+          dense
+          color="transparent"
         >
-          <v-divider vertical class="mx-1" />
           <TiptapToolbarButton
-            icon="mdi-format-indent-decrease"
-            :disabled="!editor.can().liftListItem('listItem')"
-            @click="editor.chain().focus().liftListItem('listItem').run()"
+            icon="mdi-format-list-bulleted"
+            :class="editor.isActive('bulletList') ? 'v-item--active v-btn--active' : ''"
+            @click="editor.chain().focus().toggleBulletList().run()"
           />
           <TiptapToolbarButton
-            icon="mdi-format-indent-increase"
-            :disabled="!editor.can().sinkListItem('listItem')"
-            @click="editor.chain().focus().sinkListItem('listItem').run()"
+            icon="mdi-format-list-numbered"
+            :class="editor.isActive('orderedList') ? 'v-item--active v-btn--active' : ''"
+            @click="editor.chain().focus().toggleOrderedList().run()"
           />
-        </template>
-      </v-toolbar>
+
+          <template
+            v-if="
+              editor.can().sinkListItem('listItem') ||
+              editor.can().liftListItem('listItem')
+            "
+          >
+            <v-divider vertical class="mx-1" />
+            <TiptapToolbarButton
+              icon="mdi-format-indent-decrease"
+              :disabled="!editor.can().liftListItem('listItem')"
+              @click="editor.chain().focus().liftListItem('listItem').run()"
+            />
+            <TiptapToolbarButton
+              icon="mdi-format-indent-increase"
+              :disabled="!editor.can().sinkListItem('listItem')"
+              @click="editor.chain().focus().sinkListItem('listItem').run()"
+            />
+          </template>
+        </v-toolbar>
+      </div>
     </bubble-menu>
     <editor-content class="editor__content" :editor="editor" />
   </div>
@@ -183,7 +226,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 div.editor:deep(p.is-editor-empty:first-child::before) {
   content: attr(data-placeholder);
   float: left;
@@ -206,8 +249,21 @@ div.editor:deep(.ec-tiptap-toolbar) {
   border-radius: 6px;
 }
 
+.ec-tiptap-toolbar--second,
+.ec-tiptap-toolbar__mobile-divider {
+  display: block;
+  @media #{map-get($display-breakpoints, 'sm-and-up')} {
+    display: none;
+  }
+}
+
 div.editor:deep(.ec-tiptap-toolbar .v-toolbar__content) {
   gap: 2px;
+  padding: 0 4px;
+  justify-content: space-between;
+  .v-btn {
+    margin: 0;
+  }
 }
 
 div.editor:deep(.editor__content) {

--- a/frontend/src/components/form/tiptap/TiptapToolbarButton.vue
+++ b/frontend/src/components/form/tiptap/TiptapToolbarButton.vue
@@ -1,0 +1,13 @@
+<template>
+  <v-btn icon tile height="40" width="42" color="black" class="rounded" v-on="$listeners">
+    <v-icon>{{ icon }}</v-icon>
+  </v-btn>
+</template>
+<script>
+export default {
+  name: 'TiptapToolbarButton',
+  props: {
+    icon: { type: String, required: true },
+  },
+}
+</script>

--- a/frontend/src/scss/global.scss
+++ b/frontend/src/scss/global.scss
@@ -131,9 +131,16 @@ body {
 .d-flow-root {
   display: flow-root;
 }
+.v-application {
+  .d-contents {
+    display: contents !important;
+  }
 
-.d-contents {
-  display: contents;
+  @media #{map-get($display-breakpoints, 'sm-and-up')} {
+    .d-sm-contents {
+      display: contents !important;
+    }
+  }
 }
 
 .d-grid {


### PR DESCRIPTION
Show the possibility to format as a list. I've got feedback, that the list functionality would be greatly appreciated. The user therefore did not discover the automatic list formatting. This should provide additional indicators.

<sub>Also I took the opportunity to adjust the design 😁</sub>

**before:**
![Bildschirmfoto 2023-12-02 um 16 13 22](https://github.com/ecamp/ecamp3/assets/3001985/e440ea84-2fec-4679-9b7c-5f7b1658600d)

**after:**
![Bildschirmfoto 2023-12-02 um 16 13 02](https://github.com/ecamp/ecamp3/assets/3001985/57c38c67-0d87-4b42-8ded-39f995c6a55b)

I also removed the dead code that has been waiting on #2657 