### PR TITLE
.ops: expose grafana and kubernetes-dashboard behind oauth2-proxy with github provider

### DIFF
--- a/.ops/ops-dashboard/.gitignore
+++ b/.ops/ops-dashboard/.gitignore
@@ -1,0 +1,2 @@
+/charts
+/values.access.yaml

--- a/.ops/ops-dashboard/.helmignore
+++ b/.ops/ops-dashboard/.helmignore
@@ -1,0 +1,2 @@
+/deploy.sh
+/values.access.yaml

--- a/.ops/ops-dashboard/Chart.lock
+++ b/.ops/ops-dashboard/Chart.lock
@@ -2,5 +2,11 @@ dependencies:
 - name: oauth2-proxy
   repository: https://oauth2-proxy.github.io/manifests
   version: 7.4.1
-digest: sha256:8236a07b4531b8b99d7da436a589b97791647d22b4481bb178465576e8e06737
-generated: "2024-04-27T21:54:41.277084667+02:00"
+- name: kubernetes-dashboard
+  repository: https://kubernetes.github.io/dashboard/
+  version: 7.3.2
+- name: oauth2-proxy
+  repository: https://oauth2-proxy.github.io/manifests
+  version: 7.4.1
+digest: sha256:ab82aae4a91d9cceb424baed491624311dcf069c9ec614c75617fbee7833f6ad
+generated: "2024-04-28T09:29:27.790383658+02:00"

--- a/.ops/ops-dashboard/Chart.lock
+++ b/.ops/ops-dashboard/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: oauth2-proxy
+  repository: https://oauth2-proxy.github.io/manifests
+  version: 7.4.1
+digest: sha256:8236a07b4531b8b99d7da436a589b97791647d22b4481bb178465576e8e06737
+generated: "2024-04-27T21:54:41.277084667+02:00"

--- a/.ops/ops-dashboard/Chart.yaml
+++ b/.ops/ops-dashboard/Chart.yaml
@@ -28,3 +28,10 @@ dependencies:
     alias: grafana-proxy
     version: 7.4.1
     repository: https://oauth2-proxy.github.io/manifests
+  - name: kubernetes-dashboard
+    version: 7.3.2
+    repository: https://kubernetes.github.io/dashboard/
+  - name: oauth2-proxy
+    alias: kubernetes-dashboard-proxy
+    version: 7.4.1
+    repository: https://oauth2-proxy.github.io/manifests

--- a/.ops/ops-dashboard/Chart.yaml
+++ b/.ops/ops-dashboard/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: ecamp3-logging
+description: Helm chart for deploying ops-dashboard cluster
+home: https://github.com/ecamp/ecamp3
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.1.0
+
+dependencies:
+  - name: oauth2-proxy
+    alias: grafana-proxy
+    version: 7.4.1
+    repository: https://oauth2-proxy.github.io/manifests

