### PR TITLE
ecamp3-logging: strip prefix "{datetime} std(out|err) F " in fluentd

### DIFF
--- a/.ops/ecamp3-logging/templates/fluentd/fluentd_clusterfilter.yaml
+++ b/.ops/ecamp3-logging/templates/fluentd/fluentd_clusterfilter.yaml
@@ -12,6 +12,13 @@ spec:
     - customPlugin:
         config: |
           <filter **>
+            @type record_transformer
+            enable_ruby
+            <record>
+              log ${record['log'].gsub(/^.*stdout F {/, "{")}
+            </record>
+          </filter>
+          <filter **>
             @type parser
             key_name log
             reserve_data true

--- a/.ops/ecamp3-logging/templates/fluentd/fluentd_clusterfilter.yaml
+++ b/.ops/ecamp3-logging/templates/fluentd/fluentd_clusterfilter.yaml
@@ -15,7 +15,7 @@ spec:
             @type record_transformer
             enable_ruby
             <record>
-              log ${record['log'].gsub(/^.*stdout F {/, "{")}
+              log ${record['log'].gsub(/^.*std(out|err) F {/, "{")}
             </record>
           </filter>
           <filter **>


### PR DESCRIPTION
---
ecamp3-logging: strip prefix "{datetime} stdout F " in fluentd

Before this was done by fluent-bit automatically with the tail clusterinput, when the container engine was set to containerd. Since fluent-operator helm chart 2.8.0, this does not work anymore. -> Thus we do it with fluentd.

After stripping this prefix, we can do the json parsing.

----

ecamp3-logging: also strip stderr of log messages

This allows us to also parse the messages
of Caddy as json.