### PR TITLE
frontend: report Errors to Sentry in print-nuxt/generatePdfMixin.js

### DIFF
--- a/frontend/src/components/print/print-nuxt/generatePdfMixin.js
+++ b/frontend/src/components/print/print-nuxt/generatePdfMixin.js
@@ -3,6 +3,7 @@ import slugify from 'slugify'
 import { cloneDeep } from 'lodash'
 import axios from 'axios'
 import { getEnv } from '@/environment.js'
+import * as Sentry from '@sentry/browser'
 
 const PRINT_URL = getEnv().PRINT_URL
 
@@ -58,6 +59,7 @@ export const generatePdfMixin = {
         } else {
           this.$toast.error(this.$tc('components.print.printNuxt.generatePdfMixin.error'))
         }
+        Sentry.captureException(new Error(error))
       } finally {
         this.loading = false
       }


### PR DESCRIPTION
We display an error, but the error is not reported to sentry.
(I think because we catch the error and don't rethrow).
I tested it on staging with nuxt 3, and because there we have no sentry integration yet for nuxt 3,
we have no idea how much nuxt 3 fails (except for looking at the logs). 
So we at least see the errors the frontend can measure.