### PR TITLE
http-cache: allow to disable sending X-Key headers downstream

### DIFF
--- a/.github/workflows/reusable-dev-deployment.yml
+++ b/.github/workflows/reusable-dev-deployment.yml
@@ -94,6 +94,7 @@ jobs:
             --set ingress.basicAuth.username=${{ secrets.BASIC_AUTH_USERNAME }} \
             --set ingress.basicAuth.password='${{ secrets.BASIC_AUTH_PASSWORD }}' \
             --set apiCache.enabled=${{ vars.API_CACHE_ENABLED || false }} \
+            --set apiCache.sendXKeyHeadersDownstream=${{ vars.SEND_XKEY_HEADERS_DOWNSTREAM != null && format('''{0}''', vars.SEND_XKEY_HEADERS_DOWNSTREAM) || null }} \
             --set mail.dummyEnabled=true \
             --set postgresql.url='${{ secrets.POSTGRES_URL }}/ecamp3${{ inputs.name }}?sslmode=require' \
             --set postgresql.adminUrl='${{ secrets.POSTGRES_ADMIN_URL }}/ecamp3${{ inputs.name }}?sslmode=require' \

--- a/.helm/ecamp3/templates/api_cache_deployment.yaml
+++ b/.helm/ecamp3/templates/api_cache_deployment.yaml
@@ -47,6 +47,8 @@ spec:
               value: "{{ .Values.apiCache.varnishHttpPort }}"
             - name: COOKIE_PREFIX
               value: {{ include "api.cookiePrefix" . | quote }}
+            - name: SEND_XKEY_HEADERS_DOWNSTREAM
+              value: {{ .Values.apiCache.sendXKeyHeadersDownstream | quote }}
           args:
             - -a
             - {{ printf ":%d,HTTP" (.Values.apiCache.varnishPurgePort | int) }}

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -225,6 +225,7 @@ apiCache:
   varnishSize: 50M
   varnishHttpPort: 8080
   varnishPurgePort: 8081
+  sendXKeyHeadersDownstream: false
   resources:
     requests:
       cpu: 10m

--- a/api/docker/varnish/vcl/fos_tags_xkey.vcl
+++ b/api/docker/varnish/vcl/fos_tags_xkey.vcl
@@ -38,8 +38,8 @@ sub fos_tags_xkey_recv {
 }
 
 sub fos_tags_xkey_deliver {
-    if (!resp.http.X-Cache-Debug) {
-        // Remove tag headers when delivering to non debug client
+    if (std.getenv("SEND_XKEY_HEADERS_DOWNSTREAM") != "true" || !resp.http.X-Cache-Debug) {
+        // Remove tag headers
         unset resp.http.xkey;
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
     command: -a :8081,HTTP -p http_max_hdr=96
     environment:
       - COOKIE_PREFIX=localhost_
+      - SEND_XKEY_HEADERS_DOWNSTREAM=${SEND_XKEY_HEADERS_DOWNSTREAM:-true}
       - VARNISH_HTTP_PORT=8080
 
   pdf:


### PR DESCRIPTION
The ingress-nginx in staging could not handle the big headers. We don't need the headers here, we still have can view them on ecamp3-logging in the log output of the api container.