### PR TITLE
Colorpicker: Add color swatches and contrast color

### DIFF
--- a/frontend/src/components/form/base/ColorPicker/ColorSwatch.vue
+++ b/frontend/src/components/form/base/ColorPicker/ColorSwatch.vue
@@ -1,0 +1,39 @@
+<template>
+  <v-btn
+    class="e-colorswatch"
+    fab
+    elevation="0"
+    width="30"
+    height="30"
+    :color="color"
+    @click="picker.onInput(color)"
+  ></v-btn>
+</template>
+<script>
+import { contrastColor } from '@/common/helpers/colors.js'
+
+export default {
+  name: 'ColorSwatch',
+  props: {
+    picker: { type: Object, required: true },
+    color: { type: String, required: true },
+  },
+  computed: {
+    contrast() {
+      return this.color ? contrastColor(this.color) : 'black'
+    },
+  },
+}
+</script>
+<style scoped>
+.e-colorswatch::after {
+  content: '•';
+  color: v-bind(contrast);
+  display: block;
+  width: 100%;
+  height: 100%;
+  line-height: 26px;
+  font-size: 28px;
+  text-align: center;
+}
+</style>

--- a/frontend/src/components/form/base/EColorPicker.vue
+++ b/frontend/src/components/form/base/EColorPicker.vue
@@ -16,15 +16,30 @@ Displays a field as a color picker (can be used with v-model)
     @input="$emit('input', $event)"
   >
     <template #default="picker">
-      <v-card>
+      <v-card :style="{ '--picker-contrast-color': contrast }" data-testid="colorpicker">
         <v-color-picker
           :value="removeAlpha(picker.value || '')"
           flat
           @input="picker.onInput"
         />
-        <v-btn text color="primary" @click="picker.close">
-          {{ $tc('global.button.close') }}
-        </v-btn>
+        <v-divider />
+        <div class="d-flex gap-2 pa-4 flex-wrap">
+          <ColorSwatch color="#90B7E4" :picker="picker" />
+          <ColorSwatch color="#6EDBE9" :picker="picker" />
+          <ColorSwatch color="#4dbb52" :picker="picker" />
+          <ColorSwatch color="#FF9800" :picker="picker" />
+          <ColorSwatch color="#FD7A7A" :picker="picker" />
+          <ColorSwatch color="#d584e9" :picker="picker" />
+          <ColorSwatch color="#BBBBBB" :picker="picker" />
+
+          <ColorSwatch color="#1964B1" :picker="picker" />
+          <ColorSwatch color="#1E86CA" :picker="picker" />
+          <ColorSwatch color="#3DB842" :picker="picker" />
+          <ColorSwatch color="#F1810D" :picker="picker" />
+          <ColorSwatch color="#C71A1A" :picker="picker" />
+          <ColorSwatch color="#CF3BD6" :picker="picker" />
+          <ColorSwatch color="#575757" :picker="picker" />
+        </div>
       </v-card>
     </template>
 
@@ -38,13 +53,21 @@ Displays a field as a color picker (can be used with v-model)
 <script>
 import BasePicker from './BasePicker.vue'
 import { formComponentMixin } from '@/mixins/formComponentMixin.js'
