### PR TITLE
Add EFK stack with ecamp3-logging

### DIFF
--- a/.helm/ecamp3-logging/.helmignore
+++ b/.helm/ecamp3-logging/.helmignore
@@ -1,0 +1,1 @@
+/deploy.sh

--- a/.helm/ecamp3-logging/Chart.yaml
+++ b/.helm/ecamp3-logging/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: ecamp3-logging
+description: Helm chart for deploying ecamp3-logging on Kubernetes
+home: https://github.com/ecamp/ecamp3
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.1.0

--- a/.helm/ecamp3-logging/README.md
+++ b/.helm/ecamp3-logging/README.md
@@ -1,0 +1,11 @@
+# ecamp3-logging
+
+This is a helm chart to deploy the logging stack of ecamp3.
+It uses the EFK stack (Elasticsearch, Filebeat and Kibana).
+There is currently no setup to deploy it in a continuous fashion.\
+The [deploy.sh](deploy.sh) allows to deploy the chart if you have
+a working [kubectl and helm setup](https://github.com/ecamp/ecamp3/wiki/Deployment-installation-Kubernetes#connecting-to-the-cluster).
+
+The current setup of kibana is stored here: [kibana-objects.ndjson](files%2Fkibana%2Fkibana-objects.ndjson)\
+It can be generated and restored with the scripts [dump-kibana-objects.sh](files%2Fkibana%2Fdump-kibana-objects.sh)
+and [restore-kibana-objects.sh](files%2Fkibana%2Frestore-kibana-objects.sh)

--- a/.helm/ecamp3-logging/deploy.sh
+++ b/.helm/ecamp3-logging/deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+
+helm upgrade --install ecamp3-logging --namespace=ecamp3-logging --create-namespace $SCRIPT_DIR

--- a/.helm/ecamp3-logging/files/kibana/dump-kibana-objects.sh
+++ b/.helm/ecamp3-logging/files/kibana/dump-kibana-objects.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+
+KIBANA_HOST=${KIBANA_HOST:-localhost:5601}
+
+curl -X POST $KIBANA_HOST/api/saved_objects/_export \
+      -H 'kbn-xsrf: true' \
+      -H 'Content-Type: application/json' \
+      -d '
+      {
+        "type": [
+          "dashboard", 
+          "index-pattern",
+          "search"
+        ],
+        "excludeExportDetails": true
+      }' \
+      --silent \
+      | jq -S \
+      > $SCRIPT_DIR/kibana-objects.ndjson

--- a/.helm/ecamp3-logging/files/kibana/kibana-objects.ndjson
+++ b/.helm/ecamp3-logging/files/kibana/kibana-objects.ndjson
@@ -1,0 +1,135 @@
+{
+  "attributes": {
+    "fieldAttrs": "{\"container.name\":{\"count\":2},\"kubernetes.labels.app_kubernetes_io/name\":{\"count\":2},\"kubernetes.labels.app_kubernetes_io/part-of\":{\"count\":1},\"message\":{\"count\":3},\"json.httpRequest.requestUrl\":{\"count\":1},\"kubernetes.deployment.name\":{\"count\":2}}",
+    "fieldFormatMap": "{}",
+    "fields": "[]",
+    "name": "filebeat",
+    "runtimeFieldMap": "{}",
+    "sourceFilters": "[]",
+    "timeFieldName": "@timestamp",
+    "title": "filebeat-*",
+    "typeMeta": "{}"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2023-12-29T17:30:30.306Z",
+  "id": "e270616c-823f-485b-b1e5-0d3435383b91",
+  "managed": false,
+  "references": [],
+  "sort": [
+    1703871030306,
+    11
+  ],
+  "type": "index-pattern",
+  "typeMigrationVersion": "8.0.0",
+  "updated_at": "2023-12-29T17:30:30.306Z",
+  "version": "Wzc5NCwxMV0="
+}
+{
+  "attributes": {
+    "controlGroupInput": {
+      "chainingSystem": "HIERARCHICAL",
+      "controlStyle": "oneLine",
+      "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+      "panelsJSON": "{\"559bf65c-2341-4cd1-a3f4-c3ed1893719b\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"559bf65c-2341-4cd1-a3f4-c3ed1893719b\",\"fieldName\":\"kubernetes.deployment.name\",\"title\":\"kubernetes.deployment.name\",\"grow\":true,\"width\":\"medium\",\"selectedOptions\":[\"ingress-nginx-controller\",\"ecamp3-dev-api\"],\"enhancements\":{}}}}"
+    },
+    "description": "",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+    },
+    "optionsJSON": "{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}",
+    "panelsJSON": "[{\"version\":\"8.10.2\",\"type\":\"LOG_STREAM_EMBEDDABLE\",\"gridData\":{\"x\":0,\"y\":0,\"w\":24,\"h\":15,\"i\":\"314ee8bc-8995-4a1d-a844-4e56155e9455\"},\"panelIndex\":\"314ee8bc-8995-4a1d-a844-4e56155e9455\",\"embeddableConfig\":{\"enhancements\":{}},\"title\":\"Log stream\"},{\"version\":\"8.10.2\",\"type\":\"lens\",\"gridData\":{\"x\":24,\"y\":0,\"w\":24,\"h\":15,\"i\":\"abec7a0c-b69b-4eae-8f64-9b77d8548555\"},\"panelIndex\":\"abec7a0c-b69b-4eae-8f64-9b77d8548555\",\"embeddableConfig\":{\"attributes\":{\"title\":\"\",\"description\":\"\",\"visualizationType\":\"lnsXY\",\"type\":\"lens\",\"references\":[{\"type\":\"index-pattern\",\"id\":\"e270616c-823f-485b-b1e5-0d3435383b91\",\"name\":\"indexpattern-datasource-layer-bb76a1ab-de9b-40ac-bc6c-5eeca64f616b\"}],\"state\":{\"visualization\":{\"legend\":{\"isVisible\":true,\"position\":\"right\"},\"valueLabels\":\"hide\",\"fittingFunction\":\"None\",\"axisTitlesVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"tickLabelsVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"labelsOrientation\":{\"x\":0,\"yLeft\":0,\"yRight\":0},\"gridlinesVisibilitySettings\":{\"x\":true,\"yLeft\":true,\"yRight\":true},\"preferredSeriesType\":\"area_stacked\",\"layers\":[{\"layerId\":\"bb76a1ab-de9b-40ac-bc6c-5eeca64f616b\",\"seriesType\":\"area_stacked\",\"accessors\":[\"083fd753-b44b-431d-87ad-e8aa13b2688f\"],\"layerType\":\"data\",\"splitAccessor\":\"603c118f-36b2-4e67-92f3-85c77a133b2e\",\"xAccessor\":\"66fd69ef-88f7-4002-8c09-c1416a5d4d6c\"}],\"valuesInLegend\":false},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"datasourceStates\":{\"formBased\":{\"layers\":{\"bb76a1ab-de9b-40ac-bc6c-5eeca64f616b\":{\"columns\":{\"603c118f-36b2-4e67-92f3-85c77a133b2e\":{\"label\":\"Top 500 values of json.httpRequest.status\",\"dataType\":\"number\",\"operationType\":\"terms\",\"scale\":\"ordinal\",\"sourceField\":\"json.httpRequest.status\",\"isBucketed\":true,\"params\":{\"size\":500,\"orderBy\":{\"type\":\"alphabetical\",\"fallback\":false},\"orderDirection\":\"asc\",\"otherBucket\":true,\"missingBucket\":false,\"parentFormat\":{\"id\":\"terms\"},\"include\":[],\"exclude\":[],\"includeIsRegex\":false,\"excludeIsRegex\":false}},\"66fd69ef-88f7-4002-8c09-c1416a5d4d6c\":{\"label\":\"@timestamp\",\"dataType\":\"date\",\"operationType\":\"date_histogram\",\"sourceField\":\"@timestamp\",\"isBucketed\":true,\"scale\":\"interval\",\"params\":{\"interval\":\"5m\",\"includeEmptyRows\":true,\"dropPartials\":false}},\"083fd753-b44b-431d-87ad-e8aa13b2688fX0\":{\"label\":\"Part of unique_count(json.httpRequest.status)\",\"dataType\":\"number\",\"operationType\":\"unique_count\",\"scale\":\"ratio\",\"sourceField\":\"json.httpRequest.status\",\"isBucketed\":false,\"params\":{\"emptyAsNull\":false},\"customLabel\":true},\"083fd753-b44b-431d-87ad-e8aa13b2688f\":{\"label\":\"unique_count(json.httpRequest.status)\",\"dataType\":\"number\",\"operationType\":\"formula\",\"isBucketed\":false,\"scale\":\"ratio\",\"params\":{\"formula\":\"unique_count(json.httpRequest.status)\",\"isFormulaBroken\":false},\"references\":[\"083fd753-b44b-431d-87ad-e8aa13b2688fX0\"]}},\"columnOrder\":[\"603c118f-36b2-4e67-92f3-85c77a133b2e\",\"66fd69ef-88f7-4002-8c09-c1416a5d4d6c\",\"083fd753-b44b-431d-87ad-e8aa13b2688f\",\"083fd753-b44b-431d-87ad-e8aa13b2688fX0\"],\"sampling\":0.01,\"ignoreGlobalFilters\":false,\"incompleteColumns\":{}}}},\"indexpattern\":{\"layers\":{}},\"textBased\":{\"layers\":{}}},\"internalReferences\":[],\"adHocDataViews\":{}}},\"enhancements\":{}}},{\"version\":\"8.10.2\",\"type\":\"lens\",\"gridData\":{\"x\":0,\"y\":30,\"w\":24,\"h\":15,\"i\":\"2a435cc4-cf49-4522-a01c-5de034306ae0\"},\"panelIndex\":\"2a435cc4-cf49-4522-a01c-5de034306ae0\",\"embeddableConfig\":{\"attributes\":{\"title\":\"\",\"description\":\"\",\"visualizationType\":\"lnsDatatable\",\"type\":\"lens\",\"references\":[{\"id\":\"e270616c-823f-485b-b1e5-0d3435383b91\",\"name\":\"indexpattern-datasource-layer-835bca0b-3409-43fd-b02e-8d90334ea396\",\"type\":\"index-pattern\"}],\"state\":{\"visualization\":{\"columns\":[{\"columnId\":\"7e556b41-0d8d-4351-931f-cda4c1397ea3\",\"isTransposed\":false,\"width\":459.6666666666667},{\"columnId\":\"f7399748-ce1c-4df4-89f4-e3e30a67a023\",\"isTransposed\":false},{\"isTransposed\":false,\"columnId\":\"2548689a-01e7-4752-9373-8b3bcb13c670\"},{\"columnId\":\"dfffbbfd-1a5e-409d-9dfd-1cdf36bb6d01\",\"isTransposed\":false}],\"layerId\":\"835bca0b-3409-43fd-b02e-8d90334ea396\",\"layerType\":\"data\"},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"datasourceStates\":{\"formBased\":{\"layers\":{\"835bca0b-3409-43fd-b02e-8d90334ea396\":{\"columns\":{\"7e556b41-0d8d-4351-931f-cda4c1397ea3\":{\"label\":\"Top 20 values of json.httpRequest.escapedUrl\",\"dataType\":\"string\",\"operationType\":\"terms\",\"scale\":\"ordinal\",\"sourceField\":\"json.httpRequest.escapedUrl\",\"isBucketed\":true,\"params\":{\"size\":20,\"orderBy\":{\"type\":\"column\",\"columnId\":\"f7399748-ce1c-4df4-89f4-e3e30a67a023\"},\"orderDirection\":\"desc\",\"otherBucket\":true,\"missingBucket\":false,\"parentFormat\":{\"id\":\"terms\"},\"include\":[],\"exclude\":[],\"includeIsRegex\":false,\"excludeIsRegex\":false,\"secondaryFields\":[]}},\"f7399748-ce1c-4df4-89f4-e3e30a67a023\":{\"label\":\"90th % of request time\",\"dataType\":\"number\",\"operationType\":\"percentile\",\"sourceField\":\"json.httpRequest.request_time_seconds\",\"isBucketed\":false,\"scale\":\"ratio\",\"params\":{\"percentile\":90},\"customLabel\":true},\"2548689a-01e7-4752-9373-8b3bcb13c670\":{\"label\":\"#\",\"dataType\":\"number\",\"operationType\":\"count\",\"isBucketed\":false,\"scale\":\"ratio\",\"sourceField\":\"___records___\",\"params\":{\"emptyAsNull\":true},\"customLabel\":true},\"dfffbbfd-1a5e-409d-9dfd-1cdf36bb6d01\":{\"label\":\"Median of request time\",\"dataType\":\"number\",\"operationType\":\"median\",\"sourceField\":\"json.httpRequest.request_time_seconds\",\"isBucketed\":false,\"scale\":\"ratio\",\"params\":{\"emptyAsNull\":true},\"customLabel\":true}},\"columnOrder\":[\"7e556b41-0d8d-4351-931f-cda4c1397ea3\",\"f7399748-ce1c-4df4-89f4-e3e30a67a023\",\"dfffbbfd-1a5e-409d-9dfd-1cdf36bb6d01\",\"2548689a-01e7-4752-9373-8b3bcb13c670\"],\"sampling\":1,\"ignoreGlobalFilters\":false,\"incompleteColumns\":{}}}},\"indexpattern\":{\"layers\":{}},\"textBased\":{\"layers\":{}}},\"internalReferences\":[],\"adHocDataViews\":{}}},\"enhancements\":{}}},{\"version\":\"8.10.2\",\"type\":\"lens\",\"gridData\":{\"x\":24,\"y\":15,\"w\":24,\"h\":15,\"i\":\"30f417c9-8766-433d-994c-8f1d5a1c25d0\"},\"panelIndex\":\"30f417c9-8766-433d-994c-8f1d5a1c25d0\",\"embeddableConfig\":{\"attributes\":{\"title\":\"\",\"description\":\"\",\"visualizationType\":\"lnsDatatable\",\"type\":\"lens\",\"references\":[{\"id\":\"e270616c-823f-485b-b1e5-0d3435383b91\",\"name\":\"indexpattern-datasource-layer-81072a4c-add7-4e53-86ef-48835dda22fc\",\"type\":\"index-pattern\"}],\"state\":{\"visualization\":{\"columns\":[{\"columnId\":\"b9b7e27a-d594-4923-91dd-d90b7454f5d5\",\"isTransposed\":false,\"width\":639.6666666666667},{\"columnId\":\"3b58a496-25c2-4214-843a-ea61ff397fd3\",\"isTransposed\":false},{\"columnId\":\"a11ec684-1bc7-422b-a656-e1aea15d9e2b\",\"isTransposed\":false},{\"columnId\":\"12224576-d26b-4fc0-8074-1ad971fe6286\",\"isTransposed\":false}],\"layerId\":\"81072a4c-add7-4e53-86ef-48835dda22fc\",\"layerType\":\"data\"},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"datasourceStates\":{\"formBased\":{\"layers\":{\"81072a4c-add7-4e53-86ef-48835dda22fc\":{\"columns\":{\"b9b7e27a-d594-4923-91dd-d90b7454f5d5\":{\"label\":\"Top 20 values of json.httpRequest.escapedUrlWithoutQuery\",\"dataType\":\"string\",\"operationType\":\"terms\",\"scale\":\"ordinal\",\"sourceField\":\"json.httpRequest.escapedUrlWithoutQuery\",\"isBucketed\":true,\"params\":{\"size\":20,\"orderBy\":{\"type\":\"column\",\"columnId\":\"a11ec684-1bc7-422b-a656-e1aea15d9e2b\"},\"orderDirection\":\"desc\",\"otherBucket\":true,\"missingBucket\":false,\"parentFormat\":{\"id\":\"terms\"},\"include\":[],\"exclude\":[],\"includeIsRegex\":false,\"excludeIsRegex\":false,\"accuracyMode\":true,\"secondaryFields\":[]}},\"3b58a496-25c2-4214-843a-ea61ff397fd3\":{\"label\":\"200 Response\",\"dataType\":\"number\",\"operationType\":\"count\",\"isBucketed\":false,\"scale\":\"ratio\",\"sourceField\":\"json.httpRequest.status\",\"filter\":{\"query\":\"json.httpRequest.status >= 200 and json.httpRequest.status < 300\",\"language\":\"kuery\"},\"params\":{\"emptyAsNull\":true},\"customLabel\":true},\"a11ec684-1bc7-422b-a656-e1aea15d9e2b\":{\"label\":\"500 Responses\",\"dataType\":\"number\",\"operationType\":\"count\",\"isBucketed\":false,\"scale\":\"ratio\",\"sourceField\":\"___records___\",\"filter\":{\"query\":\"json.httpRequest.status >= 500\",\"language\":\"kuery\"},\"params\":{\"emptyAsNull\":true},\"customLabel\":true},\"12224576-d26b-4fc0-8074-1ad971fe6286\":{\"label\":\"400 Responses\",\"dataType\":\"number\",\"operationType\":\"count\",\"isBucketed\":false,\"scale\":\"ratio\",\"sourceField\":\"___records___\",\"filter\":{\"query\":\"json.httpRequest.status >= 400 AND json.httpRequest.status < 500\",\"language\":\"kuery\"},\"params\":{\"emptyAsNull\":true},\"customLabel\":true}},\"columnOrder\":[\"b9b7e27a-d594-4923-91dd-d90b7454f5d5\",\"3b58a496-25c2-4214-843a-ea61ff397fd3\",\"12224576-d26b-4fc0-8074-1ad971fe6286\",\"a11ec684-1bc7-422b-a656-e1aea15d9e2b\"],\"sampling\":1,\"ignoreGlobalFilters\":false,\"incompleteColumns\":{}}}},\"indexpattern\":{\"layers\":{}},\"textBased\":{\"layers\":{}}},\"internalReferences\":[],\"adHocDataViews\":{}}},\"enhancements\":{}}},{\"version\":\"8.10.2\",\"type\":\"lens\",\"gridData\":{\"x\":0,\"y\":15,\"w\":24,\"h\":15,\"i\":\"f8ee43e1-4387-45e6-80be-c0301a4dc991\"},\"panelIndex\":\"f8ee43e1-4387-45e6-80be-c0301a4dc991\",\"embeddableConfig\":{\"attributes\":{\"title\":\"\",\"description\":\"\",\"visualizationType\":\"lnsDatatable\",\"type\":\"lens\",\"references\":[{\"id\":\"e270616c-823f-485b-b1e5-0d3435383b91\",\"name\":\"indexpattern-datasource-layer-835bca0b-3409-43fd-b02e-8d90334ea396\",\"type\":\"index-pattern\"}],\"state\":{\"visualization\":{\"columns\":[{\"columnId\":\"7e556b41-0d8d-4351-931f-cda4c1397ea3\",\"isTransposed\":false,\"width\":459.6666666666667},{\"columnId\":\"f7399748-ce1c-4df4-89f4-e3e30a67a023\",\"isTransposed\":false},{\"isTransposed\":false,\"columnId\":\"2548689a-01e7-4752-9373-8b3bcb13c670\"},{\"columnId\":\"dfffbbfd-1a5e-409d-9dfd-1cdf36bb6d01\",\"isTransposed\":false}],\"layerId\":\"835bca0b-3409-43fd-b02e-8d90334ea396\",\"layerType\":\"data\"},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"datasourceStates\":{\"formBased\":{\"layers\":{\"835bca0b-3409-43fd-b02e-8d90334ea396\":{\"columns\":{\"7e556b41-0d8d-4351-931f-cda4c1397ea3\":{\"label\":\"Top 20 values of json.httpRequest.escapedUrlWithoutQuery\",\"dataType\":\"string\",\"operationType\":\"terms\",\"scale\":\"ordinal\",\"sourceField\":\"json.httpRequest.escapedUrlWithoutQuery\",\"isBucketed\":true,\"params\":{\"size\":20,\"orderBy\":{\"type\":\"column\",\"columnId\":\"f7399748-ce1c-4df4-89f4-e3e30a67a023\"},\"orderDirection\":\"desc\",\"otherBucket\":true,\"missingBucket\":false,\"parentFormat\":{\"id\":\"terms\"},\"include\":[],\"exclude\":[],\"includeIsRegex\":false,\"excludeIsRegex\":false,\"secondaryFields\":[]}},\"f7399748-ce1c-4df4-89f4-e3e30a67a023\":{\"label\":\"90th % of request time\",\"dataType\":\"number\",\"operationType\":\"percentile\",\"sourceField\":\"json.httpRequest.request_time_seconds\",\"isBucketed\":false,\"scale\":\"ratio\",\"params\":{\"percentile\":90},\"customLabel\":true},\"2548689a-01e7-4752-9373-8b3bcb13c670\":{\"label\":\"#\",\"dataType\":\"number\",\"operationType\":\"count\",\"isBucketed\":false,\"scale\":\"ratio\",\"sourceField\":\"___records___\",\"params\":{\"emptyAsNull\":true},\"customLabel\":true},\"dfffbbfd-1a5e-409d-9dfd-1cdf36bb6d01\":{\"label\":\"Median of request time\",\"dataType\":\"number\",\"operationType\":\"median\",\"sourceField\":\"json.httpRequest.request_time_seconds\",\"isBucketed\":false,\"scale\":\"ratio\",\"params\":{\"emptyAsNull\":true},\"customLabel\":true}},\"columnOrder\":[\"7e556b41-0d8d-4351-931f-cda4c1397ea3\",\"f7399748-ce1c-4df4-89f4-e3e30a67a023\",\"dfffbbfd-1a5e-409d-9dfd-1cdf36bb6d01\",\"2548689a-01e7-4752-9373-8b3bcb13c670\"],\"sampling\":1,\"ignoreGlobalFilters\":false,\"incompleteColumns\":{}}}},\"indexpattern\":{\"layers\":{}},\"textBased\":{\"layers\":{}}},\"internalReferences\":[],\"adHocDataViews\":{}}},\"enhancements\":{}},\"title\":\"\"}]",
+    "timeRestore": false,
+    "title": "ecamp3",
+    "version": 1
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2023-12-29T17:45:49.265Z",
+  "id": "cbf725c0-705f-11ee-bdbe-0de3df9703e1",
+  "managed": false,
+  "references": [
+    {
+      "id": "e270616c-823f-485b-b1e5-0d3435383b91",
+      "name": "abec7a0c-b69b-4eae-8f64-9b77d8548555:indexpattern-datasource-layer-bb76a1ab-de9b-40ac-bc6c-5eeca64f616b",
+      "type": "index-pattern"
+    },
+    {
+      "id": "e270616c-823f-485b-b1e5-0d3435383b91",
+      "name": "2a435cc4-cf49-4522-a01c-5de034306ae0:indexpattern-datasource-layer-835bca0b-3409-43fd-b02e-8d90334ea396",
+      "type": "index-pattern"
+    },
+    {
+      "id": "e270616c-823f-485b-b1e5-0d3435383b91",
+      "name": "30f417c9-8766-433d-994c-8f1d5a1c25d0:indexpattern-datasource-layer-81072a4c-add7-4e53-86ef-48835dda22fc",
+      "type": "index-pattern"
+    },
+    {
+      "id": "e270616c-823f-485b-b1e5-0d3435383b91",
+      "name": "f8ee43e1-4387-45e6-80be-c0301a4dc991:indexpattern-datasource-layer-835bca0b-3409-43fd-b02e-8d90334ea396",
+      "type": "index-pattern"
+    },
+    {
+      "id": "e270616c-823f-485b-b1e5-0d3435383b91",
+      "name": "controlGroup_559bf65c-2341-4cd1-a3f4-c3ed1893719b:optionsListDataView",
+      "type": "index-pattern"
+    }
+  ],
+  "sort": [
+    1703871949265,
+    10
+  ],
+  "type": "dashboard",
+  "typeMigrationVersion": "8.9.0",
+  "updated_at": "2023-12-29T17:45:49.265Z",
+  "version": "WzgzNywxMV0="
+}
+{
+  "attributes": {
+    "columns": [
+      "kubernetes.deployment.name",
+      "json.httpRequest.requestUrl",
+      "json.httpRequest.escapedUrl",
+      "json.httpRequest.escapedUrlWithoutQuery"
+    ],
+    "description": "Ingress controller request urls",
+    "grid": {},
+    "hideChart": false,
+    "isTextBasedQuery": false,
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[{\"meta\":{\"alias\":null,\"disabled\":false,\"key\":\"kubernetes.deployment.name\",\"negate\":false,\"params\":{\"query\":\"ingress-nginx-controller\"},\"type\":\"phrase\",\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index\"},\"query\":{\"match_phrase\":{\"kubernetes.deployment.name\":\"ingress-nginx-controller\"}},\"$state\":{\"store\":\"appState\"}}],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+    },
+    "sort": [
+      [
+        "@timestamp",
+        "desc"
+      ]
+    ],
+    "timeRestore": false,
+    "title": "ingress-controller-requesturls",
+    "usesAdHocDataView": false,
+    "viewMode": "documents"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2023-12-29T17:30:30.306Z",
+  "id": "cd3bd7f0-a65b-11ee-b3f2-b70caab0eacb",
+  "managed": false,
+  "references": [
+    {
+      "id": "e270616c-823f-485b-b1e5-0d3435383b91",
+      "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+      "type": "index-pattern"
+    },
+    {
+      "id": "e270616c-823f-485b-b1e5-0d3435383b91",
+      "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+      "type": "index-pattern"
+    }
+  ],
+  "sort": [
+    1703871030306,
+    14
+  ],
+  "type": "search",
+  "typeMigrationVersion": "8.0.0",
+  "updated_at": "2023-12-29T17:30:30.306Z",
+  "version": "Wzc5NiwxMV0="
+}

--- a/.helm/ecamp3-logging/files/kibana/restore-kibana-objects.sh
+++ b/.helm/ecamp3-logging/files/kibana/restore-kibana-objects.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+
+KIBANA_HOST=${KIBANA_HOST:-localhost:5601}
+
+tmp_file=/tmp/$(uuidgen).ndjson
+
+cat $SCRIPT_DIR/kibana-objects.ndjson | jq -c > $tmp_file 
+
+curl -X POST "$KIBANA_HOST/api/saved_objects/_import?createNewCopies=false&overwrite=true" \
+     -H "kbn-xsrf: true" \
+     --form file=@$tmp_file

--- a/.helm/ecamp3-logging/templates/_helpers.tpl
+++ b/.helm/ecamp3-logging/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/*
+Common labels
+*/}}
+{{- define "app.commonLabels" -}}
+helm.sh/chart: {{ .Chart.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Common selector labels
+*/}}
+{{- define "app.commonSelectorLabels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ .Chart.Name }}
+{{- end }}

--- a/.helm/ecamp3-logging/templates/elasticsearch/elasticsearch_service.yaml
+++ b/.helm/ecamp3-logging/templates/elasticsearch/elasticsearch_service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: elasticsearch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: elasticsearch
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
+spec:
+  selector:
+    app: elasticsearch
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
+  clusterIP: None
+  ports:
+    - port: 9200
+      name: rest
+    - port: 9300
+      name: inter-node

--- a/.helm/ecamp3-logging/templates/elasticsearch/elasticsearch_stateful_set.yaml
+++ b/.helm/ecamp3-logging/templates/elasticsearch/elasticsearch_stateful_set.yaml
@@ -1,0 +1,84 @@
+{{- $minHeapSpace := .Values.elasticsearch.elasticNode.resources.requests.memory | replace "Mi" "" -}}
+{{- $maxHeapSpace := .Values.elasticsearch.elasticNode.resources.requests.memory | replace "Mi" "" -}}
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: es-cluster
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
+spec:
+  serviceName: elasticsearch
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elasticsearch
+      {{- include "app.commonSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+        {{- include "app.commonLabels" . | nindent 8 }}
+        {{- include "app.commonSelectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+          resources:
+            {{- toYaml .Values.elasticsearch.elasticNode.resources | nindent 12 }}
+          ports:
+            - containerPort: 9200
+              name: rest
+              protocol: TCP
+            - containerPort: 9300
+              name: inter-node
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+          env:
+            - name: cluster.name
+              value: ecamp3-logs
+            - name: xpack.security.enabled
+              value: "false"
+            - name: node.name
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: cluster.initial_master_nodes
+              value: "es-cluster-0"
+            - name: ES_JAVA_OPTS
+              value: "-Xms{{ $minHeapSpace }}m -Xmx{{ $maxHeapSpace }}m"
+      initContainers:
+        - name: fix-permissions
+          image: busybox
+          command: [ "sh", "-c", "chown -R 1000:1000 /usr/share/elasticsearch/data" ]
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+        - name: increase-vm-max-map
+          image: busybox
+          command: [ "sysctl", "-w", "vm.max_map_count=262144" ]
+          securityContext:
+            privileged: true
+        - name: increase-fd-ulimit
+          image: busybox
+          command: [ "sh", "-c", "ulimit -n 65536" ]
+          securityContext:
+            privileged: true
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app: elasticsearch
+          {{- include "app.commonLabels" . | nindent 10 }}
+          {{- include "app.commonSelectorLabels" . | nindent 10 }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: do-block-storage
+        resources:
+          {{- toYaml .Values.elasticsearch.persistence.resources | nindent 10 }}

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_cluster_role.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_cluster_role.yaml
@@ -2,23 +2,35 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: filebeat
+  # ClusterRole is a non-namespaces resource
+  # see https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
   labels:
+    app: filebeat
     k8s-app: filebeat
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
 rules:
-  - apiGroups: [""] # "" indicates the core API group
+  - apiGroups:
+      - ""
     resources:
-      - namespaces
       - pods
+      - namespaces
       - nodes
     verbs:
       - get
-      - watch
       - list
-  - apiGroups: ["apps"]
+      - watch
+  - apiGroups: [ "apps" ]
     resources:
       - replicasets
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["batch"]
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [ "batch" ]
     resources:
       - jobs
-    verbs: ["get", "list", "watch"]
+    verbs:
+      - get
+      - list
+      - watch

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_cluster_role.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_cluster_role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: filebeat
+  labels:
+    k8s-app: filebeat
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources:
+      - namespaces
+      - pods
+      - nodes
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: ["apps"]
+    resources:
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+    verbs: ["get", "list", "watch"]

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_cluster_role_binding.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: filebeat
+subjects:
+  - kind: ServiceAccount
+    name: filebeat
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: filebeat
+  apiGroup: rbac.authorization.k8s.io

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_cluster_role_binding.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_cluster_role_binding.yaml
@@ -2,11 +2,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: filebeat
-subjects:
-  - kind: ServiceAccount
-    name: filebeat
-    namespace: kube-system
+  labels:
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
 roleRef:
   kind: ClusterRole
   name: filebeat
   apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: filebeat
+    namespace: {{ .Release.Namespace }}

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_config_map.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_config_map.yaml
@@ -13,7 +13,8 @@ data:
     filebeat.inputs:
       - type: container
         paths:
-          - /var/log/containers/*.log
+          - /var/log/containers/ecamp3-*.log
+          - /var/log/containers/ingress-nginx-controller*.log
         processors:
           - add_kubernetes_metadata:
               host: ${NODE_NAME}

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_config_map.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_config_map.yaml
@@ -16,22 +16,55 @@ data:
           - /var/log/containers/ecamp3-*.log
           - /var/log/containers/ingress-nginx-controller*.log
         processors:
+          - decode_json_fields:
+              fields: [ "message" ]
+              target: json
+              max_depth: 20
+              add_error_key: true
+
           - add_kubernetes_metadata:
               host: ${NODE_NAME}
               matchers:
                 - logs_path:
                     logs_path: "/var/log/containers/"
 
-    # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:
-    #filebeat.autodiscover:
-    #  providers:
-    #    - type: kubernetes
-    #      node: ${NODE_NAME}
-    #      hints.enabled: true
-    #      hints.default_config:
-    #        type: container
-    #        paths:
-    #          - /var/log/containers/*${data.kubernetes.container.id}.log
+          - copy_fields:
+              fields:
+                - from: json.httpRequest.requestUrl
+                  to: json.httpRequest.escapedUrl
+              fail_on_error: false
+              ignore_missing: true
+
+          - replace:
+              fields:
+                - field: json.httpRequest.escapedUrl
+                  pattern: "/[0-9a-f]{6,}/?"
+                  replacement: "/{id}/"
+              fail_on_error: false
+              ignore_missing: true
+
+          - replace:
+              fields:
+                - field: json.httpRequest.escapedUrl
+                  pattern: "%2F[0-9a-f]{6,}(%2F)?"
+                  replacement: "%2F{id}%2F"
+              fail_on_error: false
+              ignore_missing: true
+
+          - copy_fields:
+              fields:
+                - from: json.httpRequest.escapedUrl
+                  to: json.httpRequest.escapedUrlWithoutQuery
+              fail_on_error: false
+              ignore_missing: true
+
+          - replace:
+              fields:
+                - field: json.httpRequest.escapedUrlWithoutQuery
+                  pattern: "\\?.*$"
+                  replacement: ""
+              fail_on_error: false
+              ignore_missing: true
 
     processors:
       - add_cloud_metadata:

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_config_map.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_config_map.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filebeat-config
+  namespace: kube-system
+  labels:
+    k8s-app: filebeat
+data:
+  filebeat.yml: |-
+    filebeat.inputs:
+      - type: container
+        paths:
+          - /var/log/containers/*.log
+        processors:
+          - add_kubernetes_metadata:
+              host: ${NODE_NAME}
+              matchers:
+                - logs_path:
+                    logs_path: "/var/log/containers/"
+
+    # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:
+    #filebeat.autodiscover:
+    #  providers:
+    #    - type: kubernetes
+    #      node: ${NODE_NAME}
+    #      hints.enabled: true
+    #      hints.default_config:
+    #        type: container
+    #        paths:
+    #          - /var/log/containers/*${data.kubernetes.container.id}.log
+
+    processors:
+      - add_cloud_metadata:
+      - add_host_metadata:
+
+    cloud.id: ${ELASTIC_CLOUD_ID}
+    cloud.auth: ${ELASTIC_CLOUD_AUTH}
+
+    output.elasticsearch:
+      hosts: ['${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}']
+      username: ${ELASTICSEARCH_USERNAME}
+      password: ${ELASTICSEARCH_PASSWORD}

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_config_map.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_config_map.yaml
@@ -74,6 +74,6 @@ data:
     cloud.auth: ${ELASTIC_CLOUD_AUTH}
 
     output.elasticsearch:
-      hosts: ['${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}']
-      username: ${ELASTICSEARCH_USERNAME}
-      password: ${ELASTICSEARCH_PASSWORD}
+      hosts: [ '${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}' ]
+      username: ${ELASTICSEARCH_USERNAME:-}
+      password: ${ELASTICSEARCH_PASSWORD:-}

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_config_map.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_config_map.yaml
@@ -2,9 +2,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: filebeat-config
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
+    app: filebeat
     k8s-app: filebeat
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
 data:
   filebeat.yml: |-
     filebeat.inputs:

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_daemon_set.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_daemon_set.yaml
@@ -2,17 +2,26 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: filebeat
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
+    app: filebeat
     k8s-app: filebeat
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      k8s-app: filebeat
+      app: filebeat
   template:
     metadata:
       labels:
-        k8s-app: filebeat
+        app: filebeat
+        {{- include "app.commonLabels" . | nindent 8 }}
+        {{- include "app.commonSelectorLabels" . | nindent 8 }}
+      annotations:
+        # This deployment should be restarted whenever either the configmap or the secrets change
+        # because the containers depend on environment variables from these places during startup
+        checksum/config: {{ include (print $.Template.BasePath "/filebeat/filebeat_config_map.yaml") . | sha256sum }}
     spec:
       serviceAccountName: filebeat
       terminationGracePeriodSeconds: 30
@@ -27,31 +36,17 @@ spec:
           ]
           env:
             - name: ELASTICSEARCH_HOST
-              value: elasticsearch
+              value: "elasticsearch"
             - name: ELASTICSEARCH_PORT
               value: "9200"
-            - name: ELASTICSEARCH_USERNAME
-              value: elastic
-            - name: ELASTICSEARCH_PASSWORD
-              value: changeme
-            - name: ELASTIC_CLOUD_ID
-              value:
-            - name: ELASTIC_CLOUD_AUTH
-              value:
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
           securityContext:
             runAsUser: 0
-            # If using Red Hat OpenShift uncomment this:
-            #privileged: true
           resources:
-            limits:
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
+            {{- toYaml .Values.filebeat.resources | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/filebeat.yml
@@ -59,26 +54,24 @@ spec:
               subPath: filebeat.yml
             - name: data
               mountPath: /usr/share/filebeat/data
-            - name: varlibdockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
-            - name: varlog
+            - name: host-logs
               mountPath: /var/log
+              readOnly: true
+            - name: container-logs
+              mountPath: /var/lib/docker/containers
               readOnly: true
       volumes:
         - name: config
           configMap:
             defaultMode: 0640
             name: filebeat-config
-        - name: varlibdockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
-        - name: varlog
-          hostPath:
-            path: /var/log
-        # data folder stores a registry of read status for all files, so we don't send everything again on a Filebeat pod restart
         - name: data
           hostPath:
-            # When filebeat runs as non-root user, this directory needs to be writable by group (g+w).
             path: /var/lib/filebeat-data
             type: DirectoryOrCreate
+        - name: host-logs
+          hostPath:
+            path: /var/log
+        - name: container-logs
+          hostPath:
+            path: /var/lib/docker/containers

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_daemon_set.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_daemon_set.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: filebeat
+  namespace: kube-system
+  labels:
+    k8s-app: filebeat
+spec:
+  selector:
+    matchLabels:
+      k8s-app: filebeat
+  template:
+    metadata:
+      labels:
+        k8s-app: filebeat
+    spec:
+      serviceAccountName: filebeat
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: filebeat
+          image: docker.elastic.co/beats/filebeat:8.11.3
+          args: [
+            "-c", "/etc/filebeat.yml",
+            "-e",
+          ]
+          env:
+            - name: ELASTICSEARCH_HOST
+              value: elasticsearch
+            - name: ELASTICSEARCH_PORT
+              value: "9200"
+            - name: ELASTICSEARCH_USERNAME
+              value: elastic
+            - name: ELASTICSEARCH_PASSWORD
+              value: changeme
+            - name: ELASTIC_CLOUD_ID
+              value:
+            - name: ELASTIC_CLOUD_AUTH
+              value:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+            # If using Red Hat OpenShift uncomment this:
+            #privileged: true
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/filebeat.yml
+              readOnly: true
+              subPath: filebeat.yml
+            - name: data
+              mountPath: /usr/share/filebeat/data
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            defaultMode: 0640
+            name: filebeat-config
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: varlog
+          hostPath:
+            path: /var/log
+        # data folder stores a registry of read status for all files, so we don't send everything again on a Filebeat pod restart
+        - name: data
+          hostPath:
+            # When filebeat runs as non-root user, this directory needs to be writable by group (g+w).
+            path: /var/lib/filebeat-data
+            type: DirectoryOrCreate

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_role_bindings.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_role_bindings.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: filebeat
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: filebeat
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: filebeat
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: filebeat-kubeadm-config
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: filebeat
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: filebeat-kubeadm-config
+  apiGroup: rbac.authorization.k8s.io

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_role_bindings.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_role_bindings.yaml
@@ -3,10 +3,15 @@ kind: RoleBinding
 metadata:
   name: filebeat
   namespace: kube-system
+  labels:
+    app: filebeat
+    k8s-app: filebeat
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: filebeat
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: filebeat
@@ -17,10 +22,15 @@ kind: RoleBinding
 metadata:
   name: filebeat-kubeadm-config
   namespace: kube-system
+  labels:
+    app: filebeat
+    k8s-app: filebeat
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: filebeat
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: filebeat-kubeadm-config

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_roles.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_roles.yaml
@@ -2,16 +2,21 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: filebeat
-  # should be the namespace where filebeat is running
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
+    app: filebeat
     k8s-app: filebeat
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
 rules:
   - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
-    verbs: ["get", "create", "update"]
+    verbs: 
+      - get
+      - create
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -19,11 +24,15 @@ metadata:
   name: filebeat-kubeadm-config
   namespace: kube-system
   labels:
+    app: filebeat
     k8s-app: filebeat
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources:
       - configmaps
     resourceNames:
       - kubeadm-config
-    verbs: ["get"]
+    verbs:
+      - get

--- a/.helm/ecamp3-logging/templates/filebeat/filebeat_roles.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/filebeat_roles.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: filebeat
+  # should be the namespace where filebeat is running
+  namespace: kube-system
+  labels:
+    k8s-app: filebeat
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: filebeat-kubeadm-config
+  namespace: kube-system
+  labels:
+    k8s-app: filebeat
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    resourceNames:
+      - kubeadm-config
+    verbs: ["get"]

--- a/.helm/ecamp3-logging/templates/filebeat/fluentd_service_account.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/fluentd_service_account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: filebeat
+  namespace: kube-system
+  labels:
+    k8s-app: filebeat

--- a/.helm/ecamp3-logging/templates/filebeat/fluentd_service_account.yaml
+++ b/.helm/ecamp3-logging/templates/filebeat/fluentd_service_account.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: filebeat
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
-    k8s-app: filebeat
+    app: filebeat
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}

--- a/.helm/ecamp3-logging/templates/kibana/kibana_deployment.yaml
+++ b/.helm/ecamp3-logging/templates/kibana/kibana_deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kibana
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kibana
+      {{- include "app.commonSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app: kibana
+        {{- include "app.commonLabels" . | nindent 8 }}
+        {{- include "app.commonSelectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: kibana
+          image: docker.elastic.co/kibana/kibana:8.11.3
+          resources:
+            {{- toYaml .Values.elasticsearch.elasticNode.resources | nindent 12 }}
+          env:
+            - name: ELASTICSEARCH_URL
+              value: http://elasticsearch:9200
+          ports:
+            - containerPort: 5601

--- a/.helm/ecamp3-logging/templates/kibana/kibana_service.yaml
+++ b/.helm/ecamp3-logging/templates/kibana/kibana_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kibana
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 5601
+  selector:
+    app: kibana
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}

--- a/.helm/ecamp3-logging/values.yaml
+++ b/.helm/ecamp3-logging/values.yaml
@@ -1,0 +1,31 @@
+elasticsearch:
+  elasticNode:
+    resources:
+      requests:
+        cpu: 300m
+        memory: 400Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+  persistence:
+    resources:
+      requests:
+        storage: 10Gi
+
+kibana:
+  resources:
+    requests:
+      cpu: 300m
+      memory: 400Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+filebeat:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 120m
+      memory: 120Mi


### PR DESCRIPTION
Adds the EFK Stack (Elasticseach, Filebeat and Kibana) to allow the following:

# Features

- We can now store and search the logs of our services for a self chosen time. (Index Life Cycle Management in Elasticsearch).
On dev i chose 3 months. This allows to analyse events which happen less often and allows to analyze them far after it occurred.
![grafik](https://github.com/ecamp/ecamp3/assets/1506818/40892f95-ab39-42f3-86f7-d69f202816d8)
With the full support of the KQL

- Browse through interleaved logs of different services:
Choose the services you want to see the logs for:
![grafik](https://github.com/ecamp/ecamp3/assets/1506818/eaa40950-2ae1-429b-a857-edcf0f7ffabb)

And see the logs
![grafik](https://github.com/ecamp/ecamp3/assets/1506818/e3572b65-25f8-44be-8beb-09a8d5599ec5)

- You can quickly see if we had a time interval with a high percentage of 500er errors.
(On dev it is not so enlightening, but with more data on prod this is hopefully better).
![grafik](https://github.com/ecamp/ecamp3/assets/1506818/f046674a-d957-4869-8155-a4d8583a8add)


- We can quickly see on which endpoints we must improve the performance.
![grafik](https://github.com/ecamp/ecamp3/assets/1506818/9a1df7c4-0c0c-486e-a6fc-d87b5a9e628f)
@manuelmeister: is it possible that you worked on the categories on 2023-12-29?
Was the experience really as bad as the data suggests?

- We can see if a certain query parameter kills the performance of an endpoint:
![grafik](https://github.com/ecamp/ecamp3/assets/1506818/28de1e87-bbbb-4e22-90ce-48c818bb1986)

- We can see which endpoints cause most of the trouble:
![grafik](https://github.com/ecamp/ecamp3/assets/1506818/08a81691-dd92-4dad-a195-6e9d3f649a45)

See for yourself with `kubectl -n ecamp3-logging port-forward services/kibana 5601:5601` on http://localhost:5601

To that i had to modify how the ingress-nginx logs requests, this can be seen here: https://github.com/ecamp/ecamp3/wiki/Deployment-installation-Kubernetes#ingress

## Cost
### Memory
Kibana and elasticsearch are quite heavy, they each require 1Gi to start, but then seem happy with less
-> maybe an additional node is needed for that.
Filebeat needs around 100Mi per node.

### Storage:
Now that we only collect the logs from our services, it seems it is not so much.
Current estimate:
- dev: 10Gi , 1$/month
- staging: 10Gi, 1$/month
- prod: 100Gi, 10$/month