### PR TITLE
Display and accept/reject personal invitations in the UI, remove hard email requirement where possible

### DIFF
--- a/api/migrations/dev-data/Version202404031358.php
+++ b/api/migrations/dev-data/Version202404031358.php
@@ -9,13 +9,21 @@ use Doctrine\Migrations\AbstractMigration;
 
 require_once __DIR__.'/helpers.php';
 
-final class Version202404012013 extends AbstractMigration {
+final class Version202404031358 extends AbstractMigration {
     public function getDescription(): string {
         return '';
     }
 
     public function up(Schema $schema): void {
         // START PHP CODE
+        $this->addSql(createTruncateDatabaseCommand());
+
+        $statements = getStatementsForMigrationFile();
+        foreach ($statements as $statement) {
+            if (trim($statement)) {
+                $this->addSql($statement);
+            }
+        }
         // END PHP CODE
     }
 

--- a/api/migrations/dev-data/data.sql
+++ b/api/migrations/dev-data/data.sql
@@ -802,6 +802,7 @@ INSERT INTO public.content_node (id, slot, "position", instancename, createtime,
 	('d82c7a45d7df', '1', 0, NULL, '2023-11-12 14:26:30', '2023-11-12 14:26:30', '190375b61413', '190375b61413', 'a4211c112939', 'responsivelayout', '{"items": [{"slot": "main"}, {"slot": "aside-top"}, {"slot": "aside-bottom"}]}'),
 	('6cdf77b5c113', 'main', 1, NULL, '2023-08-08 08:19:55', '2023-11-12 17:21:16', '0e0b0bd06918', '17ba22ea1e86', '3ef17bd1df72', 'materialnode', NULL),
 	('0253abab905c', 'aside-top', 0, NULL, '2023-08-08 09:22:58', '2023-11-12 14:39:27', '2e7a9509cd7f', 'fd1ff3d85bc6', '318e064ea0c9', 'singletext', '{"html": ""}'),
+	('95f018545e1e', '1', 1, NULL, '2024-04-01 18:07:06', '2024-04-01 18:07:06', '6fb71d916699', '6fb71d916699', '3ef17bd1df72', 'materialnode', NULL),
 	('a26a7ae09d58', 'aside-top', 0, NULL, '2023-08-08 08:19:55', '2023-11-12 17:21:33', '0e0b0bd06918', '17ba22ea1e86', '318e064ea0c9', 'singletext', '{"html": "<p>Wir stürzen ab. Der Pilot verlässt das Flugzeug früher, weil die Steuerung nicht mehr funktioniert und er der Meinung ist, dass wir in die Insel stürzen würden und er nicht sterben will. oder so ähnlch de Pilot isch denn eifach verscholle</p>"}'),
 	('17ba22ea1e86', '1', 0, NULL, '2023-11-12 17:21:12', '2023-11-12 17:21:12', '0e0b0bd06918', '0e0b0bd06918', 'a4211c112939', 'responsivelayout', '{"items": [{"slot": "main"}, {"slot": "aside-top"}, {"slot": "aside-bottom"}]}'),
 	('8e8787fea6f2', 'main', 1, NULL, '2023-08-08 10:15:50', '2023-11-12 14:16:11', '40dad30f1f06', 'fdf884fca646', '3ef17bd1df72', 'materialnode', NULL),
@@ -833,7 +834,6 @@ INSERT INTO public.content_node (id, slot, "position", instancename, createtime,
 	('e8a86edb00da', 'aside-top', 0, NULL, '2023-08-12 18:38:52', '2023-12-03 19:10:34', '20ed0b8eb618', '49debe3d36db', '318e064ea0c9', 'singletext', '{"html": "<p>Massa ultricies mi quis hendrerit dolor magna eget. Neque volutpat ac tincidunt vitae semper quis. Vel pretium lectus quam id. Varius morbi enim nunc faucibus a pellentesque. Fames ac turpis egestas sed tempus. Non blandit massa enim nec dui nunc mattis. Volutpat consequat mauris nunc congue nisi vitae. Amet consectetur adipiscing elit ut aliquam purus sit amet luctus. Lorem sed risus ultricies tristique. Magna fermentum iaculis eu non diam phasellus vestibulum lorem sed. Eget NULLa facilisi etiam dignissim diam quis enim. Enim eu turpis egestas pretium aenean pharetra magna ac.</p>"}'),
 	('49debe3d36db', '1', 0, NULL, '2023-12-03 19:09:58', '2023-12-03 19:09:58', '20ed0b8eb618', '20ed0b8eb618', 'a4211c112939', 'responsivelayout', '{"items": [{"slot": "main"}, {"slot": "aside-top"}, {"slot": "aside-bottom"}]}'),
 	('fd1ff3d85bc6', '1', 0, NULL, '2023-11-12 14:38:52', '2023-11-12 14:38:52', '2e7a9509cd7f', '2e7a9509cd7f', 'a4211c112939', 'responsivelayout', '{"items": [{"slot": "main"}, {"slot": "aside-top"}, {"slot": "aside-bottom"}]}'),
-	('95f018545e1e', '1', 1, NULL, '2024-04-01 18:07:06', '2024-04-01 18:07:06', '6fb71d916699', '6fb71d916699', '3ef17bd1df72', 'materialnode', NULL),
 	('90407006a8cd', '1', 0, NULL, '2024-04-01 18:07:04', '2024-04-01 18:07:25', '6fb71d916699', '6fb71d916699', '318e064ea0c9', 'singletext', '{"html": "<p>Wir essen in Hogwarts.</p>"}');
 
 
@@ -1003,7 +1003,6 @@ INSERT INTO public.camp_collaboration (id, inviteemail, invitekeyhash, status, r
 	('d27ca1d0e6e4', NULL, NULL, 'established', 'member', NULL, '2023-08-08 09:36:01', '2023-08-08 09:44:19', 'bae69a1c9fcc', '6973c230d6b1'),
 	('c463d2a19847', NULL, NULL, 'established', 'member', NULL, '2023-08-08 09:38:01', '2023-08-08 09:44:50', 'caeba9f7e728', '6973c230d6b1'),
 	('763c0d181b63', NULL, NULL, 'established', 'manager', NULL, '2023-08-08 09:37:16', '2023-08-08 09:45:21', 'bee7cf5b3871', '6973c230d6b1'),
-	('b32db30637c8', NULL, NULL, 'established', 'manager', NULL, '2023-08-12 17:41:55', '2023-08-12 17:41:55', '9145944210a7', '9c2447aefe38'),
 	('b7d93b2fa1be', NULL, 'mLdsTtaGGptPYSZLUDgX8sAFO54=', 'established', 'member', NULL, '2023-08-12 19:10:49', '2023-08-12 19:10:49', 'a2f4f3879c85', '9c2447aefe38'),
 	('ac1cd0bcbd69', NULL, 'V30YTcBqBqs5xS7HrFM4ODRrzbw=', 'established', 'member', NULL, '2023-08-12 19:10:28', '2023-08-12 19:10:28', 'a3d9d86dc23b', '9c2447aefe38'),
 	('8be6d2f6f7dc', NULL, 'ru6jsdD9fODk8+p8wmI909rJPkQ=', 'established', 'manager', NULL, '2023-08-12 19:11:03', '2023-08-12 19:11:03', '566aea2c2759', '9c2447aefe38'),
@@ -1017,7 +1016,8 @@ INSERT INTO public.camp_collaboration (id, inviteemail, invitekeyhash, status, r
 	('46d14f7c072c', NULL, '4KCuIMWvkGVAjSBtAnG5QcesOrI=', 'established', 'manager', NULL, '2023-09-29 23:41:30', '2023-09-29 23:41:30', 'a2f4f3879c85', '70ca971c992f'),
 	('b0bdb7202a9d', NULL, NULL, 'established', 'manager', NULL, '2023-08-08 07:53:12', '2023-08-08 07:53:12', '9145944210a7', '3c79b99ab424'),
 	('b00054c3c03e', NULL, 'XC/b4erYO0iZZTBEXOi3n/4AH9w=', 'established', 'guest', NULL, '2023-08-13 10:29:08', '2023-08-13 10:29:08', '9145944210a7', '0969e3c95dfc'),
-	('10d8f02ce5b4', NULL, 'n1MKxMj1RWkrcSmNfHdjUxKV3QY=', 'established', 'guest', NULL, '2023-09-29 23:25:49', '2023-09-29 23:25:49', '9145944210a7', '70ca971c992f');
+	('10d8f02ce5b4', NULL, 'n1MKxMj1RWkrcSmNfHdjUxKV3QY=', 'established', 'guest', NULL, '2023-09-29 23:25:49', '2023-09-29 23:25:49', '9145944210a7', '70ca971c992f'),
+	('b32db30637c8', NULL, 'AC/b4erYO0iZZTBEXOi3n/4AH9w=', 'invited', 'manager', NULL, '2023-08-12 17:41:55', '2023-08-12 17:41:55', '9145944210a7', '9c2447aefe38');
 
 
 

--- a/api/src/DTO/PersonalInvitation.php
+++ b/api/src/DTO/PersonalInvitation.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\DTO;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use App\State\PersonalInvitationAcceptProcessor;
+use App\State\PersonalInvitationProvider;
+use App\State\PersonalInvitationRejectProcessor;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * An invitation for a person who already has an account to collaborate in a camp.
+ */
+#[ApiResource(
+    operations: [
+        new Get(
+            normalizationContext: self::ITEM_NORMALIZATION_CONTEXT,
+            provider: PersonalInvitationProvider::class,
+        ),
+        new Patch(
+            uriTemplate: '/personal_invitations/{id}/'.self::ACCEPT.'{._format}',
+            openapi: new OpenApiOperation(summary: 'Accept a personal invitation.'),
+            normalizationContext: self::ITEM_NORMALIZATION_CONTEXT,
+            denormalizationContext: ['groups' => ['write']],
+            security: 'is_authenticated()',
+            validationContext: ['groups' => ['Default', 'accept']],
+            output: PersonalInvitation::class,
+            provider: PersonalInvitationProvider::class,
+            processor: PersonalInvitationAcceptProcessor::class
+        ),
+        new Patch(
+            uriTemplate: '/personal_invitations/{id}/'.self::REJECT.'{._format}',
+            openapi: new OpenApiOperation(summary: 'Reject a personal invitation.'),
+            normalizationContext: self::ITEM_NORMALIZATION_CONTEXT,
+            denormalizationContext: ['groups' => ['write']],
+            output: PersonalInvitation::class,
+            provider: PersonalInvitationProvider::class,
+            processor: PersonalInvitationRejectProcessor::class
+        ),
+        new GetCollection(
+            normalizationContext: self::ITEM_NORMALIZATION_CONTEXT,
+            security: 'is_authenticated()',
+            provider: PersonalInvitationProvider::class,
+        ),
+    ],
+)]
+class PersonalInvitation {
+    public const ACCEPT = 'accept';
+    public const REJECT = 'reject';
+    public const ITEM_NORMALIZATION_CONTEXT = [
+        'groups' => ['read'],
+        'swagger_definition_name' => 'read',
+    ];
+
+    #[ApiProperty(readable: true, writable: false, identifier: true, example: '1a2b3c4d')]
+    #[Groups('read')]
+    public string $id;
+
+    /**
+     * The id of the camp for which this invitation is valid. This is useful for
+     * redirecting the user to the correct place after they accept.
+     */
+    #[ApiProperty(writable: false, example: '1a2b3c4d')]
+    #[Groups('read')]
+    public string $campId;
+
+    /**
+     * The full title of the camp for which this invitation is valid. This should help
+     * the user to decide whether to accept or reject the invitation.
+     */
+    #[ApiProperty(writable: false, example: 'Abteilungs-Sommerlager 2022')]
+    #[Groups('read')]
+    public string $campTitle;
+
+    public function __construct(string $id, string $campId, string $campTitle) {
+        $this->id = $id;
+        $this->campId = $campId;
+        $this->campTitle = $campTitle;
+    }
+}

--- a/api/src/Repository/CampCollaborationRepository.php
+++ b/api/src/Repository/CampCollaborationRepository.php
@@ -30,6 +30,17 @@ class CampCollaborationRepository extends ServiceEntityRepository implements Can
         return $this->findOneBy(['user' => $user, 'camp' => $camp]);
     }
 
+    public function findByUserAndIdAndInvited(User $user, string $id): ?CampCollaboration {
+        return $this->findOneBy(['user' => $user, 'id' => $id, 'status' => CampCollaboration::STATUS_INVITED]);
+    }
+
+    /**
+     * @return CampCollaboration[]
+     */
+    public function findAllByPersonallyInvitedUser(User $user): array {
+        return $this->findBy(['user' => $user, 'status' => CampCollaboration::STATUS_INVITED]);
+    }
+
     public function filterByUser(QueryBuilder $queryBuilder, User $user): void {
         $rootAlias = $queryBuilder->getRootAliases()[0];
         $queryBuilder->innerJoin("{$rootAlias}.camp", 'camp');

--- a/api/src/State/CampCollaborationCreateProcessor.php
+++ b/api/src/State/CampCollaborationCreateProcessor.php
@@ -43,7 +43,8 @@ class CampCollaborationCreateProcessor extends AbstractPersistProcessor {
             $profileByInviteEmail = $this->profileRepository->findOneBy(['email' => $inviteEmail]);
             if (null != $profileByInviteEmail) {
                 // Create a personal invitation, which the invited user will be able to see and
-                // accept / reject in the UI, even without receiving the invitation email
+                // accept / reject in the UI, even without receiving the invitation email.
+                // This is done by setting the user field instead of the inviteEmail field.
                 $data->user = $profileByInviteEmail->user;
                 $data->inviteEmail = null;
                 $this->validator->validate($data, ['groups' => ['Default', 'create']]);

--- a/api/src/State/CampCollaborationCreateProcessor.php
+++ b/api/src/State/CampCollaborationCreateProcessor.php
@@ -42,6 +42,8 @@ class CampCollaborationCreateProcessor extends AbstractPersistProcessor {
         if (CampCollaboration::STATUS_INVITED == $data->status && $inviteEmail) {
             $profileByInviteEmail = $this->profileRepository->findOneBy(['email' => $inviteEmail]);
             if (null != $profileByInviteEmail) {
+                // Create a personal invitation, which the invited user will be able to see and
+                // accept / reject in the UI, even without receiving the invitation email
                 $data->user = $profileByInviteEmail->user;
                 $data->inviteEmail = null;
                 $this->validator->validate($data, ['groups' => ['Default', 'create']]);

--- a/api/src/State/PersonalInvitationAcceptProcessor.php
+++ b/api/src/State/PersonalInvitationAcceptProcessor.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\DTO\PersonalInvitation;
+use App\Entity\CampCollaboration;
+use App\Entity\User;
+use App\Repository\CampCollaborationRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @implements ProcessorInterface<PersonalInvitation,PersonalInvitation>
+ */
+class PersonalInvitationAcceptProcessor implements ProcessorInterface {
+    public function __construct(
+        private readonly CampCollaborationRepository $campCollaborationRepository,
+        private readonly UserRepository $userRepository,
+        private readonly Security $security,
+        private readonly EntityManagerInterface $em,
+    ) {}
+
+    /**
+     * @param PersonalInvitation $data
+     *
+     * @throws NoResultException
+     * @throws NonUniqueResultException
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): PersonalInvitation {
+        $user = $this->getUser();
+
+        $campCollaboration = $this->campCollaborationRepository->findByUserAndIdAndInvited($user, $data->id);
+        $campCollaboration->status = CampCollaboration::STATUS_ESTABLISHED;
+        $campCollaboration->inviteKey = null;
+        $campCollaboration->inviteKeyHash = null;
+        $campCollaboration->inviteEmail = null;
+
+        $this->em->flush();
+
+        return $data;
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    protected function getUser(): ?User {
+        $user = $this->security->getUser();
+        if (null == $user) {
+            return null;
+        }
+
+        return $this->userRepository->loadUserByIdentifier($user->getUserIdentifier());
+    }
+}

--- a/api/src/State/PersonalInvitationProvider.php
+++ b/api/src/State/PersonalInvitationProvider.php
@@ -43,7 +43,7 @@ class PersonalInvitationProvider implements ProviderInterface {
      * @throws NoResultException
      * @throws NonUniqueResultException
      */
-    protected function provideCollection(): ?array {
+    private function provideCollection(): array {
         $user = $this->getUser();
         if (null == $user) {
             return [];
@@ -51,7 +51,7 @@ class PersonalInvitationProvider implements ProviderInterface {
         $campCollaborations = $this->campCollaborationRepository->findAllByPersonallyInvitedUser($user);
 
         return array_map(function (CampCollaboration $campCollaboration) {
-            return $this->getInvitation($campCollaboration);
+            return $this->toInvitation($campCollaboration);
         }, $campCollaborations);
     }
 
@@ -59,21 +59,21 @@ class PersonalInvitationProvider implements ProviderInterface {
      * @throws NoResultException
      * @throws NonUniqueResultException
      */
-    protected function provideItem(string $id): ?PersonalInvitation {
+    private function provideItem(string $id): ?PersonalInvitation {
         $user = $this->getUser();
         if (null == $id || null == $user) {
             return null;
         }
         $campCollaboration = $this->campCollaborationRepository->findByUserAndIdAndInvited($user, $id);
 
-        return $this->getInvitation($campCollaboration);
+        return $this->toInvitation($campCollaboration);
     }
 
     /**
      * @throws NonUniqueResultException
      * @throws NoResultException
      */
-    protected function getUser(): ?User {
+    private function getUser(): ?User {
         $user = $this->security->getUser();
         if (null == $user) {
             return null;
@@ -82,7 +82,7 @@ class PersonalInvitationProvider implements ProviderInterface {
         return $this->userRepository->loadUserByIdentifier($user->getUserIdentifier());
     }
 
-    protected function getInvitation(?CampCollaboration $campCollaboration): ?PersonalInvitation {
+    private function toInvitation(?CampCollaboration $campCollaboration): ?PersonalInvitation {
         if (null == $campCollaboration) {
             return null;
         }

--- a/api/src/State/PersonalInvitationProvider.php
+++ b/api/src/State/PersonalInvitationProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\DTO\PersonalInvitation;
+use App\Entity\CampCollaboration;
+use App\Entity\User;
+use App\Repository\CampCollaborationRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @template-implements ProviderInterface<PersonalInvitation>
+ */
+class PersonalInvitationProvider implements ProviderInterface {
+    public function __construct(
+        private readonly Security $security,
+        private readonly UserRepository $userRepository,
+        private readonly CampCollaborationRepository $campCollaborationRepository
+    ) {}
+
+    /**
+     * @return null|PersonalInvitation|PersonalInvitation[]
+     *
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): null|array|PersonalInvitation {
+        if (isset($uriVariables['id'])) {
+            $id = $uriVariables['id'];
+
+            return $this->provideItem($id);
+        }
+
+        return $this->provideCollection();
+    }
+
+    /**
+     * @throws NoResultException
+     * @throws NonUniqueResultException
+     */
+    protected function provideCollection(): ?array {
+        $user = $this->getUser();
+        if (null == $user) {
+            return [];
+        }
+        $campCollaborations = $this->campCollaborationRepository->findAllByPersonallyInvitedUser($user);
+
+        return array_map(function (CampCollaboration $campCollaboration) {
+            return $this->getInvitation($campCollaboration);
+        }, $campCollaborations);
+    }
+
+    /**
+     * @throws NoResultException
+     * @throws NonUniqueResultException
+     */
+    protected function provideItem(string $id): ?PersonalInvitation {
+        $user = $this->getUser();
+        if (null == $id || null == $user) {
+            return null;
+        }
+        $campCollaboration = $this->campCollaborationRepository->findByUserAndIdAndInvited($user, $id);
+
+        return $this->getInvitation($campCollaboration);
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    protected function getUser(): ?User {
+        $user = $this->security->getUser();
+        if (null == $user) {
+            return null;
+        }
+
+        return $this->userRepository->loadUserByIdentifier($user->getUserIdentifier());
+    }
+
+    protected function getInvitation(?CampCollaboration $campCollaboration): ?PersonalInvitation {
+        if (null == $campCollaboration) {
+            return null;
+        }
+
+        $camp = $campCollaboration->camp;
+
+        return new PersonalInvitation($campCollaboration->getId(), $camp->getId(), $camp->title);
+    }
+}

--- a/api/src/State/PersonalInvitationRejectProcessor.php
+++ b/api/src/State/PersonalInvitationRejectProcessor.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\DTO\PersonalInvitation;
+use App\Entity\CampCollaboration;
+use App\Entity\User;
+use App\Repository\CampCollaborationRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @implements ProcessorInterface<PersonalInvitation,PersonalInvitation>
+ */
+class PersonalInvitationRejectProcessor implements ProcessorInterface {
+    public function __construct(
+        private readonly CampCollaborationRepository $campCollaborationRepository,
+        private readonly UserRepository $userRepository,
+        private readonly Security $security,
+        private readonly EntityManagerInterface $em,
+    ) {}
+
+    /**
+     * @param PersonalInvitation $data
+     *
+     * @throws NoResultException
+     * @throws NonUniqueResultException
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): PersonalInvitation {
+        $user = $this->getUser();
+
+        $campCollaboration = $this->campCollaborationRepository->findByUserAndIdAndInvited($user, $data->id);
+        $campCollaboration->status = CampCollaboration::STATUS_INACTIVE;
+        $campCollaboration->inviteKey = null;
+        $campCollaboration->inviteKeyHash = null;
+
+        $this->em->flush();
+
+        return $data;
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    protected function getUser(): ?User {
+        $user = $this->security->getUser();
+        if (null == $user) {
+            return null;
+        }
+
+        return $this->userRepository->loadUserByIdentifier($user->getUserIdentifier());
+    }
+}

--- a/api/src/State/PersonalInvitationRejectProcessor.php
+++ b/api/src/State/PersonalInvitationRejectProcessor.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
  * @implements ProcessorInterface<PersonalInvitation,PersonalInvitation>
@@ -35,6 +36,10 @@ class PersonalInvitationRejectProcessor implements ProcessorInterface {
         $user = $this->getUser();
 
         $campCollaboration = $this->campCollaborationRepository->findByUserAndIdAndInvited($user, $data->id);
+        if (null === $campCollaboration) {
+            throw new NoResultException();
+        }
+
         $campCollaboration->status = CampCollaboration::STATUS_INACTIVE;
         $campCollaboration->inviteKey = null;
         $campCollaboration->inviteKeyHash = null;
@@ -48,10 +53,12 @@ class PersonalInvitationRejectProcessor implements ProcessorInterface {
      * @throws NonUniqueResultException
      * @throws NoResultException
      */
-    protected function getUser(): ?User {
+    private function getUser(): ?User {
         $user = $this->security->getUser();
         if (null == $user) {
-            return null;
+            // This should never happen because it should be caught earlier by our security settings
+            // on all API operations using this processor.
+            throw new AccessDeniedHttpException();
         }
 
         return $this->userRepository->loadUserByIdentifier($user->getUserIdentifier());

--- a/api/tests/Api/Invitations/AcceptInvitationTest.php
+++ b/api/tests/Api/Invitations/AcceptInvitationTest.php
@@ -111,11 +111,6 @@ class AcceptInvitationTest extends ECampApiTestCase {
         );
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            /*
-            'campId' => $campCollaboration->camp->getId(),
-            'campTitle' => $campCollaboration->camp->title,
-            'userDisplayName' => 'Bi-Pi',
-            'userAlreadyInCamp' => false, */
             '_links' => [
                 'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
             ],
@@ -212,7 +207,14 @@ class AcceptInvitationTest extends ECampApiTestCase {
      * @throws TransportExceptionInterface
      */
     public function testNotFoundWhenInviteKeyDoesNotMatch() {
-        static::createClientWithCredentials()->request('PATCH', '/invitations/notExisting/'.Invitation::ACCEPT);
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/invitations/notExisting/'.Invitation::ACCEPT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
         $this->assertResponseStatusCodeSame(404);
     }
 
@@ -223,7 +225,14 @@ class AcceptInvitationTest extends ECampApiTestCase {
      * @throws ClientExceptionInterface
      */
     public function testNotFoundWhenNoInviteKey() {
-        static::createClientWithCredentials()->request('PATCH', '/invitations/'.Invitation::ACCEPT);
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/invitations/'.Invitation::ACCEPT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
         $this->assertResponseStatusCodeSame(404);
     }
 }

--- a/api/tests/Api/Invitations/RejectInvitationTest.php
+++ b/api/tests/Api/Invitations/RejectInvitationTest.php
@@ -64,11 +64,6 @@ class RejectInvitationTest extends ECampApiTestCase {
         );
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            /*
-            'campId' => $campCollaboration->camp->getId(),
-            'campTitle' => $campCollaboration->camp->title,
-            'userDisplayName' => null,
-            'userAlreadyInCamp' => null,*/
             '_links' => [
                 'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
             ],
@@ -98,11 +93,6 @@ class RejectInvitationTest extends ECampApiTestCase {
         );
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            /*
-            'campId' => $campCollaboration->camp->getId(),
-            'campTitle' => $campCollaboration->camp->title,
-            'userDisplayName' => 'Bi-Pi',
-            'userAlreadyInCamp' => false,*/
             '_links' => [
                 'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
             ],
@@ -151,11 +141,6 @@ class RejectInvitationTest extends ECampApiTestCase {
         );
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            /*
-            'campId' => $campCollaboration->camp->getId(),
-            'campTitle' => $campCollaboration->camp->title,
-            'userDisplayName' => 'Bi-Pi',
-            'userAlreadyInCamp' => true,*/
             '_links' => [
                 'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
             ],
@@ -187,7 +172,14 @@ class RejectInvitationTest extends ECampApiTestCase {
      * @throws TransportExceptionInterface
      */
     public function testNotFoundWhenInviteKeyDoesNotMatch() {
-        static::createClientWithCredentials()->request('PATCH', '/invitations/notExisting/'.Invitation::REJECT);
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/invitations/notExisting/'.Invitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
         $this->assertResponseStatusCodeSame(404);
     }
 
@@ -198,7 +190,14 @@ class RejectInvitationTest extends ECampApiTestCase {
      * @throws ClientExceptionInterface
      */
     public function testNotFoundWhenNoInviteKey() {
-        static::createClientWithCredentials()->request('PATCH', '/invitations/'.Invitation::REJECT);
+        static::createClientWithCredentials()->request(
+            'PATCH',
+            '/invitations/'.Invitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
         $this->assertResponseStatusCodeSame(404);
     }
 }

--- a/api/tests/Api/PersonalInvitations/AcceptPersonalInvitationTest.php
+++ b/api/tests/Api/PersonalInvitations/AcceptPersonalInvitationTest.php
@@ -118,10 +118,6 @@ class AcceptPersonalInvitationTest extends ECampApiTestCase {
         );
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            /*
-            'id' => $campCollaboration->getId(),
-            'campId' => $campCollaboration->camp->getId(),
-            'campTitle' => $campCollaboration->camp->title, */
             '_links' => [
                 'self' => ['href' => "/personal_invitations/{$campCollaboration->getId()}"],
             ],
@@ -183,7 +179,37 @@ class AcceptPersonalInvitationTest extends ECampApiTestCase {
     public function testNotFoundWhenIdDoesNotMatch() {
         /** @var Profile $profile */
         $profile = static::getFixture('profile6invited');
-        static::createClientWithCredentials(['email' => $profile->email])->request('PATCH', '/personal_invitations/notExisting/'.PersonalInvitation::ACCEPT);
+        static::createClientWithCredentials(['email' => $profile->email])->request(
+            'PATCH',
+            '/personal_invitations/notExisting/'.PersonalInvitation::ACCEPT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testNotFoundWhenUserHasNoAccessToPersonalInvitation() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile8memberOnlyInCamp2');
+        static::createClientWithCredentials(['email' => $profile->email])->request(
+            'PATCH',
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::ACCEPT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
         $this->assertResponseStatusCodeSame(404);
     }
 
@@ -196,7 +222,14 @@ class AcceptPersonalInvitationTest extends ECampApiTestCase {
     public function testMethodNotAllowedWhenNoId() {
         /** @var Profile $profile */
         $profile = static::getFixture('profile6invited');
-        static::createClientWithCredentials(['email' => $profile->email])->request('PATCH', '/personal_invitations/'.PersonalInvitation::ACCEPT);
+        static::createClientWithCredentials(['email' => $profile->email])->request(
+            'PATCH',
+            '/personal_invitations/'.PersonalInvitation::ACCEPT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
         $this->assertResponseStatusCodeSame(405);
     }
 }

--- a/api/tests/Api/PersonalInvitations/AcceptPersonalInvitationTest.php
+++ b/api/tests/Api/PersonalInvitations/AcceptPersonalInvitationTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace App\Tests\Api\Invitations;
+namespace App\Tests\Api\PersonalInvitations;
 
-use App\DTO\Invitation;
+use App\DTO\PersonalInvitation;
 use App\Entity\CampCollaboration;
+use App\Entity\Profile;
 use App\Tests\Api\ECampApiTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
@@ -18,16 +19,16 @@ use function PHPUnit\Framework\lessThanOrEqual;
 /**
  * @internal
  */
-class AcceptInvitationTest extends ECampApiTestCase {
+class AcceptPersonalInvitationTest extends ECampApiTestCase {
     /**
      * @throws TransportExceptionInterface
      */
-    public function testAcceptInvitationFailsWhenNotLoggedIn() {
+    public function testAcceptPersonalInvitationFailsWhenNotLoggedIn() {
         /** @var CampCollaboration $campCollaboration */
-        $campCollaboration = static::getFixture('campCollaboration2invitedCampUnrelated');
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
         static::createBasicClient()->request(
             'PATCH',
-            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::ACCEPT,
             [
                 'json' => [],
                 'headers' => ['Content-Type' => 'application/merge-patch+json'],
@@ -39,14 +40,14 @@ class AcceptInvitationTest extends ECampApiTestCase {
     /**
      * @throws TransportExceptionInterface
      */
-    public function testAcceptInvitationDoesNotHitDBWhenNotLoggedIn() {
+    public function testAcceptPersonalInvitationDoesNotHitDBWhenNotLoggedIn() {
         /** @var CampCollaboration $campCollaboration */
-        $campCollaboration = static::getFixture('campCollaboration2invitedCampUnrelated');
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
         $client = static::createBasicClient();
         $client->enableProfiler();
         $client->request(
             'PATCH',
-            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::ACCEPT,
             [
                 'json' => [],
                 'headers' => ['Content-Type' => 'application/merge-patch+json'],
@@ -70,12 +71,15 @@ class AcceptInvitationTest extends ECampApiTestCase {
      * @throws TransportExceptionInterface
      * @throws ServerExceptionInterface
      */
-    public function testAcceptInvitationSuccess() {
+    public function testAcceptPersonalInvitationSuccess() {
         /** @var CampCollaboration $campCollaboration */
-        $campCollaboration = static::getFixture('campCollaboration2invitedCampUnrelated');
-        static::createClientWithCredentials()->request(
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request(
             'PATCH',
-            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::ACCEPT,
             [
                 'json' => [],
                 'headers' => ['Content-Type' => 'application/merge-patch+json'],
@@ -84,7 +88,7 @@ class AcceptInvitationTest extends ECampApiTestCase {
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             '_links' => [
-                'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
+                'self' => ['href' => "/personal_invitations/{$campCollaboration->getId()}"],
             ],
         ]);
     }
@@ -96,14 +100,17 @@ class AcceptInvitationTest extends ECampApiTestCase {
      * @throws TransportExceptionInterface
      * @throws ServerExceptionInterface
      */
-    public function testCannotFindInvitationAfterSuccessfulAccept() {
+    public function testCannotFindPersonalInvitationAfterSuccessfulAccept() {
         /** @var CampCollaboration $campCollaboration */
-        $campCollaboration = static::getFixture('campCollaboration2invitedCampUnrelated');
-        $client = static::createClientWithCredentials();
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        $client = static::createClientWithCredentials(['email' => $profile->email]);
         $client->disableReboot();
         $client->request(
             'PATCH',
-            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::ACCEPT,
             [
                 'json' => [],
                 'headers' => ['Content-Type' => 'application/merge-patch+json'],
@@ -112,16 +119,15 @@ class AcceptInvitationTest extends ECampApiTestCase {
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
             /*
+            'id' => $campCollaboration->getId(),
             'campId' => $campCollaboration->camp->getId(),
-            'campTitle' => $campCollaboration->camp->title,
-            'userDisplayName' => 'Bi-Pi',
-            'userAlreadyInCamp' => false, */
+            'campTitle' => $campCollaboration->camp->title, */
             '_links' => [
-                'self' => ['href' => "/invitations/{$campCollaboration->inviteKey}/find"],
+                'self' => ['href' => "/personal_invitations/{$campCollaboration->getId()}"],
             ],
         ]);
 
-        $client->request('GET', "/invitations/{$campCollaboration->inviteKey}/find");
+        $client->request('GET', "/personal_invitations/{$campCollaboration->getId()}");
         $this->assertResponseStatusCodeSame(404);
     }
 
@@ -131,12 +137,15 @@ class AcceptInvitationTest extends ECampApiTestCase {
      * @throws TransportExceptionInterface
      * @throws ServerExceptionInterface
      */
-    public function testAcceptInvitationFailsWithExtraAttribute() {
+    public function testAcceptPersonalInvitationFailsWithExtraAttribute() {
         /** @var CampCollaboration $campCollaboration */
-        $campCollaboration = static::getFixture('campCollaboration2invitedCampUnrelated');
-        static::createClientWithCredentials()->request(
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request(
             'PATCH',
-            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::ACCEPT,
             [
                 'json' => [
                     'userAlreadyInCamp' => true,
@@ -148,46 +157,6 @@ class AcceptInvitationTest extends ECampApiTestCase {
     }
 
     /**
-     * @throws TransportExceptionInterface
-     * @throws ServerExceptionInterface
-     * @throws RedirectionExceptionInterface
-     * @throws ClientExceptionInterface
-     */
-    public function testAcceptInvitationFailsWhenUserAlreadyInCamp() {
-        /** @var CampCollaboration $campCollaboration */
-        $campCollaboration = static::getFixture('campCollaboration4invited');
-        static::createClientWithCredentials()->request(
-            'PATCH',
-            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
-            [
-                'json' => [],
-                'headers' => ['Content-Type' => 'application/merge-patch+json'],
-            ]
-        );
-        $this->assertResponseStatusCodeSame(422);
-    }
-
-    /**
-     * @throws TransportExceptionInterface
-     * @throws ServerExceptionInterface
-     * @throws RedirectionExceptionInterface
-     * @throws ClientExceptionInterface
-     */
-    public function testAcceptInvitationFailsWhenUserAlreadyInCampAndUserIsAttachedToInvitation() {
-        /** @var CampCollaboration $campCollaboration */
-        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
-        static::createClientWithCredentials()->request(
-            'PATCH',
-            "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT,
-            [
-                'json' => [],
-                'headers' => ['Content-Type' => 'application/merge-patch+json'],
-            ]
-        );
-        $this->assertResponseStatusCodeSame(422);
-    }
-
-    /**
      * @throws ClientExceptionInterface
      * @throws RedirectionExceptionInterface
      * @throws ServerExceptionInterface
@@ -196,8 +165,8 @@ class AcceptInvitationTest extends ECampApiTestCase {
     #[DataProvider('invalidMethods')]
     public function testInvalidRequestWhenWrongMethod(string $method) {
         /** @var CampCollaboration $campCollaboration */
-        $campCollaboration = static::getFixture('campCollaboration2invitedCampUnrelated');
-        static::createClientWithCredentials()->request($method, "/invitations/{$campCollaboration->inviteKey}/".Invitation::ACCEPT);
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+        static::createClientWithCredentials()->request($method, "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::ACCEPT);
         $this->assertResponseStatusCodeSame(405);
     }
 
@@ -211,8 +180,10 @@ class AcceptInvitationTest extends ECampApiTestCase {
      * @throws ServerExceptionInterface
      * @throws TransportExceptionInterface
      */
-    public function testNotFoundWhenInviteKeyDoesNotMatch() {
-        static::createClientWithCredentials()->request('PATCH', '/invitations/notExisting/'.Invitation::ACCEPT);
+    public function testNotFoundWhenIdDoesNotMatch() {
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request('PATCH', '/personal_invitations/notExisting/'.PersonalInvitation::ACCEPT);
         $this->assertResponseStatusCodeSame(404);
     }
 
@@ -222,8 +193,10 @@ class AcceptInvitationTest extends ECampApiTestCase {
      * @throws RedirectionExceptionInterface
      * @throws ClientExceptionInterface
      */
-    public function testNotFoundWhenNoInviteKey() {
-        static::createClientWithCredentials()->request('PATCH', '/invitations/'.Invitation::ACCEPT);
-        $this->assertResponseStatusCodeSame(404);
+    public function testMethodNotAllowedWhenNoId() {
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request('PATCH', '/personal_invitations/'.PersonalInvitation::ACCEPT);
+        $this->assertResponseStatusCodeSame(405);
     }
 }

--- a/api/tests/Api/PersonalInvitations/DeletePersonalInvitationTest.php
+++ b/api/tests/Api/PersonalInvitations/DeletePersonalInvitationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Tests\Api\PersonalInvitations;
+
+use App\Entity\CampCollaboration;
+use App\Entity\Profile;
+use App\Tests\Api\ECampApiTestCase;
+
+/**
+ * @internal
+ */
+class DeletePersonalInvitationTest extends ECampApiTestCase {
+    public function testDeleteIsNotAllowed() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration2invitedCampUnrelated');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request('DELETE', '/invitations/'.$campCollaboration->getId());
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+}

--- a/api/tests/Api/PersonalInvitations/FindPersonalInvitationTest.php
+++ b/api/tests/Api/PersonalInvitations/FindPersonalInvitationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Tests\Api\PersonalInvitations;
+
+use App\Entity\CampCollaboration;
+use App\Entity\Profile;
+use App\Tests\Api\ECampApiTestCase;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * @internal
+ */
+class FindPersonalInvitationTest extends ECampApiTestCase {
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public function testDoesNotFindPersonalInvitationWhenNotLoggedIn() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+        static::createBasicClient()->request('GET', "/personal_invitations/{$campCollaboration->getId()}");
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testFindOwnPersonalInvitationWhenLoggedIn() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request('GET', "/personal_invitations/{$campCollaboration->getId()}");
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'id' => $campCollaboration->getId(),
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,
+            '_links' => [
+                'self' => ['href' => "/personal_invitations/{$campCollaboration->getId()}"],
+            ],
+        ]);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testDoesNotFindOtherPersonalInvitationWhenLoggedIn() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+        static::createClientWithCredentials()->request('GET', "/personal_invitations/{$campCollaboration->getId()}");
+        $this->assertResponseStatusCodeSame(404);
+    }
+}

--- a/api/tests/Api/PersonalInvitations/PersonalInvitationGraphQLTest.php
+++ b/api/tests/Api/PersonalInvitations/PersonalInvitationGraphQLTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Tests\Api\PersonalInvitations;
+
+use App\Entity\CampCollaboration;
+use App\Entity\Profile;
+use App\Tests\Api\ECampApiTestCase;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * @internal
+ */
+class PersonalInvitationGraphQLTest extends ECampApiTestCase {
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testFindPersonalInvitationWhenNotLoggedIn() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+        $query = "
+        {
+          personalInvitation(id: \"personal_invitations/{$campCollaboration->getId()}\") {
+            id
+            campTitle
+            campId
+          }
+        }
+        ";
+
+        static::createClient()->request('GET', '/graphql?'.http_build_query(['query' => $query]));
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testFindPersonalInvitationWhenLoggedIn() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+        $query = "
+        {
+          personalInvitation(id: \"personal_invitations/{$campCollaboration->getId()}\") {
+            id
+            campTitle
+            campId
+          }
+        }
+        ";
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request('GET', '/graphql?'.http_build_query(['query' => $query]));
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'data' => [
+                'personalInvitation' => [
+                    'id' => '/personal_invitations/'.$campCollaboration->getId(),
+                    'campId' => $campCollaboration->camp->getId(),
+                    'campTitle' => $campCollaboration->camp->title,
+                ],
+            ],
+        ]);
+    }
+}

--- a/api/tests/Api/PersonalInvitations/RejectPersonalInvitationTest.php
+++ b/api/tests/Api/PersonalInvitations/RejectPersonalInvitationTest.php
@@ -61,10 +61,6 @@ class RejectPersonalInvitationTest extends ECampApiTestCase {
         );
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            /*
-            'id' => $campCollaboration->getId(),
-            'campId' => $campCollaboration->camp->getId(),
-            'campTitle' => $campCollaboration->camp->title,*/
             '_links' => [
                 'self' => ['href' => "/personal_invitations/{$campCollaboration->getId()}"],
             ],
@@ -96,10 +92,6 @@ class RejectPersonalInvitationTest extends ECampApiTestCase {
         );
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            /*
-            'id' => $campCollaboration->getId(),
-            'campId' => $campCollaboration->camp->getId(),
-            'campTitle' => $campCollaboration->camp->title,*/
             '_links' => [
                 'self' => ['href' => "/personal_invitations/{$campCollaboration->getId()}"],
             ],
@@ -164,7 +156,37 @@ class RejectPersonalInvitationTest extends ECampApiTestCase {
     public function testNotFoundWhenIdDoesNotMatch() {
         /** @var Profile $profile */
         $profile = static::getFixture('profile6invited');
-        static::createClientWithCredentials(['email' => $profile->email])->request('PATCH', '/personal_invitations/notExisting/'.PersonalInvitation::REJECT);
+        static::createClientWithCredentials(['email' => $profile->email])->request(
+            'PATCH',
+            '/personal_invitations/notExisting/'.PersonalInvitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testNotFoundWhenUserHasNoAccessToPersonalInvitation() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile8memberOnlyInCamp2');
+        static::createClientWithCredentials(['email' => $profile->email])->request(
+            'PATCH',
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
         $this->assertResponseStatusCodeSame(404);
     }
 
@@ -177,7 +199,14 @@ class RejectPersonalInvitationTest extends ECampApiTestCase {
     public function testMethodNotAllowedWhenNoId() {
         /** @var Profile $profile */
         $profile = static::getFixture('profile6invited');
-        static::createClientWithCredentials(['email' => $profile->email])->request('PATCH', '/personal_invitations/'.PersonalInvitation::REJECT);
+        static::createClientWithCredentials(['email' => $profile->email])->request(
+            'PATCH',
+            '/personal_invitations/'.PersonalInvitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
         $this->assertResponseStatusCodeSame(405);
     }
 }

--- a/api/tests/Api/PersonalInvitations/RejectPersonalInvitationTest.php
+++ b/api/tests/Api/PersonalInvitations/RejectPersonalInvitationTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Tests\Api\PersonalInvitations;
+
+use App\DTO\PersonalInvitation;
+use App\Entity\CampCollaboration;
+use App\Entity\Profile;
+use App\Tests\Api\ECampApiTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * @internal
+ */
+class RejectPersonalInvitationTest extends ECampApiTestCase {
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testRejectPersonalInvitationFailsWhenNotLoggedIn() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+        static::createBasicClient()->request(
+            'PATCH',
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testRejectPersonalInvitationSucceedsWhenLoggedIn() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request(
+            'PATCH',
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            /*
+            'id' => $campCollaboration->getId(),
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,*/
+            '_links' => [
+                'self' => ['href' => "/personal_invitations/{$campCollaboration->getId()}"],
+            ],
+        ]);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testCannotFindPersonalInvitationAfterSuccessfulReject() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        $client = static::createClientWithCredentials(['email' => $profile->email]);
+        $client->disableReboot();
+        $client->request(
+            'PATCH',
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::REJECT,
+            [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            /*
+            'id' => $campCollaboration->getId(),
+            'campId' => $campCollaboration->camp->getId(),
+            'campTitle' => $campCollaboration->camp->title,*/
+            '_links' => [
+                'self' => ['href' => "/personal_invitations/{$campCollaboration->getId()}"],
+            ],
+        ]);
+
+        $client->request('GET', "/personal_invitations/{$campCollaboration->getId()}");
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    public function testRejectPersonalInvitationFailsWithExtraAttribute() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request(
+            'PATCH',
+            "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::REJECT,
+            [
+                'json' => [
+                    'userAlreadyInCamp' => true,
+                ],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]
+        );
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    #[DataProvider('invalidMethods')]
+    public function testInvalidRequestWhenWrongMethod(string $method) {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration6invitedWithUser');
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request($method, "/personal_invitations/{$campCollaboration->getId()}/".PersonalInvitation::REJECT);
+        $this->assertResponseStatusCodeSame(405);
+    }
+
+    public static function invalidMethods(): array {
+        return ['GET' => ['GET'], 'PUT' => ['PUT'], 'POST' => ['POST'], 'DELETE' => ['DELETE'], 'OPTIONS' => ['OPTIONS']];
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function testNotFoundWhenIdDoesNotMatch() {
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request('PATCH', '/personal_invitations/notExisting/'.PersonalInvitation::REJECT);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ClientExceptionInterface
+     */
+    public function testMethodNotAllowedWhenNoId() {
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile6invited');
+        static::createClientWithCredentials(['email' => $profile->email])->request('PATCH', '/personal_invitations/'.PersonalInvitation::REJECT);
+        $this->assertResponseStatusCodeSame(405);
+    }
+}

--- a/api/tests/Api/SnapshotTests/EndpointQueryCountTest.php
+++ b/api/tests/Api/SnapshotTests/EndpointQueryCountTest.php
@@ -182,6 +182,7 @@ class EndpointQueryCountTest extends ECampApiTestCase {
                 '/auth/jubladb' => false,
                 '/auth/reset_password' => false,
                 '/invitations' => false,
+                '/personal_invitations' => false,
                 default => true
             };
         });

--- a/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
+++ b/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
@@ -114,6 +114,7 @@ class ResponseSnapshotTest extends ECampApiTestCase {
                 '/auth/jubladb' => false,
                 '/auth/reset_password' => false,
                 '/invitations' => false,
+                '/personal_invitations' => false,
                 '/users' => false,
                 default => true
             };

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
@@ -18441,6 +18441,126 @@ components:
         - moveScheduleEntries
         - start
       type: object
+    PersonalInvitation-read:
+      deprecated: false
+      description: 'An invitation for a person who already has an account to collaborate in a camp.'
+      properties:
+        campId:
+          description: |-
+            The id of the camp for which this invitation is valid. This is useful for
+            redirecting the user to the correct place after they accept.
+          example: 1a2b3c4d
+          type: string
+        campTitle:
+          description: |-
+            The full title of the camp for which this invitation is valid. This should help
+            the user to decide whether to accept or reject the invitation.
+          example: 'Abteilungs-Sommerlager 2022'
+          type: string
+        id:
+          example: 1a2b3c4d
+          type: string
+      type: object
+    PersonalInvitation-write:
+      deprecated: false
+      description: 'An invitation for a person who already has an account to collaborate in a camp.'
+      type: object
+    PersonalInvitation.jsonapi-read:
+      deprecated: false
+      description: 'An invitation for a person who already has an account to collaborate in a camp.'
+      properties:
+        campId:
+          description: |-
+            The id of the camp for which this invitation is valid. This is useful for
+            redirecting the user to the correct place after they accept.
+          example: 1a2b3c4d
+          type: string
+        campTitle:
+          description: |-
+            The full title of the camp for which this invitation is valid. This should help
+            the user to decide whether to accept or reject the invitation.
+          example: 'Abteilungs-Sommerlager 2022'
+          type: string
+        id:
+          example: 1a2b3c4d
+          type: string
+      type: object
+    PersonalInvitation.jsonapi-write:
+      deprecated: false
+      description: 'An invitation for a person who already has an account to collaborate in a camp.'
+      type: object
+    PersonalInvitation.jsonhal-read:
+      deprecated: false
+      description: 'An invitation for a person who already has an account to collaborate in a camp.'
+      properties:
+        _links:
+          properties:
+            self:
+              properties:
+                href:
+                  format: iri-reference
+                  type: string
+              type: object
+          type: object
+        campId:
+          description: |-
+            The id of the camp for which this invitation is valid. This is useful for
+            redirecting the user to the correct place after they accept.
+          example: 1a2b3c4d
+          type: string
+        campTitle:
+          description: |-
+            The full title of the camp for which this invitation is valid. This should help
+            the user to decide whether to accept or reject the invitation.
+          example: 'Abteilungs-Sommerlager 2022'
+          type: string
+        id:
+          example: 1a2b3c4d
+          type: string
+      type: object
+    PersonalInvitation.jsonld-read:
+      deprecated: false
+      description: 'An invitation for a person who already has an account to collaborate in a camp.'
+      properties:
+        '@context':
+          oneOf:
+            -
+              additionalProperties: true
+              properties:
+                '@vocab':
+                  type: string
+                hydra:
+                  enum: ['http://www.w3.org/ns/hydra/core#']
+                  type: string
+              required:
+                - '@vocab'
+                - hydra
+              type: object
+            -
+              type: string
+          readOnly: true
+        '@id':
+          readOnly: true
+          type: string
+        '@type':
+          readOnly: true
+          type: string
+        campId:
+          description: |-
+            The id of the camp for which this invitation is valid. This is useful for
+            redirecting the user to the correct place after they accept.
+          example: 1a2b3c4d
+          type: string
+        campTitle:
+          description: |-
+            The full title of the camp for which this invitation is valid. This should help
+            the user to decide whether to accept or reject the invitation.
+          example: 'Abteilungs-Sommerlager 2022'
+          type: string
+        id:
+          example: 1a2b3c4d
+          type: string
+      type: object
     Profile-read:
       deprecated: false
       description: |-
@@ -30019,6 +30139,215 @@ paths:
       summary: 'Updates the Period resource.'
       tags:
         - Period
+  /personal_invitations:
+    get:
+      deprecated: false
+      description: 'Retrieves the collection of PersonalInvitation resources.'
+      operationId: api_personal_invitations_get_collection
+      parameters: []
+      responses:
+        200:
+          content:
+            application/hal+json:
+              schema:
+                properties:
+                  _embedded: { anyOf: [{ properties: { item: { items: { $ref: '#/components/schemas/PersonalInvitation.jsonhal-read' }, type: array } }, type: object }, { type: object }] }
+                  _links: { properties: { first: { properties: { href: { format: iri-reference, type: string } }, type: object }, last: { properties: { href: { format: iri-reference, type: string } }, type: object }, next: { properties: { href: { format: iri-reference, type: string } }, type: object }, previous: { properties: { href: { format: iri-reference, type: string } }, type: object }, self: { properties: { href: { format: iri-reference, type: string } }, type: object } }, type: object }
+                  itemsPerPage: { minimum: 0, type: integer }
+                  totalItems: { minimum: 0, type: integer }
+                required:
+                  - _embedded
+                  - _links
+                type: object
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PersonalInvitation-read'
+                type: array
+            application/ld+json:
+              schema:
+                properties:
+                  'hydra:member': { items: { $ref: '#/components/schemas/PersonalInvitation.jsonld-read' }, type: array }
+                  'hydra:search': { properties: { '@type': { type: string }, 'hydra:mapping': { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string } }, type: object }
+                  'hydra:totalItems': { minimum: 0, type: integer }
+                  'hydra:view': { example: { '@id': string, 'hydra:first': string, 'hydra:last': string, 'hydra:next': string, 'hydra:previous': string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, 'hydra:first': { format: iri-reference, type: string }, 'hydra:last': { format: iri-reference, type: string }, 'hydra:next': { format: iri-reference, type: string }, 'hydra:previous': { format: iri-reference, type: string } }, type: object }
+                required:
+                  - 'hydra:member'
+                type: object
+            application/vnd.api+json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PersonalInvitation.jsonapi-read'
+                type: array
+            text/html:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PersonalInvitation-read'
+                type: array
+          description: 'PersonalInvitation collection'
+      summary: 'Retrieves the collection of PersonalInvitation resources.'
+      tags:
+        - PersonalInvitation
+    parameters: []
+  '/personal_invitations/{id}':
+    get:
+      deprecated: false
+      description: 'Retrieves a PersonalInvitation resource.'
+      operationId: api_personal_invitations_id_get
+      parameters:
+        -
+          allowEmptyValue: false
+          allowReserved: false
+          deprecated: false
+          description: 'PersonalInvitation identifier'
+          explode: false
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          style: simple
+      responses:
+        200:
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation.jsonhal-read'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation-read'
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation.jsonld-read'
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation.jsonapi-read'
+            text/html:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation-read'
+          description: 'PersonalInvitation resource'
+        404:
+          description: 'Resource not found'
+      summary: 'Retrieves a PersonalInvitation resource.'
+      tags:
+        - PersonalInvitation
+    parameters: []
+  '/personal_invitations/{id}/accept':
+    parameters: []
+    patch:
+      deprecated: false
+      description: 'Updates the PersonalInvitation resource.'
+      operationId: api_personal_invitations_idaccept_patch
+      parameters:
+        -
+          allowEmptyValue: false
+          allowReserved: false
+          deprecated: false
+          description: 'PersonalInvitation identifier'
+          explode: false
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          style: simple
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/PersonalInvitation-write'
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/PersonalInvitation.jsonapi-write'
+        description: 'The updated PersonalInvitation resource'
+        required: true
+      responses:
+        200:
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation.jsonhal-read'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation-read'
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation.jsonld-read'
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation.jsonapi-read'
+            text/html:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation-read'
+          description: 'PersonalInvitation resource updated'
+          links: []
+        400:
+          description: 'Invalid input'
+        404:
+          description: 'Resource not found'
+        422:
+          description: 'Unprocessable entity'
+      summary: 'Accept a personal invitation.'
+      tags:
+        - PersonalInvitation
+  '/personal_invitations/{id}/reject':
+    parameters: []
+    patch:
+      deprecated: false
+      description: 'Updates the PersonalInvitation resource.'
+      operationId: api_personal_invitations_idreject_patch
+      parameters:
+        -
+          allowEmptyValue: false
+          allowReserved: false
+          deprecated: false
+          description: 'PersonalInvitation identifier'
+          explode: false
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          style: simple
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/PersonalInvitation-write'
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/PersonalInvitation.jsonapi-write'
+        description: 'The updated PersonalInvitation resource'
+        required: true
+      responses:
+        200:
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation.jsonhal-read'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation-read'
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation.jsonld-read'
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation.jsonapi-read'
+            text/html:
+              schema:
+                $ref: '#/components/schemas/PersonalInvitation-read'
+          description: 'PersonalInvitation resource updated'
+          links: []
+        400:
+          description: 'Invalid input'
+        404:
+          description: 'Resource not found'
+        422:
+          description: 'Unprocessable entity'
+      summary: 'Reject a personal invitation.'
+      tags:
+        - PersonalInvitation
   /profiles:
     get:
       deprecated: false

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testRootEndpointMatchesSnapshot__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testRootEndpointMatchesSnapshot__1.json
@@ -87,6 +87,10 @@
             "href": "\/periods{\/id}{?camp,camp[]}",
             "templated": true
         },
+        "personalInvitations": {
+            "href": "/personal_invitations{/id}{/action}",
+            "templated": true
+        },
         "profiles": {
             "href": "\/profiles{\/id}{?user.collaborations.camp,user.collaborations.camp[]}",
             "templated": true

--- a/api/tests/State/PersonalInvitationAcceptProcessorTest.php
+++ b/api/tests/State/PersonalInvitationAcceptProcessorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Tests\State;
+
+use ApiPlatform\Metadata\Patch;
+use App\DTO\PersonalInvitation;
+use App\Entity\CampCollaboration;
+use App\Entity\User;
+use App\Repository\CampCollaborationRepository;
+use App\Repository\UserRepository;
+use App\State\PersonalInvitationAcceptProcessor;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @internal
+ */
+class PersonalInvitationAcceptProcessorTest extends TestCase {
+    public const ID = '1a2b3c4d';
+
+    private PersonalInvitation $invitation;
+    private CampCollaboration $campCollaboration;
+    private MockObject|User $user;
+
+    private CampCollaborationRepository|MockObject $collaborationRepository;
+    private MockObject|UserRepository $userRepository;
+    private MockObject|Security $security;
+    private EntityManagerInterface|MockObject $em;
+
+    private PersonalInvitationAcceptProcessor $processor;
+
+    /**
+     * @throws \ReflectionException
+     */
+    protected function setUp(): void {
+        $this->invitation = new PersonalInvitation(self::ID, '', '', '', false);
+        $this->campCollaboration = new CampCollaboration();
+        $this->user = $this->createMock(User::class);
+
+        $this->collaborationRepository = $this->createMock(CampCollaborationRepository::class);
+        $this->userRepository = $this->createMock(UserRepository::class);
+        $this->security = $this->createMock(Security::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+
+        $this->processor = new PersonalInvitationAcceptProcessor(
+            $this->collaborationRepository,
+            $this->userRepository,
+            $this->security,
+            $this->em
+        );
+    }
+
+    public function testUpdatesPersonalInvitationCorrectlyOnAccept() {
+        $this->user
+            ->expects(self::once())
+            ->method('getUserIdentifier')
+            ->willReturn('9876abcd')
+        ;
+        $this->collaborationRepository
+            ->expects(self::once())
+            ->method('findByUserAndIdAndInvited')
+            ->with($this->user, self::ID)
+            ->willReturn($this->campCollaboration)
+        ;
+        $this->userRepository
+            ->expects(self::once())
+            ->method('loadUserByIdentifier')
+            ->with('9876abcd')
+            ->willReturn($this->user)
+        ;
+        $this->security->expects(self::once())->method('getUser')->willReturn($this->user);
+        $this->em->expects($this->exactly(1))->method('flush');
+
+        $this->processor->process($this->invitation, new Patch());
+
+        self::assertThat($this->campCollaboration->status, self::equalTo(CampCollaboration::STATUS_ESTABLISHED));
+        self::assertThat($this->campCollaboration->inviteKey, self::isNull());
+        self::assertThat($this->campCollaboration->inviteEmail, self::isNull());
+    }
+}

--- a/api/tests/State/PersonalInvitationRejectProcessorTest.php
+++ b/api/tests/State/PersonalInvitationRejectProcessorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Tests\State;
+
+use ApiPlatform\Metadata\Patch;
+use App\DTO\PersonalInvitation;
+use App\Entity\CampCollaboration;
+use App\Entity\User;
+use App\Repository\CampCollaborationRepository;
+use App\Repository\UserRepository;
+use App\State\PersonalInvitationRejectProcessor;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * @internal
+ */
+class PersonalInvitationRejectProcessorTest extends TestCase {
+    public const ID = '1a2b3c4d';
+
+    private PersonalInvitation $invitation;
+    private CampCollaboration $campCollaboration;
+    private User $user;
+
+    private CampCollaborationRepository|MockObject $collaborationRepository;
+    private MockObject|UserRepository $userRepository;
+    private MockObject|Security $security;
+    private EntityManagerInterface|MockObject $em;
+
+    private PersonalInvitationRejectProcessor $processor;
+
+    /**
+     * @throws \ReflectionException
+     */
+    protected function setUp(): void {
+        $this->invitation = new PersonalInvitation(self::ID, '', '', '', false);
+        $this->campCollaboration = new CampCollaboration();
+        $this->user = $this->createMock(User::class);
+
+        $this->collaborationRepository = $this->createMock(CampCollaborationRepository::class);
+        $this->userRepository = $this->createMock(UserRepository::class);
+        $this->security = $this->createMock(Security::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+
+        $this->processor = new PersonalInvitationRejectProcessor(
+            $this->collaborationRepository,
+            $this->userRepository,
+            $this->security,
+            $this->em
+        );
+    }
+
+    public function testUpdatesPersonalInvitationCorrectlyOnReject() {
+        $this->user
+            ->expects(self::once())
+            ->method('getUserIdentifier')
+            ->willReturn('9876abcd')
+        ;
+        $this->collaborationRepository
+            ->expects(self::once())
+            ->method('findByUserAndIdAndInvited')
+            ->with($this->user, self::ID)
+            ->willReturn($this->campCollaboration)
+        ;
+        $this->userRepository
+            ->expects(self::once())
+            ->method('loadUserByIdentifier')
+            ->with('9876abcd')
+            ->willReturn($this->user)
+        ;
+        $this->security->expects(self::once())->method('getUser')->willReturn($this->user);
+        $this->em->expects($this->exactly(1))->method('flush');
+
+        $this->processor->process($this->invitation, new Patch());
+
+        self::assertThat($this->campCollaboration->status, self::equalTo(CampCollaboration::STATUS_INACTIVE));
+        self::assertThat($this->campCollaboration->inviteKey, self::isNull());
+        self::assertThat($this->campCollaboration->inviteEmail, self::equalTo($this->campCollaboration->inviteEmail));
+        self::assertThat($this->campCollaboration->user, self::equalTo($this->campCollaboration->user));
+    }
+}

--- a/frontend/src/components/personal_invitations/PersonalInvitations.vue
+++ b/frontend/src/components/personal_invitations/PersonalInvitations.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-list class="py-0">
+    <v-list-item
+      v-for="invitation in invitations.items"
+      :key="invitation._meta.self"
+      two-line
+    >
+      <v-list-item-content>
+        <v-list-item-title>{{ invitation.campTitle }}</v-list-item-title>
+      </v-list-item-content>
+      <v-list-item-action>
+        <PromptPersonalInvitationReject
+          :entity="invitation"
+          :camp-title="invitation.campTitle"
+          @submit="rejectInvitation(invitation)"
+        >
+          <template #activator="{ on }">
+            <v-btn text v-on="on">
+              {{ $tc('components.personalInvitations.personalInvitations.reject') }}
+            </v-btn>
+          </template>
+        </PromptPersonalInvitationReject>
+      </v-list-item-action>
+      <v-list-item-action>
+        <v-btn color="primary" @click="acceptInvitation(invitation)">
+          {{ $tc('components.personalInvitations.personalInvitations.accept') }}<br />
+        </v-btn>
+      </v-list-item-action>
+    </v-list-item>
+  </v-list>
+</template>
+<script>
+import { errorToMultiLineToast } from '../toast/toasts.js'
+import { isNavigationFailure, NavigationFailureType } from 'vue-router'
+import PromptPersonalInvitationReject from './PromptPersonalInvitationReject.vue'
+
+const ignoreNavigationFailure = (e) => {
+  if (!isNavigationFailure(e, NavigationFailureType.redirected)) {
+    return Promise.reject(e)
+  }
+}
+
+export default {
+  name: 'PersonalInvitations',
+  components: { PromptPersonalInvitationReject },
+  computed: {
+    invitations() {
+      return this.api.get().personalInvitations()
+    },
+  },
+  methods: {
+    acceptInvitation(invitation) {
+      this.api
+        .href(this.api.get(), 'personalInvitations', {
+          action: 'accept',
+          id: invitation.id,
+        })
+        .then((postUrl) => this.api.patch(postUrl, {}))
+        .then(
+          (_) => {
+            this.$router.push(this.campLink(invitation)).catch(ignoreNavigationFailure)
+          },
+          () => {
+            this.$router
+              .push({ name: 'invitationUpdateError' })
+              .catch(ignoreNavigationFailure)
+          }
+        )
+        .then(() => {
+          this.invitations.$reload()
+        })
+        .catch((e) => this.$toast.error(errorToMultiLineToast(e)))
+    },
+    rejectInvitation(invitation) {
+      this.api
+        .href(this.api.get(), 'personalInvitations', {
+          action: 'reject',
+          id: invitation.id,
+        })
+        .then((postUrl) => {
+          return this.api.patch(postUrl, {})
+        })
+        .then(() => {
+          this.invitations.$reload()
+        })
+        .catch((e) => this.$toast.error(errorToMultiLineToast(e)))
+    },
+    campLink(invitation) {
+      return {
+        name: 'camp/dashboard',
+        params: { campId: invitation.campId },
+      }
+    },
+  },
+}
+</script>

--- a/frontend/src/components/personal_invitations/PersonalInvitations.vue
+++ b/frontend/src/components/personal_invitations/PersonalInvitations.vue
@@ -15,7 +15,7 @@
           @submit="rejectInvitation(invitation)"
         >
           <template #activator="{ on }">
-            <v-btn text v-on="on">
+            <v-btn class="px-4" text v-on="on">
               {{ $tc('components.personalInvitations.personalInvitations.reject') }}
             </v-btn>
           </template>

--- a/frontend/src/components/personal_invitations/PersonalInvitations.vue
+++ b/frontend/src/components/personal_invitations/PersonalInvitations.vue
@@ -1,32 +1,62 @@
 <template>
   <v-list class="py-0">
-    <v-list-item
-      v-for="invitation in invitations.items"
-      :key="invitation._meta.self"
-      two-line
-    >
-      <v-list-item-content>
-        <v-list-item-title>{{ invitation.campTitle }}</v-list-item-title>
-      </v-list-item-content>
-      <v-list-item-action>
-        <PromptPersonalInvitationReject
-          :entity="invitation"
-          :camp-title="invitation.campTitle"
-          @submit="rejectInvitation(invitation)"
-        >
-          <template #activator="{ on }">
-            <v-btn class="px-4" text v-on="on">
-              {{ $tc('components.personalInvitations.personalInvitations.reject') }}
+    <template v-if="$vuetify.breakpoint.mdAndUp">
+      <v-list-item v-for="invitation in invitations.items" :key="invitation._meta.self">
+        <v-list-item-content>
+          <v-list-item-title>{{ invitation.campTitle }}</v-list-item-title>
+        </v-list-item-content>
+        <v-list-item-action>
+          <PromptPersonalInvitationReject
+            :entity="invitation"
+            :camp-title="invitation.campTitle"
+            align="right"
+            @submit="rejectInvitation(invitation)"
+          >
+            <template #activator="{ on }">
+              <v-btn class="px-4" text v-on="on">
+                {{ $tc('components.personalInvitations.personalInvitations.reject') }}
+              </v-btn>
+            </template>
+          </PromptPersonalInvitationReject>
+        </v-list-item-action>
+        <v-list-item-action>
+          <v-btn color="primary" @click="acceptInvitation(invitation)">
+            {{ $tc('components.personalInvitations.personalInvitations.accept') }}<br />
+          </v-btn>
+        </v-list-item-action>
+      </v-list-item>
+    </template>
+    <template v-else>
+      <v-list-group v-for="invitation in invitations.items" :key="invitation._meta.self">
+        <template #activator>
+          <v-list-item-content>
+            <v-list-item-title>{{ invitation.campTitle }}</v-list-item-title>
+          </v-list-item-content>
+        </template>
+        <v-list-item>
+          <v-list-item-action>
+            <PromptPersonalInvitationReject
+              :entity="invitation"
+              :camp-title="invitation.campTitle"
+              align="left"
+              @submit="rejectInvitation(invitation)"
+            >
+              <template #activator="{ on }">
+                <v-btn class="px-4" text v-on="on">
+                  {{ $tc('components.personalInvitations.personalInvitations.reject') }}
+                </v-btn>
+              </template>
+            </PromptPersonalInvitationReject>
+          </v-list-item-action>
+          <v-spacer />
+          <v-list-item-action>
+            <v-btn color="primary" @click="acceptInvitation(invitation)">
+              {{ $tc('components.personalInvitations.personalInvitations.accept') }}<br />
             </v-btn>
-          </template>
-        </PromptPersonalInvitationReject>
-      </v-list-item-action>
-      <v-list-item-action>
-        <v-btn color="primary" @click="acceptInvitation(invitation)">
-          {{ $tc('components.personalInvitations.personalInvitations.accept') }}<br />
-        </v-btn>
-      </v-list-item-action>
-    </v-list-item>
+          </v-list-item-action>
+        </v-list-item>
+      </v-list-group>
+    </template>
   </v-list>
 </template>
 <script>

--- a/frontend/src/components/personal_invitations/PromptPersonalInvitationReject.vue
+++ b/frontend/src/components/personal_invitations/PromptPersonalInvitationReject.vue
@@ -14,6 +14,7 @@
     cancel-icon=""
     :cancel-action="close"
     position="top"
+    :align="align"
     v-bind="$attrs"
   >
     <template #activator="scope">
@@ -47,6 +48,7 @@ export default {
   props: {
     entity: { type: Object, required: true },
     campTitle: { type: String, required: true },
+    align: { type: String, required: true },
   },
   created() {
     this.entityUri = this.entity._meta.self

--- a/frontend/src/components/personal_invitations/PromptPersonalInvitationReject.vue
+++ b/frontend/src/components/personal_invitations/PromptPersonalInvitationReject.vue
@@ -1,0 +1,62 @@
+<template>
+  <PopoverPrompt
+    v-model="showDialog"
+    type="error"
+    :error="error"
+    :submit-action="submitAction"
+    :submit-label="
+      $tc(
+        'components.personalInvitations.promptPersonalInvitationReject.rejectInvitation'
+      )
+    "
+    submit-color="error"
+    submit-icon="mdi-cancel"
+    cancel-icon=""
+    :cancel-action="close"
+    position="top"
+    v-bind="$attrs"
+  >
+    <template #activator="scope">
+      <slot name="activator" v-bind="scope" />
+    </template>
+    <slot>
+      {{
+        $tc(
+          'components.personalInvitations.promptPersonalInvitationReject.warningText',
+          0,
+          { campTitle: campTitle }
+        )
+      }}
+    </slot>
+    <template v-if="$slots.error || error" #error>
+      <slot name="error">
+        {{ error }}
+      </slot>
+    </template>
+  </PopoverPrompt>
+</template>
+
+<script>
+import DialogBase from '@/components/dialog/DialogBase.vue'
+import PopoverPrompt from '@/components/prompt/PopoverPrompt.vue'
+
+export default {
+  name: 'PromptPersonalInvitationReject',
+  components: { PopoverPrompt },
+  extends: DialogBase,
+  props: {
+    entity: { type: Object, required: true },
+    campTitle: { type: String, required: true },
+  },
+  created() {
+    this.entityUri = this.entity._meta.self
+  },
+  methods: {
+    submitAction() {
+      this.$emit('submit')
+    },
+  },
+}
+</script>
+
+<style scoped></style>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -287,6 +287,16 @@
         "profile": "Profil"
       }
     },
+    "personalInvitations": {
+      "personalInvitations": {
+        "accept": "Akzeptieren",
+        "reject": "Ablehnen"
+      },
+      "promptPersonalInvitationReject": {
+        "rejectInvitation": "Einladung ablehnen",
+        "warningText": "Möchtest du dem Lager \"{campTitle}\" wirklich nicht beitreten?"
+      }
+    },
     "print": {
       "config": {
         "activityConfig": {
@@ -674,6 +684,7 @@
     "camps": {
       "create": "Lager erstellen",
       "pastCamps": "Alte Lager",
+      "personalInvitations": "Einladungen",
       "prototypeCamps": "Vorlagen",
       "title": "Meine Lager"
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -287,6 +287,16 @@
         "profile": "Profile"
       }
     },
+    "personalInvitations": {
+      "personalInvitations": {
+        "accept": "Accept",
+        "reject": "Reject"
+      },
+      "promptPersonalInvitationReject": {
+        "rejectInvitation": "Reject invitation",
+        "warningText": "Are you sure you do not want to join the camp \"{campTitle}\"?"
+      }
+    },
     "print": {
       "config": {
         "activityConfig": {
@@ -673,6 +683,7 @@
     "camps": {
       "create": "Create a camp",
       "pastCamps": "Past camps",
+      "personalInvitations": "Invitations",
       "prototypeCamps": "Prototypes",
       "title": "My Camps"
     },

--- a/frontend/src/views/Camps.vue
+++ b/frontend/src/views/Camps.vue
@@ -89,7 +89,27 @@
           </v-expansion-panel-content>
         </v-expansion-panel>
       </v-expansion-panels>
+
+      <template v-if="!loading && invitations.length > 0 && !$vuetify.breakpoint.mdAndUp">
+        <v-toolbar class="ec-content-card__toolbar" elevation="0" dense>
+          <v-toolbar-title tag="h1" class="font-weight-bold">
+            {{ $tc('views.camps.personalInvitations') }}
+          </v-toolbar-title>
+        </v-toolbar>
+        <PersonalInvitations></PersonalInvitations>
+      </template>
     </content-card>
+
+    <template v-if="!loading && invitations.length > 0 && $vuetify.breakpoint.mdAndUp">
+      <content-card
+        :title="$tc('views.camps.personalInvitations')"
+        max-width="800"
+        toolbar
+        class="mt-5"
+      >
+        <PersonalInvitations></PersonalInvitations>
+      </content-card>
+    </template>
   </v-container>
 </template>
 
@@ -101,10 +121,12 @@ import ContentCard from '@/components/layout/ContentCard.vue'
 import ButtonAdd from '@/components/buttons/ButtonAdd.vue'
 import { mapGetters } from 'vuex'
 import UserMeta from '@/components/navigation/UserMeta.vue'
+import PersonalInvitations from '../components/personal_invitations/PersonalInvitations.vue'
 
 export default {
   name: 'Camps',
   components: {
+    PersonalInvitations,
     UserMeta,
     ContentCard,
     ButtonAdd,
@@ -133,6 +155,9 @@ export default {
       return this.nonPrototypeCamps.filter(
         (c) => !c.periods().items.some((p) => dayjs(p.end).endOf('day').isAfter(dayjs()))
       )
+    },
+    invitations() {
+      return this.api.get().personalInvitations().items
     },
     ...mapGetters({
       user: 'getLoggedInUser',


### PR DESCRIPTION
Fixes #4689

To cut down on issues we have with emails which never arrive, we could show invitations which are clearly assigned to a user account in the UI, and allow to accept or reject them there.
The validity of this logic is based on our recently reinforced assumption that the email in all profiles is verified to belong to the user in all cases.

![Screenshot 2024-04-03 at 03-01-59 eCamp v3](https://github.com/ecamp/ecamp3/assets/7566995/113a6b19-b87b-4abd-ae16-9769b444a6e2)

The easiest way to test this on the feature branch deployment is to log in as test@example.com user, invite `snoopy@example.com` into some camp, then log out and log in with `snoopy@example.com` / `test`.

UI design and backend implementation as a new DTO are up for discussion. I just wanted to get the ball rolling with this feature, since we are getting messages from confused users on a regular basis.

Note: This isn't a complete 180° turn on our [decisions](https://github.com/ecamp/ecamp3/issues/631) how the invitations should work. You can still primarily invite email adresses, not accounts like in eCamp v2. But since we already display the avatar of an existing user to the camp collaborators, it is only fair and correct to also show the inviting camp to the invited user. It's kind of just a shortcut: If we can match an existing profile to the invited email address, we just allow that profile to accept the invitation without clicking the invitation email.