### PR TITLE
Revert "Storyboard.vue: remove css with no applications"

### DIFF
--- a/frontend/src/components/activity/content/Storyboard.vue
+++ b/frontend/src/components/activity/content/Storyboard.vue
@@ -171,4 +171,13 @@ export default {
 }
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+:deep {
+  .v-text-field.v-text-field--enclosed.v-text-field--outlined:not(.v-input--dense)
+    .editor {
+    margin-top: 10px;
+    padding-top: 5px;
+    margin-bottom: 10px;
+  }
+}
+</style>


### PR DESCRIPTION
Reverts ecamp/ecamp3#5494

As can be seen in https://github.com/ecamp/ecamp3/pull/5494#pullrequestreview-2161930493
The css has an effect.

When i tested it, i had the env variable CI=true because i was working on https://github.com/ecamp/ecamp3/issues/5493
that's why the css had no effect.

Sorry guys, big blunder.