### PR TITLE
renovate.json: separate vue updates for frontend and for pdf/print

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,28 @@
       "matchUpdateTypes": [
         "major"
       ],
-      "dependencyDashboardApproval": true
+      "matchFileNames": [
+        "print/package.json",
+        "pdf/package.json"
+      ],
+      "dependencyDashboardApproval": true,
+      "groupName": "vue-major-print-pdf"
+    },
+
+    {
+      "extends": [
+        "monorepo:vue"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchFileNames": [
+        "print/package.json",
+        "pdf/package.json"
+      ],
+      "dependencyDashboardApproval": false,
+      "groupName": "vue-minor-print-pdf"
     },
     {
       "extends": [
@@ -54,7 +75,8 @@
       "matchFileNames": [
         "frontend/package.json"
       ],
-      "dependencyDashboardApproval": true
+      "dependencyDashboardApproval": true,
+      "groupName": "vue-frontend"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
In https://github.com/ecamp/ecamp3/pull/4371 i tried that renovate allows the updates for print and pdf.
This did not work.

Now is the next try with a little more force.
This time i also tested it, and it works as you can see in the PR to my repo:
https://github.com/BacLuc/ecamp3/pull/228

And my dependency dashboard:
https://github.com/BacLuc/ecamp3/issues/146

(tested it with: `docker run --rm -e LOG_LEVEL=debug renovate/renovate --token $TOKEN --include-forks true --pr-hourly-limit 0 --pr-concurrent-limit 0 --binary-source install BacLuc/ecamp3 | less`)