### PR TITLE
fix(frontend): downgrade vue to 2.7.15

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,7 +57,7 @@
         "uuid": "9.0.1",
         "v-resize-observer": "2.1.0",
         "vee-validate": "3.4.15",
-        "vue": "2.7.16",
+        "vue": "2.7.15",
         "vue-axios": "3.5.2",
         "vue-i18n": "8.28.2",
         "vue-recaptcha-v3": "1.9.0",
@@ -103,7 +103,7 @@
         "vitest": "1.1.0",
         "vitest-canvas-mock": "0.3.3",
         "vue-cli-plugin-vuetify": "2.5.8",
-        "vue-template-compiler": "2.7.16"
+        "vue-template-compiler": "2.7.15"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5152,31 +5152,13 @@
       "dev": true
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-      "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.15.tgz",
+      "integrity": "sha512-FCvIEevPmgCgqFBH7wD+3B97y7u7oj/Wr69zADBf403Tui377bThTjBvekaZvlRr4IwUAu3M6hYZeULZFJbdYg==",
       "dependencies": {
-        "@babel/parser": "^7.23.5",
+        "@babel/parser": "^7.18.4",
         "postcss": "^8.4.14",
         "source-map": "^0.6.1"
-      },
-      "optionalDependencies": {
-        "prettier": "^1.18.2 || ^2.0.0"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "optional": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@vue/component-compiler-utils": {
@@ -18174,11 +18156,11 @@
       }
     },
     "node_modules/vue": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-      "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.15.tgz",
+      "integrity": "sha512-a29fsXd2G0KMRqIFTpRgpSbWaNBK3lpCTOLuGLEDnlHWdjB8fwl6zyYZ8xCrqkJdatwZb4mGHiEfJjnw0Q6AwQ==",
       "dependencies": {
-        "@vue/compiler-sfc": "2.7.16",
+        "@vue/compiler-sfc": "2.7.15",
         "csstype": "^3.1.0"
       }
     },
@@ -18476,9 +18458,9 @@
       "dev": true
     },
     "node_modules/vue-template-compiler": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
+      "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
       "dev": true,
       "dependencies": {
         "de-indent": "^1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
     "uuid": "9.0.1",
     "v-resize-observer": "2.1.0",
     "vee-validate": "3.4.15",
-    "vue": "2.7.16",
+    "vue": "2.7.15",
     "vue-axios": "3.5.2",
     "vue-i18n": "8.28.2",
     "vue-recaptcha-v3": "1.9.0",
@@ -116,7 +116,7 @@
     "vitest": "1.1.0",
     "vitest-canvas-mock": "0.3.3",
     "vue-cli-plugin-vuetify": "2.5.8",
-    "vue-template-compiler": "2.7.16"
+    "vue-template-compiler": "2.7.15"
   },
   "eslintConfig": {
     "root": true,

--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,8 @@
         "monorepo:vue"
       ],
       "matchUpdateTypes": [
+        "patch",
+        "minor",
         "major"
       ],
       "dependencyDashboardApproval": true


### PR DESCRIPTION
It seems that the error described in https://github.com/ecamp/ecamp3/issues/4330 doesn't trigger with vue 2.7.15.

Downgrading vue & preventing renovate from auto-upgrading, until we have figured out, whether #4330 is a problem on our side or on vue side.