### PR TITLE
Fix empty submit in activity title

### DIFF
--- a/frontend/src/components/form/api/ApiWrapper.vue
+++ b/frontend/src/components/form/api/ApiWrapper.vue
@@ -140,17 +140,20 @@ export default {
     },
   },
   watch: {
-    apiValue: function (newValue) {
-      // override local value if it wasn't dirty
-      if (!this.dirty || this.overrideDirty) {
-        this.localValue = newValue
-        this.parsedLocalValue = this.parse ? this.parse(newValue) : newValue
-      }
+    apiValue: {
+      handler: function (newValue) {
+        // override local value if it wasn't dirty
+        if (!this.dirty || this.overrideDirty) {
+          this.localValue = newValue
+          this.parsedLocalValue = this.parse ? this.parse(newValue) : newValue
+        }
 
-      // clear dirty if outside value changes to same as local value (e.g. after save operation)
-      if (this.parsedLocalValue === newValue) {
-        this.dirty = false
-      }
+        // clear dirty if outside value changes to same as local value (e.g. after save operation)
+        if (this.parsedLocalValue === newValue) {
+          this.dirty = false
+        }
+      },
+      immediate: true,
     },
   },
   created() {


### PR DESCRIPTION
Attempt to fix a bug when editing the activity name and pressing ENTER to submit without changes.
Before:
[Screencast from 02-03-2024 10:56:07 PM.webm](https://github.com/ecamp/ecamp3/assets/7566995/3058db18-a71f-408c-a94b-867a19d0fddf)

After:
[Screencast from 02-03-2024 11:01:15 PM.webm](https://github.com/ecamp/ecamp3/assets/7566995/8dc05f90-0cb3-406a-843d-037ecc120d32)

However, I am unsure whether this will break something else. Any ideas?