### PR TITLE
frontend: move checklist delete button to ChecklistOverview.vue

### DIFF
--- a/frontend/src/components/checklist/ChecklistDetail.vue
+++ b/frontend/src/components/checklist/ChecklistDetail.vue
@@ -33,41 +33,9 @@
     </template>
     <template #title-actions>
       <ChecklistItemCreate :checklist="checklist" />
-      <!-- hamburger menu -->
-      <v-menu offset-y>
-        <template #activator="{ on, attrs }">
-          <v-btn icon v-bind="attrs" v-on="on">
-            <v-icon>mdi-dots-vertical</v-icon>
-          </v-btn>
-        </template>
-        <v-list>
-          <!-- remove checklist -->
-          <DialogEntityDelete
-            :entity="checklist"
-            :error-handler="deleteErrorHandler"
-            :success-handler="deleteSuccessHandler"
-          >
-            <template #activator="{ on }">
-              <v-list-item v-on="on">
-                <v-list-item-icon>
-                  <v-icon>mdi-delete</v-icon>
-                </v-list-item-icon>
-                <v-list-item-title>
-                  {{ $tc('global.button.delete') }}
-                </v-list-item-title>
-              </v-list-item>
-            </template>
-            {{ $tc('components.checklist.checklistDetail.deleteWarning') }}
-          </DialogEntityDelete>
-        </v-list>
-      </v-menu>
     </template>
     <v-list>
-      <SortableChecklist
-        v-if="checklist && !checklist._meta.deleting"
-        :parent="null"
-        :checklist="checklist"
-      />
+      <SortableChecklist :parent="null" :checklist="checklist" />
     </v-list>
   </content-card>
 </template>
@@ -77,8 +45,6 @@ import ContentCard from '@/components/layout/ContentCard.vue'
 import ChecklistItemCreate from '@/components/checklist/ChecklistItemCreate.vue'
 import SortableChecklist from '@/components/checklist/SortableChecklist.vue'
 import ApiForm from '@/components/form/api/ApiForm.vue'
-import DialogEntityDelete from '@/components/dialog/DialogEntityDelete.vue'
-import { checklistRoute } from '@/router.js'
 
 export default {
   name: 'ChecklistDetail',
@@ -87,7 +53,6 @@ export default {
     ChecklistItemCreate,
     ContentCard,
     ApiForm,
-    DialogEntityDelete,
   },
   props: {
     camp: {
@@ -112,16 +77,6 @@ export default {
   methods: {
     makeChecklistNameEditable() {
       this.editChecklistName = true
-    },
-    deleteErrorHandler(e) {
-      if (e?.response?.status === 422 /* Validation Error */) {
-        return this.$tc('components.checklist.checklistDetail.deleteError')
-      }
-      return null
-    },
-    deleteSuccessHandler() {
-      // redirect to Checklist overview
-      this.$router.replace(checklistRoute(this.camp))
     },
   },
 }

--- a/frontend/src/components/checklist/ChecklistOverview.vue
+++ b/frontend/src/components/checklist/ChecklistOverview.vue
@@ -20,6 +20,19 @@
           <v-list-item-action style="display: inline">
             <v-item-group>
               <ButtonEdit color="primary--text" text class="my-n1 v-btn--has-bg" />
+              <DialogEntityDelete
+                :entity="checklist"
+                :warning-text-entity="checklist.name"
+                :error-handler="deleteErrorHandler"
+              >
+                <template #activator="{ on }">
+                  <ButtonDelete
+                    text
+                    class="my-n1 ml-2 v-btn--has-bg"
+                    @click.prevent="on.click"
+                  />
+                </template>
+              </DialogEntityDelete>
             </v-item-group>
           </v-list-item-action>
         </v-list-item>
@@ -33,10 +46,14 @@ import ContentCard from '@/components/layout/ContentCard.vue'
 import ChecklistCreate from '@/components/checklist/ChecklistCreate.vue'
 import { checklistRoute } from '@/router.js'
 import ButtonEdit from '@/components/buttons/ButtonEdit.vue'
+import ButtonDelete from '@/components/buttons/ButtonDelete.vue'
+import DialogEntityDelete from '@/components/dialog/DialogEntityDelete.vue'
 
 export default {
   name: 'ChecklistOverview',
   components: {
+    DialogEntityDelete,
+    ButtonDelete,
     ButtonEdit,
     ChecklistCreate,
     ContentCard,
@@ -50,6 +67,14 @@ export default {
       return this.checklistCollection.items
     },
   },
-  methods: { checklistRoute },
+  methods: {
+    checklistRoute,
+    deleteErrorHandler(e) {
+      if (e?.response?.status === 422 /* Validation Error */) {
+        this.$toast.error(this.$tc('components.checklist.checklistOverview.deleteError'))
+      }
+      return null
+    },
+  },
 }
 </script>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -206,8 +206,7 @@
         "delete": "Möchtest du diesen Eintrag wirklich löschen?",
         "title": "Checklisteneintrag bearbeiten"
       },
-      "checklistDetail": {
-        "deleteWarning": "Möchtest du diese Checkliste wirklich löschen? Der komplette Inhalt dieser Checkliste wird gelöscht.",
+      "checklistOverview": {
         "deleteError": "Checkliste konnte nicht gelöscht werden. Überprüfe vor dem Löschen, dass die Checkliste nicht mehr in Aktivitäten verwendet wird."
       },
       "sortableChecklist": {


### PR DESCRIPTION
Temporary, until we can delete the entities we are currently displaying.

With this PR, we have the option to quickly change to this implementation, if we think there are too many errors with the current implementation.