### PR TITLE
fix api performance_test

### DIFF
--- a/api/config/packages/performance_test/http_cache.yaml
+++ b/api/config/packages/performance_test/http_cache.yaml
@@ -1,0 +1,2 @@
+imports:
+    - resource: ../test/http_cache.yaml

--- a/api/tests/Api/SnapshotTests/__snapshots__/performance_test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/performance_test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
@@ -4,10 +4,10 @@
 /activity_progress_labels/item: 7
 /activity_responsibles: 6
 /activity_responsibles/item: 8
-/camps: 39
-/camps/item: 32
-/camp_collaborations: 25
-/camp_collaborations/item: 25
+/camps: 36
+/camps/item: 31
+/camp_collaborations: 22
+/camp_collaborations/item: 24
 /categories: 11
 /categories/item: 9
 /content_types: 6
@@ -21,7 +21,7 @@
 /material_lists: 6
 /material_lists/item: 7
 /periods: 6
-/periods/item: 28
+/periods/item: 27
 /profiles: 6
 /profiles/item: 6
 /schedule_entries: 23
@@ -30,8 +30,8 @@
 '/activities?camp=': 213
 '/activity_progress_labels?camp=': 6
 '/activity_responsibles?activity.camp=': 6
-'/camp_collaborations?camp=': 13
-'/camp_collaborations?activityResponsibles.activity=': 25
+'/camp_collaborations?camp=': 12
+'/camp_collaborations?activityResponsibles.activity=': 24
 '/categories?camp=': 9
 '/content_types?categories=': 6
 '/day_responsibles?day.period=': 6


### PR DESCRIPTION
We also need to use the noop proxy client for the performance_tests.
And we need to update the snapshots again, they are not right anymore.