### PR TITLE
fix PurgeHttpCacheListener

### DIFF
--- a/api/src/HttpCache/PurgeHttpCacheListener.php
+++ b/api/src/HttpCache/PurgeHttpCacheListener.php
@@ -125,19 +125,22 @@ final class PurgeHttpCacheListener {
      * (e.g. for updating period on a ScheduleEntry and the IRI changes from /periods/1/schedule_entries to /periods/2/schedule_entries)
      */
     private function gatherResourceTags(object $entity, ?object $oldEntity = null): void {
-        $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
-        $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
-        $resourceIterator = $resourceMetadataCollection->getIterator();
-        while ($resourceIterator->valid()) {
-            /** @var ApiResource $metadata */
-            $metadata = $resourceIterator->current();
+        $entityClass = $this->getObjectClass($entity);
+        if ($this->resourceClassResolver->isResourceClass($entityClass)) {
+            $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
+            $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
+            $resourceIterator = $resourceMetadataCollection->getIterator();
+            while ($resourceIterator->valid()) {
+                /** @var ApiResource $metadata */
+                $metadata = $resourceIterator->current();
 
-            foreach ($metadata->getOperations() ?? [] as $operation) {
-                if ($operation instanceof GetCollection) {
-                    $this->invalidateCollection($operation, $entity, $oldEntity);
+                foreach ($metadata->getOperations() ?? [] as $operation) {
+                    if ($operation instanceof GetCollection) {
+                        $this->invalidateCollection($operation, $entity, $oldEntity);
+                    }
                 }
+                $resourceIterator->next();
             }
-            $resourceIterator->next();
         }
     }
 

--- a/api/tests/HttpCache/PurgeHttpCacheListenerTest.php
+++ b/api/tests/HttpCache/PurgeHttpCacheListenerTest.php
@@ -268,6 +268,39 @@ class PurgeHttpCacheListenerTest extends TestCase {
     }
 
     public function testNotAResourceClass(): void {
+        $nonResource = new NotAResource('foo', 'bar');
+
+        $cacheManagerProphecy = $this->prophesize(CacheManager::class);
+        $cacheManagerProphecy->invalidateTags(Argument::any())->shouldNotBeCalled();
+        $cacheManagerProphecy->flush(Argument::any())->willReturn(0);
+
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getIriFromResource($nonResource)->shouldNotBeCalled();
+
+        $metadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(NotAResource::class)->willReturn(false)->shouldBeCalled();
+
+        $uowProphecy = $this->prophesize(UnitOfWork::class);
+        $uowProphecy->getScheduledEntityInsertions()->willReturn([$nonResource])->shouldBeCalled();
+        $uowProphecy->getScheduledEntityDeletions()->willReturn([])->shouldBeCalled();
+        $uowProphecy->getScheduledEntityUpdates()->willReturn([])->shouldBeCalled();
+
+        $emProphecy = $this->prophesize(EntityManagerInterface::class);
+        $emProphecy->getUnitOfWork()->willReturn($uowProphecy->reveal())->shouldBeCalled();
+
+        $dummyClassMetadata = new ClassMetadata(ContainNonResource::class);
+        $emProphecy->getClassMetadata(NotAResource::class)->willReturn($dummyClassMetadata);
+        $eventArgs = new OnFlushEventArgs($emProphecy->reveal());
+
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+
+        $listener = new PurgeHttpCacheListener($iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(), $metadataFactoryProphecy->reveal(), $cacheManagerProphecy->reveal());
+        $listener->onFlush($eventArgs);
+    }
+
+    public function testPropertyIsNotAResourceClass(): void {
         $containNonResource = new ContainNonResource();
         $nonResource = new NotAResource('foo', 'bar');
 

--- a/api/tests/HttpCache/PurgeHttpCacheListenerTest.php
+++ b/api/tests/HttpCache/PurgeHttpCacheListenerTest.php
@@ -287,6 +287,7 @@ class PurgeHttpCacheListenerTest extends TestCase {
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $resourceClassResolverProphecy->getResourceClass(Argument::type(ContainNonResource::class))->willReturn(ContainNonResource::class)->shouldBeCalled();
+        $resourceClassResolverProphecy->isResourceClass(ContainNonResource::class)->willReturn(true)->shouldBeCalled();
         $resourceClassResolverProphecy->isResourceClass(NotAResource::class)->willReturn(false)->shouldBeCalled();
 
         $uowProphecy = $this->prophesize(UnitOfWork::class);


### PR DESCRIPTION
Ignore entities not exposed by the API

Example:
Accessing Google OAuth

OAuthState is not part of the API (has no ApiPlatform Metadata).
But PurgeHttpCacheListener is called with this Entity.

