### PR TITLE
Bugfix: Prevent wrong dirty reset

### DIFF
--- a/frontend/src/components/form/api/ApiRichtext.vue
+++ b/frontend/src/components/form/api/ApiRichtext.vue
@@ -14,6 +14,7 @@ Displays a field as a e-textarea + write access via API wrapper
       :outlined="outlined"
       :filled="filled"
       @input="wrapper.on.input"
+      @blur="wrapper.on.blur"
     >
       <template #append>
         <api-wrapper-append :wrapper="wrapper" />

--- a/frontend/src/components/form/api/ApiTextField.vue
+++ b/frontend/src/components/form/api/ApiTextField.vue
@@ -16,6 +16,7 @@ Displays a field as a e-text-field + write access via API wrapper
       :filled="filled"
       :dense="dense"
       @input="wrapper.on.input"
+      @blur="wrapper.on.blur"
     >
       <template #append>
         <api-wrapper-append :wrapper="wrapper" />

--- a/frontend/src/components/form/api/ApiTextarea.vue
+++ b/frontend/src/components/form/api/ApiTextarea.vue
@@ -15,6 +15,7 @@ Displays a field as a e-textarea + write access via API wrapper
       :filled="filled"
       :dense="dense"
       @input="wrapper.on.input"
+      @blur="wrapper.on.blur"
     >
       <template #append>
         <api-wrapper-append :wrapper="wrapper" />

--- a/frontend/src/components/form/api/ApiWrapper.vue
+++ b/frontend/src/components/form/api/ApiWrapper.vue
@@ -53,6 +53,7 @@ export default {
       localValue: null,
       parsedLocalValue: null,
       isSaving: false,
+      isPreSaving: false,
       isLoading: false,
       isMounted: false,
       showIconSuccess: false,
@@ -173,13 +174,14 @@ export default {
       this.localValue = newValue
       this.parsedLocalValue = this.parse ? this.parse(newValue) : newValue
       this.dirty = this.parsedLocalValue !== this.apiValue
+      this.isPreSaving = true
 
       if (this.autoSave) {
         this.debouncedSave()
       }
     },
     async onBlur() {
-      if (!this.isSaving && this.autoSave) {
+      if (!(this.isSaving || this.isPreSaving) && this.autoSave) {
         this.localValue = this.apiValue
         this.parsedLocalValue = this.parse ? this.parse(this.apiValue) : this.apiValue
       }
@@ -236,6 +238,7 @@ export default {
 
       // reset all dirty flags and start saving
       this.resetErrors()
+      this.isPreSaving = false
       this.isSaving = true
 
       // construct payload (nested path allowed)

--- a/frontend/src/components/form/api/ApiWrapper.vue
+++ b/frontend/src/components/form/api/ApiWrapper.vue
@@ -67,6 +67,7 @@ export default {
         reset: this.reset,
         reload: this.reload,
         input: this.onInput,
+        blur: this.onBlur,
       },
     }
   },
@@ -177,6 +178,12 @@ export default {
         this.debouncedSave()
       }
     },
+    async onBlur() {
+      if (!this.isSaving && this.autoSave) {
+        this.localValue = this.apiValue
+        this.parsedLocalValue = this.parse ? this.parse(this.apiValue) : this.apiValue
+      }
+    },
     // reload data from API (doesn't force loading from server if available locally)
     reload() {
       this.resetErrors()
@@ -196,12 +203,12 @@ export default {
     },
     reset() {
       this.localValue = this.apiValue
+      this.dirty = false
       this.resetErrors()
       this.$emit('reseted')
       this.$emit('finished')
     },
     resetErrors() {
-      this.dirty = false
       this.hasLoadingError = false
       this.hasServerError = false
       this.serverErrorMessage = null

--- a/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
@@ -130,7 +130,7 @@ describe('Testing ApiWrapper [autoSave=true;  manual external value]', () => {
 
   test('calls api.patch after onInput was triggered', async () => {
     const newValue = 'new value'
-    const newValueFromApi = 'NEW VALUE'
+    const newValueFromApi = 'new value'
 
     await vm.onInput(newValue)
 
@@ -148,7 +148,7 @@ describe('Testing ApiWrapper [autoSave=true;  manual external value]', () => {
 
     // saving started
     expect(vm.isSaving).toBe(true)
-    expect(vm.dirty).toBe(false)
+    expect(vm.dirty).toBe(true)
     expect(vm.status).toBe('saving')
 
     // API patch method called
@@ -163,6 +163,7 @@ describe('Testing ApiWrapper [autoSave=true;  manual external value]', () => {
     await wrapper.setProps({ value: newValueFromApi })
     await wrapper.vm.$nextTick()
     expect(vm.localValue).toBe(newValueFromApi)
+    expect(vm.dirty).toBe(false)
 
     // success state
     expect(vm.status).toBe('success')


### PR DESCRIPTION
Initially, we reset the dirty flag before each save request. 
My PR defines `dirty` as _"local value is not the same as api value"_, on devel it is currently defined as _"time between entering a different value and starting to patch to api"_.
 
Some api fields have a `InputFilter/Trim` in the backend, which means that the api value returned will never contain spaces around the value. If the user leaves the input, the `localValue` should be reset to the `apiValue`, to correctly represent the actual db value, without disrupting the user.

Closes #3875