### PR TITLE
chore: upgrade cypress-io/github-action to v6

### DIFF
--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -51,7 +51,7 @@ jobs:
       # start necessary containers
       - run: docker compose up -d php caddy frontend pdf print browserless database docker-host http-cache mail
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@v6
         with:
           working-directory: e2e
           browser: ${{ matrix.browser }}


### PR DESCRIPTION
This will fix the following warnings on Github workflow:

![image](https://github.com/ecamp/ecamp3/assets/449555/5a329866-cf9d-4f8c-9071-c67699b8963b)

For me it's not entirely clear why this was not upgraded by renovate. Does renovate only work, if we pin the action to the specific SHA?