### PR TITLE
enables renovate updates for frankenphp

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,11 +2,8 @@
 
 # Adapted from https://github.com/api-platform/api-platform/blob/fa1c5808305d7cadbf7b8392e0fddb6e80fb2092/api/Dockerfile
 
-# renovate: datasource=docker depName=php
-ARG PHP_VERSION=8.3.7
-
 # Versions
-FROM dunglas/frankenphp:1.1.4-php${PHP_VERSION} AS frankenphp_upstream
+FROM dunglas/frankenphp:1.1-php8.3.7 AS frankenphp_upstream
 
 # the different stages of this Dockerfile are meant to be built into separate images
 # https://docs.docker.com/develop/develop-images/multistage-build/#stop-at-a-specific-build-stage

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,6 @@
       "dependencyDashboardApproval": true,
       "groupName": "vue-major-print-pdf"
     },
-
     {
       "extends": [
         "monorepo:vue"
@@ -86,9 +85,11 @@
     },
     {
       "matchPackageNames": [
-        "php"
+        "php",
+        "dunglas/frankenphp"
       ],
-      "automerge": false
+      "automerge": false,
+      "groupName": "php"
     },
     {
       "matchPackagePatterns": [
@@ -118,6 +119,12 @@
         "browserless/chrome"
       ],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<compatibility>\\w+)-(?<build>\\d+)\\.(\\d+)\\.(\\d+)?$"
+    },
+    {
+      "matchPackageNames": [
+        "dunglas/frankenphp"
+      ],
+      "versioning": "regex:^(?<build>\\d+)\\.(?<revision>\\d+)-(?<compatibility>\\w+)(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
Frankenphp uses 2 version numbers in its docker tags (frankenphp version and php version), so this needs an additional regex to tell renovate about this version template 

I used php as the leading version (major, minor, patch), so we can synchronize with the other php upgrades.

Frankenphp used 4th and 5th position (build and revision). Unfortunately, renovate doesn't support a sixth version number, so we have to live without pinning the patch version for frankenphp.

Example PR from renovate on my own repo:
https://github.com/usu/ecamp3/pull/20