### PR TITLE
renovate.json: do not group the linter/formatter packages anymore

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -97,27 +97,6 @@
       "groupName": "tiptap"
     },
     {
-      "matchPackagePatterns": [
-        "^(@.*\\/|(.*-)?)eslint(-.*)?$",
-        "^(@.*\\/|(.*-)?)lint(-.*)?$",
-        "^(@.*\\/|(.*-)?)stylelint(-.*)?$",
-        "^(@.*\\/|(.*-)?)prettier(-.*)?$"
-      ],
-      "excludePackageNames": [
-        "@vue/cli-plugin-eslint",
-        "lint-staged"
-      ],
-      "groupName": "js-linter"
-    },
-    {
-      "matchPackageNames": [
-        "phpstan/phpstan",
-        "friendsofphp/php-cs-fixer",
-        "vimeo/psalm"
-      ],
-      "groupName": "php-linter"
-    },
-    {
       "matchPackageNames": [
         "browserless/chrome",
         "caddy",


### PR DESCRIPTION
Now that we auto merge the branches, we can merge them separately. 
And if prettier or php-cs-fixer introduce formatting changes, we can fix them, but have all the other packages up to date.