### PR TITLE
renovate.json: remove limit on open PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":prConcurrentLimitNone"
   ],
   "force": {
     "constraints": {


### PR DESCRIPTION
In times we don't have much time to review, the open major updates block the minor updates which would go through.
The limit was 10 before (which is the default).