### PR TITLE
renovate.json: do not update @vue/test-utils for frontend anymore

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -80,6 +80,16 @@
     },
     {
       "matchDepNames": [
+        "@vue/test-utils"
+      ],
+      "matchFileNames": [
+        "frontend/package.json"
+      ],
+      "dependencyDashboardApproval": true,
+      "groupName": "vue-test-utils-frontend"
+    },
+    {
+      "matchDepNames": [
         "sass"
       ],
       "dependencyDashboardApproval": true


### PR DESCRIPTION
Else we always have to separate the update for the frontend from the update for the other modules.

Result can be seen here:
https://github.com/BacLuc/ecamp3/issues/146
and here
https://github.com/BacLuc/ecamp3/pull/247