### PR TITLE
'Block Kategorie' ersetzt mit 'Block-Kategorie'

### DIFF
--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -88,7 +88,7 @@
   "entity": {
     "activity": {
       "fields": {
-        "category": "Block Kategorie",
+        "category": "Block-Kategorie",
         "location": "Ort",
         "progressLabel": "Status",
         "responsible": "Verantwortlich",
@@ -147,7 +147,7 @@
         "numberingStyle": "Nummerierung",
         "short": "Kürzel"
       },
-      "name": "Block Kategorien",
+      "name": "Block-Kategorien",
       "numberingStyles": {
         "1": "1, 2, 3 - Zahlen",
         "A": "A, B, C - grosse Buchstaben",


### PR DESCRIPTION
Kleinen Grammatikfehler korrigiert, siehe Link für mehr Info.
https://www.duden.de/sprachwissen/sprachratgeber/Zusammengesetzte-Substantive