### PR TITLE
Autofocus and autoselect title of new activity

### DIFF
--- a/frontend/src/components/program/DialogActivityCreate.vue
+++ b/frontend/src/components/program/DialogActivityCreate.vue
@@ -71,7 +71,7 @@
         </v-list-item>
       </div>
     </div>
-    <DialogActivityForm :activity="entityData" :period="period">
+    <DialogActivityForm :activity="entityData" :period="period" :autoselect-title="true">
       <template v-if="clipboardAccessDenied" #textFieldTitleAppend>
         <PopoverPrompt
           v-model="copyActivitySourceUrlShowPopover"
@@ -191,7 +191,7 @@ export default {
       if (showDialog) {
         this.refreshCopyActivitySource()
         this.setEntityData({
-          title: this.entityData?.title || this.$tc('entity.activity.new'),
+          title: this.entityData?.title,
           location: '',
           scheduleEntries: [
             {

--- a/frontend/src/components/program/DialogActivityForm.vue
+++ b/frontend/src/components/program/DialogActivityForm.vue
@@ -6,6 +6,8 @@
         :name="$tc('entity.activity.fields.title')"
         vee-rules="required"
         class="flex-grow-1"
+        autofocus
+        @focus="autoselectTitle ? $event.target.select() : null"
       />
       <slot name="textFieldTitleAppend" />
     </div>
@@ -67,6 +69,10 @@ export default {
     period: {
       type: Function,
       required: true,
+    },
+    autoselectTitle: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {


### PR DESCRIPTION
When using eCamp myself, I noticed that the activity create dialog could be faster to use if we autofocused and pre-selected the activity title in the dialog (but only when the activity in the dialog is new).

Also I removed the default title "New activity", because this name will only lead to nondescript activities. The activity title must be descriptive in order for coaches to review a picasso. Therefore, we should stop making it easier to input badly named activities. For users who write good, descriptive names for their activities, this change does not make any difference.