### PR TITLE
renovate.json: do not use the force key anymore

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,11 +4,9 @@
     "config:recommended",
     ":prConcurrentLimitNone"
   ],
-  "force": {
-    "constraints": {
-      "node": "22.3.0",
-      "php": "8.3.7"
-    }
+  "constraints": {
+    "node": "22.3.0",
+    "php": "8.3.7"
   },
   "automergeType": "branch",
   "rebaseWhen": "conflicted",


### PR DESCRIPTION
From the renovate run logs:
"warnings": [
 {
  "topic": "Configuration Error",
  "message": "The \"force\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
  }
].

It also works like this now.