### PR TITLE
dateHelperVCalendar.js: make timezone independent

### DIFF
--- a/common/helpers/__tests__/dateHelperVCalendar.spec.js
+++ b/common/helpers/__tests__/dateHelperVCalendar.spec.js
@@ -1,0 +1,34 @@
+import dayjs from 'dayjs'
+import { timestampToUtcString, utcStringToTimestamp } from '../dateHelperVCalendar'
+
+const dateTimesToTest = [
+  dayjs.utc('2022-01-01T16:40'),
+  dayjs.utc('2023-03-26T02:30'),
+  dayjs.utc('2023-10-29T02:30'),
+  dayjs.utc('2023-06-04T00:00'),
+  dayjs.utc('2023-01-01T23:59'),
+  dayjs.utc('2023-06-15T12:00'),
+]
+
+const parametersToTest = dateTimesToTest.map((dateTime) => ({
+  epochMillis: dateTime.valueOf(),
+  utcString: dateTime.format(),
+}))
+
+describe('timestampToUtcString', () => {
+  it.each(parametersToTest)(
+    'converts a timestamp $epochMillis into $utcString',
+    ({ epochMillis, utcString }) => {
+      expect(timestampToUtcString(epochMillis)).toEqual(utcString)
+    }
+  )
+})
+
+describe('utcStringToTimestamp', () => {
+  it.each(parametersToTest)(
+    'converts a utcString $utcString into epochMillis $epochMillis',
+    ({ epochMillis, utcString }) => {
+      expect(utcStringToTimestamp(utcString)).toEqual(epochMillis)
+    }
+  )
+})

--- a/common/helpers/dateHelperVCalendar.js
+++ b/common/helpers/dateHelperVCalendar.js
@@ -2,12 +2,12 @@ import dayjs from './dayjs.js'
 
 // converts a timestamp (local timezone) into ISO String format (UTC timezone)
 function timestampToUtcString(timestamp) {
-  return dayjs.utc(dayjs(timestamp).format('YYYY-MM-DD HH:mm')).format()
+  return dayjs.utc(dayjs.utc(timestamp).format('YYYY-MM-DD HH:mm')).format()
 }
 
 // converts ISO String format (UTC timezone) into a timestamp (local timezone)
 function utcStringToTimestamp(string) {
-  return dayjs(dayjs.utc(string).format('YYYY-MM-DD HH:mm')).valueOf()
+  return dayjs.utc(dayjs.utc(string).format('YYYY-MM-DD HH:mm')).valueOf()
 }
 
 export { timestampToUtcString, utcStringToTimestamp }


### PR DESCRIPTION
As you can see in https://github.com/BacLuc/ecamp3/actions/runs/7315399347, the pdf tests only work if the TZ is set to UTC.
This is because the .utc got forgotten here.

The further plan is to run the frontend and pdf tests in multiple timezones, that we detect this sooner.
But only after #4316 when i can use matrix jobs without breaking the required status checks.
