### PR TITLE
continuous-integration.yml: disable concurrent_skipping

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,7 +33,6 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
           paths: |
             [
@@ -50,7 +49,6 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
           paths: |
             [


### PR DESCRIPTION
The default is 'never'.
https://github.com/fkirc/skip-duplicate-actions/tree/84931c63f7562abc89860097e0caf563c7b87f65?tab=readme-ov-file#concurrent_skipping

Reason: the skipped checks of push or pull_request finish before the other. If the other fails, we have a PR with failed checks in the devel branch.