### PR TITLE
reusable-e2e-tests-run.yml: print running containers at end

### DIFF
--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -70,6 +70,10 @@ jobs:
           path: |
             e2e/data/**/*
 
+      # print running containers
+      - run: docker ps -a
+        if: always()
+
       # print docker container logs (good for debugging; can be disabled again later on)
       - run: docker compose logs --tail="all"
         if: always()


### PR DESCRIPTION
That we see which services survived.
I have the suspicion that some of the failing tests are caused by the api crashing.