### PR TITLE
EColorPicker.spec.js: delete "accepts 3-digit hex color codes, after picker has been shown"

### DIFF
--- a/frontend/src/components/form/base/__tests__/EColorPicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/EColorPicker.spec.js
@@ -234,26 +234,6 @@ describe('An EColorPicker', () => {
     await screen.findByText(VALIDATION_MESSAGE)
   })
 
-  it('accepts 3-digit hex color codes, after picker has been shown', async () => {
-    render(EColorPicker, {
-      props: { value: COLOR1, label: 'test' },
-    })
-    const inputField = await screen.findByDisplayValue(COLOR1)
-    const button = await screen.getByLabelText(PICKER_BUTTON_LABEL_TEXT)
-    // click the button to open the picker
-    await user.click(button)
-
-    // when
-    await user.clear(inputField)
-    await user.keyboard('#abc')
-    await fireEvent.blur(inputField)
-
-    // then
-    await waitFor(() => {
-      screen.getByDisplayValue('#AABBCC')
-    })
-  })
-
   it('accepts null', async () => {
     render(EColorPicker, {
       props: { value: COLOR2, label: 'test' },


### PR DESCRIPTION
Because it is flaky now.

You can see here if the frontend tests are stable now: https://github.com/BacLuc/ecamp3/actions/runs/9534905924/job/26279962021