### PR TITLE
Replace colorpicker icon with ColorSwatch

### DIFF
--- a/frontend/src/components/form/base/BasePicker.vue
+++ b/frontend/src/components/form/base/BasePicker.vue
@@ -30,14 +30,23 @@ Displays a field as a picker (can be used with v-model)
           @click="(...args) => (openOnTextFieldClick ? onMenuOpen(on, ...args) : null)"
           @input="debouncedParseValue"
         >
-          <template v-if="icon" #prepend>
-            <v-icon
+          <template #prepend>
+            <slot
+              name="prepend"
               :color="iconColor"
-              :aria-label="$tc(buttonAriaLabelI18nKey, 0, { label: label || name })"
-              @click="(...args) => onMenuOpen(on, ...args)"
+              :attrs="{
+                'aria-label': $tc(buttonAriaLabelI18nKey, 0, { label: label || name }),
+              }"
+              :on="{ click: (...args) => onMenuOpen(on, ...args) }"
             >
-              {{ icon }}
-            </v-icon>
+              <v-icon
+                :color="iconColor"
+                :aria-label="$tc(buttonAriaLabelI18nKey, 0, { label: label || name })"
+                @click="(...args) => onMenuOpen(on, ...args)"
+              >
+                {{ icon }}
+              </v-icon>
+            </slot>
           </template>
 
           <!-- passing the append slot through -->

--- a/frontend/src/components/form/base/ColorPicker/ColorSwatch.vue
+++ b/frontend/src/components/form/base/ColorPicker/ColorSwatch.vue
@@ -6,6 +6,7 @@
     width="30"
     height="30"
     :color="color"
+    :ripple="false"
     @click="$emit('selectColor', color)"
     v-on="$listeners"
   ></v-btn>

--- a/frontend/src/components/form/base/ColorPicker/ColorSwatch.vue
+++ b/frontend/src/components/form/base/ColorPicker/ColorSwatch.vue
@@ -6,7 +6,8 @@
     width="30"
     height="30"
     :color="color"
-    @click="picker.onInput(color)"
+    @click="$emit('selectColor', color)"
+    v-on="$listeners"
   ></v-btn>
 </template>
 <script>
@@ -15,12 +16,12 @@ import { contrastColor } from '@/common/helpers/colors.js'
 export default {
   name: 'ColorSwatch',
   props: {
-    picker: { type: Object, required: true },
     color: { type: String, required: true },
   },
   computed: {
     contrast() {
-      return this.color ? contrastColor(this.color) : 'black'
+      // Vuetify returns invalid value #NANNAN in the initialization phase
+      return this.color && this.color !== '#NANNAN' ? contrastColor(this.color) : 'black'
     },
   },
 }

--- a/frontend/src/components/form/base/EColorPicker.vue
+++ b/frontend/src/components/form/base/EColorPicker.vue
@@ -15,6 +15,9 @@ Displays a field as a color picker (can be used with v-model)
     open-on-text-field-click
     @input="$emit('input', $event)"
   >
+    <template #prepend="{ color, attrs, on }">
+      <ColorSwatch :color="color" class="mt-n1" v-bind="attrs" v-on="on" />
+    </template>
     <template #default="picker">
       <v-card :style="{ '--picker-contrast-color': contrast }" data-testid="colorpicker">
         <v-color-picker
@@ -24,21 +27,12 @@ Displays a field as a color picker (can be used with v-model)
         />
         <v-divider />
         <div class="d-flex gap-2 pa-4 flex-wrap">
-          <ColorSwatch color="#90B7E4" :picker="picker" />
-          <ColorSwatch color="#6EDBE9" :picker="picker" />
-          <ColorSwatch color="#4dbb52" :picker="picker" />
-          <ColorSwatch color="#FF9800" :picker="picker" />
-          <ColorSwatch color="#FD7A7A" :picker="picker" />
-          <ColorSwatch color="#d584e9" :picker="picker" />
-          <ColorSwatch color="#BBBBBB" :picker="picker" />
-
-          <ColorSwatch color="#1964B1" :picker="picker" />
-          <ColorSwatch color="#1E86CA" :picker="picker" />
-          <ColorSwatch color="#3DB842" :picker="picker" />
-          <ColorSwatch color="#F1810D" :picker="picker" />
-          <ColorSwatch color="#C71A1A" :picker="picker" />
-          <ColorSwatch color="#CF3BD6" :picker="picker" />
-          <ColorSwatch color="#575757" :picker="picker" />
+          <ColorSwatch
+            v-for="swatch in swatches"
+            :key="swatch"
+            :color="swatch"
+            @selectColor="picker.onInput"
+          />
         </div>
       </v-card>
     </template>
