### PR TITLE
Fix vite 5 deprecation warning

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -43,7 +43,7 @@ export default defineConfig(({ mode }) => ({
   },
   plugins,
   worker: {
-    plugins: [comlink()],
+    plugins: () => [comlink()],
   },
   optimizeDeps: {
     include: [


### PR DESCRIPTION
`worker.plugins is now a function that returns an array of plugins. Please update your Vite config accordingly.`
https://vitejs.dev/guide/migration#worker-plugins-is-now-a-function