### PR TITLE
Fix expired oauth state cookie

### DIFF
--- a/api/src/OAuth/JWTStateOAuth2Client.php
+++ b/api/src/OAuth/JWTStateOAuth2Client.php
@@ -31,7 +31,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * longer-living token and with parts of the cookie available to JavaScript.
  */
 class JWTStateOAuth2Client extends OAuth2Client implements OAuth2ClientInterface {
-    public const JWT_TTL = 300; // seconds, i.e. 5 minutes of validity for the JWT token
+    public const JWT_TTL = 900; // seconds, i.e. 15 minutes of validity for the JWT token
 
     public function __construct(
         AbstractProvider $provider,
@@ -101,7 +101,7 @@ class JWTStateOAuth2Client extends OAuth2Client implements OAuth2ClientInterface
     /**
      * Checks the validity of the temporary JWT cookie, and checks that the state parameter is correct.
      * Any irregularities would indicate someone tampering with the login system (or someone taking longer
-     * than 5 minutes to authenticate with the external service...)
+     * than 15 minutes to authenticate with the external service...)
      * After this custom state parameter check, we delegate to the original implementation to finish the OAuth
      * flow.
      *

--- a/api/src/OAuth/JWTStateOAuth2Client.php
+++ b/api/src/OAuth/JWTStateOAuth2Client.php
@@ -109,6 +109,10 @@ class JWTStateOAuth2Client extends OAuth2Client implements OAuth2ClientInterface
      */
     public function getAccessToken(array $options = []): AccessTokenInterface {
         $jwt = $this->getCurrentRequest()->cookies->get($this->getCookieName($this->cookiePrefix));
+        if (null === $jwt) {
+            throw new InvalidStateException('Expired state');
+        }
+
         $actualState = $this->getCurrentRequest()->get('state');
 
         try {

--- a/api/src/Security/OAuth/GoogleAuthenticator.php
+++ b/api/src/Security/OAuth/GoogleAuthenticator.php
@@ -12,6 +12,7 @@ use League\OAuth2\Client\Provider\GoogleUser;
 use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -100,6 +101,6 @@ class GoogleAuthenticator extends OAuth2Authenticator {
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response {
         $message = strtr($exception->getMessageKey(), $exception->getMessageData());
 
-        return new Response($message, Response::HTTP_FORBIDDEN);
+        return new JsonResponse(['message' => $message, 'code' => Response::HTTP_FORBIDDEN], Response::HTTP_FORBIDDEN);
     }
 }

--- a/api/src/Security/OAuth/HitobitoAuthenticator.php
+++ b/api/src/Security/OAuth/HitobitoAuthenticator.php
@@ -13,6 +13,7 @@ use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -107,6 +108,6 @@ class HitobitoAuthenticator extends OAuth2Authenticator {
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response {
         $message = strtr($exception->getMessageKey(), $exception->getMessageData());
 
-        return new Response($message, Response::HTTP_FORBIDDEN);
+        return new JsonResponse(['message' => $message, 'code' => Response::HTTP_FORBIDDEN], Response::HTTP_FORBIDDEN);
     }
 }


### PR DESCRIPTION
Improve https://ecamp.sentry.io/issues/3531734868/?project=5912620

We could also display a nicer error message in the frontend to the user in this case, but I'm still working on passing an error message to the frontend, when we don't even have the temporary cookie to know where the frontend is...