@@ -63,6 +57,25 @@ export default {
   props: {
     value: { type: String, required: true },
   },
+  data: () => ({
+    swatches: [
+      '#90B7E4',
+      '#6EDBE9',
+      '#4dbb52',
+      '#FF9800',
+      '#FD7A7A',
+      '#d584e9',
+      '#BBBBBB',
+
+      '#1964B1',
+      '#1E86CA',
+      '#3DB842',
+      '#F1810D',
+      '#C71A1A',
+      '#CF3BD6',
+      '#575757',
+    ],
+  }),
   computed: {
     contrast() {
       // Vuetify returns invalid value #NANNAN in the initialization phase

--- a/frontend/src/components/form/base/__tests__/__snapshots__/EColorPicker.spec.js.snap
+++ b/frontend/src/components/form/base/__tests__/__snapshots__/EColorPicker.spec.js.snap
@@ -49,12 +49,6 @@ exports[`An EColorPicker > looks like a color picker > pickeropen 1`] = `
                                  style="height: 30px; width: 30px; background-color: rgb(255, 0, 0); border-color: #ff0000; --ee5e0d96-contrast: #fff;"
                                  type="button">
                               <span class="v-btn__content"></span>
-                              <span class="v-ripple__container">
-                                   <span class="v-ripple__animation v-ripple__animation--visible v-ripple__animation--out"
-                                         data-activated="9261.342420995235"
-                                         data-is-hiding="true"
-                                         style="width: 0px; height: 0px; transform: translate(0px, 0px) scale3d(1,1,1); webkit-transform: translate(0px, 0px) scale3d(1,1,1);"></span>
-                              </span>
                          </button>
                     </div>
                     <div class="v-input__control">

--- a/frontend/src/components/form/base/__tests__/__snapshots__/EColorPicker.spec.js.snap
+++ b/frontend/src/components/form/base/__tests__/__snapshots__/EColorPicker.spec.js.snap
@@ -10,9 +10,11 @@ exports[`An EColorPicker > looks like a color picker > pickerclosed 1`] = `
                     <div class="v-input v-input--hide-details theme--light v-text-field v-text-field--filled v-text-field--enclosed">
                          <div class="v-input__prepend-outer">
                               <button aria-label="Dialog öffnen um eine Farbe für test zu wählen"
-                                      class="v-icon notranslate v-icon--link mdi mdi-palette theme--light"
-                                      style="color: rgb(255, 0, 0); caret-color: #ff0000;"
-                                      type="button"></button>
+                                      class="e-colorswatch mt-n1 v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                      style="height: 30px; width: 30px; background-color: rgb(255, 0, 0); border-color: #ff0000; --ee5e0d96-contrast: #fff;"
+                                      type="button">
+                                   <span class="v-btn__content"></span>
+                              </button>
                          </div>
                          <div class="v-input__control">
                               <div class="v-input__slot">
@@ -43,9 +45,17 @@ exports[`An EColorPicker > looks like a color picker > pickeropen 1`] = `
                <div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field v-text-field--filled v-text-field--is-booted v-text-field--enclosed">
                     <div class="v-input__prepend-outer">
                          <button aria-label="Dialog öffnen um eine Farbe für test zu wählen"
-                                 class="v-icon notranslate v-icon--link mdi mdi-palette theme--light"
-                                 style="color: rgb(255, 0, 0); caret-color: #ff0000;"
-                                 type="button"></button>
+                                 class="e-colorswatch mt-n1 v-btn v-btn--fab v-btn--has-bg v-btn--round theme--light elevation-0 v-size--default"
+                                 style="height: 30px; width: 30px; background-color: rgb(255, 0, 0); border-color: #ff0000; --ee5e0d96-contrast: #fff;"
+                                 type="button">
+                              <span class="v-btn__content"></span>
+                              <span class="v-ripple__container">
+                                   <span class="v-ripple__animation v-ripple__animation--visible v-ripple__animation--out"
+                                         data-activated="9261.342420995235"
+                                         data-is-hiding="true"
+                                         style="width: 0px; height: 0px; transform: translate(0px, 0px) scale3d(1,1,1); webkit-transform: translate(0px, 0px) scale3d(1,1,1);"></span>
+                              </span>
+                         </button>
                     </div>
                     <div class="v-input__control">
                          <div class="v-input__slot">


### PR DESCRIPTION
It makes sense to use the swatch, as it also shows the contrast color.

Before:
![Bildschirmfoto 2023-12-29 um 21 11 21](https://github.com/ecamp/ecamp3/assets/3001985/ea9df62b-3ee0-4969-9b0c-18054521bce8)

After:
![Bildschirmfoto 2023-12-29 um 21 10 46](https://github.com/ecamp/ecamp3/assets/3001985/d5f03ae9-86d4-4869-8c70-89d5ba8a308a)
