### PR TITLE
reverse-proxy-nginx.conf: reverse proxy upgrade response for websockets

### DIFF
--- a/reverse-proxy-nginx.conf
+++ b/reverse-proxy-nginx.conf
@@ -6,6 +6,11 @@ events {
   worker_connections  1024;
 }
 http {
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
   resolver 127.0.0.11;
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
@@ -21,6 +26,8 @@ http {
 
     location / {
       proxy_pass http://frontend:3000;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
     }
     
     location /api/ {
@@ -31,14 +38,20 @@ http {
       proxy_busy_buffers_size 256k;
       proxy_set_header X-Forwarded-Prefix /api;
       proxy_pass http://api:3001/;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
     }
     
     location /print {
       proxy_pass http://print:3003;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
     }
     
     location /mail {
       proxy_pass http://mail:1080;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
     }
   }
   server {
@@ -47,6 +60,8 @@ http {
 
     location / {
       proxy_pass http://frontend:3000;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
     }
     
     location /api/ {
@@ -57,14 +72,20 @@ http {
       proxy_busy_buffers_size 256k;
       proxy_set_header X-Forwarded-Prefix /api;
       proxy_pass http://http-cache:8080/;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
     }
     
     location /print {
       proxy_pass http://print:3003;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
     }
     
     location /mail {
       proxy_pass http://mail:1080;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
     }
   }
 }


### PR DESCRIPTION
This allows the web socket connection to the vite server(s) for hot reloading again.
I also added this for the other upstreams, that they can also use websockets if they wish in the future.
See https://nginx.org/en/docs/http/websocket.html for the docs. Don't overwrite the http version...if the client comes with a too low http version, he will anyway not be able to use websockets.