### PR TITLE
frontend: fix jest is not defined

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,6 +40,22 @@ jobs:
               ".github/workflows/continuous-integration.yml"
             ]
           do_not_skip: '["workflow_dispatch", "schedule"]'
+          
+  frontend-check-needed:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          skip_after_successful_duplicate: 'true'
+          paths: |
+            [
+              "frontend/**",
+              ".github/workflows/continuous-integration.yml"
+            ]
+          do_not_skip: '["workflow_dispatch", "schedule"]'
   
   e2e-check-needed:
     runs-on: ubuntu-latest
@@ -100,6 +116,9 @@ jobs:
   frontend-eslint:
     name: 'Lint: Frontend (ESLint)'
     runs-on: ubuntu-latest
+    needs:
+      - frontend-check-needed
+    if: needs.frontend-check-needed.outputs.should_skip != 'true'
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
@@ -326,6 +345,9 @@ jobs:
   frontend-tests:
     name: 'Tests: Frontend'
     runs-on: ubuntu-latest
+    needs:
+      - frontend-check-needed
+    if: needs.frontend-check-needed.outputs.should_skip != 'true'
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -156,6 +156,8 @@ export default defineConfig(({ mode }) => ({
     alias: [{ find: /^vue$/, replacement: 'vue/dist/vue.runtime.common.js' }],
     globalSetup: './tests/globalSetup.js',
     setupFiles: './tests/setup.js',
+    maxWorkers: 1,
+    minWorkers: 1,
     coverage: {
       all: true,
       exclude: [...configDefaults.coverage.exclude, '**/src/pdf/**'],


### PR DESCRIPTION
Can be seen here: https://github.com/BacLuc/ecamp3/actions/runs/11426812684/job/31790180774
Also only run the frontend checks if needed, now that they take 2 minutes.

---

frontend: set vitest test workers to 1

That makes our ci more stable by eliminating the
"jest is not defined" errors.
It also increased the duration from 1 minutes to 2.5 minutes.

---

continuous-integration.yml: do not run frontend checks if not needed

---