### PR TITLE
replace hard coded api urls with templated links

### DIFF
--- a/frontend/src/components/campAdmin/DialogActivityProgressLabelCreate.vue
+++ b/frontend/src/components/campAdmin/DialogActivityProgressLabelCreate.vue
@@ -33,7 +33,7 @@ export default {
   data() {
     return {
       entityProperties: ['camp', 'position', 'title'],
-      entityUri: '/activity_progress_labels',
+      entityUri: '',
     }
   },
   watch: {
@@ -52,6 +52,11 @@ export default {
         this.clearEntityData()
       }
     },
+  },
+  mounted() {
+    this.api
+      .href(this.api.get(), 'activityProgressLabels')
+      .then((uri) => (this.entityUri = uri))
   },
   methods: {
     createDialogActivityProgressLabelCreate() {

--- a/frontend/src/components/campAdmin/DialogCategoryCreate.vue
+++ b/frontend/src/components/campAdmin/DialogCategoryCreate.vue
@@ -126,7 +126,7 @@ export default {
     return {
       entityProperties: ['camp', 'short', 'name', 'color', 'numberingStyle'],
       embeddedCollections: ['preferredContentTypes'],
-      entityUri: '/categories',
+      entityUri: '',
       clipboardPermission: 'unknown',
       copyCategorySource: null,
       copyCategorySourceUrl: null,
@@ -223,6 +223,9 @@ export default {
         }
       )
     },
+  },
+  mounted() {
+    this.api.href(this.api.get(), 'categories').then((uri) => (this.entityUri = uri))
   },
   methods: {
     async createCategory() {

--- a/frontend/src/components/campAdmin/DialogMaterialListCreate.vue
+++ b/frontend/src/components/campAdmin/DialogMaterialListCreate.vue
@@ -33,7 +33,7 @@ export default {
   data() {
     return {
       entityProperties: ['camp', 'name'],
-      entityUri: '/material_lists',
+      entityUri: '',
     }
   },
   watch: {
@@ -48,6 +48,9 @@ export default {
         this.clearEntityData()
       }
     },
+  },
+  mounted() {
+    this.api.href(this.api.get(), 'materialLists').then((uri) => (this.entityUri = uri))
   },
   methods: {
     createMaterialList() {

--- a/frontend/src/components/campAdmin/DialogPeriodCreate.vue
+++ b/frontend/src/components/campAdmin/DialogPeriodCreate.vue
@@ -32,7 +32,7 @@ export default {
   data() {
     return {
       entityProperties: ['camp', 'description', 'start', 'end'],
-      entityUri: '/periods',
+      entityUri: '',
     }
   },
   watch: {
@@ -49,6 +49,9 @@ export default {
         this.clearEntityData()
       }
     },
+  },
+  mounted() {
+    this.api.href(this.api.get(), 'periods').then((uri) => (this.entityUri = uri))
   },
   methods: {
     createPeriod() {

--- a/frontend/src/components/collaborator/CollaboratorCreate.vue
+++ b/frontend/src/components/collaborator/CollaboratorCreate.vue
@@ -52,7 +52,7 @@ export default {
   data() {
     return {
       entityProperties: ['camp', 'inviteEmail', 'role'],
-      entityUri: '/camp_collaborations',
+      entityUri: '',
     }
   },
   watch: {
@@ -68,6 +68,11 @@ export default {
         this.clearEntityData()
       }
     },
+  },
+  mounted() {
+    this.api
+      .href(this.api.get(), 'campCollaborations')
+      .then((uri) => (this.entityUri = uri))
   },
   methods: {
     createCollaboration() {

--- a/frontend/src/components/collaborator/CollaboratorEdit.vue
+++ b/frontend/src/components/collaborator/CollaboratorEdit.vue
@@ -153,7 +153,7 @@ export default {
       resendingEmail: false,
       emailSent: false,
       entityProperties: ['camp', 'inviteEmail', 'role', 'status'],
-      entityUri: '/camp_collaborations',
+      entityUri: '',
     }
   },
   computed: {
@@ -194,6 +194,11 @@ export default {
         this.clearEntityData()
       }
     },
+  },
+  mounted() {
+    this.api
+      .href(this.api.get(), 'campCollaborations')
+      .then((uri) => (this.entityUri = uri))
   },
   methods: {
     resendInvitation() {

--- a/frontend/src/components/program/DialogActivityCreate.vue
+++ b/frontend/src/components/program/DialogActivityCreate.vue
@@ -138,7 +138,7 @@ export default {
       copyActivitySourceUrlShowPopover: false,
       entityProperties: ['title', 'location', 'scheduleEntries'],
       embeddedEntities: ['category'],
-      entityUri: '/activities',
+      entityUri: '',
     }
   },
   computed: {
@@ -246,6 +246,9 @@ export default {
         }
       )
     },
+  },
+  mounted() {
+    this.api.href(this.api.get(), 'activities').then((url) => (this.entityUri = url))
   },
   methods: {
     refreshCopyActivitySource() {


### PR DESCRIPTION
fixes #977
successfully tested by verifying that all `mounted()` functions are called at least once and checking that the api calls still work by doing the corresponding action in the ui