### PR TITLE
Storyboard.vue: remove css with no applications

### DIFF
--- a/frontend/src/components/activity/content/Storyboard.vue
+++ b/frontend/src/components/activity/content/Storyboard.vue
@@ -171,13 +171,4 @@ export default {
 }
 </script>
 
-<style scoped lang="scss">
-:deep {
-  .v-text-field.v-text-field--enclosed.v-text-field--outlined:not(.v-input--dense)
-    .editor {
-    margin-top: 10px;
-    padding-top: 5px;
-    margin-bottom: 10px;
-  }
-}
-</style>
+<style scoped lang="scss"></style>


### PR DESCRIPTION
The css violates vue-scoped-css/require-v-deep-argument which will be more strictly enforced by vue3.

I changed all the values to 10'000, and it had no effect. Because there was no explanation why this is here
in the commit message, in the PR or in the comments, i delete this css.

Was introduced in:
PR:
- https://github.com/ecamp/ecamp3/pull/3224
Commit: 9060a33