### PR TITLE
remove version from docker-compose.yml files

### DIFF
--- a/.helm/ecamp3/files/db-backup-restore-image/docker-compose.yml
+++ b/.helm/ecamp3/files/db-backup-restore-image/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services: 
   db-backup-restore-image:
     image: ${CONTAINER_REGISTRY:-docker.io}/${REPO_OWNER:-ecamp}/ecamp3-db-backup-restore:${VERSION:-local}

--- a/.helm/ecamp3/files/db_backup_job/docker-compose.yml
+++ b/.helm/ecamp3/files/db_backup_job/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   create-backup:
     build:

--- a/.helm/ecamp3/files/hook_db_restore/docker-compose.yml
+++ b/.helm/ecamp3/files/hook_db_restore/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   restore-backup:
     build:

--- a/.ops/aws-setup/docker-compose.yml
+++ b/.ops/aws-setup/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   aws-setup:
     image: pulumi/pulumi-nodejs:3.116.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   frontend:
     image: node:20.12.2


### PR DESCRIPTION
Fixes
WARN[0000] /home/lucius/projects/ecamp/ecamp3/main/docker-compose.yml: `version` is obsolete