### PR TITLE
api/oauth: also activate user after successful oauth authentication

### DIFF
--- a/api/src/Security/OAuth/GoogleAuthenticator.php
+++ b/api/src/Security/OAuth/GoogleAuthenticator.php
@@ -67,6 +67,9 @@ class GoogleAuthenticator extends OAuth2Authenticator {
                     $profile->surname = $googleUser->getLastName();
                     $user = new User();
                     $user->profile = $profile;
+                }
+
+                if (in_array($user->state, [null, User::STATE_NONREGISTERED, User::STATE_REGISTERED])) {
                     $user->state = User::STATE_ACTIVATED;
                 }
 

--- a/api/src/Security/OAuth/HitobitoAuthenticator.php
+++ b/api/src/Security/OAuth/HitobitoAuthenticator.php
@@ -74,6 +74,9 @@ class HitobitoAuthenticator extends OAuth2Authenticator {
                     $profile->nickname = $hitobitoUser->getNickName();
                     $user = new User();
                     $user->profile = $profile;
+                }
+
+                if (in_array($user->state, [null, User::STATE_NONREGISTERED, User::STATE_REGISTERED])) {
                     $user->state = User::STATE_ACTIVATED;
                 }
 


### PR DESCRIPTION
Issue: #4670

Previously this only happened if the user was created after the oauth authentication.
Now this also happens if an existing not activated user authenticates with oauth, because we trust the email provided via oauth.