### PR TITLE
Fix overflow with long words/URLs

### DIFF
--- a/frontend/src/components/form/tiptap/TiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/TiptapEditor.vue
@@ -349,6 +349,7 @@ div.editor:deep(.editor__content .ProseMirror) {
   outline: none;
   color: rgba(0, 0, 0, 0.87);
   line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 .theme--light.v-input--is-disabled div.editor:deep(.editor__content .ProseMirror) {

--- a/pdf/src/CampPrint.vue
+++ b/pdf/src/CampPrint.vue
@@ -25,6 +25,9 @@ import Picasso from '@/campPrint/picasso/Picasso.vue'
 import Story from '@/campPrint/story/Story.vue'
 import Program from '@/campPrint/program/Program.vue'
 import Activity from '@/campPrint/activity/Activity.vue'
+import { wordHyphenation } from '@react-pdf/textkit'
+
+const originalHyphenationCallback = wordHyphenation()
 
 export default {
   name: 'CampPrint',
@@ -47,6 +50,13 @@ export default {
 }
 
 const registerFonts = async () => {
+  Font.registerHyphenationCallback((word) => {
+    if (word && word.length > 70) {
+      return word.split('')
+    }
+    return originalHyphenationCallback(word)
+  })
+
   Font.register({
     family: 'InterDisplay',
     fonts: [

--- a/print/assets/tailwind.css
+++ b/print/assets/tailwind.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/*
+ * TODO: Remove once https://github.com/tailwindlabs/tailwindcss/pull/12128 is merged
+ */
+.tw-break-anywhere {
+  overflow-wrap: anywhere;
+}

--- a/print/components/generic/RichText.vue
+++ b/print/components/generic/RichText.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -->
-  <div class="tw-prose tw-prose-neutral wrap-anywhere" v-html="purifiedHtml" />
+  <div class="tw-prose tw-prose-neutral tw-break-anywhere" v-html="purifiedHtml" />
 </template>
 
 <script>
@@ -23,9 +23,3 @@ export default {
   },
 }
 </script>
-
-<style lang="scss">
-.wrap-anywhere {
-  word-wrap: anywhere;
-}
-</style>

--- a/print/components/generic/RichText.vue
+++ b/print/components/generic/RichText.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- eslint-disable-next-line vue/no-v-html -->
-  <div class="tw-prose tw-prose-neutral" v-html="purifiedHtml" />
+  <div class="tw-prose tw-prose-neutral wrap-anywhere" v-html="purifiedHtml" />
 </template>
 
 <script>
@@ -23,3 +23,9 @@ export default {
   },
 }
 </script>
+
+<style lang="scss">
+.wrap-anywhere {
+  word-wrap: anywhere;
+}
+</style>

--- a/print/components/scheduleEntry/contentNode/Material.vue
+++ b/print/components/scheduleEntry/contentNode/Material.vue
@@ -2,7 +2,11 @@
   <content-node-content :content-node="contentNode" :icon-path="mdiPackageVariant">
     <generic-error-message v-if="error" :error="error" />
     <table v-else>
-      <tr v-for="item in items" :key="item.id" class="item tw-tabular-nums">
+      <tr
+        v-for="item in items"
+        :key="item.id"
+        class="item tw-tabular-nums tw-break-anywhere"
+      >
         <td align="right">
           {{ item.quantity }}
         </td>

--- a/print/components/scheduleEntry/contentNode/Storyboard.vue
+++ b/print/components/scheduleEntry/contentNode/Storyboard.vue
@@ -14,7 +14,7 @@
           </th>
         </tr>
       </thead>
-      <tbody>
+      <tbody class="tw-break-anywhere">
         <tr v-for="(section, key) in sections" :key="key">
           <td class="column column1 tw-tabular-nums tw-text-right">
             {{ section.column1 }}


### PR DESCRIPTION
Uses the `overflow-wrap` instead of the nonstandard `word-wrap` property of #5448 

Fixes https://github.com/ecamp/ecamp3/issues/5446