### PR TITLE
replace uri-js with uri-js-replace

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -4076,14 +4076,12 @@
       }
     },
     "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "name": "uri-js-replace",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/url-parse": {
       "version": "1.5.10",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -23,5 +23,8 @@
     "eslint-plugin-prettier": "5.2.1",
     "globals": "15.9.0",
     "prettier": "3.3.3"
+  },
+  "overrides": {
+    "uri-js": "npm:uri-js-replace"
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11731,14 +11731,12 @@
       }
     },
     "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "name": "uri-js-replace",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/url-parse": {
       "version": "1.5.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -121,6 +121,9 @@
     "vitest-canvas-mock": "0.3.3",
     "vue-template-compiler": "2.7.15"
   },
+  "overrides": {
+    "uri-js": "npm:uri-js-replace"
+  },
   "postcss": {
     "plugins": {
       "autoprefixer": {}

--- a/pdf/package-lock.json
+++ b/pdf/package-lock.json
@@ -7439,14 +7439,12 @@
       }
     },
     "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "name": "uri-js-replace",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/url-parse": {
       "version": "1.5.10",

--- a/pdf/package.json
+++ b/pdf/package.json
@@ -58,5 +58,8 @@
     "url-template": "3.1.1",
     "vite": "5.4.4",
     "vitest": "2.1.0"
+  },
+  "overrides": {
+    "uri-js": "npm:uri-js-replace"
   }
 }

--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -16928,14 +16928,12 @@
       "license": "MIT"
     },
     "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "name": "uri-js-replace",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/url-parse": {
       "version": "1.5.10",

--- a/print/package.json
+++ b/print/package.json
@@ -60,5 +60,8 @@
     "vite-svg-loader": "5.1.0",
     "vitest": "2.1.0",
     "vue": "3.5.3"
+  },
+  "overrides": {
+    "uri-js": "npm:uri-js-replace"
   }
 }


### PR DESCRIPTION
That we have less dependencies on punycode.
uri-js is not maintained anymore, thus we won't get an update. uri-js-replace removed the dependency on punycode.

This starts to solve the deprecation warning:
"punycode is deprecated, use a userland alternative instead."

Issue: #5843

Can be reverted as soon as the dependencies don't depend on uri-js anymore.