### PR TITLE
pdf: fix migrate eslint config

### DIFF
--- a/pdf/eslint.config.mjs
+++ b/pdf/eslint.config.mjs
@@ -22,6 +22,9 @@ export default [
     'plugin:prettier/recommended',
     '@vue/eslint-config-prettier'
   ),
+  {
+    ignores: ['dist/*.mjs'],
+  },
 
   includeIgnoreFile(gitignorePath),
 
@@ -35,9 +38,6 @@ export default [
         ...globals.node,
         ...globals.jest,
       },
-
-      ecmaVersion: 5,
-      sourceType: 'commonjs',
 
       parserOptions: {
         parser: '@babel/eslint-parser',

--- a/pdf/package.json
+++ b/pdf/package.json
@@ -10,10 +10,10 @@
     "preview": "vite preview",
     "test:unit": "vitest --coverage",
     "lint": "npm run lint:eslint && npm run lint:prettier",
-    "lint:eslint": "eslint --fix",
+    "lint:eslint": "eslint --fix .",
     "lint:prettier": "prettier --write --ignore-path .prettierignore **/*.{css,scss,json,mjs}",
     "lint:check": "npm run lint:check:eslint && npm run lint:check:prettier",
-    "lint:check:eslint": "eslint",
+    "lint:check:eslint": "eslint .",
     "lint:check:prettier": "prettier --check --ignore-path .prettierignore **/*.{css,scss,json,mjs}"
   },
   "dependencies": {


### PR DESCRIPTION
The . after the eslint command is important, else it lints nothing. Explicitly exclude the generated files, ignoring it via the .gitignored files did not work.

Issue: #5282