### PR TITLE
Claim personal invitations

### DIFF
--- a/api/src/Entity/Profile.php
+++ b/api/src/Entity/Profile.php
@@ -96,8 +96,9 @@ class Profile extends BaseEntity {
     // addresses received from Oauth providers are trusted in the sense that email ownership has
     // previously been verified by the corresponding service. When adding more providers, either
     // - validate this assumption for the new provider, or
-    // - remove the logic setting the user state to active for existing non-activated user profiles
-    //   in the new authenticator implementation (api/src/Security/OAuth/*Authenticator.php)
+    // - remove the logic setting the user state to active and claiming personal camp invitations
+    //   for existing non-activated user profiles in the new authenticator implementation
+    //   (api/src/Security/OAuth/*Authenticator.php)
 
     /**
      * Google id of the user.

--- a/api/src/Repository/CampCollaborationRepository.php
+++ b/api/src/Repository/CampCollaborationRepository.php
@@ -38,6 +38,13 @@ class CampCollaborationRepository extends ServiceEntityRepository implements Can
     /**
      * @return CampCollaboration[]
      */
+    public function findAllByInviteEmailAndInvited(string $inviteEmail): array {
+        return $this->findBy(['inviteEmail' =>$inviteEmail, 'status' => CampCollaboration::STATUS_INVITED]);
+    }
+
+    /**
+     * @return CampCollaboration[]
+     */
     public function findAllByPersonallyInvitedUser(User $user): array {
         return $this->findBy(['user' => $user, 'status' => CampCollaboration::STATUS_INVITED]);
     }

--- a/api/src/Repository/CampCollaborationRepository.php
+++ b/api/src/Repository/CampCollaborationRepository.php
@@ -39,7 +39,7 @@ class CampCollaborationRepository extends ServiceEntityRepository implements Can
      * @return CampCollaboration[]
      */
     public function findAllByInviteEmailAndInvited(string $inviteEmail): array {
-        return $this->findBy(['inviteEmail' =>$inviteEmail, 'status' => CampCollaboration::STATUS_INVITED]);
+        return $this->findBy(['inviteEmail' => $inviteEmail, 'status' => CampCollaboration::STATUS_INVITED]);
     }
 
     /**

--- a/api/src/Security/OAuth/GoogleAuthenticator.php
+++ b/api/src/Security/OAuth/GoogleAuthenticator.php
@@ -5,6 +5,7 @@ namespace App\Security\OAuth;
 use App\Entity\Profile;
 use App\Entity\User;
 use App\OAuth\JWTStateOAuth2Client;
+use App\Service\ClaimInvitationService;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
@@ -30,6 +31,7 @@ class GoogleAuthenticator extends OAuth2Authenticator {
         private EntityManagerInterface $entityManager,
         private Security $security,
         private JWTEncoderInterface $jwtDecoder,
+        private ClaimInvitationService $claimInvitationService,
     ) {}
 
     public function supports(Request $request): ?bool {
@@ -70,7 +72,9 @@ class GoogleAuthenticator extends OAuth2Authenticator {
                     $user->profile = $profile;
                 }
 
+                $newlyActivatedUser = false;
                 if (in_array($user->state, [null, User::STATE_NONREGISTERED, User::STATE_REGISTERED])) {
+                    $newlyActivatedUser = true;
                     $user->state = User::STATE_ACTIVATED;
                 }
 
@@ -78,6 +82,12 @@ class GoogleAuthenticator extends OAuth2Authenticator {
                 $profile->googleId = $googleUser->getId();
                 $this->entityManager->persist($user);
                 $this->entityManager->flush();
+
+                if ($newlyActivatedUser) {
+                    // Only after the user is persisted, claim invitations to make
+                    // sure any errors during this process don't prevent user sign up
+                    $this->claimInvitationService->claimInvitations($user, $email);
+                }
 
                 return $user;
             })

--- a/api/src/Security/OAuth/HitobitoAuthenticator.php
+++ b/api/src/Security/OAuth/HitobitoAuthenticator.php
@@ -6,6 +6,7 @@ use App\Entity\Profile;
 use App\Entity\User;
 use App\OAuth\HitobitoUser;
 use App\OAuth\JWTStateOAuth2Client;
+use App\Service\ClaimInvitationService;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Client\OAuth2Client;
@@ -31,6 +32,7 @@ class HitobitoAuthenticator extends OAuth2Authenticator {
         private EntityManagerInterface $entityManager,
         private Security $security,
         private JWTEncoderInterface $jwtDecoder,
+        private ClaimInvitationService $claimInvitationService,
     ) {}
 
     public function supports(Request $request): ?bool {
@@ -77,7 +79,9 @@ class HitobitoAuthenticator extends OAuth2Authenticator {
                     $user->profile = $profile;
                 }
 
+                $newlyActivatedUser = false;
                 if (in_array($user->state, [null, User::STATE_NONREGISTERED, User::STATE_REGISTERED])) {
+                    $newlyActivatedUser = true;
                     $user->state = User::STATE_ACTIVATED;
                 }
 
@@ -85,6 +89,12 @@ class HitobitoAuthenticator extends OAuth2Authenticator {
                 $profile->{"{$provider}Id"} = $hitobitoUser->getId();
                 $this->entityManager->persist($user);
                 $this->entityManager->flush();
+
+                if ($newlyActivatedUser) {
+                    // Only after the user is persisted, claim invitations to make
+                    // sure any errors during this process don't prevent user sign up
+                    $this->claimInvitationService->claimInvitations($user, $email);
+                }
 
                 return $user;
             })

--- a/api/src/Service/ClaimInvitationService.php
+++ b/api/src/Service/ClaimInvitationService.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\User;
+use App\Repository\CampCollaborationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ClaimInvitationService {
+    public function __construct(
+        private readonly CampCollaborationRepository $campCollaborationRepository,
+        private readonly EntityManagerInterface $em,
+    ) {}
+
+    public function claimInvitations(User $user, string $email): void {
+        $personalInvitationsForNewEmail = $this->campCollaborationRepository->findAllByInviteEmailAndInvited($email);
+        foreach ($personalInvitationsForNewEmail as $invitation) {
+            // Convert all invitations who specifically invited this email address to
+            // personal invitations, which the invited user will be able to see and
+            // accept / reject in the UI, even without receiving the invitation email.
+            // This is done by setting the user field instead of the inviteEmail field.
+            $invitation->inviteEmail = null;
+            $invitation->user = $user;
+            $this->em->persist($invitation);
+            $this->em->flush();
+        }
+    }
+}

--- a/api/src/Service/ClaimInvitationService.php
+++ b/api/src/Service/ClaimInvitationService.php
@@ -4,6 +4,7 @@ namespace App\Service;
 
 use App\Entity\User;
 use App\Repository\CampCollaborationRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 
 class ClaimInvitationService {
@@ -12,17 +13,46 @@ class ClaimInvitationService {
         private readonly EntityManagerInterface $em,
     ) {}
 
+    /**
+     * Convert all invitations who specifically invited this email address to
+     * personal invitations, which the invited user will be able to see and
+     * accept / reject in the UI, even without receiving the invitation email.
+     * This is done by setting the user field instead of the inviteEmail field.
+     * @param User $user
+     * @param string $email
+     * @return void
+     */
     public function claimInvitations(User $user, string $email): void {
         $personalInvitationsForNewEmail = $this->campCollaborationRepository->findAllByInviteEmailAndInvited($email);
+
         foreach ($personalInvitationsForNewEmail as $invitation) {
-            // Convert all invitations who specifically invited this email address to
-            // personal invitations, which the invited user will be able to see and
-            // accept / reject in the UI, even without receiving the invitation email.
-            // This is done by setting the user field instead of the inviteEmail field.
-            $invitation->inviteEmail = null;
-            $invitation->user = $user;
-            $this->em->persist($invitation);
-            $this->em->flush();
+            if ($this->campCollaborationRepository->findOneBy([
+                'user' => $user,
+                'camp' => $invitation->camp,
+            ]) !== null) {
+                // If the user is already part of the camp, we skip claiming this invitation,
+                // because it would otherwise create a unique constraint violation, or we would
+                // need to merge the existing collaboration and the invitation, which would be
+                //very complex for an extremely rare use case which can easily be resolved by
+                // the camp leaders in the UI.
+                // We could also discard the invitation in this case, but previously, when users
+                // have had problems with receiving their invitation emails, we have recommended
+                // them to send an invitation to another email address and claim that other
+                // invitation. So this invitation could still be useful to someone. This way, we
+                // also minimize shenanigans with vanishing invitations, which could be
+                // confusing for the users.
+                continue;
+            }
+            try {
+                $invitation->inviteEmail = null;
+                $invitation->user = $user;
+                $this->em->persist($invitation);
+                $this->em->flush();
+            } catch (UniqueConstraintViolationException $e) {
+                // Even though we already handle this case above, it could still happen due
+                // to race conditions. Just ignore it.
+                $this->em->clear();
+            }
         }
     }
 }

