### PR TITLE
More intelligent proposed times when adding more schedule entries to an activity

### DIFF
--- a/frontend/src/components/program/FormScheduleEntryList.vue
+++ b/frontend/src/components/program/FormScheduleEntryList.vue
@@ -68,13 +68,32 @@ export default {
     scheduleEntriesWithoutDeleted() {
       return this.scheduleEntries.filter((entry) => !entry.deleted)
     },
+    lastScheduleEntry() {
+      return this.localScheduleEntries[this.localScheduleEntries.length - 1]
+    },
+    lastScheduleEntryStart() {
+      return dayjs.utc(this.lastScheduleEntry.start)
+    },
+    lastScheduleEntryEnd() {
+      return dayjs.utc(this.lastScheduleEntry.end)
+    },
+    lastScheduleEntryDuration() {
+      return this.lastScheduleEntryEnd.diff(this.lastScheduleEntryStart)
+    },
   },
   methods: {
     addScheduleEntry() {
+      const proposedStart = this.lastScheduleEntryStart.add(1, 'day')
+      const proposedEnd = proposedStart.add(this.lastScheduleEntryDuration)
+      const periodEnd = dayjs.utc(this.period.end).add(24, 'hour')
+      const start = proposedEnd.isSameOrBefore(periodEnd)
+        ? proposedStart
+        : dayjs.utc(this.period.start).add(7, 'hour')
+      const end = start.add(this.lastScheduleEntryDuration)
       this.localScheduleEntries.push({
         period: () => this.period,
-        start: dayjs.utc(this.period.start).add(7, 'hour').format(),
-        end: dayjs.utc(this.period.start).add(8, 'hour').format(),
+        start: start.format(),
+        end: end.format(),
         key: uniqueId(),
         deleted: false,
       })


### PR DESCRIPTION
Proposed by Matrix. When adding schedule entries to an existing activity going from 08:00 to 10:00, this will propose a time of 08:00 to 10:00 on the next day, and so on. If that does not fit into the period anymore, we fall back to the previous behaviour of fixed start time on 07:00 on the first day of the period (but still reuse the duration of the existing schedule entry).