### PR TITLE
fix: add ipv6 localhost to trusted_proxies

### DIFF
--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -36,6 +36,7 @@ php:
   appSecret: ""
   corsAllowOrigin: "^https://.*?\\.chart-example\\.local$"
   trustedProxies:
+    - "::1"
     - "127.0.0.1"
     - "10.0.0.0/8"
     - "172.16.0.0/12"

--- a/api/.env
+++ b/api/.env
@@ -14,7 +14,7 @@
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
 # API Platform distribution
-TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+TRUSTED_PROXIES=::1,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 ADDITIONAL_TRUSTED_HOSTS=localhost
 COOKIE_PREFIX=localhost_
 


### PR DESCRIPTION
This fixes the problem of SwaggerUI not properly loading

Reason for the problem:
- On symfony side, remote address of proxy was received as ipv6 (::1)
- this address was not in the list of trusted proxies
- if the proxy is not trusted, then the `X-forwarded-prefix` header is ignored
- hence, the BasePath is calculated wrongly and the assets for SwaggerUi cannot load

I'm not entirely sure, why the address changed from ipv4 to ipv6, however it seems completely unrelated to symfony version or api-platform version. For me, it correlated with an upgrade of Docker Desktop (I believe from 4.27.0 to 4.29.0).