### PR TITLE
frontend: add components.story.storyDay.noStory to frontend

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -442,6 +442,11 @@
         "title": "Wirklich löschen?"
       }
     },
+    "story": {
+      "storyDay": {
+        "noStory": "Die Blöcke an diesem Tag enthalten keinen roten Faden."
+      }
+    },
     "toast": {
       "toasts": {
         "multiLineToast": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -440,6 +440,11 @@
         "title": "Really delete?"
       }
     },
+    "story": {
+      "storyDay": {
+        "noStory":  "The activities on this day do not contain any story content."
+      }
+    },
     "toast": {
       "toasts": {
         "multiLineToast": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -484,6 +484,11 @@
       "409": "Oooops... Cette action a provoqué une erreur côté serveur.",
       "short": "erreur de serveur"
     },
+    "story": {
+      "storyDay": {
+        "noStory": "Aucun file rouge trouvé ce jour-là..."
+      }
+    },
     "toast": {
       "copied": "{source} copié"
     },

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -385,6 +385,11 @@
         "title": "Davvero cancellare?"
       }
     },
+    "story": {
+      "storyDay": {
+        "noStory": "Nessun contenuto di storia trovato in questo giorno..."
+      }
+    },
     "toast": {
       "toasts": {
         "multiLineToast": {


### PR DESCRIPTION
In a6578ee, the story component in print was generalized to a summary component.
By renaming the translation key in common, this also effected the frontend. Leave the other translation key in common, because the pdf module might also use it in the future.

closes #6009