### PR TITLE
Disable Sentry session tracking

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -29,7 +29,8 @@ if (env && env.SENTRY_FRONTEND_DSN) {
     Vue,
     dsn: env.SENTRY_FRONTEND_DSN,
     environment: sentryEnvironment,
-    tracing: false,
+    enableTracing: false,
+    autoSessionTracking: false,
     logErrors: process.env.NODE_ENV !== 'production',
   })
 }

--- a/print/server/plugin/sentry.ts
+++ b/print/server/plugin/sentry.ts
@@ -14,6 +14,8 @@ export default defineNitroPlugin((nitroApp) => {
   Sentry.init({
     dsn: sentry.dsn,
     environment: sentry.environment,
+    enableTracing: false,
+    autoSessionTracking: false,
     integrations: [new CaptureConsole({ levels: ['warn', 'error'] })],
   })
 


### PR DESCRIPTION
As per our terms of service, we currently only send data to [Sentry](https://www.ecamp3.ch/en/tos/#sentry) when [errors happen](https://www.ecamp3.ch/en/tos/#data-disclosure). This PR is the minimal change needed to get the TOS and the app behaviour to agree with each other.

We disable [autoSessionTracking](https://docs.sentry.io/platforms/javascript/configuration/options/#auto-session-tracking) which is on by default, and which is used for Sentry's [release health](https://docs.sentry.io/platforms/javascript/configuration/releases/#release-health) feature. Also we update the outdated `tracing: false` option to [`enableTracing: false`](https://docs.sentry.io/platforms/javascript/configuration/options/#enable-tracing), just to make sure we still aren't using the [tracing](https://docs.sentry.io/platforms/javascript/usage/distributed-tracing/) feature.

If we want to re-enable some of these features, we should think about how to include this in the TOS, and whether we need to offer an opt-out for this. In the error case I think we can argue that it is essential for us as volunteers to know about errors that happen, in order to maintain the application. But sending tracking requests on every navigation might be a step too far for the new DSG.