### PR TITLE
Fix printing in languages other than English

### DIFF
--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -259,6 +259,7 @@ export default {
         config,
         this.camp(),
         VueI18n.availableLocales,
+        this.lang,
         repairers,
         this.defaultContents()
       )

--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -111,6 +111,7 @@ import DownloadClientPdfButton from '@/components/print/print-client/DownloadCli
 import { getEnv } from '@/environment.js'
 import cloneDeep from 'lodash/cloneDeep'
 import VueI18n from '../../plugins/i18n/index.js'
+import repairConfig from './repairPrintConfig.js'
 
 export default {
   name: 'PrintConfigurator',
@@ -249,24 +250,20 @@ export default {
       })
     },
     repairConfig(config) {
-      if (!config) config = {}
-      if (!(VueI18n.availableLocales.includes(config.language))) config.language = 'en'
-      if (!config.documentName) config.documentName = this.camp().name
-      if (config.camp !== this.camp()._meta.self) config.camp = this.camp()._meta.self
-      if (typeof config.contents?.map !== 'function') {
-        config.contents = this.defaultContents()
-      }
-      config.contents = config.contents
-        .map((content) => {
-          if (!content.type) return null
-          const component = this.contentComponents[content.type]
-          if (!component) return null
-          if (typeof component.repairConfig !== 'function') return content
-          return component.repairConfig(content, this.camp())
-        })
-        .filter((component) => component)
+      const repairers = Object.fromEntries(
+        Object.entries(this.contentComponents).map(([componentName, component]) => [
+          componentName,
+          component.repairConfig,
+        ])
+      )
 
-      return config
+      return repairConfig(
+        config,
+        this.camp(),
+        VueI18n.availableLocales,
+        repairers,
+        this.defaultContents()
+      )
     },
   },
 }

