### PR TITLE
Fix phpstan warnings

### DIFF
--- a/api/src/State/InvitationAcceptProcessor.php
+++ b/api/src/State/InvitationAcceptProcessor.php
@@ -12,7 +12,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 
 /**
- * @implements ProcessorInterface<Invitation>
+ * @implements ProcessorInterface<Invitation, Invitation>
  */
 class InvitationAcceptProcessor implements ProcessorInterface {
     public function __construct(

--- a/api/src/State/InvitationRejectProcessor.php
+++ b/api/src/State/InvitationRejectProcessor.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 
 /**
- * @implements ProcessorInterface<Invitation>
+ * @implements ProcessorInterface<Invitation, Invitation>
  */
 class InvitationRejectProcessor implements ProcessorInterface {
     public function __construct(

--- a/api/src/State/ResetPasswordCreateProcessor.php
+++ b/api/src/State/ResetPasswordCreateProcessor.php
@@ -15,7 +15,7 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
 /**
- * @implements ProcessorInterface<ResetPassword>
+ * @implements ProcessorInterface<ResetPassword, ResetPassword>
  */
 class ResetPasswordCreateProcessor implements ProcessorInterface {
     public function __construct(

--- a/api/src/State/ResetPasswordUpdateProcessor.php
+++ b/api/src/State/ResetPasswordUpdateProcessor.php
@@ -13,7 +13,7 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
 /**
- * @implements ProcessorInterface<ResetPassword>
+ * @implements ProcessorInterface<ResetPassword, ResetPassword>
  */
 class ResetPasswordUpdateProcessor implements ProcessorInterface {
     public function __construct(

--- a/api/src/State/Util/AbstractPersistProcessor.php
+++ b/api/src/State/Util/AbstractPersistProcessor.php
@@ -8,7 +8,7 @@ use ApiPlatform\State\ProcessorInterface;
 /**
  * @template T
  *
- * @template-implements ProcessorInterface<T>
+ * @template-implements ProcessorInterface<T, T>
  */
 abstract class AbstractPersistProcessor implements ProcessorInterface {
     /**

--- a/api/src/State/Util/AbstractRemoveProcessor.php
+++ b/api/src/State/Util/AbstractRemoveProcessor.php
@@ -8,7 +8,7 @@ use ApiPlatform\State\ProcessorInterface;
 /**
  * @template T
  *
- * @template-implements ProcessorInterface<T>
+ * @template-implements ProcessorInterface<T, T>
  */
 abstract class AbstractRemoveProcessor implements ProcessorInterface {
     public function __construct(


### PR DESCRIPTION
Make devel green again!

Since https://github.com/api-platform/core/pull/6103 which came in with https://github.com/ecamp/ecamp3/pull/4506, our phpstan requires more specific typing.

This problem currently blocks the staging deployment, because our [rudimentary check](https://github.com/ecamp/ecamp3/blob/devel/.github/workflows/fast-forward.yml#L49) for fast-forwards also requires all optional checks to be green.