### PR TITLE
frontend: comment some eslint violations

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -138,6 +138,8 @@ export default {
 </style>
 
 <style scoped>
+/* <v-footer> is transformed to <footer class="v-footer"> */
+/* eslint-disable-next-line vue-scoped-css/no-unused-selector */
 .v-footer {
   border-top: 3px solid #c80d0d;
   z-index: 4;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -56,6 +56,8 @@ export default {
   },
 }
 </script>
+<!-- these styles must be global -->
+<!-- eslint-disable-next-line vue-scoped-css/enforce-style-type -->
 <style lang="scss">
 @import 'src/scss/global';
 @import '~@mdi/font/css/materialdesignicons.css';

--- a/frontend/src/components/activity/DaySwitcher.vue
+++ b/frontend/src/components/activity/DaySwitcher.vue
@@ -115,15 +115,21 @@ export default {
 }
 </script>
 
+<!-- these styles should apply to inner elements -->
+<!-- eslint-disable-next-line vue-scoped-css/enforce-style-type -->
 <style>
 .basis-num {
   flex-basis: 2.5ch;
 }
 
+/* .e-day-switcher__menu is in the <e-select> tag */
+/*noinspection CssUnusedSymbol*/
 .e-day-switcher__menu {
   transform: translateX(-12px);
 }
 
+/* ..v-input__append-inner is in an inner tag */
+/*noinspection CssUnusedSymbol*/
 .e-day-switcher__select .v-input__append-inner {
   align-self: center;
   margin-top: 0;

--- a/frontend/src/components/category/CategoryProperties.vue
+++ b/frontend/src/components/category/CategoryProperties.vue
@@ -34,6 +34,8 @@ export default {
 </script>
 
 <style scoped>
+/* makes the input fields smaller */
+/* eslint-disable-next-line vue-scoped-css/no-unused-selector */
 div {
   max-width: 600px;
 }

--- a/frontend/src/components/form/api/ApiWrapper.vue
+++ b/frontend/src/components/form/api/ApiWrapper.vue
@@ -280,6 +280,8 @@ export default {
 }
 </style>
 
+<!-- This does not work with scoped css -->
+<!-- eslint-disable-next-line vue-scoped-css/enforce-style-type -->
 <style lang="scss">
 .api-wrapper--inline .v-text-field {
   border-top-right-radius: 0;

--- a/frontend/src/views/auth/Activate.vue
+++ b/frontend/src/views/auth/Activate.vue
@@ -73,4 +73,4 @@ export default {
 }
 </script>
 
-<style></style>
+<style scoped></style>

--- a/frontend/src/views/auth/RegisterDone.vue
+++ b/frontend/src/views/auth/RegisterDone.vue
@@ -25,4 +25,4 @@ export default {
 }
 </script>
 
-<style></style>
+<style scoped></style>


### PR DESCRIPTION
And also add the scoped attribute to the empty styles.

It is easier to remove the comments than to find out why this class is here or why it is not scoped.