### PR TITLE
ecamp3-logging: use own script to remove old indexes

### DIFF
--- a/.ops/ecamp3-logging/.gitignore
+++ b/.ops/ecamp3-logging/.gitignore
@@ -1,1 +1,2 @@
 /charts
+.env

--- a/.ops/ecamp3-logging/files/elasticsearch/remove-old-indexes/.env-example
+++ b/.ops/ecamp3-logging/files/elasticsearch/remove-old-indexes/.env-example
@@ -1,0 +1,2 @@
+ELASTICSEARCH_URL=http://localhost:9200
+MAX_INDEX_AGE=15

--- a/.ops/ecamp3-logging/files/elasticsearch/remove-old-indexes/README.md
+++ b/.ops/ecamp3-logging/files/elasticsearch/remove-old-indexes/README.md
@@ -1,0 +1,25 @@
+# remove old indexes
+
+With the 2G Memory we use in prod, the elasticsearch life cycle management
+does not work properly.
+Thus we have this small script that does that.
+
+1. Copy the [.env-example](.env-example) file to [.env](.env)
+
+   ```shell
+   cp .env-example .env
+   ```
+
+2. Fill in the variables of [.env](.env)
+
+3. Do a port forward of the elasticsearch port if necessary
+
+   ```shell
+   kubectl -n ecamp3-logging port-forward services/elasticsearch 9200:9200
+   ```
+
+4. Run the image with the script
+
+   ```shell
+   docker compose run --rm remove-old-indexes
+   ```

--- a/.ops/ecamp3-logging/files/elasticsearch/remove-old-indexes/docker-compose.yml
+++ b/.ops/ecamp3-logging/files/elasticsearch/remove-old-indexes/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  remove-old-indexes:
+    image: node:22.5.1
+    volumes:
+      - ./src:/src
+    command:
+      - node
+      - /src/remove-old-indexes.mjs
+    env_file: .env
+    network_mode: host

--- a/.ops/ecamp3-logging/files/elasticsearch/remove-old-indexes/src/remove-old-indexes.mjs
+++ b/.ops/ecamp3-logging/files/elasticsearch/remove-old-indexes/src/remove-old-indexes.mjs
@@ -1,0 +1,31 @@
+const ELASTICSEARCH_URL = process.env.ELASTICSEARCH_URL
+const MAX_INDEX_AGE = parseInt(process.env.MAX_INDEX_AGE)
+
+const MILLIS_OF_DAY = 24 * 60 * 60 * 1000;
+
+process.on("SIGINT", () => {
+  process.exit(1)
+});
+
+process.on("SIGTERM", () => {
+  process.exit(1)
+});
+
+// noinspection InfiniteLoopJS
+while (true) {
+  const response = await fetch(`${ELASTICSEARCH_URL}/_cat/indices/logstash*?h=index,id,creation.date.string&format=json`)
+  const body = await response.json()
+
+  for (const index of body) {
+    const date = new Date(index["creation.date.string"])
+    if (Date.now() - date > MAX_INDEX_AGE * MILLIS_OF_DAY) {
+      console.log(`Deleting ${index.index} with creation date '${date}'`)
+      await fetch(`${ELASTICSEARCH_URL}/${index.index}`, {
+        method: "DELETE"
+      })
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  
+  await new Promise((resolve) => setTimeout(resolve, MILLIS_OF_DAY))
+}

--- a/.ops/ecamp3-logging/templates/elasticsearch/elasticsearch_stateful_set.yaml
+++ b/.ops/ecamp3-logging/templates/elasticsearch/elasticsearch_stateful_set.yaml
@@ -55,6 +55,21 @@ spec:
                   fieldPath: metadata.name
             - name: ES_JAVA_OPTS
               value: "-Xms{{ $minHeapSpace }}m -Xmx{{ $maxHeapSpace }}m"
+        {{- if not (.Values.elasticsearch.removeOldIndexes.maxIndexAge | empty) }}
+        - name: remove-old-indexes
+          image: {{ .Values.elasticsearch.removeOldIndexes.image }}
+          command:
+            - node
+            - /src/remove-old-indexes.mjs
+          env:
+            - name: ELASTICSEARCH_URL
+              value: "http://localhost:9200"
+            - name: MAX_INDEX_AGE
+              value: {{ .Values.elasticsearch.removeOldIndexes.maxIndexAge | quote }}
+          volumeMounts:
+            - name: remove-old-indexes 
+              mountPath: /src
+        {{- end }}
       initContainers:
         - name: fix-permissions
           image: busybox
@@ -74,6 +89,12 @@ spec:
           command: [ "sh", "-c", "ulimit -n 65536" ]
           securityContext:
             privileged: true
+      {{- if not (.Values.elasticsearch.removeOldIndexes.maxIndexAge | empty) }}
+      volumes:
+        - name: remove-old-indexes
+          configMap:
+            name: remove-old-indexes
+      {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/.ops/ecamp3-logging/templates/elasticsearch/remove_old_indexes_configmap.yaml
+++ b/.ops/ecamp3-logging/templates/elasticsearch/remove_old_indexes_configmap.yaml
@@ -1,0 +1,15 @@
+{{- if not (.Values.elasticsearch.removeOldIndexes.maxIndexAge | empty) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: remove-old-indexes
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: elasticsearch
+    {{- include "app.commonLabels" . | nindent 4 }}
+    {{- include "app.commonSelectorLabels" . | nindent 4 }}
+data:
+  remove-old-indexes.mjs: |
+    {{ range .Files.Lines "files/elasticsearch/remove-old-indexes/src/remove-old-indexes.mjs" }}
+    {{ . }}{{ end }}
+{{- end }}

--- a/.ops/ecamp3-logging/values.yaml
+++ b/.ops/ecamp3-logging/values.yaml
@@ -46,6 +46,9 @@ elasticsearch:
     resources:
       requests:
         storage: 10Gi
+  removeOldIndexes:
+    maxIndexAge: 15
+    image: node:22.5.1
 
 kibana:
   name: kibana


### PR DESCRIPTION
With the 2GB of memory, the Index Lifecycle Management (ilm) of elasticsearch does not work reliably.
But in prod, we need these indexes deleted, else the RAM consumption rises and the volume gets full.
With this script, we can do the index lifecycle management with a lot less ram.