### PR TITLE
frontend add tests for slot forwarding

### DIFF
--- a/frontend/src/components/form/base/__tests__/ECheckbox.spec.js
+++ b/frontend/src/components/form/base/__tests__/ECheckbox.spec.js
@@ -5,6 +5,7 @@ import formBaseComponents from '@/plugins/formBaseComponents'
 
 import { mount as mountComponent } from '@vue/test-utils'
 import ECheckbox from '../ECheckbox.vue'
+import { screen } from '@testing-library/vue'
 
 Vue.use(Vuetify)
 Vue.use(formBaseComponents)
@@ -22,7 +23,9 @@ describe('An ECheckbox', () => {
       },
       template: `
         <div data-app>
-          <e-checkbox label="test" v-model="data"/>
+          <e-checkbox label="test" v-model="data">
+            ${options?.children}
+          </e-checkbox>
         </div>
       `,
     })
@@ -81,5 +84,17 @@ describe('An ECheckbox', () => {
     jest.resetAllMocks()
     await input.trigger('click')
     expect(wrapper.vm.data).toBe(false)
+  })
+
+  test('allows to use the append slot', async () => {
+    mount({
+      children: `
+        <template #append>
+          <span>append</span>
+        </template>
+      `,
+    })
+
+    expect(await screen.findByText('append')).toBeVisible()
   })
 })

--- a/frontend/src/components/form/base/__tests__/ENumberField.spec.js
+++ b/frontend/src/components/form/base/__tests__/ENumberField.spec.js
@@ -5,6 +5,7 @@ import formBaseComponents from '@/plugins/formBaseComponents'
 
 import { mount as mountComponent } from '@vue/test-utils'
 import ENumberField from '../ENumberField.vue'
+import { screen } from '@testing-library/vue'
 
 Vue.use(Vuetify)
 Vue.use(formBaseComponents)
@@ -21,9 +22,11 @@ describe('An ENumberField', () => {
         }
       },
       template: `
-      <div data-app>
-        <e-number-field label="test" v-model="data"/>
-      </div>
+        <div data-app>
+          <e-number-field label="test" v-model="data">
+            ${options?.children}
+          </e-number-field>
+        </div>
       `,
     })
     return mountComponent(app, { vuetify, attachTo: document.body, ...options })
@@ -113,5 +116,17 @@ describe('An ENumberField', () => {
     await input.trigger('input')
 
     expect(wrapper.vm.data).toBe(expected)
+  })
+
+  test('allows to use the append slot', async () => {
+    mount({
+      children: `
+        <template #append>
+          <span>append</span>
+        </template>
+      `,
+    })
+
+    expect(await screen.findByText('append')).toBeVisible()
   })
 })

--- a/frontend/src/components/form/base/__tests__/ENumberField.spec.js
+++ b/frontend/src/components/form/base/__tests__/ENumberField.spec.js
@@ -20,7 +20,11 @@ describe('An ENumberField', () => {
           data: null,
         }
       },
-      template: `<div data-app><e-number-field label="test" v-model="data"/></div>`,
+      template: `
+      <div data-app>
+        <e-number-field label="test" v-model="data"/>
+      </div>
+      `,
     })
     return mountComponent(app, { vuetify, attachTo: document.body, ...options })
   }

--- a/frontend/src/components/form/base/__tests__/EParseField.spec.js
+++ b/frontend/src/components/form/base/__tests__/EParseField.spec.js
@@ -5,6 +5,7 @@ import formBaseComponents from '@/plugins/formBaseComponents'
 
 import EParseField from '@/components/form/base/EParseField.vue'
 import { mount as mountComponent } from '@vue/test-utils'
+import { screen } from '@testing-library/vue'
 
 Vue.use(Vuetify)
 Vue.use(formBaseComponents)
@@ -30,7 +31,9 @@ describe('An EParseField', () => {
       },
       template: `
         <div data-app>
-          <e-parse-field label="test" :parse="parse" :format="format" v-model="data" :value="data"/>
+          <e-parse-field label="test" :parse="parse" :format="format" v-model="data" :value="data">
+            ${options?.children}
+          </e-parse-field>
         </div>
       `,
     })
@@ -89,5 +92,17 @@ describe('An EParseField', () => {
     await input.trigger('input')
 
     expect(wrapper.vm.data).toBe(expected)
+  })
+
+  test('allows to use the append slot', async () => {
+    mount({
+      children: `
+        <template #append>
+          <span>append</span>
+        </template>
+      `,
+    })
+
+    expect(await screen.findByText('append')).toBeVisible()
   })
 })

--- a/frontend/src/components/form/base/__tests__/EParseField.spec.js
+++ b/frontend/src/components/form/base/__tests__/EParseField.spec.js
@@ -28,7 +28,11 @@ describe('An EParseField', () => {
           return value === null ? '' : `${value}`
         },
       },
-      template: `<div data-app><e-parse-field label="test" :parse="parse" :format="format" v-model="data"/></div>`,
+      template: `
+        <div data-app>
+          <e-parse-field label="test" :parse="parse" :format="format" v-model="data" :value="data"/>
+        </div>
+      `,
     })
     return mountComponent(app, { vuetify, attachTo: document.body, ...options })
   }

--- a/frontend/src/components/form/base/__tests__/ESelect.spec.js
+++ b/frontend/src/components/form/base/__tests__/ESelect.spec.js
@@ -5,6 +5,7 @@ import { formBaseComponents } from '@/plugins'
 
 import { mount as mountComponent } from '@vue/test-utils'
 import ESelect from '../ESelect.vue'
