### PR TITLE
e2e: pin cypress image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,7 @@ services:
       - FUNCTION_ENABLE_INCOGNITO_MODE=true
 
   e2e:
-    image: cypress/included:13.13.0
+    image: cypress/included:cypress-13.13.0-node-20.15.1-chrome-126.0.6478.114-1-ff-128.0-edge-126.0.2592.61-1@sha256:f9733a2cadc3aa270e40f8ce1158a23cb99703476a9db7154b4ecc51ba02bd5c
     profiles: ['e2e']
     container_name: 'ecamp3-e2e'
     environment:

--- a/renovate.json
+++ b/renovate.json
@@ -140,6 +140,14 @@
         "postgres"
       ],
       "allowedVersions": "15-alpine"
+    },
+    {
+      "matchDepNames": [
+        "cypress",
+        "cypress/included"
+      ],
+      "automerge": false,
+      "groupName": "cypress"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Even to digest, that we control it when the image changes-

In a future PR:
Get renovate to update this image and the version in the package.json to be updated synchronously, but without auto merge.