### PR TITLE
view_user_camps; lists all visible camps for a user

### DIFF
--- a/api/config/packages/doctrine.yaml
+++ b/api/config/packages/doctrine.yaml
@@ -28,3 +28,4 @@ doctrine:
         schema_ignore_classes:
             - App\Entity\CampRootContentNode
             - App\Entity\PeriodMaterialItem
+            - App\Entity\UserCamp

--- a/api/migrations/schema/Version20240414092957.php
+++ b/api/migrations/schema/Version20240414092957.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240414092957 extends AbstractMigration {
+    public function getDescription(): string {
+        return 'Add View view_user_camps to fast resolve visible camps';
+    }
+
+    public function up(Schema $schema): void {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql(
+            <<<'EOF'
+                    CREATE OR REPLACE VIEW public.view_user_camps
+                    AS
+                    SELECT CONCAT(u.id, c.id) id, u.id userid,  c.id campid
+                    from camp c, "user" u
+                    where c.isprototype = TRUE
+                    union all
+                    select	cc.id, cc.userid, cc.campid
+                    from	camp_collaboration cc
+                    where 	cc.status = 'established'
+                EOF
+        );
+    }
+
+    public function down(Schema $schema): void {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP VIEW public.view_user_camps');
+    }
+}

--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -75,6 +75,13 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     public Collection $collaborations;
 
     /**
+     * UserCamp Collections
+     * Based von view_user_camps; lists all user who can see this camp.
+     */
+    #[ORM\OneToMany(targetEntity: UserCamp::class, mappedBy: 'camp')]
+    public Collection $userCamps;
+
+    /**
      * The time periods of the camp, there must be at least one. Periods in a camp may not overlap.
      * When creating a camp, the initial periods may be specified as nested payload, but updating,
      * adding or removing periods later should be done through the period endpoints.
@@ -361,6 +368,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     public function __construct() {
         parent::__construct();
         $this->collaborations = new ArrayCollection();
+        $this->userCamps = new ArrayCollection();
         $this->periods = new ArrayCollection();
         $this->categories = new ArrayCollection();
         $this->progressLabels = new ArrayCollection();

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -88,6 +88,13 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
     public Collection $collaborations;
 
     /**
+     * UserCamp Collections
+     * Based von view_user_camps; lists all camps a user can see.
+     */
+    #[ORM\OneToMany(targetEntity: UserCamp::class, mappedBy: 'user')]
+    public Collection $userCamps;
+
+    /**
      * The state of this user.
      */
     #[ApiProperty(readable: false, writable: false)]
@@ -163,6 +170,7 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
         parent::__construct();
         $this->ownedCamps = new ArrayCollection();
         $this->collaborations = new ArrayCollection();
+        $this->userCamps = new ArrayCollection();
     }
 
     /**

--- a/api/src/Entity/UserCamp.php
+++ b/api/src/Entity/UserCamp.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * view_user_camps
+ * List all visible camps for each user.
+ */
+#[ORM\Entity(readOnly: true)]
+#[ORM\Table(name: 'view_user_camps')]
+class UserCamp {
+    #[ORM\Id]
+    #[ORM\Column(type: 'string', length: 32, nullable: false)]
+    public string $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'userCamps')]
+    public User $user;
+
+    #[ORM\ManyToOne(targetEntity: Camp::class, inversedBy: 'userCamps')]
+    public Camp $camp;
+}


### PR DESCRIPTION
Until now we have joined camp and camp_collaboration to the query; 
now it is a where-clause with `id in (...)` for which this view is used.

The view shows all visible camps for each user.