### PR TITLE
continuous-integration.yml: use one job to collect the status of all …

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -389,10 +389,9 @@ jobs:
           parallel-finished: true
           carryforward: "api,frontend,print,pdf"
           fail-on-error: false
-
-  ci-passed-event:
-    name: 'Send out CI success event'
-    if: github.event_name == 'push' && (github.event.pull_request && github.event.pull_request.number)
+          
+  workflow-success:
+    name: workflow-success
     needs:
       - api-cs-check
       - frontend-eslint
@@ -402,6 +401,15 @@ jobs:
       - frontend-tests
       - print-tests
       - e2e-tests-run
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+
+  ci-passed-event:
+    name: 'Send out CI success event'
+    if: github.event_name == 'push' && (github.event.pull_request && github.event.pull_request.number)
+    needs:
+      - workflow-success
     runs-on: ubuntu-latest
     steps:
       - uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2


### PR DESCRIPTION
…jobs in the workflow

That we can use one required status check in the branch protection rules. This allows to:
- Allows review of the settings which jobs should be required. The merge of a pr leads to the new settings being active
- Not having to synchronize the settings of the required status check with the devel branch. This happens automatically because the configuration is checked in.
- Not having to merge/rebase devel into PRs because the names of the jobs changed but the old/new job names are in the required status checks.
(see https://github.com/ecamp/ecamp3/pull/4204#issuecomment-1859215946)