--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -155,14 +155,12 @@ export default {
     },
     cnf() {
       return this.repairConfig(
-        cloneDeep(
-          this.$store.getters.getLastPrintConfig(this.camp()._meta.self, {
-            language: this.lang,
-            documentName: this.camp().name,
-            camp: this.camp()._meta.self,
-            contents: this.defaultContents(),
-          })
-        )
+        this.$store.getters.getLastPrintConfig(this.camp()._meta.self, {
+          language: this.lang,
+          documentName: this.camp().name,
+          camp: this.camp()._meta.self,
+          contents: this.defaultContents(),
+        })
       )
     },
     isDev() {

--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -250,7 +250,7 @@ export default {
     },
     repairConfig(config) {
       if (!config) config = {}
-      if (!(config.language in VueI18n.availableLocales)) config.language = 'en'
+      if (!(VueI18n.availableLocales.includes(config.language))) config.language = 'en'
       if (!config.documentName) config.documentName = this.camp().name
       if (config.camp !== this.camp()._meta.self) config.camp = this.camp()._meta.self
       if (typeof config.contents?.map !== 'function') {

--- a/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
+++ b/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
@@ -1,0 +1,903 @@
+import repairConfig from '../repairPrintConfig.js'
+import PicassoConfig from '../config/PicassoConfig.vue'
+import ActivityConfig from '../config/ActivityConfig.vue'
+import CoverConfig from '../config/CoverConfig.vue'
+import ProgramConfig from '../config/ProgramConfig.vue'
+import StoryConfig from '../config/StoryConfig.vue'
+import TocConfig from '../config/TocConfig.vue'
+
+describe('repairConfig', () => {
+  const camp = {
+    _meta: { self: '/camps/1a2b3c4d' },
+    name: 'test camp',
+    periods: () => ({
+      items: [
+        {
+          _meta: { self: '/periods/1a2b3c4d' },
+        },
+      ],
+    }),
+  }
+  const availableLocales = ['en-GB', 'de-CH', 'de-CH-scout']
+  const componentRepairers = Object.fromEntries(
+    [
+      ActivityConfig,
+      CoverConfig,
+      PicassoConfig,
+      ProgramConfig,
+      StoryConfig,
+      TocConfig,
+    ].map((component) => [component.name.replace(/Config$/, ''), component.repairConfig])
+  )
+  const defaultContents = [
+    { type: 'Picasso', options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' } },
+  ]
+  const args = [camp, availableLocales, componentRepairers, defaultContents]
+
+  test('fills empty config with default data', async () => {
+    // given
+    const config = {}
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en',
+    })
+  })
+
+  test('leaves valid config alone', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en',
+    }
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en',
+    })
+  })
+
+  test('allows valid language', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'de-CH-scout',
+    }
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'de-CH-scout',
+    })
+  })
+
+  test('replaces invalid language', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'definitely-not-a-supported-language',
+    }
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en',
+    })
+  })
+
+  test('leaves custom documentName alone', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'foobar',
+      language: 'en',
+    }
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'foobar',
+      language: 'en',
+    })
+  })
+
+  test('fills in missing documentName', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: '',
+      language: 'en',
+    }
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en',
+    })
+  })
+
+  test('overwrites camp URI', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d?something',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en',
+    }
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en',
+    })
+  })
+
+  test('overwrites invalid contents with default', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d',
+      contents: {},
+      documentName: 'test camp',
+      language: 'en',
+    }
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en',
+    })
+  })
+
+  test('overwrites null contents with default', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d',
+      contents: null,
+      documentName: 'test camp',
+      language: 'en',
+    }
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en',
+    })
+  })
+
+  test('leaves empty content alone', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d',
+      contents: [],
+      documentName: 'test camp',
+      language: 'en',
+    }
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [],
+      documentName: 'test camp',
+      language: 'en',
+    })
+  })
+
+  test('filters out unknown content', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'SomethingUnsupported',
+          options: {},
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en',
+    }
+
+    // when
+    const result = repairConfig(config, ...args)
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [],
+      documentName: 'test camp',
+      language: 'en',
+    })
+  })
+
+  describe('activity', () => {
+    test('leaves config alone', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Activity',
+            foo: 'bar',
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Activity',
+            foo: 'bar',
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+  })
+
+  describe('cover', () => {
+    test('leaves config alone', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Cover',
+            foo: 'bar',
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Cover',
+            foo: 'bar',
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+  })
+
+  describe('picasso', () => {
+    test('adds missing options', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: [], orientation: 'L' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('allows landscape mode', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('allows portrait mode', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: ['/periods/1a2b3c4d'], orientation: 'P' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: ['/periods/1a2b3c4d'], orientation: 'P' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('allows empty periods', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: [], orientation: 'L' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: [], orientation: 'L' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('overwrites invalid orientation', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: ['/periods/1a2b3c4d'], orientation: 'hello' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('filters out unknown periods', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: {
+              periods: ['/periods/11112222', '/periods/1a2b3c4d'],
+              orientation: 'L',
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+  })
+
+  describe('program', () => {
+    test('adds missing options', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: {
+              periods: [],
+              dayOverview: true,
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('adds missing dayOverview flag', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              dayOverview: true,
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('allows dayOverview false', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              dayOverview: false,
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              dayOverview: false,
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('allows empty periods', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: { periods: [], dayOverview: true },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: { periods: [], dayOverview: true },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('filters out unknown periods', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: {
+              periods: ['/periods/11112222', '/periods/1a2b3c4d'],
+              dayOverview: true,
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              dayOverview: true,
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+  })
+
+  describe('story', () => {
+    test('adds missing options', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Story',
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Story',
+            options: { periods: [] },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('allows empty periods', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Story',
+            options: { periods: [] },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Story',
+            options: { periods: [] },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+
+    test('filters out unknown periods', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Story',
+            options: {
+              periods: ['/periods/11112222', '/periods/1a2b3c4d'],
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Story',
+            options: { periods: ['/periods/1a2b3c4d'] },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+  })
+
+  describe('toc', () => {
+    test('leaves config alone', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Toc',
+            foo: 'bar',
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Toc',
+            foo: 'bar',
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en',
+      })
+    })
+  })
+})

--- a/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
+++ b/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
@@ -32,7 +32,7 @@ describe('repairConfig', () => {
   const defaultContents = [
     { type: 'Picasso', options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' } },
   ]
-  const args = [camp, availableLocales, componentRepairers, defaultContents]
+  const args = [camp, availableLocales, 'en', componentRepairers, defaultContents]
 
   test('fills empty config with default data', async () => {
     // given
@@ -51,7 +51,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     })
   })
 
@@ -66,7 +66,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     }
 
     // when
@@ -82,7 +82,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     })
   })
 
@@ -117,7 +117,7 @@ describe('repairConfig', () => {
     })
   })
 
-  test('replaces invalid language', async () => {
+  test('replaces invalid language with fallback language', async () => {
     // given
     const config = {
       camp: '/camps/1a2b3c4d',
@@ -132,7 +132,14 @@ describe('repairConfig', () => {
     }
 
     // when
-    const result = repairConfig(config, ...args)
+    const result = repairConfig(
+      config,
+      camp,
+      availableLocales,
+      'de-CH-scout',
+      componentRepairers,
+      defaultContents
+    )
 
     // then
     expect(result).toEqual({
@@ -144,7 +151,45 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'test camp',
-      language: 'en',
+      language: 'de-CH-scout',
+    })
+  })
+
+  test('replaces invalid language with any valid language if fallback language is also invalid', async () => {
+    // given
+    const config = {
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'definitely-not-a-supported-language',
+    }
+
+    // when
+    const result = repairConfig(
+      config,
+      camp,
+      availableLocales,
+      'definitely-not-a-valid-language',
+      componentRepairers,
+      defaultContents
+    )
+
+    // then
+    expect(result).toEqual({
+      camp: '/camps/1a2b3c4d',
+      contents: [
+        {
+          type: 'Picasso',
+          options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' },
+        },
+      ],
+      documentName: 'test camp',
+      language: 'en-GB',
     })
   })
 
@@ -159,7 +204,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'foobar',
-      language: 'en',
+      language: 'en-GB',
     }
 
     // when
@@ -175,7 +220,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'foobar',
-      language: 'en',
+      language: 'en-GB',
     })
   })
 
@@ -190,7 +235,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: '',
-      language: 'en',
+      language: 'en-GB',
     }
 
     // when
@@ -206,7 +251,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     })
   })
 
@@ -221,7 +266,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     }
 
     // when
@@ -237,7 +282,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     })
   })
 
