### PR TITLE
docker-compose.yml: make it easy to restrict db resources

### DIFF
--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -12,6 +12,8 @@ jobs:
     name: 'Tests: End-to-end'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      DB_CPU_LIMIT: 4
     strategy:
       fail-fast: false
       matrix:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,11 @@ services:
       - target: 5432
         published: 5432
         protocol: tcp
+    deploy:
+      resources:
+        limits:
+          memory: ${DB_MEMORY_LIMIT:-128G}
+          cpus: ${DB_CPU_LIMIT:-8}
 
   mail:
     image: maildev/maildev


### PR DESCRIPTION
As we learned, postgres may behave differently depending on the available RAM.
You can now test the database nearer to production by adding
DB_MEMORY_LIMIT=1G
DB_CPU_LIMIT=1
to your .env file.

IntelliJ does not like the env variable interpolation, but it works.

I used 128G as fallback, because normally while developing you don't want a slow DB.
With the cpus it was not possible to limit to more cpu than the machine has. Thus, i limited to 8 cores which
every developer machine has hopefully.