### PR TITLE
Make progress label clearable

### DIFF
--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -211,6 +211,7 @@ Displays a single scheduleEntry
                   fieldname="progressLabel"
                   :items="progressLabels"
                   :disabled="layoutMode || !isContributor"
+                  clearable
                   dense
                 />
               </v-col>


### PR DESCRIPTION
Currently it is not possible to remove a progress label once it is set.
Close #4535 