### PR TITLE
ops-dashboard: fix chart name

### DIFF
--- a/.ops/ops-dashboard/Chart.yaml
+++ b/.ops/ops-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: ecamp3-logging
+name: ops-dashboard
 description: Helm chart for deploying ops-dashboard cluster
 home: https://github.com/ecamp/ecamp3
 


### PR DESCRIPTION
This was a copy and paste error.