### PR TITLE
ActivityRow: remove unused css class mt-2px

### DIFF
--- a/frontend/src/components/dashboard/ActivityRow.vue
+++ b/frontend/src/components/dashboard/ActivityRow.vue
@@ -197,10 +197,6 @@ tr + tr :is(td, th) {
   font-size: 0.75em;
 }
 
-.mt-2px {
-  margin-top: 2px;
-}
-
 .my-6px {
   margin-top: 6px;
   margin-bottom: 6px;


### PR DESCRIPTION
fix: 200:1  warning  The selector `.mt-2px` is unused  vue-scoped-css/no-unused-selector