### PR TITLE
api: fix The "openapiContext" option is deprecated, use "openapi" instead.'

### DIFF
--- a/api/src/DTO/Invitation.php
+++ b/api/src/DTO/Invitation.php
@@ -7,6 +7,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use App\State\InvitationAcceptProcessor;
 use App\State\InvitationProvider;
 use App\State\InvitationRejectProcessor;
@@ -23,7 +24,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             provider: InvitationProvider::class,
             uriTemplate: '/invitations/{inviteKey}/find{._format}', // TO DISCUSS: Wouldn't '/{inviteKey}{._format}' be more REST-like
             normalizationContext: self::ITEM_NORMALIZATION_CONTEXT,
-            openapiContext: ['description' => 'Use myInviteKey to find an invitation in the dev environment.']
+            openapi: new OpenApiOperation(description: 'Use myInviteKey to find an invitation in the dev environment.')
         ),
         new Patch(
             provider: InvitationProvider::class,
@@ -33,7 +34,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             uriTemplate: '/invitations/{inviteKey}/'.self::ACCEPT.'{._format}',
             denormalizationContext: ['groups' => ['write']],
             normalizationContext: self::ITEM_NORMALIZATION_CONTEXT,
-            openapiContext: ['summary' => 'Accept an Invitation.', 'description' => 'Use myInviteKey2 to accept an invitation in dev environment.'],
+            openapi: new OpenApiOperation(summary: 'Accept an Invitation.', description: 'Use myInviteKey2 to accept an invitation in dev environment.'),
             validationContext: ['groups' => ['Default', 'accept']]
         ),
         new Patch(
@@ -43,13 +44,12 @@ use Symfony\Component\Validator\Constraints as Assert;
             uriTemplate: '/invitations/{inviteKey}/'.self::REJECT.'{._format}',
             denormalizationContext: ['groups' => ['write']],
             normalizationContext: self::ITEM_NORMALIZATION_CONTEXT,
-            openapiContext: ['summary' => 'Reject an Invitation.', 'description' => 'Use myInviteKey to reject an invitation in dev environment.']
+            openapi: new OpenApiOperation(summary: 'Reject an Invitation.', description: 'Use myInviteKey to reject an invitation in dev environment.')
         ),
         new GetCollection(
             provider: InvitationProvider::class,
             security: 'false',
-            openapi: false,
-            openapiContext: ['description' => 'Not implemented. Only needed that we can show this endpoint in /index.jsonhal.']
+            openapi: false
         ),
     ],
 )]

--- a/api/src/DTO/ResetPassword.php
+++ b/api/src/DTO/ResetPassword.php
@@ -7,6 +7,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use App\InputFilter;
 use App\State\ResetPasswordCreateProcessor;
 use App\State\ResetPasswordProvider;
@@ -36,7 +37,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             output: false,
             denormalizationContext: ['groups' => ['create']],
             normalizationContext: ['groups' => ['read']],
-            openapiContext: ['summary' => 'Request Password-Reset-Mail', 'description' => 'Password-Reset-Link will be sent to the given email']
+            openapi: new OpenApiOperation(summary: 'Request Password-Reset-Mail', description: 'Password-Reset-Link will be sent to the given email')
         ),
     ],
     routePrefix: '/auth'

--- a/api/src/Entity/CampCollaboration.php
+++ b/api/src/Entity/CampCollaboration.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use App\InputFilter;
 use App\Repository\CampCollaborationRepository;
 use App\State\CampCollaborationCreateProcessor;
@@ -50,7 +51,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: '(is_authenticated() && user === object.user) or is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)',
             uriTemplate: 'camp_collaborations/{id}/'.self::RESEND_INVITATION,
             denormalizationContext: ['groups' => ['resend_invitation']],
-            openapiContext: ['summary' => 'Send the invitation email for this CampCollaboration again. Only possible, if the status is already invited.'],
+            openapi: new OpenApiOperation(summary: 'Send the invitation email for this CampCollaboration again. Only possible, if the status is already invited.'),
             validationContext: ['groups' => ['Default', 'resend_invitation']]
         ),
         new GetCollection(
@@ -61,7 +62,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             processor: CampCollaborationCreateProcessor::class,
             denormalizationContext: ['groups' => ['write', 'create']],
             normalizationContext: self::ITEM_NORMALIZATION_CONTEXT,
-            openapiContext: ['description' => 'Also sends an invitation email to the inviteEmail address, if specified.'],
+            openapi: new OpenApiOperation(description: 'Also sends an invitation email to the inviteEmail address, if specified.'),
             securityPostDenormalize: 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)'
         ),
     ],

--- a/api/tests/Serializer/PreventAutomaticEmbeddingPropertyMetadataFactoryTest.php
+++ b/api/tests/Serializer/PreventAutomaticEmbeddingPropertyMetadataFactoryTest.php
@@ -6,6 +6,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use App\Serializer\PreventAutomaticEmbeddingPropertyMetadataFactory;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type as PropertyInfoType;
 
 /**
  * @internal
@@ -27,20 +28,20 @@ class PreventAutomaticEmbeddingPropertyMetadataFactoryTest extends TestCase {
             'deprecationReason',
             true,
             true,
-            [],
-            [],
-            [],
+            ['jsonldContext'],
+            ['openapiContext'],
+            ['jsonSchemaContext'],
             true,
             true,
             'securityPostDenormalize',
-            [],
-            [],
-            [],
+            ['types'],
+            [new PropertyInfoType(builtinType: PropertyInfoType::BUILTIN_TYPE_INT)],
+            ['schema'],
             true,
-            [],
+            ['iris'],
             true,
-            '',
-            []
+            'uriTemplate',
+            ['extraProperties']
         );
         $decorated->expects($this->once())
             ->method('create')
@@ -68,7 +69,7 @@ class PreventAutomaticEmbeddingPropertyMetadataFactoryTest extends TestCase {
         $this->assertEquals($apiProperty->isFetchable(), $result->isFetchable());
         $this->assertEquals($apiProperty->getFetchEager(), $result->getFetchEager());
         $this->assertEquals($apiProperty->getJsonldContext(), $result->getJsonldContext());
-        $this->assertEquals($apiProperty->getOpenapiContext(), $result->getJsonldContext());
+        $this->assertEquals($apiProperty->getOpenapiContext(), $result->getOpenapiContext());
         $this->assertEquals($apiProperty->getJsonSchemaContext(), $result->getJsonSchemaContext());
         $this->assertEquals($apiProperty->getPush(), $result->getPush());
         $this->assertEquals($apiProperty->getSecurity(), $result->getSecurity());


### PR DESCRIPTION
1.
api: fix deprecation 'Since api-platform/core 3.1: The "openapiContext" option is deprecated, use "openapi" instead.'

2.
api: fix comparison with wrong value in PreventAutomaticEmbeddingPropertyMetadataFactoryTest

And use values which say something about the parameter that this is less likely to happen anymore.