### PR TITLE
docker-compose.yml: switch to normal digest to pin browsers for cypress

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
       - FUNCTION_ENABLE_INCOGNITO_MODE=true
 
   e2e:
-    image: cypress/included:cypress-13.13.0-node-20.15.1-chrome-126.0.6478.114-1-ff-128.0-edge-126.0.2592.61-1@sha256:f9733a2cadc3aa270e40f8ce1158a23cb99703476a9db7154b4ecc51ba02bd5c
+    image: cypress/included:13.13.0@sha256:f9733a2cadc3aa270e40f8ce1158a23cb99703476a9db7154b4ecc51ba02bd5c
     profiles: ['e2e']
     container_name: 'ecamp3-e2e'
     environment:


### PR DESCRIPTION
Because updating them with renovate did not work.
There is anyway only one build with a digest for the
browser versions per build...and they would not be updated under the hood because
that would change the digest

See https://github.com/bacluc-test-org/ecamp3/commit/5577beb2a33579aadef6e35fe7ea55e14ffa6eeb
and https://github.com/bacluc-test-org/ecamp3/commit/edceebf909f2831a2b721531eb9fd19fb594e43c
on https://github.com/bacluc-test-org/ecamp3/commits/renovate/cypress/