@@ -247,7 +292,7 @@ describe('repairConfig', () => {
       camp: '/camps/1a2b3c4d',
       contents: {},
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     }
 
     // when
@@ -263,7 +308,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     })
   })
 
@@ -273,7 +318,7 @@ describe('repairConfig', () => {
       camp: '/camps/1a2b3c4d',
       contents: null,
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     }
 
     // when
@@ -289,7 +334,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     })
   })
 
@@ -299,7 +344,7 @@ describe('repairConfig', () => {
       camp: '/camps/1a2b3c4d',
       contents: [],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     }
 
     // when
@@ -310,7 +355,7 @@ describe('repairConfig', () => {
       camp: '/camps/1a2b3c4d',
       contents: [],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     })
   })
 
@@ -325,7 +370,7 @@ describe('repairConfig', () => {
         },
       ],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     }
 
     // when
@@ -336,7 +381,7 @@ describe('repairConfig', () => {
       camp: '/camps/1a2b3c4d',
       contents: [],
       documentName: 'test camp',
-      language: 'en',
+      language: 'en-GB',
     })
   })
 
@@ -352,7 +397,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -368,7 +413,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
   })
@@ -385,7 +430,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -401,7 +446,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
   })
@@ -417,7 +462,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -433,7 +478,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -448,7 +493,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -464,7 +509,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -479,7 +524,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -495,7 +540,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -510,7 +555,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -526,7 +571,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -541,7 +586,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -557,7 +602,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -575,7 +620,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -591,7 +636,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
   })
@@ -607,7 +652,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -626,7 +671,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -643,7 +688,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -662,7 +707,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -680,7 +725,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -699,7 +744,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -714,7 +759,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -730,7 +775,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -748,7 +793,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -767,7 +812,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
   })
@@ -783,7 +828,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -799,7 +844,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -814,7 +859,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -830,7 +875,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
 
@@ -847,7 +892,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -863,7 +908,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
   })
@@ -880,7 +925,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       }
 
       // when
@@ -896,7 +941,7 @@ describe('repairConfig', () => {
           },
         ],
         documentName: 'test camp',
-        language: 'en',
+        language: 'en-GB',
       })
     })
   })

