### PR TITLE
fix: docker build cache for varnish

### DIFF
--- a/.github/workflows/reusable-build-and-push.yml
+++ b/.github/workflows/reusable-build-and-push.yml
@@ -104,8 +104,8 @@ jobs:
             ${{ ((inputs.tag != '') && format('{0}/ecamp3-varnish:{1}', vars.DOCKER_HUB_USERNAME, inputs.tag) || '') }}
             ${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-varnish:${{ inputs.sha }}
           context: .
-          cache-from: type=gha,scope=print
-          cache-to: type=gha,scope=print,mode=max
+          cache-from: type=gha,scope=varnish
+          cache-to: type=gha,scope=varnish,mode=max
 
       - name: Build and push db-backup-restore docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Fixes a copy-paste-typo in the build workflow
(workflow already works, but is not using proper docker layer cache)