### PR TITLE
fix(api): mitigate slow queries

### DIFF
--- a/api/src/Doctrine/Filter/ContentNodePeriodFilter.php
+++ b/api/src/Doctrine/Filter/ContentNodePeriodFilter.php
@@ -71,8 +71,7 @@ final class ContentNodePeriodFilter extends AbstractFilter {
         $queryBuilder
             ->join("{$rootAlias}.root", $rootJoinAlias)
             ->join(Activity::class, $activityJoinAlias, Join::WITH, "{$activityJoinAlias}.rootContentNode = {$rootJoinAlias}.id")
-            ->join("{$activityJoinAlias}.scheduleEntries", $scheduleEntryJoinAlias)
-            ->andWhere($queryBuilder->expr()->eq("{$scheduleEntryJoinAlias}.period", ":{$periodParameterName}"))
+            ->join("{$activityJoinAlias}.scheduleEntries", $scheduleEntryJoinAlias, Join::WITH, $queryBuilder->expr()->eq("{$scheduleEntryJoinAlias}.period", ":{$periodParameterName}"))
         ;
 
         $queryBuilder->setParameter($periodParameterName, $period);

--- a/api/src/Repository/FiltersByCampCollaboration.php
+++ b/api/src/Repository/FiltersByCampCollaboration.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\CampCollaboration;
 use App\Entity\User;
+use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 
 trait FiltersByCampCollaboration {
@@ -14,14 +15,19 @@ trait FiltersByCampCollaboration {
      * the alias of the camp as the third argument if it's anything other than "camp".
      */
     public function filterByCampCollaboration(QueryBuilder $queryBuilder, User $user, string $campAlias = 'camp'): void {
-        $queryBuilder->leftJoin("{$campAlias}.collaborations", "filter_{$campAlias}_campCollaboration");
+        $queryBuilder->leftJoin(
+            "{$campAlias}.collaborations",
+            "filter_{$campAlias}_campCollaboration",
+            Join::WITH,
+            $queryBuilder->expr()->andX(
+                $queryBuilder->expr()->eq("filter_{$campAlias}_campCollaboration.user", ':current_user'),
+                $queryBuilder->expr()->eq("filter_{$campAlias}_campCollaboration.status", ':established'),
+            )
+        );
         $queryBuilder->andWhere(
             $queryBuilder->expr()->orX(
                 // user is established collaborator in the camp
-                $queryBuilder->expr()->andX(
-                    $queryBuilder->expr()->eq("filter_{$campAlias}_campCollaboration.user", ':current_user'),
-                    $queryBuilder->expr()->eq("filter_{$campAlias}_campCollaboration.status", ':established'),
-                ),
+                $queryBuilder->expr()->isNotNull("filter_{$campAlias}_campCollaboration.id"),
 
                 // camp is a Prototype = all Prototypes are readable
                 $queryBuilder->expr()->eq("{$campAlias}.isPrototype", ':true'),

--- a/api/tests/Api/ContentNodes/ContentNode/ListContentNodesTest.php
+++ b/api/tests/Api/ContentNodes/ContentNode/ListContentNodesTest.php
@@ -8,9 +8,18 @@ use App\Tests\Api\ECampApiTestCase;
  * @internal
  */
 class ListContentNodesTest extends ECampApiTestCase {
-    // TODO security tests when not logged in or not collaborator
+    // TODO add tests for filtering by contentType and root
 
-    public function testListContentNodesIsAllowedForCollaborator() {
+    public function testListContentNodesIsDeniedForAnonymousUser() {
+        static::createBasicClient()->request('GET', '/content_nodes');
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertJsonContains([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    public function testListContentNodesIsAllowedForLoggedInUserButFiltered() {
         $response = static::createClientWithCredentials()->request('GET', '/content_nodes');
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
@@ -44,6 +53,81 @@ class ListContentNodesTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('multiSelect1')],
             ['href' => $this->getIriFor('multiSelect2')],
             ['href' => $this->getIriFor('responsiveLayout1')],
+        ], $response->toArray()['_links']['items']);
+    }
+
+    public function testListContentNodesFilteredByPeriodIsAllowedForCollaborator() {
+        $period = static::getFixture('period1');
+        $response = static::createClientWithCredentials()->request('GET', '/content_nodes?period=%2Fperiods%2F'.$period->getId());
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'totalItems' => 12,
+            '_links' => [
+                'items' => [],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
+        $this->assertEqualsCanonicalizing([
+            ['href' => $this->getIriFor('columnLayout1')],
+            ['href' => $this->getIriFor('columnLayoutChild1')],
+            ['href' => $this->getIriFor('columnLayout3')],
+            ['href' => $this->getIriFor('singleText1')],
+            ['href' => $this->getIriFor('singleText2')],
+            ['href' => $this->getIriFor('safetyConcept1')],
+            ['href' => $this->getIriFor('materialNode1')],
+            ['href' => $this->getIriFor('storyboard1')],
+            ['href' => $this->getIriFor('storyboard2')],
+            ['href' => $this->getIriFor('multiSelect1')],
+            ['href' => $this->getIriFor('multiSelect2')],
+            ['href' => $this->getIriFor('responsiveLayout1')],
+        ], $response->toArray()['_links']['items']);
+    }
+
+    public function testListContentNodesFilteredByPeriodIsDeniedForUnrelatedUser() {
+        $period = static::getFixture('period1');
+        $response = static::createClientWithCredentials(['email' => static::$fixtures['user4unrelated']->getEmail()])
+            ->request('GET', '/content_nodes?period=%2Fperiods%2F'.$period->getId())
+        ;
+
+        $this->assertResponseStatusCodeSame(400);
+
+        $this->assertJsonContains([
+            'title' => 'An error occurred',
+            'detail' => 'Item not found for "'.$this->getIriFor('period1').'".',
+        ]);
+    }
+
+    public function testListContentNodesFilteredByPeriodIsDeniedForInactiveCollaborator() {
+        $period = static::getFixture('period1');
+        $response = static::createClientWithCredentials(['email' => static::$fixtures['user5inactive']->getEmail()])
+            ->request('GET', '/content_nodes?period=%2Fperiods%2F'.$period->getId())
+        ;
+
+        $this->assertResponseStatusCodeSame(400);
+
+        $this->assertJsonContains([
+            'title' => 'An error occurred',
+            'detail' => 'Item not found for "'.$this->getIriFor('period1').'".',
+        ]);
+    }
+
+    public function testListContentNodesFilteredByPeriodInCampPrototypeIsAllowedForCollaborator() {
+        $period = static::getFixture('period1campPrototype');
+        $response = static::createClientWithCredentials()->request('GET', '/content_nodes?period=%2Fperiods%2F'.$period->getId());
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'totalItems' => 1,
+            '_links' => [
+                'items' => [],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
+        $this->assertEqualsCanonicalizing([
+            ['href' => $this->getIriFor('columnLayout1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
 }

--- a/api/tests/Doctrine/Filter/ContentNodePeriodFilterTest.php
+++ b/api/tests/Doctrine/Filter/ContentNodePeriodFilterTest.php
@@ -132,11 +132,6 @@ class ContentNodePeriodFilterTest extends TestCase {
 
         $this->queryBuilderMock
             ->expects($this->once())
-            ->method('andWhere')
-        ;
-
-        $this->queryBuilderMock
-            ->expects($this->once())
             ->method('setParameter')
             ->with('period_a1', $period)
         ;


### PR DESCRIPTION
We have a bunch of very slow queries, mainly on the /content_nodes endpoint.

Normally, it shouldn't make much difference whether to use WHERE or ON for join statements and the DB would optimize them anyway. But seems, our queries are too complex and this optimization doesn't work.

Hope I caught the biggest offenders. Appreciate if we can test & deploy this as soon as possible.

### Timing tests on my local machine (with prod data dump), before PR
![Screenshot 2024-01-22 204335](https://github.com/ecamp/ecamp3/assets/449555/d60801c8-5d86-47e5-b821-8920b39cf03b)
![Screenshot 2024-01-22 204407](https://github.com/ecamp/ecamp3/assets/449555/92d3d311-8042-4964-b86f-c257195012cf)
![Screenshot 2024-01-22 204434](https://github.com/ecamp/ecamp3/assets/449555/518129aa-8866-4a36-a260-6195b6f7c920)

### Timing tests on my local machine (with pod data dump), after PR 
![Screenshot 2024-01-22 204104](https://github.com/ecamp/ecamp3/assets/449555/da72b8d1-b8db-4431-9420-b21f55276f78)
![Screenshot 2024-01-22 204149](https://github.com/ecamp/ecamp3/assets/449555/0ea44171-e48e-4a2f-8970-848cedf62566)
![Screenshot 2024-01-22 204209](https://github.com/ecamp/ecamp3/assets/449555/5b1ad9e0-0735-433f-afeb-5a08f1c603e0)

### How to check for slow queries
(documentation for the next time)
I followed this guide: https://www.crunchydata.com/blog/tentative-smarter-query-optimization-in-postgres-starts-with-pg_stat_statements

```
CREATE EXTENSION pg_stat_statements;
```
And then use the following query:
```
SELECT
  (total_exec_time / 1000 / 60) as total_min,
  mean_exec_time as avg_ms,
  calls,
  query
FROM pg_stat_statements
ORDER BY 1 DESC
LIMIT 500;
```
The 4 top entries are all from the /content_nodes endpoint and with average runtime between 8 and 40 seconds (!).
![image](https://github.com/ecamp/ecamp3/assets/449555/aa371af3-6778-45ab-a15f-5c6e407ce368)