+import { screen } from '@testing-library/vue'
 
 Vue.use(Vuetify)
 Vue.use(formBaseComponents)
@@ -36,10 +37,12 @@ describe('An ESelect', () => {
         }
       },
       template: `
-          <div data-app>
-            <e-select label='test' :items="selectValues" v-model="data"/>
-          </div>
-        `,
+        <div data-app>
+          <e-select label="test" :items="selectValues" v-model="data">
+            ${options?.children}
+          </e-select>
+        </div>
+      `,
     })
     return mountComponent(app, { vuetify, attachTo: document.body, ...options })
   }
@@ -100,5 +103,37 @@ describe('An ESelect', () => {
     expect(
       wrapper.findAll('[role="option"]').at(0).element.getAttribute('aria-selected')
     ).not.toBe('true')
+  })
+
+  test('allows to use the append slot', async () => {
+    mount({
+      children: `
+        <template #append>
+          <span>append</span>
+        </template>
+      `,
+    })
+
+    expect(await screen.findByText('append')).toBeVisible()
+  })
+
+  test('allows to use the append slot with scope', async () => {
+    const textText = 'myTestText'
+    const wrapper = mount({
+      children: `
+        <template #item="{ item, on, attrs }">
+          <v-list-item-title :key="item.text" v-bind="attrs" v-on="on">
+            {{ item }}
+          </v-list-item-title>
+          <v-list-item-subtitle>
+            ${textText}
+          </v-list-item-subtitle>
+      </template>
+      `,
+    })
+
+    await wrapper.find('.v-input__slot').trigger('click')
+
+    expect(await screen.findAllByText(textText)).toHaveLength(3)
   })
 })

--- a/frontend/src/components/form/base/__tests__/ESelect.spec.js
+++ b/frontend/src/components/form/base/__tests__/ESelect.spec.js
@@ -37,7 +37,7 @@ describe('An ESelect', () => {
       },
       template: `
           <div data-app>
-          <e-select label='test' :items="selectValues" v-model="data"/>
+            <e-select label='test' :items="selectValues" v-model="data"/>
           </div>
         `,
     })

--- a/frontend/src/components/form/base/__tests__/ESwitch.spec.js
+++ b/frontend/src/components/form/base/__tests__/ESwitch.spec.js
@@ -6,6 +6,7 @@ import formBaseComponents from '@/plugins/formBaseComponents'
 import { mount as mountComponent } from '@vue/test-utils'
 import ESwitch from '@/components/form/base/ESwitch.vue'
 import { touch } from '@/test/util'
+import { screen } from '@testing-library/vue'
 
 Vue.use(Vuetify)
 Vue.use(formBaseComponents)
@@ -23,7 +24,9 @@ describe('An ESwitch', () => {
       },
       template: `
         <div data-app>
-          <e-switch label="test" v-model="data"/>
+          <e-switch label="test" v-model="data">
+            ${options?.children}
+          </e-switch>
         </div>
       `,
     })
@@ -106,5 +109,17 @@ describe('An ESwitch', () => {
     jest.resetAllMocks()
     input.trigger('keydown.left')
     expect(wrapper.vm.data).toBe(false)
+  })
+
+  test('allows to use the append slot', async () => {
+    mount({
+      children: `
+        <template #append>
+          <span>append</span>
+        </template>
+      `,
+    })
+
+    expect(await screen.findByText('append')).toBeVisible()
   })
 })

--- a/frontend/src/components/form/base/__tests__/ETextField.spec.js
+++ b/frontend/src/components/form/base/__tests__/ETextField.spec.js
@@ -20,7 +20,11 @@ describe('An ETextField', () => {
           data: null,
         }
       },
-      template: `<div data-app><e-text-field label="test" v-model="data"/></div>`,
+      template: `
+        <div data-app>
+          <e-text-field label="test" v-model="data"/>
+        </div>
+      `,
     })
     return mountComponent(app, { vuetify, attachTo: document.body, ...options })
   }

--- a/frontend/src/components/form/base/__tests__/ETextField.spec.js
+++ b/frontend/src/components/form/base/__tests__/ETextField.spec.js
@@ -5,6 +5,7 @@ import formBaseComponents from '@/plugins/formBaseComponents'
 
 import { mount as mountComponent } from '@vue/test-utils'
 import ETextField from '../ETextField.vue'
+import { screen } from '@testing-library/vue'
 
 Vue.use(Vuetify)
 Vue.use(formBaseComponents)
@@ -22,7 +23,9 @@ describe('An ETextField', () => {
       },
       template: `
         <div data-app>
-          <e-text-field label="test" v-model="data"/>
+          <e-text-field label="test" v-model="data">
+            ${options?.children}
+          </e-text-field>
         </div>
       `,
     })
@@ -67,5 +70,17 @@ describe('An ETextField', () => {
     await input.trigger('input')
 
     expect(wrapper.vm.data).toBe(text)
+  })
+
+  test('allows to use the append slot', async () => {
+    mount({
+      children: `
+        <template #append>
+          <span>append</span>
+        </template>
+      `,
+    })
+
+    expect(await screen.findByText('append')).toBeVisible()
   })
 })


### PR DESCRIPTION
frontend: add tests for slot forwarding

That we have tests when we turn the following rules on:
"vue/no-deprecated-dollar-scopedslots-api": "off",
"vue/no-deprecated-slot-attribute": "off",
"vue/no-deprecated-slot-scope-attribute": "off",

Issue: #5121

Related to: #5170,