### PR TITLE
EndpointPerformanceTest: add collection endpoints with filter

### DIFF
--- a/api/tests/Api/SnapshotTests/EndpointPerformanceTest.php
+++ b/api/tests/Api/SnapshotTests/EndpointPerformanceTest.php
@@ -54,6 +54,13 @@ class EndpointPerformanceTest extends ECampApiTestCase {
             }
         }
 
+        foreach ($this->getPerformanceCriticalUrls() as $url => $id) {
+            list($statusCode, $queryCount, $executionTimeSeconds) = $this->measurePerformanceFor($url.$id);
+            $responseCodes[$url] = $statusCode;
+            $numberOfQueries[$url] = $queryCount;
+            $queryExecutionTime[$url] = $executionTimeSeconds;
+        }
+
         $not200Responses = array_filter($responseCodes, fn ($value) => 200 != $value);
         assertThat($not200Responses, equalTo([]));
 
@@ -212,6 +219,25 @@ class EndpointPerformanceTest extends ECampApiTestCase {
         });
 
         return $normalEndpoints;
+    }
+
+    private function getPerformanceCriticalUrls(): array {
+        return [
+            '/activities?camp=' => urlencode($this->getIriFor('camp1')),
+            '/activity_progress_labels?camp=' => urlencode($this->getIriFor('camp1')),
+            '/activity_responsibles?activity.camp=' => urlencode($this->getIriFor('camp1')),
+            '/camp_collaborations?camp=' => urlencode($this->getIriFor('camp1')),
+            '/camp_collaborations?activityResponsibles.activity=' => urlencode($this->getIriFor('activity1')),
+            '/categories?camp=' => urlencode($this->getIriFor('camp1')),
+            '/content_types?categories=' => urlencode($this->getIriFor('category1')),
+            '/day_responsibles?day.period=' => urlencode($this->getIriFor('period1')),
+            '/material_items?materialList=' => urlencode($this->getIriFor('materialList1')),
+            '/material_items?materialNode=' => urlencode($this->getIriFor('materialNode1')),
+            '/material_items?period=' => urlencode($this->getIriFor('period1')),
+            '/material_lists?camp=' => urlencode($this->getIriFor('camp1')),
+            '/profiles?user.collaboration.camp=' => urlencode($this->getIriFor('camp1')),
+            '/schedule_entries?period=' => urlencode($this->getIriFor('period1')),
+        ];
     }
 
     private function getFixtureFor(string $collectionEndpoint) {

--- a/api/tests/Api/SnapshotTests/__snapshots__/performance_test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/performance_test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
@@ -27,3 +27,17 @@
 /schedule_entries: 23
 /schedule_entries/item: 221
 /users/item: 6
+'/activities?camp=': 213
+'/activity_progress_labels?camp=': 6
+'/activity_responsibles?activity.camp=': 6
+'/camp_collaborations?camp=': 13
+'/camp_collaborations?activityResponsibles.activity=': 25
+'/categories?camp=': 9
+'/content_types?categories=': 6
+'/day_responsibles?day.period=': 6
+'/material_items?materialList=': 7
+'/material_items?materialNode=': 7
+'/material_items?period=': 208
+'/material_lists?camp=': 6
+'/profiles?user.collaboration.camp=': 6
+'/schedule_entries?period=': 13

--- a/api/tests/Api/SnapshotTests/__snapshots__/test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
@@ -27,3 +27,17 @@
 /schedule_entries: 23
 /schedule_entries/item: 21
 /users/item: 6
+'/activities?camp=': 13
+'/activity_progress_labels?camp=': 6
+'/activity_responsibles?activity.camp=': 6
+'/camp_collaborations?camp=': 13
+'/camp_collaborations?activityResponsibles.activity=': 15
+'/categories?camp=': 9
+'/content_types?categories=': 6
+'/day_responsibles?day.period=': 6
+'/material_items?materialList=': 7
+'/material_items?materialNode=': 7
+'/material_items?period=': 8
+'/material_lists?camp=': 6
+'/profiles?user.collaboration.camp=': 6
+'/schedule_entries?period=': 13


### PR DESCRIPTION
We learned that they may lead to inefficient queries, thus i would like to test them in the ci.