### PR TITLE
Allow editing instance name in layout mode

### DIFF
--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -61,10 +61,20 @@ Displays a single scheduleEntry
             </v-list-item>
           </v-list>
         </v-menu>
-        <a v-if="!editActivityTitle" style="color: inherit" @click="makeTitleEditable()">
+        <a v-if="!editActivityTitle" style="color: inherit">
           {{ activity.title }}
         </a>
       </v-toolbar-title>
+      <v-btn
+        v-if="isContributor && !editActivityTitle"
+        icon
+        class="ml-1 visible-on-hover"
+        width="24"
+        height="24"
+        @click="makeTitleEditable()"
+      >
+        <v-icon small>mdi-pencil</v-icon>
+      </v-btn>
       <div v-if="editActivityTitle" class="mx-2 flex-grow-1">
         <api-text-field
           :uri="activity._meta.self"
@@ -418,6 +428,15 @@ export default {
   margin-bottom: 0;
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   padding: 1.5rem 16px;
+}
+
+:deep(.ec-content-card__toolbar:not(:hover) button.visible-on-hover:not(:focus)) {
+  opacity: 0;
+}
+
+:deep(.ec-content-card__toolbar button.visible-on-hover) {
+  opacity: 1;
+  transition: opacity 0.2s linear;
 }
 
 .e-category-chip-save-icon {

--- a/frontend/src/components/activity/content/layout/ContentNodeCard.vue
+++ b/frontend/src/components/activity/content/layout/ContentNodeCard.vue
@@ -36,7 +36,7 @@
         />
 
         <v-btn
-          v-if="!editInstanceName && !layoutMode && !disabled"
+          v-if="!editInstanceName && !disabled"
           icon
           class="visible-on-hover"
           width="36"

--- a/frontend/src/components/activity/content/layout/ContentNodeCard.vue
+++ b/frontend/src/components/activity/content/layout/ContentNodeCard.vue
@@ -27,6 +27,18 @@
           {{ instanceOrContentTypeName }}
         </v-toolbar-title>
 
+        <v-btn
+          v-if="!editInstanceName && !disabled"
+          icon
+          class="ml-1"
+          :class="{ 'visible-on-hover': !layoutMode }"
+          width="24"
+          height="24"
+          @click="toggleEditInstanceName"
+        >
+          <v-icon small>mdi-pencil</v-icon>
+        </v-btn>
+
         <v-spacer v-if="!editInstanceName" />
         <IconWithTooltip
           v-if="!editInstanceName && !layoutMode"
@@ -34,17 +46,6 @@
           width="36"
           height="36"
         />
-
-        <v-btn
-          v-if="!editInstanceName && !disabled"
-          icon
-          class="visible-on-hover"
-          width="36"
-          height="36"
-          @click="toggleEditInstanceName"
-        >
-          <v-icon>mdi-pencil</v-icon>
-        </v-btn>
 
         <DialogEntityDelete
           v-if="layoutMode && !disabled"
@@ -134,23 +135,14 @@ export default {
   }
 }
 
-.v-card:not(:hover):deep(button.visible-on-hover),
+:deep(.v-toolbar__content:not(:hover) button.visible-on-hover:not(:focus)),
 .v-card:not(:hover):deep(button.tooltip-activator) {
   opacity: 0;
-  width: 0px !important;
-
-  transition:
-    opacity 0.2s linear,
-    width 0.3s steps(1, end);
 }
-.v-card:hover:deep(button.visible-on-hover),
+:deep(.v-toolbar__content button.visible-on-hover),
 .v-card:hover:deep(button.tooltip-activator) {
   opacity: 1;
-  width: 36px !important;
-
-  transition:
-    opacity 0.2s linear,
-    width 0.3s steps(1, start);
+  transition: opacity 0.2s linear;
 }
 
 ::v-deep {


### PR DESCRIPTION
Requested by Listo. I have to say I agree with this wish: Layout mode is the correct mode in which I am building up my activity structure, and in which I am adding e.g. a Schlechtwetterprogramm which is a prime example for the usage of layout mode.

In case we decide against this, we currently have a bug: If I activate the instance name edit text field and then switch to layout mode, the text field is still visible and can be saved from within layout mode.