### PR TITLE
ops-dashboard: add workflow to deploy it with github actions

### DIFF
--- a/.github/workflows/deploy-ecamp3-logging.yml
+++ b/.github/workflows/deploy-ecamp3-logging.yml
@@ -1,0 +1,63 @@
+name: Deploy ecamp3-logging
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Choose environment'
+        type: environment
+        required: true
+
+jobs:
+  deploy-ecamp3-logging:
+    name: "Deploy ecamp3-logging"
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    steps:
+      - name: Validate environment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (!"${{ github.event.inputs.environment }}".startsWith("ecamp3-logging")) {
+                throw new Error("Environment must start with 'ecamp3-logging'");
+            }
+
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Dump secrets to .env
+        run: |
+          echo '${{ toJSON(secrets) }}' | jq -r 'keys[] as $k | select(.[$k] |contains("\n") | not) | "\($k)=\"\(.[$k])\""' >> .env
+        working-directory: .ops/ecamp3-logging
+
+      - name: Dump variables to .env
+        run: |
+          echo '${{ toJSON(vars) }}' | jq -r 'keys[] as $k | select(.[$k] |contains("\n") | not) | "\($k)=\"\(.[$k])\""' >> .env
+        working-directory: .ops/ecamp3-logging
+
+      - name: Show .env for debugging
+        run: echo "$(cat .env | sort)"
+        working-directory: .ops/ecamp3-logging
+
+      - name: Setup helm
+        run: |
+          mkdir ~/.kube && echo '${{ secrets.KUBECONFIG }}' > ~/.kube/config && chmod go-r ~/.kube/config
+
+      - name: Add helm repositories
+        run: |
+          helm repo add fluent https://fluent.github.io/helm-charts
+          helm repo update
+
+      - name: Diff deployment
+        run: |
+          ./deploy.sh diff || true
+        working-directory: .ops/ecamp3-logging
+
+      - name: Show values.out.yaml
+        run: cat values.out.yaml
+        working-directory: .ops/ecamp3-logging
+
+      - name: Deploy
+        run: |
+          ./deploy.sh deploy
+        working-directory: .ops/ecamp3-logging

--- a/.ops/ecamp3-logging/.gitignore
+++ b/.ops/ecamp3-logging/.gitignore
@@ -1,2 +1,3 @@
-/charts
 .env
+/charts
+/values.out.yaml

--- a/.ops/ecamp3-logging/.helmignore
+++ b/.ops/ecamp3-logging/.helmignore
@@ -1,1 +1,3 @@
+.env
 /deploy.sh
+/values.out.yaml

--- a/.ops/ecamp3-logging/README.md
+++ b/.ops/ecamp3-logging/README.md
@@ -35,7 +35,5 @@ sh files/kibana/restore-kibana-objects.sh
 
 To diff the deployment
 ```shell
-helm template \
-    --namespace ecamp3-logging --no-hooks --skip-tests \
-    ecamp3-logging . --values=values.yaml --values=values-prod.yaml | kubectl diff --namespace ecamp3-logging -f - | batcat -l diff -
+./deploy.sh diff
 ```

--- a/.ops/ecamp3-logging/deploy.sh
+++ b/.ops/ecamp3-logging/deploy.sh
@@ -1,21 +1,35 @@
-#!/bin/bash
+#!/bin/sh
 
-set -e
+set -ea
 
 SCRIPT_DIR=$(realpath "$(dirname "$0")")
 cd $SCRIPT_DIR
 
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <prod|dev>"
-    echo "(or other environments)"
-    exit 1
+ELASTIC_NODE_REQUESTS_MEMORY=1000Mi
+ELASTIC_NODE_LIMITS_MEMORY=1000Mi
+
+if [ -f $SCRIPT_DIR/.env ]; then
+  . $SCRIPT_DIR/.env
 fi
 
-# to debug: --dry-run --debug
+envsubst < $SCRIPT_DIR/values.yaml > $SCRIPT_DIR/values.out.yaml
+
 helm dep build
-helm upgrade --install ecamp3-logging \
-    --namespace=ecamp3-logging \
-    --create-namespace \
-    $SCRIPT_DIR \
-    --values $SCRIPT_DIR/values.yaml \
-    --values $SCRIPT_DIR/values-$1.yaml
+
+if [ $1 = "deploy" ]; then
+  # to debug: --dry-run --debug
+  helm upgrade --install ecamp3-logging \
+      --namespace ecamp3-logging \
+      --create-namespace \
+      $SCRIPT_DIR \
+      --values $SCRIPT_DIR/values.out.yaml
+  exit 0
+fi
+
+if [ $1 = "diff" ]; then
+  helm template \
+      --namespace ecamp3-logging --no-hooks --skip-tests ecamp3-logging  \
+      $SCRIPT_DIR \
+      --values $SCRIPT_DIR/values.out.yaml | kubectl diff --namespace ecamp3-logging -f -
+  exit 0
+fi

--- a/.ops/ecamp3-logging/values-prod.yaml
+++ b/.ops/ecamp3-logging/values-prod.yaml
@@ -1,7 +1,0 @@
-elasticsearch:
-  elasticNode:
-    resources:
-      requests:
-        memory: 2000Mi
-      limits:
-        memory: 2000Mi

--- a/.ops/ecamp3-logging/values.yaml
+++ b/.ops/ecamp3-logging/values.yaml
@@ -38,9 +38,9 @@ elasticsearch:
   elasticNode:
     resources:
       requests:
-        memory: 1000Mi
+        memory: ${ELASTIC_NODE_REQUESTS_MEMORY}
       limits:
-        memory: 1000Mi
+        memory: ${ELASTIC_NODE_LIMITS_MEMORY}
   persistence:
     storageClassName: do-block-storage
     resources:


### PR DESCRIPTION
Use set -a to export the variables in .env directly. We can only use single line env variables as vars and secrets here.

The idea is to have the envornments ops-dashboard-dev and ops-dashboard-prod, and deploy from tags on the devel branch.
Successful run is here: https://github.com/BacLuc/ecamp3/actions/runs/11645316610/job/32428206176