--- a/api/src/Service/ClaimInvitationService.php
+++ b/api/src/Service/ClaimInvitationService.php
@@ -18,22 +18,19 @@ class ClaimInvitationService {
      * personal invitations, which the invited user will be able to see and
      * accept / reject in the UI, even without receiving the invitation email.
      * This is done by setting the user field instead of the inviteEmail field.
-     * @param User $user
-     * @param string $email
-     * @return void
      */
     public function claimInvitations(User $user, string $email): void {
         $personalInvitationsForNewEmail = $this->campCollaborationRepository->findAllByInviteEmailAndInvited($email);
 
         foreach ($personalInvitationsForNewEmail as $invitation) {
-            if ($this->campCollaborationRepository->findOneBy([
+            if (null !== $this->campCollaborationRepository->findOneBy([
                 'user' => $user,
                 'camp' => $invitation->camp,
-            ]) !== null) {
+            ])) {
                 // If the user is already part of the camp, we skip claiming this invitation,
                 // because it would otherwise create a unique constraint violation, or we would
                 // need to merge the existing collaboration and the invitation, which would be
-                //very complex for an extremely rare use case which can easily be resolved by
+                // very complex for an extremely rare use case which can easily be resolved by
                 // the camp leaders in the UI.
                 // We could also discard the invitation in this case, but previously, when users
                 // have had problems with receiving their invitation emails, we have recommended
@@ -43,6 +40,7 @@ class ClaimInvitationService {
                 // confusing for the users.
                 continue;
             }
+
             try {
                 $invitation->inviteEmail = null;
                 $invitation->user = $user;

--- a/api/src/State/ProfileUpdateProcessor.php
+++ b/api/src/State/ProfileUpdateProcessor.php
@@ -5,9 +5,16 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Profile;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\ClaimInvitationService;
 use App\Service\MailService;
 use App\State\Util\AbstractPersistProcessor;
 use App\Util\IdGenerator;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
@@ -16,10 +23,16 @@ use Symfony\Component\PasswordHasher\PasswordHasherInterface;
  * @template-extends AbstractPersistProcessor<Profile>
  */
 class ProfileUpdateProcessor extends AbstractPersistProcessor {
+
+    private $emailAddressVerificationPerformed = false;
+
     public function __construct(
         ProcessorInterface $decorated,
         private PasswordHasherFactoryInterface $pwHasherFactory,
-        private MailService $mailService
+        private MailService $mailService,
+        private readonly Security $security,
+        private readonly UserRepository $userRepository,
+        private readonly ClaimInvitationService $claimInvitationService,
     ) {
         parent::__construct($decorated);
     }
@@ -28,6 +41,7 @@ class ProfileUpdateProcessor extends AbstractPersistProcessor {
      * @param Profile $data
      */
     public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []): Profile {
+        $this->emailAddressVerificationPerformed = false;
         /** @var Profile $data */
         if (isset($data->newEmail)) {
             $verificationKey = IdGenerator::generateRandomHexString(64);
@@ -47,6 +61,8 @@ class ProfileUpdateProcessor extends AbstractPersistProcessor {
             $data->untrustedEmail = null;
             $data->untrustedEmailKey = null;
             $data->untrustedEmailKeyHash = null;
+
+            $this->emailAddressVerificationPerformed = true;
         }
 
         return $data;
@@ -58,9 +74,29 @@ class ProfileUpdateProcessor extends AbstractPersistProcessor {
             $this->mailService->sendEmailVerificationMail($data->user, $data);
             $data->untrustedEmailKey = null;
         }
+
+        if ($this->emailAddressVerificationPerformed) {
+            $user = $this->getUser();
+            $this->claimInvitationService->claimInvitations($user, $data->email);
+        }
     }
 
     private function getResetKeyHasher(): PasswordHasherInterface {
         return $this->pwHasherFactory->getPasswordHasher('EmailVerification');
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    private function getUser(): ?User {
+        $user = $this->security->getUser();
+        if (null == $user) {
+            // This should never happen because it should be caught earlier by our security settings
+            // on all API operations using this processor.
+            throw new AccessDeniedHttpException();
+        }
+
+        return $this->userRepository->loadUserByIdentifier($user->getUserIdentifier());
     }
 }

--- a/api/src/State/ProfileUpdateProcessor.php
+++ b/api/src/State/ProfileUpdateProcessor.php
@@ -23,7 +23,6 @@ use Symfony\Component\PasswordHasher\PasswordHasherInterface;
  * @template-extends AbstractPersistProcessor<Profile>
  */
 class ProfileUpdateProcessor extends AbstractPersistProcessor {
-
     private $emailAddressVerificationPerformed = false;
 
     public function __construct(
@@ -42,6 +41,7 @@ class ProfileUpdateProcessor extends AbstractPersistProcessor {
      */
     public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []): Profile {
         $this->emailAddressVerificationPerformed = false;
+
         /** @var Profile $data */
         if (isset($data->newEmail)) {
             $verificationKey = IdGenerator::generateRandomHexString(64);

--- a/api/src/State/UserActivateProcessor.php
+++ b/api/src/State/UserActivateProcessor.php
@@ -5,6 +5,7 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\User;
+use App\Service\ClaimInvitationService;
 use App\State\Util\AbstractPersistProcessor;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -13,7 +14,8 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  */
 class UserActivateProcessor extends AbstractPersistProcessor {
     public function __construct(
-        ProcessorInterface $decorated
+        ProcessorInterface $decorated,
+        private readonly ClaimInvitationService $claimInvitationService,
     ) {
         parent::__construct($decorated);
     }
@@ -31,5 +33,11 @@ class UserActivateProcessor extends AbstractPersistProcessor {
         }
 
         return $data;
+    }
+
+    public function onAfter($data, Operation $operation, array $uriVariables = [], array $context = []): void {
+        /** @var User $user */
+        $user = $data;
+        $this->claimInvitationService->claimInvitations($user, $user->getEmail());
     }
 }

--- a/api/tests/Api/PersonalInvitations/ListPersonalInvitationsTest.php
+++ b/api/tests/Api/PersonalInvitations/ListPersonalInvitationsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Tests\Api\PersonalInvitations;
+
+use App\Entity\User;
+use App\Tests\Api\ECampApiTestCase;
+
+/**
+ * @internal
+ */
+class ListPersonalInvitationsTest extends ECampApiTestCase {
+    public function testListPersonalInvitationsIsDeniedForAnonymousUser() {
+        static::createBasicClient()->request('GET', '/personal_invitations');
+        $this->assertResponseStatusCodeSame(401);
+        $this->assertJsonContains([
+            'code' => 401,
+            'message' => 'JWT Token not found',
+        ]);
+    }
+
+    public function testListPersonalInvitationsIsAllowedForLoggedInUserButFiltered() {
+        /** @var User $user */
+        $user = static::getFixture('user6invited');
+        $client = static::createClientWithCredentials(['email' => $user->getProfile()->email]);
+        $client->request('GET', '/personal_invitations');
+        $this->assertResponseStatusCodeSame(200);
+        $invitation = static::getFixture('campCollaboration6invitedWithUser');
+        $this->assertJsonContains([
+            'totalItems' => 1,
+            '_links' => [
+                'items' => [
+                    ['href' => "/personal_invitations/{$invitation->getId()}"]
+                ],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
+    }
+}

--- a/api/tests/Api/PersonalInvitations/ListPersonalInvitationsTest.php
+++ b/api/tests/Api/PersonalInvitations/ListPersonalInvitationsTest.php
@@ -29,7 +29,7 @@ class ListPersonalInvitationsTest extends ECampApiTestCase {
             'totalItems' => 1,
             '_links' => [
                 'items' => [
-                    ['href' => "/personal_invitations/{$invitation->getId()}"]
+                    ['href' => "/personal_invitations/{$invitation->getId()}"],
                 ],
             ],
             '_embedded' => [

--- a/api/tests/Api/Profiles/UpdateProfileTest.php
+++ b/api/tests/Api/Profiles/UpdateProfileTest.php
@@ -6,7 +6,6 @@ use App\Entity\Camp;
 use App\Entity\CampCollaboration;
 use App\Entity\Profile;
 use App\Entity\User;
-use App\Repository\ProfileRepository;
 use App\Service\MailService;
 use App\Tests\Api\ECampApiTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -104,7 +103,7 @@ class UpdateProfileTest extends ECampApiTestCase {
 
         $untrustedEmailKey = null;
         $mailServiceMock = $this->createMock(MailService::class);
-        $mailServiceMock->expects($this->once())->method('sendEmailVerificationMail')->willReturnCallback(function($user, $profile) use(&$untrustedEmailKey) {
+        $mailServiceMock->expects($this->once())->method('sendEmailVerificationMail')->willReturnCallback(function ($user, $profile) use (&$untrustedEmailKey) {
             $untrustedEmailKey = $profile->untrustedEmailKey;
         });
         $this->getContainer()->set(MailService::class, $mailServiceMock);
@@ -222,7 +221,7 @@ class UpdateProfileTest extends ECampApiTestCase {
 
         $untrustedEmailKey = null;
         $mailServiceMock = $this->createMock(MailService::class);
-        $mailServiceMock->expects($this->once())->method('sendEmailVerificationMail')->willReturnCallback(function($user, $profile) use(&$untrustedEmailKey) {
+        $mailServiceMock->expects($this->once())->method('sendEmailVerificationMail')->willReturnCallback(function ($user, $profile) use (&$untrustedEmailKey) {
             $untrustedEmailKey = $profile->untrustedEmailKey;
         });
         $this->getContainer()->set(MailService::class, $mailServiceMock);
@@ -260,7 +259,7 @@ class UpdateProfileTest extends ECampApiTestCase {
             'totalItems' => 1,
             '_links' => [
                 'items' => [
-                    ['href' => "/personal_invitations/{$invitation1->getId()}"]
+                    ['href' => "/personal_invitations/{$invitation1->getId()}"],
                 ],
             ],
             '_embedded' => [
@@ -289,7 +288,7 @@ class UpdateProfileTest extends ECampApiTestCase {
 
         $untrustedEmailKey = null;
         $mailServiceMock = $this->createMock(MailService::class);
-        $mailServiceMock->expects($this->once())->method('sendEmailVerificationMail')->willReturnCallback(function($user, $profile) use(&$untrustedEmailKey) {
+        $mailServiceMock->expects($this->once())->method('sendEmailVerificationMail')->willReturnCallback(function ($user, $profile) use (&$untrustedEmailKey) {
             $untrustedEmailKey = $profile->untrustedEmailKey;
         });
         $this->getContainer()->set(MailService::class, $mailServiceMock);

--- a/api/tests/Api/Profiles/UpdateProfileTest.php
+++ b/api/tests/Api/Profiles/UpdateProfileTest.php
@@ -269,6 +269,65 @@ class UpdateProfileTest extends ECampApiTestCase {
         ]);
     }
 
+    public function testActivatingEmailClaimingPersonalInvitationHandlesUniqueConstraintViolationGracefully() {
+        $client = static::createClientWithCredentials();
+        // Disable resetting the database between the two requests
+        $client->disableReboot();
+
+        $camp = $this->getEntityManager()->find(Camp::class, static::getFixture('camp1')->getId());
+
+        // create an invitation which will be claimed by the user, in a camp where the user already collaborates
+        $invitation1 = new CampCollaboration();
+        $invitation1->camp = $camp;
+        $invitation1->status = CampCollaboration::STATUS_INVITED;
+        $invitation1->inviteEmail = 'new@example.com';
+        $invitation1->inviteKeyHash = '1234123412341234';
+        $invitation1->role = CampCollaboration::ROLE_MANAGER;
+        $this->getEntityManager()->persist($invitation1);
+
+        $this->getEntityManager()->flush();
+
+        $untrustedEmailKey = null;
+        $mailServiceMock = $this->createMock(MailService::class);
+        $mailServiceMock->expects($this->once())->method('sendEmailVerificationMail')->willReturnCallback(function($user, $profile) use(&$untrustedEmailKey) {
+            $untrustedEmailKey = $profile->untrustedEmailKey;
+        });
+        $this->getContainer()->set(MailService::class, $mailServiceMock);
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile1manager');
+
+        $client->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
+            'newEmail' => 'new@example.com',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+
+        // when
+        $client->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
+            'untrustedEmailKey' => $untrustedEmailKey,
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+
+        // then
+
+        // we need to log in again after changing the email address, because the login email is in the JWT token
+        $profile = $this->getEntityManager()->find(Profile::class, $profile->getId());
+        $jwtToken = static::getContainer()->get('lexik_jwt_authentication.jwt_manager')->create($profile->user);
+        $lastPeriodPosition = strrpos($jwtToken, '.');
+        $jwtHeaderAndPayload = substr($jwtToken, 0, $lastPeriodPosition);
+        $jwtSignature = substr($jwtToken, $lastPeriodPosition + 1);
+        $cookies = $client->getCookieJar();
+        $cookies->set(new Cookie('example_com_jwt_hp', $jwtHeaderAndPayload, null, null, 'localhost', false, false, false, 'strict'));
+        $cookies->set(new Cookie('example_com_jwt_s', $jwtSignature, null, null, 'localhost', false, true, false, 'strict'));
+
+        $client->request('GET', '/personal_invitations');
+
+        // User has one personal invitation waiting for them
+        $this->assertJsonContains([
+            'totalItems' => 0,
+        ]);
+    }
+
     public function testPatchProfileTrimsFirstname() {
         $profile = static::getFixture('profile1manager');
         static::createClientWithCredentials()->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [

--- a/api/tests/Api/Profiles/UpdateProfileTest.php
+++ b/api/tests/Api/Profiles/UpdateProfileTest.php
@@ -2,10 +2,15 @@
 
 namespace App\Tests\Api\Profiles;
 
+use App\Entity\Camp;
+use App\Entity\CampCollaboration;
 use App\Entity\Profile;
+use App\Entity\User;
+use App\Repository\ProfileRepository;
 use App\Service\MailService;
 use App\Tests\Api\ECampApiTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\BrowserKit\Cookie;
 
 /**
  * @internal
@@ -121,6 +126,147 @@ class UpdateProfileTest extends ECampApiTestCase {
         $this->assertResponseStatusCodeSame(200);
         $profile = $this->getEntityManager()->find(Profile::class, $profile->getId());
         $this->assertEquals('new@example.com', $profile->email);
+    }
+
+    public function testPatchProfileDoesNotClaimPersonalInvitation() {
+        $client = static::createClientWithCredentials();
+        // Disable resetting the database between the two requests
+        $client->disableReboot();
+
+        $camp = $this->getEntityManager()->find(Camp::class, static::getFixture('campUnrelated')->getId());
+        $camp2 = $this->getEntityManager()->find(Camp::class, static::getFixture('campPrototype')->getId());
+
+        // create an invitation which could be claimed by the user
+        $invitation1 = new CampCollaboration();
+        $invitation1->camp = $camp;
+        $invitation1->status = CampCollaboration::STATUS_INVITED;
+        $invitation1->inviteEmail = 'test@example.com';
+        $invitation1->inviteKeyHash = '1234123412341234';
+        $invitation1->role = CampCollaboration::ROLE_MANAGER;
+        $this->getEntityManager()->persist($invitation1);
+
+        // create a rejected invitation which will not be claimed by the user
+        $invitation2 = new CampCollaboration();
+        $invitation2->camp = $camp2;
+        $invitation2->status = CampCollaboration::STATUS_INACTIVE;
+        $invitation2->inviteEmail = 'test@example.com';
+        $invitation2->inviteKeyHash = '2341234123412341';
+        $invitation2->role = CampCollaboration::ROLE_MANAGER;
+        $this->getEntityManager()->persist($invitation2);
+
+        // create an unrelated invitation which will not be claimed by the user
+        $invitation3 = new CampCollaboration();
+        $invitation3->camp = $camp;
+        $invitation3->status = CampCollaboration::STATUS_INVITED;
+        $invitation3->inviteEmail = 'someone-else@example.com';
+        $invitation3->inviteKeyHash = '3412341234123412';
+        $invitation3->role = CampCollaboration::ROLE_MANAGER;
+        $this->getEntityManager()->persist($invitation3);
+
+        $this->getEntityManager()->flush();
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile1manager');
+
+        // when
+        $client->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
+            'nickname' => 'Linux',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+
+        // then
+        $client->request('GET', '/personal_invitations');
+
+        // User has one personal invitation waiting for them
+        $this->assertJsonContains([
+            'totalItems' => 0,
+        ]);
+    }
+
+    public function testActivatingEmailClaimsPersonalInvitation() {
+        $client = static::createClientWithCredentials();
+        // Disable resetting the database between the two requests
+        $client->disableReboot();
+
+        $camp = $this->getEntityManager()->find(Camp::class, static::getFixture('campUnrelated')->getId());
+        $camp2 = $this->getEntityManager()->find(Camp::class, static::getFixture('campPrototype')->getId());
+
+        // create an invitation which will be claimed by the user
+        $invitation1 = new CampCollaboration();
+        $invitation1->camp = $camp;
+        $invitation1->status = CampCollaboration::STATUS_INVITED;
+        $invitation1->inviteEmail = 'new@example.com';
+        $invitation1->inviteKeyHash = '1234123412341234';
+        $invitation1->role = CampCollaboration::ROLE_MANAGER;
+        $this->getEntityManager()->persist($invitation1);
+
+        // create a rejected invitation which will not be claimed by the user
+        $invitation2 = new CampCollaboration();
+        $invitation2->camp = $camp2;
+        $invitation2->status = CampCollaboration::STATUS_INACTIVE;
+        $invitation2->inviteEmail = 'new@example.com';
+        $invitation2->inviteKeyHash = '2341234123412341';
+        $invitation2->role = CampCollaboration::ROLE_MANAGER;
+        $this->getEntityManager()->persist($invitation2);
+
+        // create an unrelated invitation which will not be claimed by the user
+        $invitation3 = new CampCollaboration();
+        $invitation3->camp = $camp;
+        $invitation3->status = CampCollaboration::STATUS_INVITED;
+        $invitation3->inviteEmail = 'someone-else@example.com';
+        $invitation3->inviteKeyHash = '3412341234123412';
+        $invitation3->role = CampCollaboration::ROLE_MANAGER;
+        $this->getEntityManager()->persist($invitation3);
+
+        $this->getEntityManager()->flush();
+
+        $untrustedEmailKey = null;
+        $mailServiceMock = $this->createMock(MailService::class);
+        $mailServiceMock->expects($this->once())->method('sendEmailVerificationMail')->willReturnCallback(function($user, $profile) use(&$untrustedEmailKey) {
+            $untrustedEmailKey = $profile->untrustedEmailKey;
+        });
+        $this->getContainer()->set(MailService::class, $mailServiceMock);
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile1manager');
+
+        $client->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
+            'newEmail' => 'new@example.com',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+
+        // when
+        $client->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
+            'untrustedEmailKey' => $untrustedEmailKey,
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+
+        // then
+
+        // we need to log in again after changing the email address, because the login email is in the JWT token
+        $profile = $this->getEntityManager()->find(Profile::class, $profile->getId());
+        $jwtToken = static::getContainer()->get('lexik_jwt_authentication.jwt_manager')->create($profile->user);
+        $lastPeriodPosition = strrpos($jwtToken, '.');
+        $jwtHeaderAndPayload = substr($jwtToken, 0, $lastPeriodPosition);
+        $jwtSignature = substr($jwtToken, $lastPeriodPosition + 1);
+        $cookies = $client->getCookieJar();
+        $cookies->set(new Cookie('example_com_jwt_hp', $jwtHeaderAndPayload, null, null, 'localhost', false, false, false, 'strict'));
+        $cookies->set(new Cookie('example_com_jwt_s', $jwtSignature, null, null, 'localhost', false, true, false, 'strict'));
+
+        $client->request('GET', '/personal_invitations');
+
+        // User has one personal invitation waiting for them
+        $this->assertJsonContains([
+            'totalItems' => 1,
+            '_links' => [
+                'items' => [
+                    ['href' => "/personal_invitations/{$invitation1->getId()}"]
+                ],
+            ],
+            '_embedded' => [
+                'items' => [],
+            ],
+        ]);
     }
 
     public function testPatchProfileTrimsFirstname() {

--- a/api/tests/Api/Profiles/UpdateProfileTest.php
+++ b/api/tests/Api/Profiles/UpdateProfileTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Api\Profiles;
 
 use App\Entity\Profile;
+use App\Service\MailService;
 use App\Tests\Api\ECampApiTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -89,6 +90,37 @@ class UpdateProfileTest extends ECampApiTestCase {
         $this->assertJsonContains([
             'detail' => 'Extra attributes are not allowed ("email" is unknown).',
         ]);
+    }
+
+    public function testPatchProfileValidatesChangedEmail() {
+        $client = static::createClientWithCredentials();
+        // Disable resetting the database between the two requests
+        $client->disableReboot();
+
+        $untrustedEmailKey = null;
+        $mailServiceMock = $this->createMock(MailService::class);
+        $mailServiceMock->expects($this->once())->method('sendEmailVerificationMail')->willReturnCallback(function($user, $profile) use(&$untrustedEmailKey) {
+            $untrustedEmailKey = $profile->untrustedEmailKey;
+        });
+        $this->getContainer()->set(MailService::class, $mailServiceMock);
+
+        /** @var Profile $profile */
+        $profile = static::getFixture('profile1manager');
+
+        $client->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
+            'newEmail' => 'new@example.com',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+
+        // when
+        $client->request('PATCH', '/profiles/'.$profile->getId(), ['json' => [
+            'untrustedEmailKey' => $untrustedEmailKey,
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+
+        // then
+        $this->assertResponseStatusCodeSame(200);
+        $profile = $this->getEntityManager()->find(Profile::class, $profile->getId());
+        $this->assertEquals('new@example.com', $profile->email);
     }
 
     public function testPatchProfileTrimsFirstname() {

--- a/api/tests/Api/Users/CreateUserTest.php
+++ b/api/tests/Api/Users/CreateUserTest.php
@@ -145,7 +145,7 @@ class CreateUserTest extends ECampApiTestCase {
             'totalItems' => 1,
             '_links' => [
                 'items' => [
-                    ['href' => "/personal_invitations/{$invitation1->getId()}"]
+                    ['href' => "/personal_invitations/{$invitation1->getId()}"],
                 ],
             ],
             '_embedded' => [

--- a/api/tests/Service/ClaimInvitationServiceTest.php
+++ b/api/tests/Service/ClaimInvitationServiceTest.php
@@ -11,15 +11,16 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
+/**
+ * @internal
+ */
 class ClaimInvitationServiceTest extends KernelTestCase {
-
     private CampCollaborationRepository $campCollaborationRepository;
     private EntityManagerInterface $em;
     private ClaimInvitationService $claimInvitationService;
 
     private User $user;
     private string $email = 'test@example.com';
-
 
     protected function setUp(): void {
         static::bootKernel();
@@ -38,7 +39,8 @@ class ClaimInvitationServiceTest extends KernelTestCase {
             ->expects($this->once())
             ->method('findAllByInviteEmailAndInvited')
             ->with($this->email)
-            ->willReturn([]);
+            ->willReturn([])
+        ;
 
         // then
         $this->em->expects($this->never())->method('persist');
@@ -61,7 +63,8 @@ class ClaimInvitationServiceTest extends KernelTestCase {
             ->expects($this->once())
             ->method('findAllByInviteEmailAndInvited')
             ->with($this->email)
-            ->willReturn([ $invitation ]);
+            ->willReturn([$invitation])
+        ;
 
         // then
         $this->em->expects($this->once())->method('persist')->with($invitation);
@@ -97,13 +100,15 @@ class ClaimInvitationServiceTest extends KernelTestCase {
             ->expects($this->once())
             ->method('findAllByInviteEmailAndInvited')
             ->with($this->email)
-            ->willReturn([ $invitation ]);
+            ->willReturn([$invitation])
+        ;
 
         $this->campCollaborationRepository
             ->expects($this->once())
             ->method('findOneBy')
             ->with(['user' => $this->user, 'camp' => $camp])
-            ->willReturn($existingCollaboration);
+            ->willReturn($existingCollaboration)
+        ;
 
         // then
         $this->em->expects($this->never())->method('persist');
@@ -139,13 +144,15 @@ class ClaimInvitationServiceTest extends KernelTestCase {
             ->expects($this->once())
             ->method('findAllByInviteEmailAndInvited')
             ->with($this->email)
-            ->willReturn([ $invitation ]);
+            ->willReturn([$invitation])
+        ;
 
         $this->campCollaborationRepository
             ->expects($this->once())
             ->method('findOneBy')
             ->with(['user' => $this->user, 'camp' => $camp])
-            ->willReturn($existingCollaboration);
+            ->willReturn($existingCollaboration)
+        ;
 
         // then
         $this->em->expects($this->never())->method('persist');
@@ -181,24 +188,30 @@ class ClaimInvitationServiceTest extends KernelTestCase {
             ->expects($this->once())
             ->method('findAllByInviteEmailAndInvited')
             ->with($this->email)
-            ->willReturn([ $invitation, $invitation2 ]);
+            ->willReturn([$invitation, $invitation2])
+        ;
 
         // then
         $matcher1 = $this->exactly(2);
         $this->em->expects($matcher1)
             ->method('persist')
             ->willReturnCallback(function (CampCollaboration $value) use ($matcher1, $invitation, $invitation2) {
-                if ($matcher1->numberOfInvocations() === 1) $this->assertEquals($invitation, $value);
-                else $this->assertEquals($invitation2, $value);
-            });
+                if (1 === $matcher1->numberOfInvocations()) {
+                    $this->assertEquals($invitation, $value);
+                } else {
+                    $this->assertEquals($invitation2, $value);
+                }
+            })
+        ;
         $matcher2 = $this->exactly(2);
         $this->em->expects($matcher2)
             ->method('flush')
             ->willReturnCallback(function () use ($matcher2) {
-                if ($matcher2->numberOfInvocations() === 1) {
+                if (1 === $matcher2->numberOfInvocations()) {
                     throw $this->createMock(UniqueConstraintViolationException::class);
                 }
-            });
+            })
+        ;
         $this->em->expects($this->once())->method('clear');
 
         // when

--- a/api/tests/Service/ClaimInvitationServiceTest.php
+++ b/api/tests/Service/ClaimInvitationServiceTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Camp;
+use App\Entity\CampCollaboration;
+use App\Entity\User;
+use App\Repository\CampCollaborationRepository;
+use App\Service\ClaimInvitationService;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ClaimInvitationServiceTest extends KernelTestCase {
+
+    private CampCollaborationRepository $campCollaborationRepository;
+    private EntityManagerInterface $em;
+    private ClaimInvitationService $claimInvitationService;
+
+    private User $user;
+    private string $email = 'test@example.com';
+
+
+    protected function setUp(): void {
+        static::bootKernel();
+
+        $this->campCollaborationRepository = $this->createMock(CampCollaborationRepository::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+
+        $this->user = new User();
+
+        $this->claimInvitationService = new ClaimInvitationService($this->campCollaborationRepository, $this->em);
+    }
+
+    public function testDoesNothingWhenNoInvitationPresent() {
+        // given
+        $this->campCollaborationRepository
+            ->expects($this->once())
+            ->method('findAllByInviteEmailAndInvited')
+            ->with($this->email)
+            ->willReturn([]);
+
+        // then
+        $this->em->expects($this->never())->method('persist');
+        $this->em->expects($this->never())->method('flush');
+
+        // when
+        $this->claimInvitationService->claimInvitations($this->user, $this->email);
+    }
+
+    public function testClaimsInvitation() {
+        // given
+        $invitation = new CampCollaboration();
+        $invitation->user = null;
+        $invitation->inviteEmail = 'new@example.com';
+        $invitation->inviteKeyHash = 'asdfasdfasdf';
+        $camp = new Camp();
+        $invitation->camp = $camp;
+
+        $this->campCollaborationRepository
+            ->expects($this->once())
+            ->method('findAllByInviteEmailAndInvited')
+            ->with($this->email)
+            ->willReturn([ $invitation ]);
+
+        // then
+        $this->em->expects($this->once())->method('persist')->with($invitation);
+        $this->em->expects($this->once())->method('flush');
+
+        // when
+        $this->claimInvitationService->claimInvitations($this->user, $this->email);
+
+        // then
+        $this->assertEquals($invitation->user, $this->user);
+        $this->assertNull($invitation->inviteEmail);
+        $this->assertEquals($invitation->inviteKeyHash, 'asdfasdfasdf');
+        $this->assertEquals($invitation->camp, $camp);
+    }
+
+    public function testIgnoresInvitationWhenUserAlreadyPartOfCamp() {
+        // given
+        $camp = new Camp();
+
+        $invitation = new CampCollaboration();
+        $invitation->status = CampCollaboration::STATUS_INVITED;
+        $invitation->user = null;
+        $invitation->inviteEmail = 'new@example.com';
+        $invitation->inviteKeyHash = 'asdfasdfasdf';
+        $invitation->camp = $camp;
+
+        $existingCollaboration = new CampCollaboration();
+        $existingCollaboration->user = $this->user;
+        $existingCollaboration->status = CampCollaboration::STATUS_ESTABLISHED;
+        $existingCollaboration->camp = $camp;
+
+        $this->campCollaborationRepository
+            ->expects($this->once())
+            ->method('findAllByInviteEmailAndInvited')
+            ->with($this->email)
+            ->willReturn([ $invitation ]);
+
+        $this->campCollaborationRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['user' => $this->user, 'camp' => $camp])
+            ->willReturn($existingCollaboration);
+
+        // then
+        $this->em->expects($this->never())->method('persist');
+        $this->em->expects($this->never())->method('flush');
+
+        // when
+        $this->claimInvitationService->claimInvitations($this->user, $this->email);
+
+        // then
+        $this->assertNull($invitation->user);
+        $this->assertEquals($invitation->inviteEmail, 'new@example.com');
+        $this->assertEquals($invitation->inviteKeyHash, 'asdfasdfasdf');
+        $this->assertEquals($invitation->camp, $camp);
+    }
+
+    public function testIgnoresInvitationWhenUserWasPreviouslyPartOfCamp() {
+        // given
+        $camp = new Camp();
+
+        $invitation = new CampCollaboration();
+        $invitation->status = CampCollaboration::STATUS_INVITED;
+        $invitation->user = null;
+        $invitation->inviteEmail = 'new@example.com';
+        $invitation->inviteKeyHash = 'asdfasdfasdf';
+        $invitation->camp = $camp;
+
+        $existingCollaboration = new CampCollaboration();
+        $existingCollaboration->user = $this->user;
+        $existingCollaboration->status = CampCollaboration::STATUS_INACTIVE;
+        $existingCollaboration->camp = $camp;
+
+        $this->campCollaborationRepository
+            ->expects($this->once())
+            ->method('findAllByInviteEmailAndInvited')
+            ->with($this->email)
+            ->willReturn([ $invitation ]);
+
+        $this->campCollaborationRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['user' => $this->user, 'camp' => $camp])
+            ->willReturn($existingCollaboration);
+
+        // then
+        $this->em->expects($this->never())->method('persist');
+        $this->em->expects($this->never())->method('flush');
+
+        // when
+        $this->claimInvitationService->claimInvitations($this->user, $this->email);
+
+        // then
+        $this->assertNull($invitation->user);
+        $this->assertEquals($invitation->inviteEmail, 'new@example.com');
+        $this->assertEquals($invitation->inviteKeyHash, 'asdfasdfasdf');
+        $this->assertEquals($invitation->camp, $camp);
+    }
+
+    public function testHandlesUniqueConstraintViolationWhenUserAlreadyPartOfCamp() {
+        // given
+        $invitation = new CampCollaboration();
+        $invitation->user = null;
+        $invitation->inviteEmail = 'new@example.com';
+        $invitation->inviteKeyHash = 'asdfasdfasdf';
+        $camp = new Camp();
+        $invitation->camp = $camp;
+
+        $invitation2 = new CampCollaboration();
+        $invitation2->user = null;
+        $invitation2->inviteEmail = 'new@example.com';
+        $invitation2->inviteKeyHash = 'asdfasdfasdf';
+        $camp = new Camp();
+        $invitation2->camp = $camp;
+
+        $this->campCollaborationRepository
+            ->expects($this->once())
+            ->method('findAllByInviteEmailAndInvited')
+            ->with($this->email)
+            ->willReturn([ $invitation, $invitation2 ]);
+
+        // then
+        $matcher1 = $this->exactly(2);
+        $this->em->expects($matcher1)
+            ->method('persist')
+            ->willReturnCallback(function (CampCollaboration $value) use ($matcher1, $invitation, $invitation2) {
+                if ($matcher1->numberOfInvocations() === 1) $this->assertEquals($invitation, $value);
+                else $this->assertEquals($invitation2, $value);
+            });
+        $matcher2 = $this->exactly(2);
+        $this->em->expects($matcher2)
+            ->method('flush')
+            ->willReturnCallback(function () use ($matcher2) {
+                if ($matcher2->numberOfInvocations() === 1) {
+                    throw $this->createMock(UniqueConstraintViolationException::class);
+                }
+            });
+        $this->em->expects($this->once())->method('clear');
+
+        // when
+        $this->claimInvitationService->claimInvitations($this->user, $this->email);
+
+        // then
+        $this->assertEquals($invitation2->user, $this->user);
+        $this->assertNull($invitation2->inviteEmail);
+        $this->assertEquals($invitation2->inviteKeyHash, 'asdfasdfasdf');
+        $this->assertEquals($invitation2->camp, $camp);
+    }
+}

--- a/api/tests/State/ProfileUpdateProcessorTest.php
+++ b/api/tests/State/ProfileUpdateProcessorTest.php
@@ -6,10 +6,13 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Profile;
 use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\ClaimInvitationService;
 use App\Service\MailService;
 use App\State\ProfileUpdateProcessor;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
@@ -43,7 +46,10 @@ class ProfileUpdateProcessorTest extends TestCase {
         $this->processor = new ProfileUpdateProcessor(
             $decoratedProcessor,
             $this->pwHasherFactory,
-            $this->mailService
+            $this->mailService,
+            $this->createMock(Security::class),
+            $this->createMock(UserRepository::class),
+            $this->createMock(ClaimInvitationService::class),
         );
     }
 

--- a/api/tests/State/UserActivateProcessorTest.php
+++ b/api/tests/State/UserActivateProcessorTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\State;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\User;
+use App\Service\ClaimInvitationService;
 use App\State\UserActivateProcessor;
 use PHPUnit\Framework\TestCase;
 
@@ -24,6 +25,7 @@ class UserActivateProcessorTest extends TestCase {
         $decoratedProcessor = $this->createMock(ProcessorInterface::class);
         $this->processor = new UserActivateProcessor(
             $decoratedProcessor,
+            $this->createMock(ClaimInvitationService::class),
         );
     }
 


### PR DESCRIPTION
This is the missing part of #4865 which @usu expected during testing: When there already exists an open invitation for some email, and a new eCamp account with this email is activated, or an existing eCamp account changes its email to this email, then the invitation is converted to a personal invitation.

TODO:
- [x] Also claim invitations when registering via OAuth
- [x] Handle unique constraint violations more gracefully when they happen during this conversion.