### PR TITLE
CI: pin cypress/github-action to v6.6.1

### DIFF
--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -51,7 +51,7 @@ jobs:
       # start necessary containers
       - run: docker compose up -d php caddy frontend pdf print browserless database docker-host http-cache mail
 
-      - uses: cypress-io/github-action@v6
+      - uses: cypress-io/github-action@v6.6.1
         with:
           working-directory: e2e
           browser: ${{ matrix.browser }}


### PR DESCRIPTION
Instead of using v6.
Cypress does not create tags for their actions.
And pinning the action is anyway better than in place update.

Like this the update with renovate works.
Tested it on my fork, and can be seen with this commit: https://github.com/BacLuc/ecamp3/commit/e730e7cd02b7a1f046dada6cdafa412b20ac31bd