+import { contrastColor } from '@/common/helpers/colors.js'
+import ColorSwatch from '@/components/form/base/ColorPicker/ColorSwatch.vue'
 
 export default {
   name: 'EColorPicker',
-  components: { BasePicker },
+  components: { ColorSwatch, BasePicker },
   mixins: [formComponentMixin],
   props: {
     value: { type: String, required: true },
+  },
+  computed: {
+    contrast() {
+      // Vuetify returns invalid value #NANNAN in the initialization phase
+      return this.value && this.value !== '#NANNAN' ? contrastColor(this.value) : 'black'
+    },
   },
   methods: {
     /**
@@ -71,4 +94,14 @@ export default {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+:deep(.v-color-picker__dot > div::before) {
+  content: '•';
+  color: var(--picker-contrast-color);
+  display: block;
+  width: 100%;
+  line-height: 26px;
+  font-size: 28px;
+  text-align: center;
+}
+</style>

--- a/frontend/src/components/form/base/__tests__/EColorPicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/EColorPicker.spec.js
@@ -50,7 +50,7 @@ describe('An EColorPicker', () => {
     await user.click(screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT))
 
     // then
-    await screen.findByText('Schliessen')
+    await screen.findByTestId('colorpicker')
     expect(snapshotOf(container)).toMatchSnapshot('pickeropen')
   })
 
@@ -66,7 +66,7 @@ describe('An EColorPicker', () => {
 
     // then
     await waitFor(async () => {
-      expect(await screen.findByText('Schliessen')).toBeVisible()
+      expect(await screen.findByTestId('colorpicker')).toBeVisible()
     })
   })
 
@@ -82,28 +82,7 @@ describe('An EColorPicker', () => {
 
     // then
     await waitFor(async () => {
-      expect(await screen.findByText('Schliessen')).toBeVisible()
-    })
-  })
-
-  it('closes the picker when clicking the close button', async () => {
-    // given
-    render(EColorPicker, {
-      props: { value: COLOR1, name: 'test' },
-    })
-    const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
-    await user.click(button)
-    await waitFor(async () => {
-      expect(await screen.findByText('Schliessen')).toBeVisible()
-    })
-    const closeButton = screen.getByText('Schliessen')
-
-    // when
-    await user.click(closeButton)
-
-    // then
-    await waitFor(async () => {
-      expect(await screen.queryByText('Schliessen')).not.toBeVisible()
+      expect(await screen.findByTestId('colorpicker')).toBeVisible()
     })
   })
 
@@ -115,7 +94,7 @@ describe('An EColorPicker', () => {
     const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
     await user.click(button)
     await waitFor(async () => {
-      expect(await screen.findByText('Schliessen')).toBeVisible()
+      expect(await screen.findByTestId('colorpicker')).toBeVisible()
     })
 
     // when
@@ -123,7 +102,7 @@ describe('An EColorPicker', () => {
 
     // then
     await waitFor(async () => {
-      expect(await screen.queryByText('Schliessen')).not.toBeVisible()
+      expect(await screen.queryByTestId('colorpicker')).not.toBeVisible()
     })
   })
 
@@ -135,7 +114,7 @@ describe('An EColorPicker', () => {
     const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
     await user.click(button)
     await waitFor(async () => {
-      expect(await screen.findByText('Schliessen')).toBeVisible()
+      expect(await screen.findByTestId('colorpicker')).toBeVisible()
     })
 
     // when
@@ -143,7 +122,7 @@ describe('An EColorPicker', () => {
 
     // then
     await waitFor(async () => {
-      expect(await screen.queryByText('Schliessen')).not.toBeVisible()
+      expect(await screen.queryByTestId('colorpicker')).not.toBeVisible()
     })
   })
 
@@ -155,7 +134,7 @@ describe('An EColorPicker', () => {
     const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
     await user.click(button)
     await waitFor(async () => {
-      expect(await screen.findByText('Schliessen')).toBeVisible()
+      expect(await screen.findByTestId('colorpicker')).toBeVisible()
     })
 
     // when
@@ -167,7 +146,7 @@ describe('An EColorPicker', () => {
     // close button should stay visible
     await expect(
       waitFor(() => {
-        expect(screen.queryByText('Schliessen')).not.toBeVisible()
+        expect(screen.queryByTestId('colorpicker')).not.toBeVisible()
       })
     ).rejects.toThrow(/Received element is visible/)
   })
@@ -216,7 +195,7 @@ describe('An EColorPicker', () => {
     const canvas = container.querySelector('canvas')
     await user.click(canvas, { clientX: 10, clientY: 10 })
     // click the close button
-    await user.click(screen.getByText('Schliessen'))
+    await user.click(screen.getByTestId('colorpicker'))
 
     // then
     await waitFor(async () => {

--- a/frontend/src/components/form/base/__tests__/__snapshots__/EColorPicker.spec.js.snap
+++ b/frontend/src/components/form/base/__tests__/__snapshots__/EColorPicker.spec.js.snap
@@ -68,7 +68,8 @@ exports[`An EColorPicker > looks like a color picker > pickeropen 1`] = `
           role="menu"
           style="max-height: auto; min-width: 290px; max-width: 290px; top: 12px; left: 0px; transform-origin: top left; z-index: 8; display: none;">
           <div id>
-               <div class="v-card v-sheet theme--light">
+               <div class="v-card v-sheet theme--light"
+                    style="--picker-contrast-color: #fff;">
                     <div class="v-color-picker v-sheet theme--light v-color-picker--flat theme--light"
                          style="max-width: 300px;">
                          <div class="v-color-picker__canvas"
@@ -148,10 +149,81 @@ exports[`An EColorPicker > looks like a color picker > pickeropen 1`] = `
                               </div>
                          </div>
                     </div>
-                    <button class="v-btn v-btn--text theme--light v-size--default primary--text"
-                            type="button">
-                         <span class="v-btn__content"> Schliessen </span>
-                    </button>
+                    <hr aria-orientation="horizontal"
+                        class="v-divider theme--light"
+                        role="separator">
+                    <div class="d-flex gap-2 pa-4 flex-wrap">
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(144, 183, 228); border-color: #90b7e4; --ee5e0d96-contrast: #000;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(110, 219, 233); border-color: #6edbe9; --ee5e0d96-contrast: #000;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(77, 187, 82); border-color: #4dbb52; --ee5e0d96-contrast: #000;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(255, 152, 0); border-color: #ff9800; --ee5e0d96-contrast: #000;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(253, 122, 122); border-color: #fd7a7a; --ee5e0d96-contrast: #000;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(213, 132, 233); border-color: #d584e9; --ee5e0d96-contrast: #000;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(187, 187, 187); border-color: #bbbbbb; --ee5e0d96-contrast: #000;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(25, 100, 177); border-color: #1964b1; --ee5e0d96-contrast: #fff;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(30, 134, 202); border-color: #1e86ca; --ee5e0d96-contrast: #fff;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(61, 184, 66); border-color: #3db842; --ee5e0d96-contrast: #fff;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(241, 129, 13); border-color: #f1810d; --ee5e0d96-contrast: #fff;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(199, 26, 26); border-color: #c71a1a; --ee5e0d96-contrast: #fff;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(207, 59, 214); border-color: #cf3bd6; --ee5e0d96-contrast: #fff;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                         <button class="e-colorswatch v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(87, 87, 87); border-color: #575757; --ee5e0d96-contrast: #fff;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                         </button>
+                    </div>
                </div>
           </div>
      </div>


### PR DESCRIPTION
The colors should be relatively colorblind safe.
The dot on the swatch indicates the contrast text color.

![Bildschirmfoto 2023-12-07 um 17 00 55](https://github.com/ecamp/ecamp3/assets/3001985/4863790a-65c6-4a86-916c-c89d24da16bb)

Relates to #467 