### PR TITLE
feat: resend activation key

### DIFF
--- a/api/src/DTO/UserActivation.php
+++ b/api/src/DTO/UserActivation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\DTO;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use App\InputFilter;
+use App\State\ResendActivationProcessor;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[ApiResource(
+    operations: [
+        new Post(
+            processor: ResendActivationProcessor::class,
+            uriTemplate: '/resend_activation{._format}',
+            security: 'true',
+            status: 204,
+            output: false,
+            denormalizationContext: ['groups' => ['create']],
+            openapi: new OpenApiOperation(summary: 'Request activation email again', description: 'Activation email will be sent to the given email again.')
+        ),
+    ],
+    routePrefix: '/auth'
+)]
+class UserActivation {
+    #[InputFilter\Trim]
+    #[ApiProperty(readable: false, writable: true)]
+    #[Groups(['create'])]
+    public ?string $email = null;
+
+    #[ApiProperty(readable: false, writable: true)]
+    #[Groups(['create'])]
+    public ?string $recaptchaToken = null;
+}

--- a/api/src/Serializer/Normalizer/UriTemplateNormalizer.php
+++ b/api/src/Serializer/Normalizer/UriTemplateNormalizer.php
@@ -52,6 +52,7 @@ class UriTemplateNormalizer implements NormalizerInterface {
         $result['_links']['oauthCevidb'] = ['href' => $this->urlGenerator->generate('connect_cevidb_start').'{?callback}', 'templated' => true];
         $result['_links']['oauthJubladb'] = ['href' => $this->urlGenerator->generate('connect_jubladb_start').'{?callback}', 'templated' => true];
         $result['_links']['resetPassword'] = ['href' => $this->urlGenerator->generate('_api_/auth/reset_password{._format}_post').'{/id}', 'templated' => true];
+        $result['_links']['resendActivation'] = ['href' => $this->urlGenerator->generate('_api_/auth/resend_activation{._format}_post'), 'templated' => false];
 
         return $result;
     }

--- a/api/src/State/ResendActivationProcessor.php
+++ b/api/src/State/ResendActivationProcessor.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\DTO\UserActivation;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Security\ReCaptcha\ReCaptchaWrapper;
+use App\Service\MailService;
+use App\Util\IdGenerator;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * @implements ProcessorInterface<UserActivation,null>
+ */
+readonly class ResendActivationProcessor implements ProcessorInterface {
+    public function __construct(
+        private ReCaptchaWrapper $reCaptcha,
+        private EntityManagerInterface $em,
+        private UserRepository $userRepository,
+        private MailService $mailService,
+    ) {}
+
+    /**
+     * @param UserActivation $data
+     *
+     * @throws NoResultException
+     * @throws NonUniqueResultException
+     */
+    public function process($data, Operation $operation, array $uriVariables = [], array $context = []): null {
+        $resp = $this->reCaptcha->verify($data->recaptchaToken);
+        if (!$resp->isSuccess()) {
+            throw new HttpException(422, 'ReCaptcha failed');
+        }
+
+        $user = $this->userRepository->loadUserByIdentifier($data->email);
+
+        if (null == $user) {
+            return null;
+        }
+
+        if (User::STATE_REGISTERED !== $user->state) {
+            return null;
+        }
+
+        $user->activationKey = IdGenerator::generateRandomHexString(64);
+        $user->activationKeyHash = md5($user->activationKey);
+        $this->em->flush();
+
+        $this->mailService->sendUserActivationMail($user, $user->activationKey);
+
+        return null;
+    }
+}

