### PR TITLE
renovate.json: allow vue updates <= minor for all modules except frontend

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,9 +38,21 @@
         "monorepo:vue"
       ],
       "matchUpdateTypes": [
-        "patch",
-        "minor",
         "major"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "extends": [
+        "monorepo:vue"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchFileNames": [
+        "frontend/package.json"
       ],
       "dependencyDashboardApproval": true
     },


### PR DESCRIPTION
Else the vue updates for the other modules are blocked. 
(And grouped together with the frontend update which we have to split up again).