### PR TITLE
frontend: remove jest references

### DIFF
--- a/common/eslint-local-rules/__tests__/matchingTranslationKeys.spec.js
+++ b/common/eslint-local-rules/__tests__/matchingTranslationKeys.spec.js
@@ -13,7 +13,6 @@ const ruleTester = new RuleTester({
   root: true,
   env: {
     node: true,
-    jest: true,
   },
   extends: [
     'plugin:vue/recommended',

--- a/common/eslint-local-rules/__tests__/packageDirectory.spec.js
+++ b/common/eslint-local-rules/__tests__/packageDirectory.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import factory from '../packageDirectory.js'
 import path from 'path'
 import fs from 'fs'

--- a/common/helpers/__tests__/activityResponsibles.spec.js
+++ b/common/helpers/__tests__/activityResponsibles.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { activityResponsiblesCommaSeparated } from '../activityResponsibles.js'
 
 describe('activityResponsibles', () => {

--- a/common/helpers/__tests__/campCollaborationDisplayName.spec.js
+++ b/common/helpers/__tests__/campCollaborationDisplayName.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import campCollaborationDisplayName from '../campCollaborationDisplayName.js'
 
 describe('campCollaborationDisplayName', () => {

--- a/common/helpers/__tests__/campCollaborationInitials.spec.js
+++ b/common/helpers/__tests__/campCollaborationInitials.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import campCollaborationInitials from '../campCollaborationInitials.js'
 
 describe('campCollaborationInitials', () => {

--- a/common/helpers/__tests__/campCollaborationLegalName.spec.js
+++ b/common/helpers/__tests__/campCollaborationLegalName.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import campCollaborationLegalName from '../campCollaborationLegalName.js'
 
 describe('campCollaborationLegalName', () => {

--- a/common/helpers/__tests__/campShortTitle.spec.js
+++ b/common/helpers/__tests__/campShortTitle.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import { campShortTitle } from '../campShortTitle.js'
 
 describe('campShortTitle', () => {

--- a/common/helpers/__tests__/colors.spec.js
+++ b/common/helpers/__tests__/colors.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { campCollaborationColor, idToColor, userColor } from '../colors.js'
 
 describe('idToColor', () => {

--- a/common/helpers/__tests__/dateHelperUTCFormatted.spec.js
+++ b/common/helpers/__tests__/dateHelperUTCFormatted.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import {
   dateRange,
   rangeLongEnd,

--- a/common/helpers/__tests__/dayResponsibles.spec.js
+++ b/common/helpers/__tests__/dayResponsibles.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import {
   dayResponsiblesCommaSeparated,
   filterDayResponsiblesByDay,

--- a/common/helpers/__tests__/initials.spec.js
+++ b/common/helpers/__tests__/initials.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import initials from '../initials.js'
 
 describe('initials', () => {

--- a/common/helpers/__tests__/interpolation.spec.js
+++ b/common/helpers/__tests__/interpolation.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { lerp, clamp, invlerp, range } from '../interpolation.js'
 
 describe('lerp', () => {

--- a/common/helpers/__tests__/materialListsSorted.spec.js
+++ b/common/helpers/__tests__/materialListsSorted.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import materialListsSorted from '../materialListsSorted.js'
 
 describe('materialListsSorted', () => {

--- a/common/helpers/__tests__/picasso.spec.js
+++ b/common/helpers/__tests__/picasso.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { splitDaysIntoPages, calculateBedtime } from '../picasso.js'
 import dayjs from '@/common/helpers/dayjs.js'
 

--- a/common/helpers/__tests__/userDisplayName.spec.js
+++ b/common/helpers/__tests__/userDisplayName.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import userDisplayName from '../userDisplayName.js'
 
 describe('userDisplayName', () => {

--- a/common/helpers/__tests__/userInitials.spec.js
+++ b/common/helpers/__tests__/userInitials.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import userInitials from '../userInitials.js'
 
 describe('userInitials', () => {

--- a/common/helpers/__tests__/userLegalName.spec.js
+++ b/common/helpers/__tests__/userLegalName.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import userLegalName from '../userLegalName.js'
 
 describe('userLegalName', () => {

--- a/common/helpers/dayjs/__tests__/formatDatePeriod.spec.js
+++ b/common/helpers/dayjs/__tests__/formatDatePeriod.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, expect, it } from 'vitest'
 import dayjs from '@/common/helpers/dayjs.js'
 
 describe('formatDatePeriod dayjs plugin', () => {

--- a/common/helpers/dayjs/__tests__/parseTime.spec.js
+++ b/common/helpers/dayjs/__tests__/parseTime.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, expect, it } from 'vitest'
 import { default as dayjs, dayjsLocaleMap } from '../../dayjs'
 import parseTime from '../parseTime'
 import { padStart, range } from 'lodash'

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -37,7 +37,6 @@ export default [
     languageOptions: {
       globals: {
         ...globals.node,
-        ...globals.jest,
       },
 
       parserOptions: {

--- a/frontend/src/components/activity/content/columnLayout/__tests__/calculateNextSlotName.spec.js
+++ b/frontend/src/components/activity/content/columnLayout/__tests__/calculateNextSlotName.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import { calculateNextSlotName, adjustColumnWidths } from '../calculateNextSlotName.js'
 
 describe('generating a next slot name', () => {

--- a/frontend/src/components/form/api/__tests__/ApiCheckbox.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiCheckbox.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, vi, test, expect } from 'vitest'
 import ApiCheckbox from '../ApiCheckbox.vue'
 import ApiWrapper from '@/components/form/api/ApiWrapper.vue'
 import Vue from 'vue'
@@ -26,7 +27,7 @@ describe('An ApiCheckbox', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
     wrapper.destroy()
   })
 

--- a/frontend/src/components/form/api/__tests__/ApiColorField.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiColorField.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, vi, test, expect } from 'vitest'
 import ApiColorField from '../ApiColorField.vue'
 import { fireEvent, screen, waitFor } from '@testing-library/vue'
 import { render } from '@/test/renderWithVuetify.js'
@@ -23,7 +24,7 @@ describe('An ApiColorField', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
   })
 
   test('triggers api.patch and status update if input changes', async () => {

--- a/frontend/src/components/form/api/__tests__/ApiColorPicker.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiColorPicker.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, vi, test, expect } from 'vitest'
 import ApiColorPicker from '../ApiColorPicker.vue'
 import { screen, waitFor } from '@testing-library/vue'
 import { render } from '@/test/renderWithVuetify.js'
@@ -24,7 +25,7 @@ describe('An ApiColorPicker', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
   })
 
   test('triggers api.patch and status update if input changes', async () => {

--- a/frontend/src/components/form/api/__tests__/ApiDatePicker.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiDatePicker.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, vi, test, expect, it } from 'vitest'
 import ApiDatePicker from '../ApiDatePicker.vue'
 import { screen, waitFor } from '@testing-library/vue'
 import { render, setTestLocale } from '@/test/renderWithVuetify.js'
@@ -19,7 +20,7 @@ describe('An ApiDatePicker', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
   })
 
   it('triggers api.patch and status update if input changes', async () => {

--- a/frontend/src/components/form/api/__tests__/ApiNumberField.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiNumberField.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, vi, test, expect } from 'vitest'
 import ApiNumberField from '../ApiNumberField.vue'
 import ApiWrapper from '@/components/form/api/ApiWrapper.vue'
 import Vue from 'vue'
@@ -28,7 +29,7 @@ describe('An ApiNumberField', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
     wrapper.destroy()
   })
 

--- a/frontend/src/components/form/api/__tests__/ApiSelect.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiSelect.spec.js
@@ -1,4 +1,5 @@
 // Libraries
+import { describe, beforeEach, afterEach, vi, test, expect } from 'vitest'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 
@@ -40,7 +41,7 @@ describe('An ApiSelect', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
     wrapper.destroy()
   })
 

--- a/frontend/src/components/form/api/__tests__/ApiSwitch.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiSwitch.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, vi, test, expect } from 'vitest'
 import ApiSwitch from '../ApiSwitch.vue'
 import ApiWrapper from '@/components/form/api/ApiWrapper.vue'
 import Vue from 'vue'
@@ -26,7 +27,7 @@ describe('An ApiSwitch', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
     wrapper.destroy()
   })
 

--- a/frontend/src/components/form/api/__tests__/ApiTextField.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiTextField.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, vi, test, expect } from 'vitest'
 import ApiTextField from '../ApiTextField.vue'
 import ApiWrapper from '@/components/form/api/ApiWrapper.vue'
 import Vue from 'vue'
@@ -28,7 +29,7 @@ describe('An ApiTextField', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
     wrapper.destroy()
   })
 

--- a/frontend/src/components/form/api/__tests__/ApiTextarea.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiTextarea.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, vi, test, expect } from 'vitest'
 import ApiTextarea from '@/components/form/api/ApiTextarea.vue'
 import ApiWrapper from '@/components/form/api/ApiWrapper.vue'
 import Vue from 'vue'
@@ -32,7 +33,7 @@ describe('An ApiTextarea', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
     wrapper.destroy()
   })
 

--- a/frontend/src/components/form/api/__tests__/ApiTimePicker.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiTimePicker.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, vi, expect, it } from 'vitest'
 import ApiTimePicker from '../ApiTimePicker.vue'
 import { screen, waitFor } from '@testing-library/vue'
 import { render, setTestLocale } from '@/test/renderWithVuetify.js'
@@ -19,7 +20,7 @@ describe('An ApiTimePicker', () => {
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
   })
 
   it('triggers api.patch and status update if input changes', async () => {

--- a/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
+++ b/frontend/src/components/form/api/__tests__/ApiWrapper.spec.js
@@ -99,7 +99,7 @@ describe('Testing ApiWrapper [autoSave=true;  manual external value]', () => {
     wrapper = shallowMount(ApiWrapper, config)
     vm = wrapper.vm
 
-    apiPatch = jest.spyOn(config.mocks.api, 'patch')
+    apiPatch = vi.spyOn(config.mocks.api, 'patch')
 
     validateCalled = new Promise((resolve) => (validateResolveFunction = resolve))
 

--- a/frontend/src/components/form/base/__tests__/ECheckbox.spec.js
+++ b/frontend/src/components/form/base/__tests__/ECheckbox.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, vi, test, expect } from 'vitest'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 
@@ -81,7 +82,7 @@ describe('An ECheckbox', () => {
     await input.trigger('click')
     expect(wrapper.vm.data).toBe(true)
 
-    jest.resetAllMocks()
+    vi.resetAllMocks()
     await input.trigger('click')
     expect(wrapper.vm.data).toBe(false)
   })

--- a/frontend/src/components/form/base/__tests__/EColorField.spec.js
+++ b/frontend/src/components/form/base/__tests__/EColorField.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, test, expect } from 'vitest'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 

--- a/frontend/src/components/form/base/__tests__/EColorPicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/EColorPicker.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, expect, it } from 'vitest'
 import { fireEvent, screen, waitFor } from '@testing-library/vue'
 import { render, setTestLocale, snapshotOf } from '@/test/renderWithVuetify.js'
 import user from '@testing-library/user-event'

--- a/frontend/src/components/form/base/__tests__/EDatePicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/EDatePicker.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, expect, it } from 'vitest'
 import { screen, waitFor } from '@testing-library/vue'
 import { render, setTestLocale, snapshotOf } from '@/test/renderWithVuetify.js'
 import user from '@testing-library/user-event'

--- a/frontend/src/components/form/base/__tests__/ENumberField.spec.js
+++ b/frontend/src/components/form/base/__tests__/ENumberField.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, test, expect } from 'vitest'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 

--- a/frontend/src/components/form/base/__tests__/EParseField.spec.js
+++ b/frontend/src/components/form/base/__tests__/EParseField.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, test, expect } from 'vitest'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 

--- a/frontend/src/components/form/base/__tests__/ESelect.spec.js
+++ b/frontend/src/components/form/base/__tests__/ESelect.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, test, expect } from 'vitest'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 

--- a/frontend/src/components/form/base/__tests__/ESwitch.spec.js
+++ b/frontend/src/components/form/base/__tests__/ESwitch.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, vi, test, expect } from 'vitest'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 
@@ -91,7 +92,7 @@ describe('An ESwitch', () => {
     touch(wrapper.find('.v-input--selection-controls__ripple')).start(0, 0).end(20, 0)
     expect(wrapper.vm.data).toBe(true)
 
-    jest.resetAllMocks()
+    vi.resetAllMocks()
     touch(wrapper.find('.v-input--selection-controls__ripple')).start(0, 0).end(-20, 0)
     expect(wrapper.vm.data).toBe(false)
   })
@@ -106,7 +107,7 @@ describe('An ESwitch', () => {
     input.trigger('keydown.right')
     expect(wrapper.vm.data).toBe(true)
 
-    jest.resetAllMocks()
+    vi.resetAllMocks()
     input.trigger('keydown.left')
     expect(wrapper.vm.data).toBe(false)
   })

--- a/frontend/src/components/form/base/__tests__/ETextArea.spec.js
+++ b/frontend/src/components/form/base/__tests__/ETextArea.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, test, expect } from 'vitest'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 

--- a/frontend/src/components/form/base/__tests__/ETextField.spec.js
+++ b/frontend/src/components/form/base/__tests__/ETextField.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, test, expect } from 'vitest'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 

--- a/frontend/src/components/form/base/__tests__/ETimePicker.spec.js
+++ b/frontend/src/components/form/base/__tests__/ETimePicker.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, expect, it } from 'vitest'
 import { screen, waitFor } from '@testing-library/vue'
 import { render, setTestLocale, snapshotOf } from '@/test/renderWithVuetify.js'
 import user from '@testing-library/user-event'

--- a/frontend/src/components/material/__tests__/shortScheduleEntryDescription.spec.js
+++ b/frontend/src/components/material/__tests__/shortScheduleEntryDescription.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import shortScheduleEntryDescription from '../shortScheduleEntryDescription.js'
 import createI18n from '@/components/print/print-client/i18n.js'
 import { i18n } from '@/plugins/i18n'

--- a/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
+++ b/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
@@ -1,3 +1,4 @@
+import { describe, test, expect } from 'vitest'
 import repairConfig from '../repairPrintConfig.js'
 import PicassoConfig from '../config/PicassoConfig.vue'
 import ActivityConfig from '../config/ActivityConfig.vue'

--- a/frontend/src/helpers/__tests__/querySyncHelper.spec.js
+++ b/frontend/src/helpers/__tests__/querySyncHelper.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import {
   halUriToId,
   idToHalUri,

--- a/frontend/src/helpers/__tests__/serverError.spec.js
+++ b/frontend/src/helpers/__tests__/serverError.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, vi, expect, it } from 'vitest'
 import { transformViolations } from '@/helpers/serverError'
 import cloneDeep from 'lodash/cloneDeep'
 import { fallbackLocales } from '@/plugins/i18n'
@@ -33,8 +34,8 @@ describe('transformViolations', () => {
   })
 
   describe('with i18n', () => {
-    const te = jest.fn()
-    const tc = jest.fn()
+    const te = vi.fn()
+    const tc = vi.fn()
     const i18n = { te, tc }
 
     beforeEach(() => {

--- a/frontend/src/helpers/__tests__/vCalendarDragAndDrop.spec.js
+++ b/frontend/src/helpers/__tests__/vCalendarDragAndDrop.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import {
   toTime,
   roundTimeToNearestQuarterHour,

--- a/frontend/src/plugins/__tests__/auth.spec.js
+++ b/frontend/src/plugins/__tests__/auth.spec.js
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { describe, beforeEach, afterEach, vi, expect, it } from 'vitest'
 import Vue from 'vue'
 import { auth } from '@/plugins/auth'
 import Cookies from 'js-cookie'
@@ -63,7 +63,7 @@ vi.mock('@/router', async () => {
 
 describe('authentication logic', () => {
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
     Cookies.remove('localhost_jwt_hp')
     window.environment = cloneDeep(envBackup)
   })
@@ -110,7 +110,7 @@ describe('authentication logic', () => {
     it('sends a POST request to the API', async () => {
       // given
       store.replaceState(createState())
-      jest.spyOn(apiStore, 'post').mockImplementation(async () => {})
+      vi.spyOn(apiStore, 'post').mockImplementation(async () => {})
 
       // when
       await auth.register({ email: 'bar', password: 'baz' })
@@ -128,7 +128,7 @@ describe('authentication logic', () => {
     it('resolves to true if the user successfully logs in', async () => {
       // given
       store.replaceState(createState())
-      jest.spyOn(apiStore, 'post').mockImplementation(async () => {
+      vi.spyOn(apiStore, 'post').mockImplementation(async () => {
         Cookies.set('localhost_jwt_hp', validJWTPayload)
       })
 
@@ -146,7 +146,7 @@ describe('authentication logic', () => {
 
     it('resolves to false if the login fails', async () => {
       // given
-      jest.spyOn(apiStore, 'post').mockImplementation(async () => {
+      vi.spyOn(apiStore, 'post').mockImplementation(async () => {
         // login fails, no cookie added
       })
 
@@ -167,7 +167,7 @@ describe('authentication logic', () => {
     it('resolves to null if not logged in', async () => {
       // given
       store.replaceState(createState())
-      jest.spyOn(apiStore, 'get')
+      vi.spyOn(apiStore, 'get')
 
       // when
       const result = await auth.loadUser()
@@ -181,7 +181,7 @@ describe('authentication logic', () => {
       // given
       store.replaceState(createState())
       Cookies.set('localhost_jwt_hp', validJWTPayload)
-      jest.spyOn(apiStore, 'get')
+      vi.spyOn(apiStore, 'get')
 
       // when
       const result = await auth.loadUser()
@@ -208,8 +208,8 @@ describe('authentication logic', () => {
             }),
           },
         }
-        jest.spyOn(apiStore, 'get').mockImplementation(() => user)
-        jest.spyOn(auth, 'logout')
+        vi.spyOn(apiStore, 'get').mockImplementation(() => user)
+        vi.spyOn(auth, 'logout')
 
         // when
         const result = await auth.loadUser()

--- a/frontend/src/plugins/__tests__/preferences.spec.js
+++ b/frontend/src/plugins/__tests__/preferences.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, afterEach, expect, it } from 'vitest'
 import { getters, loadFromLocalStorage, mutations } from '@/plugins/store/preferences'
 
 const CAMP_URI = '/camps/1a2b3c4d'

--- a/frontend/src/plugins/i18n/__tests__/apiFallbackLocalesFor.spec.js
+++ b/frontend/src/plugins/i18n/__tests__/apiFallbackLocalesFor.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import { fallbackLocales } from '@/plugins/i18n'
 import fallbackLocalesFor from '@/plugins/i18n/apiFallbackLocalesFor'
 

--- a/frontend/src/plugins/veeValidate/__tests__/greaterThan.spec.js
+++ b/frontend/src/plugins/veeValidate/__tests__/greaterThan.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import greaterThan from '@/plugins/veeValidate/greaterThan'
 
 const mockI18n = {

--- a/frontend/src/plugins/veeValidate/__tests__/greaterThanOrEqual_date.spec.js
+++ b/frontend/src/plugins/veeValidate/__tests__/greaterThanOrEqual_date.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, expect, it } from 'vitest'
 import greaterThanOrEqual_date from '../greaterThanOrEqual_date.js'
 import dayjs from '@/common/helpers/dayjs.js'
 

--- a/frontend/src/plugins/veeValidate/__tests__/greaterThan_time.spec.js
+++ b/frontend/src/plugins/veeValidate/__tests__/greaterThan_time.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, expect, it } from 'vitest'
 import greaterThan_time from '../greaterThan_time.js'
 import dayjs from '@/common/helpers/dayjs.js'
 

--- a/frontend/src/plugins/veeValidate/__tests__/lessThanOrEqual_date.spec.js
+++ b/frontend/src/plugins/veeValidate/__tests__/lessThanOrEqual_date.spec.js
@@ -1,3 +1,4 @@
+import { describe, beforeEach, expect, it } from 'vitest'
 import lessThanOrEqual_date from '../lessThanOrEqual_date.js'
 import dayjs from '@/common/helpers/dayjs.js'
 

--- a/frontend/src/plugins/veeValidate/__tests__/oneEmojiOrTwoCharacters.spec.js
+++ b/frontend/src/plugins/veeValidate/__tests__/oneEmojiOrTwoCharacters.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import oneEmojiOrTwoCharacters from '../oneEmojiOrTwoCharacters.js'
 
 const mockI18n = {

--- a/frontend/src/test/mockEventClass.js
+++ b/frontend/src/test/mockEventClass.js
@@ -1,3 +1,4 @@
+import { beforeEach, afterEach } from 'vitest'
 /**
  * @param { "ClipboardEvent" | "DragEvent" } eventName
  */

--- a/frontend/src/views/admin/__tests__/Admin.spec.js
+++ b/frontend/src/views/admin/__tests__/Admin.spec.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import Vue from 'vue'
 import { fireEvent } from '@testing-library/vue'
 import { render } from '@/test/renderWithVuetify.js'

--- a/frontend/tests/infrastructure/package-lock.spec.js
+++ b/frontend/tests/infrastructure/package-lock.spec.js
@@ -1,3 +1,4 @@
+import { describe, test, expect } from 'vitest'
 import { lockfileVersion } from '../../package-lock.json'
 
 describe('The package-lock.json', () => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -152,7 +152,6 @@ export default defineConfig(({ mode }) => ({
     },
   },
   test: {
-    globals: true,
     environment: 'jsdom',
     alias: [{ find: /^vue$/, replacement: 'vue/dist/vue.runtime.common.js' }],
     globalSetup: './tests/globalSetup.js',


### PR DESCRIPTION
From time to time we get the error "jest is not defined". We are anyway using vitest, and vitest also
injected a "jest" object, which implemented its functions with vitest.

Also set globals to false, that we see what we import and from where.