### PR TITLE
fixes naming and uriTemplate of category subresource

### DIFF
--- a/api/src/Entity/Category.php
+++ b/api/src/Entity/Category.php
@@ -58,7 +58,6 @@ use Symfony\Component\Validator\Constraints as Assert;
             securityPostDenormalize: 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)'
         ),
         new GetCollection(
-            name: 'BelongsToCamp_App\Entity\Category_get_collection',
             uriTemplate: self::CAMP_SUBRESOURCE_URI_TEMPLATE,
             uriVariables: [
                 'campId' => new Link(
@@ -79,7 +78,7 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
     use ClassInfoTrait;
     use HasRootContentNodeTrait;
 
-    public const CAMP_SUBRESOURCE_URI_TEMPLATE = '/camps/{campId}/categories.{_format}';
+    public const CAMP_SUBRESOURCE_URI_TEMPLATE = '/camps/{campId}/categories{._format}';
 
     public const ITEM_NORMALIZATION_CONTEXT = [
         'groups' => [

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
@@ -22659,7 +22659,7 @@ paths:
     get:
       deprecated: false
       description: 'Retrieves the collection of Category resources.'
-      operationId: BelongsToCamp_App\Entity\Category_get_collection
+      operationId: api_camps_campIdcategories_get_collection
       parameters:
         -
           allowEmptyValue: false


### PR DESCRIPTION
some legacy inconsistencies detected during review of #5408 