### PR TITLE
fix: use DOCKER_HUB_USERNAME instead of default `ecamp` for varnish image

### DIFF
--- a/.github/workflows/reusable-dev-deployment.yml
+++ b/.github/workflows/reusable-dev-deployment.yml
@@ -85,6 +85,7 @@ jobs:
             --set print.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-print' \
             --set php.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-api-php' \
             --set caddy.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-api-caddy' \
+            --set apiCache.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-varnish' \
             --set postgresql.dbBackupRestoreImage.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-db-backup-restore' \
             --set termsOfServiceLinkTemplate='https://ecamp3.ch/{lang}/tos' \
             --set newsLink='https://ecamp3.ch/blog' \

--- a/.github/workflows/reusable-stage-prod-deployment.yml
+++ b/.github/workflows/reusable-stage-prod-deployment.yml
@@ -44,6 +44,7 @@ jobs:
             --set print.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-print' \
             --set php.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-api-php' \
             --set caddy.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-api-caddy' \
+            --set apiCache.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-varnish' \
             --set postgresql.dbBackupRestoreImage.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-db-backup-restore' \
             --set termsOfServiceLinkTemplate='https://ecamp3.ch/{lang}/tos' \
             --set newsLink='https://ecamp3.ch/blog' \


### PR DESCRIPTION
I enabled API_CACHE_ENABLED on Github `dev` environment and on `feature-branch` environment.

Varnish didn't deploy properly, though. Reason was, that it looked for the image at `docker.io/ecamp/ecamp3-varnish`, however we're publishing the images at `docker.io/ecamp3travis/ecamp3-varnish`.

Does anyone remember, whether there was a specific reason why we switched from ecamp to ecamp3travis. We last published on ecamp in March 2023. ecamp is marked as a "community organization", while ecamp3travis seems to be a normal "community user".

