### PR TITLE
Bugfix: EditCategory shows wrong properties

### DIFF
--- a/frontend/src/views/category/Category.vue
+++ b/frontend/src/views/category/Category.vue
@@ -67,7 +67,11 @@
             </h3>
           </v-expansion-panel-header>
           <v-expansion-panel-content>
-            <CategoryProperties :category="category" :disabled="!isManager" />
+            <CategoryProperties
+              :key="category"
+              :category="category"
+              :disabled="!isManager"
+            />
           </v-expansion-panel-content>
         </v-expansion-panel>
 


### PR DESCRIPTION
close #5217

When a different category is selected in the SideBar, recreate CategoryProperties.



![image](https://github.com/user-attachments/assets/e02a154f-ad3f-4563-91db-7b4db776539b)
