### PR TITLE
ecamp3-logging: switch back to fluent-operator image

### DIFF
--- a/.ops/ecamp3-logging/values.yaml
+++ b/.ops/ecamp3-logging/values.yaml
@@ -19,9 +19,6 @@ fluent-operator:
     watchedNamespaces:
       - default
       - ingress-nginx
-    image: 
-      repository: bacluc/fluentd
-      tag: 1.15.3
     enable: true
 
 fluentd:


### PR DESCRIPTION
They use ghcr.io/fluent/fluent-operator/fluentd:v1.17.0 with v2.9.0, which seems to work again.

closes #5320