--- a/frontend/src/components/print/print-client/i18n.js
+++ b/frontend/src/components/print/print-client/i18n.js
@@ -1,6 +1,8 @@
 import {
   compileToFunction,
   createCoreContext,
+  fallbackWithLocaleChain,
+  registerLocaleFallbacker,
   registerMessageCompiler,
   resolveValue,
   translate,
@@ -8,6 +10,7 @@ import {
 
 const createI18n = (translationData, language) => {
   registerMessageCompiler(compileToFunction)
+  registerLocaleFallbacker(fallbackWithLocaleChain)
 
   const context = createCoreContext({
     locale: language,

--- a/frontend/src/components/print/repairPrintConfig.js
+++ b/frontend/src/components/print/repairPrintConfig.js
@@ -1,0 +1,25 @@
+export default function repairConfig(
+  config,
+  camp,
+  availableLocales,
+  componentRepairers,
+  defaultContents
+) {
+  if (!config) config = {}
+  if (!availableLocales.includes(config.language)) config.language = 'en'
+  if (!config.documentName) config.documentName = camp.name
+  if (config.camp !== camp._meta.self) config.camp = camp._meta.self
+  if (typeof config.contents?.map !== 'function') {
+    config.contents = defaultContents
+  }
+  config.contents = config.contents
+    .map((content) => {
+      if (!content.type || !(content.type in componentRepairers)) return null
+      const componentRepairer = componentRepairers[content.type]
+      if (typeof componentRepairer !== 'function') return content
+      return componentRepairer(content, camp)
+    })
+    .filter((component) => component)
+
+  return config
+}

--- a/frontend/src/components/print/repairPrintConfig.js
+++ b/frontend/src/components/print/repairPrintConfig.js
@@ -4,11 +4,18 @@ export default function repairConfig(
   config,
   camp,
   availableLocales,
+  fallbackLocale,
   componentRepairers,
   defaultContents
 ) {
   const configClone = config ? cloneDeep(config) : {}
-  if (!availableLocales.includes(configClone.language)) configClone.language = 'en'
+  if (!availableLocales.includes(configClone.language)) {
+    configClone.language = availableLocales.includes(fallbackLocale)
+      ? fallbackLocale
+      : availableLocales.length > 0
+        ? availableLocales[0]
+        : 'en'
+  }
   if (!configClone.documentName) configClone.documentName = camp.name
   if (configClone.camp !== camp._meta.self) configClone.camp = camp._meta.self
   if (typeof configClone.contents?.map !== 'function') {

--- a/frontend/src/components/print/repairPrintConfig.js
+++ b/frontend/src/components/print/repairPrintConfig.js
@@ -1,3 +1,5 @@
+import cloneDeep from 'lodash/cloneDeep'
+
 export default function repairConfig(
   config,
   camp,
@@ -5,14 +7,14 @@ export default function repairConfig(
   componentRepairers,
   defaultContents
 ) {
-  if (!config) config = {}
-  if (!availableLocales.includes(config.language)) config.language = 'en'
-  if (!config.documentName) config.documentName = camp.name
-  if (config.camp !== camp._meta.self) config.camp = camp._meta.self
-  if (typeof config.contents?.map !== 'function') {
-    config.contents = defaultContents
+  const configClone = config ? cloneDeep(config) : {}
+  if (!availableLocales.includes(configClone.language)) configClone.language = 'en'
+  if (!configClone.documentName) configClone.documentName = camp.name
+  if (configClone.camp !== camp._meta.self) configClone.camp = camp._meta.self
+  if (typeof configClone.contents?.map !== 'function') {
+    configClone.contents = defaultContents
   }
-  config.contents = config.contents
+  configClone.contents = configClone.contents
     .map((content) => {
       if (!content.type || !(content.type in componentRepairers)) return null
       const componentRepairer = componentRepairers[content.type]
@@ -21,5 +23,5 @@ export default function repairConfig(
     })
     .filter((component) => component)
 
-  return config
+  return configClone
 }


### PR DESCRIPTION
Fixes https://github.com/ecamp/ecamp3/pull/4751#issuecomment-1995410670, another regression introduced in #4559 which caused the print configurator to always use `'en'` as the language for the pdf.

Also added extensive tests for the print config repairing, since this is already the second bug which would have been caught if I had created these earlier.