### PR TITLE
Switch from lokalise to crowdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The following commonly requested improvements over eCamp v2 are already implemen
 - Improved saving features - where possible, data are auto-saved on the fly.
 - Usability on mobile phones - the design is mobile-first.
 - Login via MiData account of the Swiss Guide and Scouts Movement is possible
-- Switching the user interface language, powered by [Lokalise](https://lokalise.com)
-- Formatting texts (bold, italic, etc.)
+- Switching the user interface language
+- Formatting texts (bold, italic, bullet lists etc.)
 
 eCamp v3 is made up of a backend based on the PHP framework API Platform (Symfony), which offers an API, as well as a Vue.js frontend and some other smaller services.
 
@@ -27,6 +27,7 @@ eCamp v3 is made up of a backend based on the PHP framework API Platform (Symfon
 Thanks for helping! There are a few ways to get started.
 
 - Visit our test environment at [https://dev.ecamp3.ch](https://dev.ecamp3.ch). If you discover a bug, [open a new issue for it](https://github.com/ecamp/ecamp3/issues/new).
+- To help us translate eCamp v3 into other languages, visit our [translation tool](https://translate.ecamp3.ch).
 - To run the project locally on your computer, follow one of the installation guides:
   - [Installation with Docker on Linux](https://github.com/ecamp/ecamp3/wiki/Development-install-on-linux)
   - [Installation with Docker on Windows + WSL2](https://github.com/ecamp/ecamp3/wiki/Development-installation-on-Windows)
@@ -49,8 +50,8 @@ Folgende Verbesserungen, die bei eCamp v2 oft gewünscht wurden, sind bereits im
 - Bessere Speicher-Funktion - wo immer möglich werden die Daten laufend automatisch gespeichert.
 - Benutzbarkeit auf dem Mobiltelefon - das Design ist mobile-first.
 - Login via MiData-Account der Pfadibewegung Schweiz ist möglich
-- Mehrsprachigkeit mit [Lokalise](https://lokalise.com)
-- Formatierung in Texten (fett, kursiv, etc.)
+- Mehrsprachigkeit
+- Formatierung in Texten (fett, kursiv, Aufzählungen etc.)
 
 eCamp v3 besteht aus einem Backend basierend auf dem PHP-Framework API Platform (Symfony), welches eine API anbietet, einem Vue.js-Frontend sowie einigen weiteren kleineren Services.
 
@@ -59,6 +60,7 @@ eCamp v3 besteht aus einem Backend basierend auf dem PHP-Framework API Platform 
 Danke dass du mithelfen möchtest! Es gibt ein paar verschiedene Arten wie du beginnen kannst.
 
 - Besuche unsere Testumgebung auf https://dev.ecamp3.ch. Wenn du einen Fehler entdeckst, [eröffne ein Issue dafür](https://github.com/ecamp/ecamp3/issues/new).
+- Wenn du uns helfen möchtest, eCamp v3 auf andere Sprachen zu übersetzen, besuche unser [Übersetzungs-Tool](https://translate.ecamp3.ch).
 - Um das Projekt bei dir auf dem Computer laufen zu lassen, folge einer der Installationsanleitungen:
   - [Installation mit Docker auf Linux](https://github.com/ecamp/ecamp3/wiki/Development-install-on-linux#Deutsch)
   - [Installation mit Docker auf Windows + WSL2](https://github.com/ecamp/ecamp3/wiki/Development-installation-on-Windows) (nur englisch)

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,9 @@
+files:
+  - source: /frontend/src/locales/en.json
+    translation: /frontend/src/locales/%locale%.json
+  - source: /common/locales/en.json
+    translation: /common/locales/%locale%.json
+  - source: /api/translations/email+intl-icu.en.json
+    translation: /api/translations/email+intl-icu.%locale%.json
+  - source: /api/translations/validators.en.yml
+    translation: /api/translations/validators.%locale_with_underscore%.yml

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -460,7 +460,6 @@
     },
     "language": "Deutsch",
     "loading": "Laden …",
-    "lokaliseMessage": "Übersetzungen unterstützt durch lokalise.com",
     "navigation": {
       "admin": {
         "title": "Admin"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -460,7 +460,6 @@
     },
     "language": "English",
     "loading": "Loading …",
-    "lokaliseMessage": "Language switching powered by lokalise.com",
     "navigation": {
       "admin": {
         "title": "Admin"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -443,7 +443,6 @@
     },
     "language": "Français",
     "loading": "Chargement ...",
-    "lokaliseMessage": "Changement de langue grâce à lokalise.com",
     "navigation": {
       "admin": {
         "title": "Admin"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -443,7 +443,6 @@
     },
     "language": "Italiano",
     "loading": "Caricamento ...",
-    "lokaliseMessage": "Cambio di lingua alimentato da lokalise.com",
     "navigation": {
       "admin": {
         "title": "Admin"

--- a/frontend/src/locales/rm.json
+++ b/frontend/src/locales/rm.json
@@ -407,7 +407,6 @@
     },
     "language": "Rumantsch",
     "loading": "Chargiar…",
-    "lokaliseMessage": "Translaziuns sustegnidas da lokalise.com",
     "navigation": {
       "admin": {
         "title": "Admin"

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -54,9 +54,6 @@
             fieldname="language"
             :items="availableLocales"
           />
-          <p class="text-caption blue-grey--text mb-0">
-            {{ $tc('global.lokaliseMessage') }}
-          </p>
           <v-btn
             v-if="!$vuetify.breakpoint.mdAndUp"
             class="mt-2"


### PR DESCRIPTION
This is the code change required for switching to Crowdin.

Crowdin is a service similar to Lokalise. Notable differences are better translation file format support and open-source affinity including a voting system. In Lokalise, the normal mode of use was to invite just a few known (usually paid) translators, and let them translate everything. In Crowdin, we can lower the hurdle of becoming a translator, even first-time contributors can be part-time translators, and if multiple people disagree on which translation is the best, the translation with the most votes is used. Translators can also ask questions, e.g. in case the context for a translation is unclear.

When translations are updated on Crowdin, Crowdin will automatically open a pull request like this one: https://github.com/carlobeltrame/ecamp3/pull/15 and keep it updated when more translations are changed. From there we can approve and merge the changes when we feel like it.
When we add new translations to the codebase, Crowdin will sync these into its web UI in configurable regular intervals (at most hourly) or at our request.

I have tested the integration on my fork. However, I associated the Crowdin project with my personal Crowdin account. Once this PR is merged, I will do the setup once more in a shared ecamp Crowdin account, so that this shared account is the owner of the Crowdin project instead of my personal account. I will have to re-apply for an Open Source license, but they were very quick last time.