### PR TITLE
chore(print): improved request logging for nuxt-print

### DIFF
--- a/print/server/api/pdf.js
+++ b/print/server/api/pdf.js
@@ -12,22 +12,19 @@ import { performance } from 'perf_hooks'
 import { URL } from 'url'
 import { memoryUsage } from 'process'
 
-let lastTime = null
-function measurePerformance(msg) {
+function measurePerformance(performanceMeasurements, key) {
   const now = performance.now()
   const memory = memoryUsage()
 
-  if (lastTime !== null) {
-    console.log(
-      `(took ${Math.round(now - lastTime)} millisecons / using ${
-        memory.heapUsed / 1000000
-      }MB)`
-    )
-  }
-  lastTime = now
+  const lastTime = performanceMeasurements.lastTime
 
-  console.log('\n')
-  console.log(msg || '')
+  if (lastTime !== null && key !== null) {
+    performanceMeasurements.measurements[key] = {
+      duration: Math.round(now - lastTime),
+      memory: memory.heapUsed / 1000000,
+    }
+  }
+  performanceMeasurements.lastTime = now
 }
 
 export default defineEventHandler(async (event) => {
@@ -41,16 +38,25 @@ export default defineEventHandler(async (event) => {
   } = useRuntimeConfig(event)
 
   let browser = null
+  let status = 200
+  const performanceMeasurements = {
+    lastTime: null,
+    measurements: {},
+  }
+  const logOutput = {
+    timestamp: new Date(),
+  }
 
   try {
-    measurePerformance('Connecting to puppeteer...')
+    measurePerformance(performanceMeasurements)
+
     // Connect to browserless.io (puppeteer websocket)
     browser = await puppeteer.connect({
       browserWSEndpoint: browserWsEndpoint,
     })
     const context = await browser.createIncognitoBrowserContext()
+    measurePerformance(performanceMeasurements, 'puppeteer_connect')
 
-    measurePerformance('Open new page & set cookies...')
     const page = await context.newPage()
     const printUrlObj = new URL(printUrl)
     const requestCookies = parseCookies(event)
@@ -81,6 +87,7 @@ export default defineEventHandler(async (event) => {
       extraHeaders['Authorization'] = `Basic ${basicAuthToken}`
       await page.setExtraHTTPHeaders(extraHeaders)
     }
+    measurePerformance(performanceMeasurements, 'open_page')
 
     /**
      * Debugging puppeteer
@@ -100,20 +107,20 @@ export default defineEventHandler(async (event) => {
     }) */
 
     // set HTML content of current page
-    measurePerformance('Puppeteer load HTML content...')
     page.setUserAgent(
       'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:96.0) Gecko/20100101 Firefox/96.0'
     )
 
     // HTTP request back to Print Nuxt App
     const queryParams = getQuery(event)
+    logOutput.config = queryParams.config
     await page.goto(`${printUrl}/?config=${queryParams.config}`, {
       timeout: renderHtmlTimeoutMs || 30000,
       waitUntil: 'networkidle0',
     })
+    measurePerformance(performanceMeasurements, 'load_content')
 
     // print pdf
-    measurePerformance('Generate PDf...')
     const pdf = await page.pdf({
       printBackground: true,
       format: 'A4',
@@ -129,10 +136,9 @@ export default defineEventHandler(async (event) => {
       },
       timeout: renderPdfTimeoutMs || 30000,
     })
+    measurePerformance(performanceMeasurements, 'generate_pdf')
 
-    measurePerformance()
     browser.disconnect()
-
     defaultContentType(event, 'application/pdf')
     return pdf
   } catch (error) {
@@ -141,7 +147,7 @@ export default defineEventHandler(async (event) => {
     }
 
     let errorMessage = null
-    let status = 500
+    status = 500
     if (error.error) {
       // error is a WebSocket ErrorEvent Object which contains an error property
       errorMessage = error.error.message
@@ -154,10 +160,14 @@ export default defineEventHandler(async (event) => {
     }
 
     captureError(error)
-
+    logOutput.error = errorMessage
     setResponseStatus(event, status)
     defaultContentType(event, 'application/problem+json')
     return { status, title: errorMessage }
+  } finally {
+    logOutput.measurements = performanceMeasurements.measurements
+    logOutput.status = status
+    console.log(logOutput)
   }
 })
 


### PR DESCRIPTION
Improves logging output for nuxt-print

Instead of writing individual single lines to console, this combines all relevant data in a `logOutput` object and writes everything to the console in json format at the end of the request.

This enables our new EFFK stack to properly capture and analyze the logging output.

### Example outputs (from local dev)

**Successful print**
![image](https://github.com/ecamp/ecamp3/assets/449555/b4bda785-6d3b-4246-b85f-d196d507f07f)

**Error output (browserless is down)**
![image](https://github.com/ecamp/ecamp3/assets/449555/640bcb82-2f3a-44df-9d1f-b7a61601b26b)

