### PR TITLE
Display content node instance name in delete dialog

### DIFF
--- a/frontend/src/components/activity/MenuCardlessContentNode.vue
+++ b/frontend/src/components/activity/MenuCardlessContentNode.vue
@@ -10,6 +10,7 @@
       <dialog-entity-delete
         v-if="showDelete"
         :entity="contentNode"
+        :warning-text-entity="contentNodeName"
         @error="deletingFailed"
       >
         <template #activator="{ on }">
@@ -29,6 +30,7 @@
 <script>
 import DialogEntityDelete from '@/components/dialog/DialogEntityDelete.vue'
 import { errorToMultiLineToast } from '@/components/toast/toasts'
+import camelCase from 'lodash/camelCase.js'
 
 export default {
   name: 'MenuCardlessContentNode',
@@ -61,6 +63,9 @@ export default {
       return this.deletingDisabled
         ? this.$tc('components.activity.menuCardlessContentNode.deletingDisabled')
         : this.$tc('global.button.delete')
+    },
+    contentNodeName() {
+      return this.$tc(`contentNode.${camelCase(this.contentNode.contentTypeName)}.name`)
     },
   },
   methods: {

--- a/frontend/src/components/activity/content/layout/ContentNodeCard.vue
+++ b/frontend/src/components/activity/content/layout/ContentNodeCard.vue
@@ -46,7 +46,11 @@
           <v-icon>mdi-pencil</v-icon>
         </v-btn>
 
-        <DialogEntityDelete v-if="layoutMode && !disabled" :entity="contentNode">
+        <DialogEntityDelete
+          v-if="layoutMode && !disabled"
+          :entity="contentNode"
+          :warning-text-entity="instanceOrContentTypeName"
+        >
           <template #activator="{ on }">
             <v-btn
               icon


### PR DESCRIPTION
Fixes #4545

I checked all other uses of DialogEntityDelete and dialog-entity-delete, everything else looks fine to me.