### PR TITLE
CI: use image in docker compose again to run e2e tests

### DIFF
--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -52,12 +52,15 @@ jobs:
       # start necessary containers
       - run: docker compose up -d api frontend pdf print browserless database docker-host http-cache mail
 
-      - uses: cypress-io/github-action@v6.7.1
-        with:
-          working-directory: e2e
-          browser: ${{ matrix.browser }}
-          wait-on: 'http://localhost:3000, http://localhost:3000/api, http://localhost:3000/print/health'
-          wait-on-timeout: 300
+      # pull cypress while container are starting up
+      - run: docker compose pull e2e
+
+      - run: sh -x wait-for-container-startup.sh
+
+      - run: docker compose --profile e2e run --rm e2e --browser ${{ matrix.browser }}
+
+      - run: sudo chown -R $USER e2e
+        if: always()
 
       # store screenshots and videos on GitHub as artifacts, for downloading and debugging in case of problems
       - uses: actions/upload-artifact@v4

--- a/wait-for-container-startup.sh
+++ b/wait-for-container-startup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+echo "Waiting for API container to start up and migrate DB..."
+until curl --output /dev/null --silent --fail http://localhost:3000/api
+do
+  sleep 2
+done
+echo "API container is ready."
+
+echo "Waiting for print container to start up..."
+until curl --output /dev/null --silent --fail http://localhost:3000/print/health
+do
+  sleep 2
+done
+echo "Frontend container is ready."
+
+echo "Waiting for frontend container to start up..."
+until curl --output /dev/null --silent --fail http://localhost:3000
+do
+  sleep 2
+done
+echo "Frontend container is ready."


### PR DESCRIPTION
If it is more stable you can see here:
https://github.com/BacLuc/ecamp3/actions/runs/9618853598

And compare it with:

https://github.com/ecamp/ecamp3/actions/workflows/e2e-tests.yml?query=event%3Aschedule