### PR TITLE
feat(print-nuxt): auto-grow picasso instead of fixed height

### DIFF
--- a/print/assets/calendar/CalendarDaily.sass
+++ b/print/assets/calendar/CalendarDaily.sass
@@ -108,14 +108,18 @@
   height: 100%
 
 .v-calendar-daily__intervals-body
+  display: flex
+  flex-direction: column
+  height: 100%
   flex: none
   user-select: none
 
 .v-calendar-daily__interval
+  display: flex
+  flex-basis: 0
   text-align: $calendar-daily-interval-gutter-align
   padding-right: $calendar-daily-interval-gutter-line-width
   border-bottom: none
-  position: relative
 
   &::after
     width: $calendar-daily-interval-gutter-line-width

--- a/print/components/PicassoChunk.vue
+++ b/print/components/PicassoChunk.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="tw-break-after-page" :class="{ 'landscape-page': landscape }">
-    <div :class="landscape ? 'landscape' : 'portrait'">
-      <div class="tw-flex tw-flex-row tw-items-baseline fullwidth">
+    <div class="tw-flex tw-flex-col" :class="landscape ? 'landscape' : 'portrait'">
+      <div class="tw-flex-initial tw-flex tw-flex-row tw-items-baseline fullwidth">
         <h1
           :id="`content_${index}_period_${period.id}`"
           class="text-2xl-relative tw-font-bold tw-mb-1 tw-flex-grow tw-d-inline"
@@ -19,15 +19,14 @@
         />
       </div>
 
-      <div class="fullwidth">
+      <div class="tw-flex-auto fullwidth">
         <picasso-calendar
           :days="days"
           :times="times"
           :schedule-entries="scheduleEntries"
-          :content-height="landscape ? 480 : 768"
         />
       </div>
-      <div class="categories fullwidth text-sm-relative">
+      <div class="tw-flex-initial categories fullwidth text-sm-relative">
         <div
           v-for="category in camp.categories().items"
           :key="category.id"
@@ -39,7 +38,7 @@
           </div>
         </div>
       </div>
-      <div class="footer fullwidth text-sm-relative">
+      <div class="tw-flex-initial footer fullwidth text-sm-relative">
         <div class="footer-column">
           <span v-if="camp.courseKind || camp.kind">
             {{ joinWithoutBlanks([camp.courseKind, camp.kind], ', ') }}

--- a/print/components/picasso/Calendar.vue
+++ b/print/components/picasso/Calendar.vue
@@ -1,5 +1,8 @@
 <template>
-  <div role="grid" class="v-calendar v-calendar-daily theme--light v-calendar-events">
+  <div
+    role="grid"
+    class="v-calendar v-calendar-daily theme--light v-calendar-events tw-h-full"
+  >
     <div class="v-calendar-daily__head" style="margin-right: 0px">
       <div class="v-calendar-daily__intervals-head" style="width: 46px" />
       <div v-for="day in days" :key="day.id" class="v-calendar-daily_head-day v-future">
@@ -11,14 +14,14 @@
     </div>
     <div class="v-calendar-daily__body">
       <div class="v-calendar-daily__scroll-area">
-        <div class="v-calendar-daily__pane" :style="`height: ${contentHeight}px`">
+        <div class="v-calendar-daily__pane tw-h-full">
           <div class="v-calendar-daily__day-container">
             <div class="v-calendar-daily__intervals-body" style="width: 46px">
               <div
-                v-for="{ time, height } in displayedTimes"
+                v-for="{ time, weight } in displayedTimes"
                 :key="time"
                 class="v-calendar-daily__interval"
-                :style="`height: ${height}px`"
+                :style="`flex-grow: ${weight}`"
               >
                 <div class="v-calendar-daily__interval-text">
                   {{ time }}
@@ -41,27 +44,18 @@
 </template>
 
 <script>
-import { timesWeightsSum } from '../../../common/helpers/picasso.js'
-
 export default {
   props: {
     days: { type: Array, required: true },
     times: { type: Array, required: true },
     scheduleEntries: { type: Array, default: () => [] },
-    contentHeight: { type: Number, default: 0 },
   },
   computed: {
-    intervalHeight() {
-      return this.contentHeight / timesWeightsSum(this.times)
-    },
-
     displayedTimes() {
       const displayedTimes = this.times.map(([time, weight], index) => {
-        if (index === 0 || weight === 0)
-          return { time: ' ', weight, height: weight * this.intervalHeight }
+        if (index === 0 || weight === 0) return { time: ' ', weight }
         return {
           weight,
-          height: weight * this.intervalHeight,
           time: this.$date()
             .hour(0)
             .minute(time * 60)

--- a/print/components/picasso/CalendarDay.vue
+++ b/print/components/picasso/CalendarDay.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="v-calendar-daily__day v-future">
+  <div class="v-calendar-daily__day v-future tw-flex tw-flex-col">
     <!-- background interval shades -->
     <div
       v-for="(time, i) in displayedTimes"
       :key="i"
       class="v-calendar-daily__day-interval"
-      :style="`height: ${time.height}px`"
+      :style="`flex-grow: ${time.weight}`"
     />
 
     <div class="v-event-timed-container">


### PR DESCRIPTION
Copy & paste from existing implementation in client print

This now prevents the picasso from not consuming all available space or from overflowing to next page, if footer is too long.