--- a/api/tests/Api/FirewallTest.php
+++ b/api/tests/Api/FirewallTest.php
@@ -113,6 +113,7 @@ class FirewallTest extends ECampApiTestCase {
             '/auth/cevidb' => false,
             '/auth/jubladb' => false,
             '/auth/reset_password' => false,
+            '/auth/resend_activation' => false,
             '/content_types' => false,
             '/invitations' => false,
             default => true

--- a/api/tests/Api/SnapshotTests/EndpointPerformanceTest.php
+++ b/api/tests/Api/SnapshotTests/EndpointPerformanceTest.php
@@ -227,6 +227,7 @@ class EndpointPerformanceTest extends ECampApiTestCase {
                 '/auth/cevidb' => false,
                 '/auth/jubladb' => false,
                 '/auth/reset_password' => false,
+                '/auth/resend_activation' => false,
                 '/invitations' => false,
                 '/personal_invitations' => false,
                 default => true

--- a/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
+++ b/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
@@ -113,6 +113,7 @@ class ResponseSnapshotTest extends ECampApiTestCase {
                 '/auth/cevidb' => false,
                 '/auth/jubladb' => false,
                 '/auth/reset_password' => false,
+                '/auth/resend_activation' => false,
                 '/invitations' => false,
                 '/personal_invitations' => false,
                 '/users' => false,

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
@@ -20667,6 +20667,84 @@ components:
         - password
         - profile
       type: object
+    UserActivation-create:
+      deprecated: false
+      description: ''
+      properties:
+        email:
+          type:
+            - 'null'
+            - string
+          writeOnly: true
+        recaptchaToken:
+          type:
+            - 'null'
+            - string
+          writeOnly: true
+      type: object
+    UserActivation.jsonapi:
+      deprecated: false
+      description: ''
+      properties:
+        data:
+          properties:
+            attributes:
+              properties:
+                email:
+                  type: ['null', string]
+                  writeOnly: true
+                recaptchaToken:
+                  type: ['null', string]
+                  writeOnly: true
+              type: object
+            id:
+              type: string
+            type:
+              type: string
+          required:
+            - id
+            - type
+          type: object
+      type: object
+    UserActivation.jsonhal-create:
+      deprecated: false
+      description: ''
+      properties:
+        _links:
+          properties:
+            self:
+              properties:
+                href:
+                  format: iri-reference
+                  type: string
+              type: object
+          type: object
+        email:
+          type:
+            - 'null'
+            - string
+          writeOnly: true
+        recaptchaToken:
+          type:
+            - 'null'
+            - string
+          writeOnly: true
+      type: object
+    UserActivation.jsonld-create:
+      deprecated: false
+      description: ''
+      properties:
+        email:
+          type:
+            - 'null'
+            - string
+          writeOnly: true
+        recaptchaToken:
+          type:
+            - 'null'
+            - string
+          writeOnly: true
+      type: object
   securitySchemes:
     JWT:
       bearerFormat: JWT
@@ -21497,6 +21575,54 @@ paths:
         - OAuth
     parameters: []
     ref: 'PBS MiData OAuth'
+  /auth/resend_activation:
+    parameters: []
+    post:
+      deprecated: false
+      description: 'Activation email will be sent to the given email again.'
+      operationId: api_authresend_activation_post
+      parameters: []
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+              $ref: '#/components/schemas/UserActivation.jsonhal-create'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserActivation-create'
+          application/ld+json:
+            schema:
+              $ref: '#/components/schemas/UserActivation.jsonld-create'
+          application/vnd.api+json:
+            schema:
+              $ref: '#/components/schemas/UserActivation.jsonapi'
+          text/html:
+            schema:
+              $ref: '#/components/schemas/UserActivation-create'
+        description: 'The new UserActivation resource'
+        required: true
+      responses:
+        204:
+          content:
+            application/hal+json:
+              schema: []
+            application/json:
+              schema: []
+            application/ld+json:
+              schema: []
+            application/vnd.api+json:
+              schema: []
+            text/html:
+              schema: []
+          description: 'UserActivation resource created'
+          links: []
+        400:
+          description: 'Invalid input'
+        422:
+          description: 'Unprocessable entity'
+      summary: 'Request activation email again'
+      tags:
+        - UserActivation
   /auth/reset_password:
     parameters: []
     post:

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testRootEndpointMatchesSnapshot__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testRootEndpointMatchesSnapshot__1.json
@@ -95,6 +95,10 @@
             "href": "\/profiles{\/id}{?user.collaborations.camp,user.collaborations.camp[]}",
             "templated": true
         },
+        "resendActivation": {
+            "href": "\/auth\/resend_activation",
+            "templated": false
+        },
         "resetPassword": {
             "href": "\/auth\/reset_password{\/id}",
             "templated": true

--- a/api/tests/Api/UserActivation/ResendActivationTest.php
+++ b/api/tests/Api/UserActivation/ResendActivationTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Api\UserActivation;
+
+use ApiPlatform\Metadata\Post;
+use App\Entity\User;
+use App\Tests\Api\ECampApiTestCase;
+
+/**
+ * @internal
+ */
+class ResendActivationTest extends ECampApiTestCase {
+    public function testPostResendActivationSendsActivationEmail() {
+        $client = static::createBasicClient();
+        // Disable resetting the database between the two requests
+        $client->disableReboot();
+
+        // register user
+        $result = $client->request(
+            'POST',
+            '/users',
+            [
+                'json' => $this->getExampleWriteUserPayload(),
+            ]
+        );
+        $this->assertResponseStatusCodeSame(201);
+
+        $userId = $result->toArray()['id'];
+        $user = $this->getEntityManager()->getRepository(User::class)->find($userId);
+
+        $client->request(
+            'POST',
+            '/auth/resend_activation',
+            [
+                'json' => [
+                    'email' => $user->getEmail(),
+                ],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(204);
+        self::assertEmailCount(1);
+        $mailerMessage = self::getMailerMessage();
+        self::assertEmailAddressContains($mailerMessage, 'To', $user->getEmail());
+        self::assertEmailHeaderSame($mailerMessage, 'subject', 'Welcome to eCamp v3');
+
+        self::assertEmailHtmlBodyContains($mailerMessage, $user->getDisplayName());
+        self::assertEmailHtmlBodyContains($mailerMessage, '/activate');
+
+        // and use activation code
+        $user = $this->getEntityManager()->getRepository(User::class)->find($userId);
+
+        // activate user
+        $client->request('PATCH', "/users/{$userId}/activate", ['json' => [
+            'activationKey' => $user->activationKey,
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseIsSuccessful();
+
+        // login
+        $client->request('POST', '/authentication_token', ['json' => [
+            'identifier' => 'bi-pi@example.com',
+            'password' => 'learning-by-doing-101',
+        ]]);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testPostResendActivationTrimsEmail() {
+        $client = static::createBasicClient();
+        // Disable resetting the database between the two requests
+        $client->disableReboot();
+
+        // register user
+        $result = $client->request(
+            'POST',
+            '/users',
+            [
+                'json' => $this->getExampleWriteUserPayload(),
+            ]
+        );
+        $this->assertResponseStatusCodeSame(201);
+
+        $userId = $result->toArray()['id'];
+        $user = $this->getEntityManager()->getRepository(User::class)->find($userId);
+
+        $client->request(
+            'POST',
+            '/auth/resend_activation',
+            [
+                'json' => [
+                    'email' => " {$user->getEmail()}\t ",
+                ],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(204);
+        self::assertEmailCount(1);
+    }
+
+    public function testPostResendActivationInvalidatesPreviousValidationKey() {
+        $client = static::createBasicClient();
+        // Disable resetting the database between the two requests
+        $client->disableReboot();
+
+        // register user
+        $result = $client->request(
+            'POST',
+            '/users',
+            [
+                'json' => $this->getExampleWriteUserPayload(),
+            ]
+        );
+        $this->assertResponseStatusCodeSame(201);
+
+        $userId = $result->toArray()['id'];
+        $user = $this->getEntityManager()->getRepository(User::class)->find($userId);
+
+        $activationKey = 'myActivationKey';
+        $user->activationKeyHash = md5($activationKey);
+        $this->getEntityManager()->persist($user);
+        $this->getEntityManager()->flush();
+
+        $client->request(
+            'POST',
+            '/auth/resend_activation',
+            [
+                'json' => [
+                    'email' => " {$user->getEmail()}\t ",
+                ],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(204);
+        self::assertEmailCount(1);
+
+        // activate user
+        $client->request('PATCH', "/users/{$userId}/activate", ['json' => [
+            'activationKey' => $activationKey,
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPostResendActivationReturns204ForUnknownEmailButSendsNoEmails() {
+        $this->createBasicClient()->request(
+            'POST',
+            '/auth/resend_activation',
+            [
+                'json' => [
+                    'email' => 'a@b.com',
+                ],
+            ]
+        );
+
+        $this->assertResponseStatusCodeSame(204);
+        self::assertEmailCount(0);
+    }
+
+    public function getExampleWriteUserPayload($attributes = [], $except = [], $mergeEmbeddedAttributes = []) {
+        $examplePayload = $this->getExamplePayload(
+            User::class,
+            Post::class,
+            $attributes,
+            [],
+            $except
+        );
+
+        return array_replace_recursive($examplePayload, $mergeEmbeddedAttributes);
+    }
+}

--- a/api/tests/Serializer/Normalizer/UriTemplateNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/UriTemplateNormalizerTest.php
@@ -46,6 +46,9 @@ class UriTemplateNormalizerTest extends TestCase {
                 case 'connect_jubladb_start':
                     return '/auth/jubladb';
 
+                case '_api_/auth/resend_activation{._format}_post':
+                    return '/auth/resend_activation';
+
                 case '_api_/auth/reset_password{._format}_post':
                     return '/auth/reset_password';
 
@@ -80,6 +83,10 @@ class UriTemplateNormalizerTest extends TestCase {
             'oauthJubladb' => [
                 'href' => '/auth/jubladb{?callback}',
                 'templated' => true,
+            ],
+            'resendActivation' => [
+                'href' => '/auth/resend_activation',
+                'templated' => false,
             ],
             'resetPassword' => [
                 'href' => '/auth/reset_password{/id}',

--- a/api/tests/State/ResendActivationProcessorTest.php
+++ b/api/tests/State/ResendActivationProcessorTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace State;
+
+use ApiPlatform\Metadata\Post;
+use App\DTO\UserActivation;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Security\ReCaptcha\ReCaptchaWrapper;
+use App\Service\MailService;
+use App\State\ResendActivationProcessor;
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReCaptcha\Response;
+
+use function PHPUnit\Framework\isNull;
+use function PHPUnit\Framework\logicalNot;
+
+/**
+ * @internal
+ */
+class ResendActivationProcessorTest extends TestCase {
+    public const EMAIL = 'a@b.com';
+
+    private UserActivation $userActivation;
+
+    private MockObject|Response $recaptchaResponse;
+    private MockObject|UserRepository $userRepository;
+    private MailService|MockObject $mailService;
+
+    /**
+     * @throws Exception
+     */
+    protected function setUp(): void {
+        $this->userActivation = new UserActivation();
+
+        $this->recaptchaResponse = $this->createMock(Response::class);
+        $recaptcha = $this->createMock(ReCaptchaWrapper::class);
+        $entityManager = $this->createMock(EntityManager::class);
+        $this->userRepository = $this->createMock(UserRepository::class);
+        $this->mailService = $this->createMock(MailService::class);
+
+        $recaptcha->expects(self::any())
+            ->method('verify')
+            ->willReturn($this->recaptchaResponse)
+        ;
+
+        $this->processor = new ResendActivationProcessor(
+            $recaptcha,
+            $entityManager,
+            $this->userRepository,
+            $this->mailService
+        );
+    }
+
+    public function testCreateRequiresReCaptcha() {
+        $this->recaptchaResponse->expects(self::once())
+            ->method('isSuccess')
+            ->willReturn(false)
+        ;
+        $this->userActivation->recaptchaToken = 'token';
+
+        $this->expectException(\Exception::class);
+        $this->processor->process($this->userActivation, new Post());
+    }
+
+    public function testCreateWithUnknownEmailDoesNothing() {
+        $this->recaptchaResponse->expects(self::once())
+            ->method('isSuccess')
+            ->willReturn(true)
+        ;
+        $this->userRepository->expects(self::once())
+            ->method('loadUserByIdentifier')
+            ->willReturn(null)
+        ;
+        $this->mailService->expects(self::never())
+            ->method('sendPasswordResetLink')
+        ;
+
+        $this->userActivation->recaptchaToken = 'token';
+        $this->userActivation->email = self::EMAIL;
+
+        $data = $this->processor->process($this->userActivation, new Post());
+
+        self::assertThat($data, self::isNull());
+    }
+
+    #[TestWith([User::STATE_REGISTERED])]
+    public function testCreateWithInactiveUserResendsActivationeMail(string $state) {
+        $this->recaptchaResponse->expects(self::once())
+            ->method('isSuccess')
+            ->willReturn(true)
+        ;
+        $user = new User();
+        $user->state = $state;
+        $user->activationKey = 'activationKey';
+        $user->activationKeyHash = 'activationKey';
+
+        $this->userRepository->expects(self::once())
+            ->method('loadUserByIdentifier')
+            ->with(self::EMAIL)
+            ->willReturn($user)
+        ;
+
+        $this->mailService->expects(self::once())
+            ->method('sendUserActivationMail')
+            ->with($user, logicalNot(isNull()))
+        ;
+
+        $this->userActivation->recaptchaToken = 'token';
+        $this->userActivation->email = self::EMAIL;
+        $data = $this->processor->process($this->userActivation, new Post());
+
+        self::assertThat($data, self::isNull());
+    }
+
+    #[TestWith([User::STATE_NONREGISTERED])]
+    #[TestWith([User::STATE_ACTIVATED])]
+    #[TestWith([User::STATE_DELETED])]
+    public function testCreateWithActiveOrDeletedUserDoesNothing(string $state) {
+        $this->recaptchaResponse->expects(self::once())
+            ->method('isSuccess')
+            ->willReturn(true)
+        ;
+        $user = new User();
+        $user->state = $state;
+        $user->activationKey = 'activationKey';
+        $user->activationKeyHash = 'activationKey';
+
+        $this->userRepository->expects(self::once())
+            ->method('loadUserByIdentifier')
+            ->with(self::EMAIL)
+            ->willReturn($user)
+        ;
+
+        $this->mailService->expects(self::never())
+            ->method('sendUserActivationMail')
+        ;
+
+        $this->userActivation->recaptchaToken = 'token';
+        $this->userActivation->email = self::EMAIL;
+        $data = $this->processor->process($this->userActivation, new Post());
+
+        self::assertThat($data, self::isNull());
+    }
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -587,6 +587,7 @@
           "loginInProgress": "Du wirst eingeloggt"
         },
         "or": "oder mit",
+        "notActivated": "Nicht aktiviert?",
         "password": "Passwort",
         "passwordForgotten": "Passwort vergessen?",
         "provider": {
@@ -597,6 +598,8 @@
           "midata": "MiData"
         },
         "registernow": "Jetzt registrieren",
+        "resendActivation": "Aktivierungsmail erneut senden",
+        "resetPassword": "Passwort zurücksetzen",
         "termsOfServiceLink": "Nutzungsbedingungen"
       },
       "register": {
@@ -611,6 +614,12 @@
         "message": "Wir haben dir eine Mail geschickt. Bitte schliesse die Registrierung ab, in dem du den Aktivierungs-Link im Mail aufrufst.",
         "success": "Erfolgreich registriert",
         "title": "Konto erstellen"
+      },
+      "resendActivation": {
+        "errorMessage": "Erneutes Senden der Aktivierung fehlgeschlagen.",
+        "send": "Abschicken",
+        "successMessage": "Mail mit Link für 'Aktivierung' wird versendet.",
+        "title": "Aktivierungsmail erneut senden"
       },
       "resetPassword": {
         "errorMessage": "Passwort konnte nicht geändert werden.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -586,6 +586,7 @@
         "loginCallback": {
           "loginInProgress": "You will be logged in"
         },
+        "notActivated": "Not activated?",
         "or": "or with",
         "password": "Password",
         "passwordForgotten": "Forgotten your password?",
@@ -597,6 +598,8 @@
           "midata": "MiData"
         },
         "registernow": "Register now",
+        "resendActivation": "Send activation email again",
+        "resetPassword": "Reset password",
         "termsOfServiceLink": "terms of service"
       },
       "register": {
@@ -611,6 +614,12 @@
         "message": "We sent you an email. Please complete your registration by clicking the activation-link in the email",
         "success": "Successfully registered",
         "title": "Create account"
+      },
+      "resendActivation": {
+        "errorMessage": "Sending the activation email again failed.",
+        "send": "Send",
+        "successMessage": "Mail with link to activate your account will be delivered.",
+        "title": "Send activation email again"
       },
       "resetPassword": {
         "errorMessage": "Reset password failed.",

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -72,6 +72,11 @@ async function resetPassword(id, password, recaptchaToken) {
   return apiStore.patch(url, { password: password, recaptchaToken: recaptchaToken })
 }
 
+async function resendUserActivation(email, recaptchaToken) {
+  const url = await apiStore.href(apiStore.get(), 'resendActivation')
+  return apiStore.post(url, { email: email, recaptchaToken: recaptchaToken })
+}
+
 async function loadUser() {
   if (!getJWTPayloadFromCookie()) {
     store.commit('logout')
@@ -165,6 +170,7 @@ export const auth = {
   loadUser,
   resetPasswordRequest,
   resetPassword,
+  resendUserActivation,
 }
 
 class AuthPlugin {

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -64,6 +64,14 @@ export default new Router({
       },
     },
     {
+      path: '/resend-activation',
+      name: 'resendActivation',
+      components: {
+        navigation: NavigationAuth,
+        default: () => import('./views/auth/ResendActivation.vue'),
+      },
+    },
+    {
       path: '/reset-password',
       name: 'resetPasswordRequest',
       components: {

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -24,7 +24,19 @@
       </div>
     </v-alert>
     <v-alert v-if="error" outlined text border="left" type="error">
-      {{ error }}
+      <span class="d-block">{{ error }}</span>
+      <span class="d-block mt-1"
+        >{{ $tc('views.auth.login.passwordForgotten') }}
+        <router-link :to="{ name: 'resetPasswordRequest' }">
+          {{ $tc('views.auth.login.resetPassword') }}
+        </router-link>
+      </span>
+      <span class="d-block mt-1"
+        >{{ $tc('views.auth.login.notActivated') }}
+        <router-link :to="{ name: 'resendActivation' }">
+          {{ $tc('views.auth.login.resendActivation') }}
+        </router-link>
+      </span>
     </v-alert>
     <v-form @submit.prevent="login">
       <e-text-field

--- a/frontend/src/views/auth/ResendActivation.vue
+++ b/frontend/src/views/auth/ResendActivation.vue
@@ -1,0 +1,104 @@
+<template>
+  <auth-container>
+    <h1 class="display-1 text-center mb-4">
+      {{ $tc('views.auth.resendActivation.title') }}
+    </h1>
+
+    <v-alert v-if="status === 'success'" type="success">
+      {{ $tc('views.auth.resendActivation.successMessage') }}
+    </v-alert>
+
+    <v-alert v-if="status === 'error'" type="error">
+      {{ $tc('views.auth.resendActivation.errorMessage') }}
+    </v-alert>
+
+    <v-form
+      v-if="status === 'mounted' || status === 'sending'"
+      @submit.prevent="resendActivationEmail"
+    >
+      <e-text-field
+        v-model="email"
+        :label="$tc('entity.user.fields.email')"
+        name="email"
+        vee-rules="email"
+        append-icon="mdi-at"
+        :dense="$vuetify.breakpoint.xsOnly"
+        type="email"
+        autocomplete="username"
+        autofocus
+      />
+      <v-btn
+        type="submit"
+        block
+        :color="email ? 'blue darken-2' : 'blue lightne-4'"
+        :disabled="!email"
+        outlined
+        :x-large="$vuetify.breakpoint.smAndUp"
+        class="my-4"
+      >
+        <v-progress-circular v-if="status === 'sending'" indeterminate size="24" />
+        <v-icon v-else>$vuetify.icons.ecamp</v-icon>
+        <v-spacer />
+        <span>{{ $tc('views.auth.resendActivation.send') }}</span>
+        <v-spacer />
+        <icon-spacer />
+      </v-btn>
+    </v-form>
+    <p class="mt-8 mb0 text--secondary text-center">
+      <router-link :to="{ name: 'login' }">
+        {{ $tc('global.button.login') }}
+      </router-link>
+    </p>
+  </auth-container>
+</template>
+
+<script>
+import { load } from 'recaptcha-v3'
+import { getEnv } from '@/environment.js'
+import AuthContainer from '@/components/layout/AuthContainer.vue'
+import IconSpacer from '@/components/layout/IconSpacer.vue'
+
+export default {
+  name: 'ResetPasswordRequest',
+  components: { IconSpacer, AuthContainer },
+
+  data() {
+    return {
+      email: '',
+      status: 'mounted',
+      recaptcha: null,
+    }
+  },
+
+  mounted() {
+    if (getEnv().RECAPTCHA_SITE_KEY) {
+      this.recaptcha = load(getEnv().RECAPTCHA_SITE_KEY, {
+        explicitRenderParameters: {
+          badge: 'bottomleft',
+        },
+      })
+    }
+  },
+
+  methods: {
+    async resendActivationEmail() {
+      this.status = 'sending'
+
+      let recaptchaToken = null
+      if (this.recaptcha) {
+        const recaptcha = await this.recaptcha
+        recaptchaToken = await recaptcha.execute('login')
+      }
+
+      this.$auth
+        .resendUserActivation(this.email, recaptchaToken)
+        .then(() => {
+          this.status = 'success'
+        })
+        .catch(() => {
+          this.status = 'error'
+        })
+    },
+  },
+}
+</script>


### PR DESCRIPTION
In case the first email is lost,
you can now send again an activation key,
which now may arrive at your email.

closes #4670