--- a/.ops/ops-dashboard/README.md
+++ b/.ops/ops-dashboard/README.md
@@ -13,6 +13,13 @@ helm repo add oauth2-proxy https://oauth2-proxy.github.io/manifests
 helm repo update
 ```
 
+You also need the kubernetes-dashboard helm chart:
+
+```shell
+helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+helm repo update
+```
+
 ## Deployment
 
 First, make sure you don't overwrite the configuration currently applied:

--- a/.ops/ops-dashboard/README.md
+++ b/.ops/ops-dashboard/README.md
@@ -1,0 +1,28 @@
+# ops-dashboard
+
+This is a helm chart to deploy an oauth2-proxy and a homer dashboard.
+Then the ecamp3-developers can use their github login
+to see our applications like graphana, kibana, kubernetes-dashboard...
+
+## Prerequisites
+
+You need the oauth2-proxy helm chart:
+
+```shell
+helm repo add oauth2-proxy https://oauth2-proxy.github.io/manifests
+helm repo update
+```
+
+## Deployment
+
+First, make sure you don't overwrite the configuration currently applied:
+
+```shell
+helm get values ops-dashboard
+```
+
+Fill in the values for values.access.yaml according to demo.values.access.yaml
+
+```shell
+cp demo.values.access.yaml values.access.yaml 
+```

--- a/.ops/ops-dashboard/demo.values.access.yaml
+++ b/.ops/ops-dashboard/demo.values.access.yaml
@@ -14,3 +14,18 @@ grafana-proxy:
     # Create a new secret with the following command
     # openssl rand -base64 32 | head -c 32 | base64
     cookieSecret: ""
+kubernetes-dashboard-proxy:
+  ingress:
+    hosts:
+      # dev, stage or prod kubernetes-dashboard url
+      - dev-kubernetes-dashboard.ecamp3.ch
+  extraArgs:
+    # dev, stage or prod kubernetes-dashboard url
+    whitelist-domain: dev-kubernetes-dashboard.ecamp3.ch
+  config:
+    # OAuth client ID
+    clientID: ""
+    # OAuth client secret
+    clientSecret: ""
+    # use the same cookieSecret as above
+    cookieSecret: ""

--- a/.ops/ops-dashboard/demo.values.access.yaml
+++ b/.ops/ops-dashboard/demo.values.access.yaml
@@ -1,0 +1,16 @@
+grafana-proxy:
+  ingress: 
+    hosts:
+      # dev, stage or prod grafana url
+      - dev-grafana.ecamp3.ch
+  extraArgs:
+    # dev, stage or prod grafana url
+    whitelist-domain: dev-grafana.ecamp3.ch
+  config:
+    # OAuth client ID
+    clientID: ""
+    # OAuth client secret
+    clientSecret: ""
+    # Create a new secret with the following command
+    # openssl rand -base64 32 | head -c 32 | base64
+    cookieSecret: ""

--- a/.ops/ops-dashboard/deploy.sh
+++ b/.ops/ops-dashboard/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+cd $SCRIPT_DIR
+
+# to debug: --dry-run --debug
+helm dep build && helm upgrade --install ops-dashboard --namespace=ops-dashboard --create-namespace $SCRIPT_DIR --values $SCRIPT_DIR/values.yaml --values $SCRIPT_DIR/values.access.yaml

--- a/.ops/ops-dashboard/templates/kubernetes_dashboard_cluster_admin_cluster_role_binding.yaml
+++ b/.ops/ops-dashboard/templates/kubernetes_dashboard_cluster_admin_cluster_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-dashboard-admin-user
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-dashboard-admin-user
+    namespace: {{ .Release.Namespace }}

--- a/.ops/ops-dashboard/templates/kubernetes_dashboard_cluster_admin_user.yaml
+++ b/.ops/ops-dashboard/templates/kubernetes_dashboard_cluster_admin_user.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernetes-dashboard-admin-user
+  namespace: {{ .Release.Namespace }}

--- a/.ops/ops-dashboard/values.yaml
+++ b/.ops/ops-dashboard/values.yaml
@@ -1,0 +1,8 @@
+grafana-proxy:
+  ingress:
+    enabled: true
+    className: nginx
+  extraArgs: 
+    provider: github
+    github-org: ecamp
+    upstream: http://kube-prometheus-stack-grafana.kube-prometheus-stack.svc.cluster.local:80

--- a/.ops/ops-dashboard/values.yaml
+++ b/.ops/ops-dashboard/values.yaml
@@ -6,3 +6,12 @@ grafana-proxy:
     provider: github
     github-org: ecamp
     upstream: http://kube-prometheus-stack-grafana.kube-prometheus-stack.svc.cluster.local:80
+kubernetes-dashboard-proxy: 
+  ingress:
+    enabled: true
+    className: nginx
+  extraArgs:
+    provider: github
+    github-org: ecamp
+    upstream: https://ops-dashboard-kong-proxy.ops-dashboard.svc.cluster.local
+    ssl-upstream-insecure-skip-verify: true


### PR DESCRIPTION
That we don't need kubectl to access these internal services. 
Can be used for the kibana from https://github.com/ecamp/ecamp3/pull/5039, 
or the kubernetes dashboard from https://github.com/ecamp/ecamp3/issues/4134

See for yourself at https://dev-grafana.ecamp3.ch/?orgId=1

Also add kubernetes-dashboard behind oauth-proxy

An access token can be generated with
`kubectl -n ops-dashboard create token kubernetes-dashboard-admin-user`
(I will move this text to the wiki once the PR is merged)

See at https://dev-kubernetes-dashboard.ecamp3.ch

closes #4134