### PR TITLE
Feature / Picasso full size

### DIFF
--- a/frontend/src/components/program/ScheduleEntries.vue
+++ b/frontend/src/components/program/ScheduleEntries.vue
@@ -114,7 +114,7 @@ export default {
   position: fixed;
   bottom: calc(16px + 56px + env(safe-area-inset-bottom)) !important;
   @media #{map-get($display-breakpoints, 'md-and-up')} {
-    bottom: calc(16px + 36px + env(safe-area-inset-bottom)) !important;
+    bottom: calc(16px + env(safe-area-inset-bottom)) !important;
   }
 }
 </style>

--- a/frontend/src/components/program/ScheduleEntryFilters.vue
+++ b/frontend/src/components/program/ScheduleEntryFilters.vue
@@ -223,6 +223,12 @@ export default {
       this.loadEndpointData('campCollaborations', 'responsible', true)
       this.loadEndpointData('progressLabels', 'progressLabel', true)
     }
+    const resizeObserver = new ResizeObserver(() => {
+      const rs = getComputedStyle(this.$el)
+      const h = rs.getPropertyValue('height')
+      this.$emit('height-changed', h)
+    })
+    resizeObserver.observe(this.$el)
   },
   methods: {
     campCollaborationDisplayName(campCollaboration) {

--- a/frontend/src/components/program/ScheduleEntryFilters.vue
+++ b/frontend/src/components/program/ScheduleEntryFilters.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="d-flex flex-wrap items-baseline" style="overflow-y: auto; gap: 10px">
+  <div
+    v-resizeobserver:0.immediate="onResize"
+    class="d-flex flex-wrap items-baseline"
+    style="overflow-y: auto; gap: 10px"
+  >
     <BooleanFilter
       v-if="loadingEndpoints !== true && loadingEndpoints.campCollaborations !== true"
       v-model="showOnlyMyActivities"
@@ -223,12 +227,6 @@ export default {
       this.loadEndpointData('campCollaborations', 'responsible', true)
       this.loadEndpointData('progressLabels', 'progressLabel', true)
     }
-    const resizeObserver = new ResizeObserver(() => {
-      const rs = getComputedStyle(this.$el)
-      const h = rs.getPropertyValue('height')
-      this.$emit('height-changed', h)
-    })
-    resizeObserver.observe(this.$el)
   },
   methods: {
     campCollaborationDisplayName(campCollaboration) {
@@ -250,6 +248,9 @@ export default {
       this.value.category = []
       this.value.responsible = []
       this.value.progressLabel = []
+    },
+    onResize({ height }) {
+      this.$emit('height-changed', height)
     },
   },
 }

--- a/frontend/src/components/program/picasso/Picasso.vue
+++ b/frontend/src/components/program/picasso/Picasso.vue
@@ -382,7 +382,7 @@ export default {
   }
 
   @media #{map-get($display-breakpoints, 'md-and-up')} {
-    height: calc(100vh - 136px);
+    height: calc(100vh - 136px - var(--schedule-entry-filters-height));
   }
 
   :deep {

--- a/frontend/src/components/program/picasso/Picasso.vue
+++ b/frontend/src/components/program/picasso/Picasso.vue
@@ -382,7 +382,7 @@ export default {
   }
 
   @media #{map-get($display-breakpoints, 'md-and-up')} {
-    height: calc(100vh - 168px);
+    height: calc(100vh - 136px);
   }
 
   :deep {

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -290,12 +290,12 @@ export default {
     },
     openFilterChanged(openFilter) {
       if (!openFilter) {
-        this.scheduleEntryFiltersHeightChanged('0px')
+        this.scheduleEntryFiltersHeightChanged(0)
       }
     },
     scheduleEntryFiltersHeightChanged(h) {
       const root = document.querySelector(':root')
-      root.style.setProperty('--schedule-entry-filters-height', h)
+      root.style.setProperty('--schedule-entry-filters-height', `${h}px`)
     },
   },
 }

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -90,6 +90,7 @@ Show all activity schedule entries of a single period.
       class="ec-content-card__toolbar--border pb-4 justify-center"
       :loading-endpoints="loadingEndpoints"
       :camp="camp"
+      @height-changed="scheduleEntryFiltersHeightChanged"
     />
     <template v-if="loading">
       <v-skeleton-loader type="table" />
@@ -224,6 +225,7 @@ export default {
     },
   },
   watch: {
+    openFilter: 'openFilterChanged',
     'filter.category': 'persistRouterState',
     'filter.responsible': 'persistRouterState',
     'filter.progressLabel': 'persistRouterState',
@@ -283,6 +285,22 @@ export default {
       if (filterAndQueryAreEqual(query, this.$route.query)) return
       this.$router.replace({ query }).catch((err) => console.warn(err))
     },
+    openFilterChanged(openFilter) {
+      if (!openFilter) {
+        this.scheduleEntryFiltersHeightChanged('0px')
+      }
+    },
+    scheduleEntryFiltersHeightChanged(h) {
+      console.log(h)
+      var root = document.querySelector(':root')
+      root.style.setProperty('--schedule-entry-filters-height', h)
+    },
   },
 }
 </script>
+
+<style>
+:root {
+  --schedule-entry-filters-height: 0px;
+}
+</style>

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -294,8 +294,7 @@ export default {
       }
     },
     scheduleEntryFiltersHeightChanged(h) {
-      console.log(h)
-      var root = document.querySelector(':root')
+      const root = document.querySelector(':root')
       root.style.setProperty('--schedule-entry-filters-height', h)
     },
   },

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -225,7 +225,10 @@ export default {
     },
   },
   watch: {
-    openFilter: 'openFilterChanged',
+    openFilter: {
+      immediate: true,
+      handler: 'openFilterChanged',
+    },
     'filter.category': 'persistRouterState',
     'filter.responsible': 'persistRouterState',
     'filter.progressLabel': 'persistRouterState',


### PR DESCRIPTION
Since we no longer have a status line at the bottom (Commit ID), we have a too large gap below the Picasso. 
This PR enlarges the Picasso - and reduces the gap.

Old:
![image](https://github.com/ecamp/ecamp3/assets/470237/094e1148-a887-49e7-a9d0-5f233e8aa99d)

New:
![image](https://github.com/ecamp/ecamp3/assets/470237/a3bd4dd1-cc56-43cf-ae2b-936812b4ca74)
