### PR TITLE
Fix story printing when there are multiple periods

### DIFF
--- a/frontend/src/views/camp/Story.vue
+++ b/frontend/src/views/camp/Story.vue
@@ -64,9 +64,7 @@ export default {
           {
             type: 'Story',
             options: {
-              periods: this.camp()
-                .periods()
-                .items.map((period) => period._meta.self),
+              periods: [this.period()._meta.self],
             },
           },
         ],

--- a/print/components/story/StoryPeriod.vue
+++ b/print/components/story/StoryPeriod.vue
@@ -30,27 +30,30 @@ const props = defineProps({
 
 const { $api } = useNuxtApp()
 
-const { data, error } = await useAsyncData('StoryPeriod', async () => {
-  const contentTypeStorycontext = (
-    await $api.get().contentTypes().$loadItems()
-  ).items.find((contentType) => contentType.name === 'Storycontext')
+const { data, error } = await useAsyncData(
+  `StoryPeriod-${props.period._meta.self}`,
+  async () => {
+    const contentTypeStorycontext = (
+      await $api.get().contentTypes().$loadItems()
+    ).items.find((contentType) => contentType.name === 'Storycontext')
 
-  const [periodStoryChapters] = await Promise.all([
-    $api
-      .get()
-      .contentNodes({
-        period: props.period._meta.self,
-        contentType: contentTypeStorycontext._meta.self,
-      })
-      .$loadItems(),
-    props.period.days().$loadItems(),
-    props.period.scheduleEntries().$loadItems(),
-    props.period.camp().categories().$loadItems(),
-  ])
+    const [periodStoryChapters] = await Promise.all([
+      $api
+        .get()
+        .contentNodes({
+          period: props.period._meta.self,
+          contentType: contentTypeStorycontext._meta.self,
+        })
+        .$loadItems(),
+      props.period.days().$loadItems(),
+      props.period.scheduleEntries().$loadItems(),
+      props.period.camp().categories().$loadItems(),
+    ])
 
-  return {
-    days: props.period.days().items,
-    periodStoryChapters: periodStoryChapters.items,
+    return {
+      days: props.period.days().items,
+      periodStoryChapters: periodStoryChapters.items,
+    }
   }
-})
+)
 </script>


### PR DESCRIPTION
Since the story overview UI only shows the story of one period at a time, we should also only print the story of that period when using the quick print feature.

Also, I fixed a wrong `useAsyncData` call in nuxt print. `useAsyncData` requires a string key as the first argument, and for all calls to `useAsyncData` with the same key, the same result data is returned. This led to nuxt print always printing the last period of the camp.

There are more wrong usages of `useAsyncData` in nuxt print, but I think we should fix these separately, in order not to block this supposedly small fix PR. I wasn't able to easily fix a connected issue in nuxt print that only happens locally: When using the print configurator to print a single activity, nuxt print outputs `Error: props.scheduleEntry._meta is undefined`.