### PR TITLE
api: fix "Passing an instance of DateTimeImmutable is deprecated"

### DIFF
--- a/api/src/Types/Doctrine/UTCDateTimeType.php
+++ b/api/src/Types/Doctrine/UTCDateTimeType.php
@@ -4,6 +4,7 @@ namespace App\Types\Doctrine;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\DateTimeImmutableType;
 use Doctrine\DBAL\Types\DateTimeType;
 
 /**
@@ -37,6 +38,10 @@ class UTCDateTimeType extends DateTimeType {
 
         if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             $value = $value->setTimeZone(self::getUtc());
+
+            if ($value instanceof \DateTimeImmutable) {
+                return (new DateTimeImmutableType())->convertToDatabaseValue($value, $platform);
+            }
 
             return parent::convertToDatabaseValue($value, $platform);
         }

--- a/api/src/Types/Doctrine/UTCDateType.php
+++ b/api/src/Types/Doctrine/UTCDateType.php
@@ -4,6 +4,7 @@ namespace App\Types\Doctrine;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\DateImmutableType;
 use Doctrine\DBAL\Types\DateType;
 
 class UTCDateType extends DateType {
@@ -21,6 +22,10 @@ class UTCDateType extends DateType {
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string {
         if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
             $value = $value->setTimezone(self::getUtc());
+        }
+
+        if ($value instanceof \DateTimeImmutable) {
+            return (new DateImmutableType())->convertToDatabaseValue($value, $platform);
         }
 
         return parent::convertToDatabaseValue($value, $platform);


### PR DESCRIPTION
Passing an instance of DateTimeImmutable is deprecated, use Doctrine\DBAL\Types\DateTimeImmutableType::convertToDatabaseValue() instead. (DateTimeType.php:51 called by UTCDateTimeType.php:41, https://github.com/doctrine/dbal/pull/6017, package doctrine/dbal)