### PR TITLE
ecamp3-logging: switch to self built fluentd image

### DIFF
--- a/.ops/ecamp3-logging/values.yaml
+++ b/.ops/ecamp3-logging/values.yaml
@@ -19,6 +19,9 @@ fluent-operator:
     watchedNamespaces:
       - default
       - ingress-nginx
+    image: 
+      repository: bacluc/fluentd
+      tag: 1.15.3
     enable: true
 
 fluentd:


### PR DESCRIPTION
This is the image:
https://github.com/fluent/fluent-operator/blob/2de2b934e4d9f4475e278da7d9db74d89ef9a037/cmd/fluent-watcher/fluentd/Dockerfile.amd64 built in a devcontainer of the repository and then pushed to dockerhub. The command to build the container was:
@BacLuc ➜ /workspaces/fluent-operator (master) $ docker build . -f cmd/fluent-watcher/fluentd/Dockerfile.amd64 -t docker.io/bacluc/fluentd:1.15.3

They seem to have problem with the images they publish in the fluent-operator repository. It also contains the following fix: https://github.com/fluent/fluent-operator/pull/1195