### PR TITLE
campShortTitle.js: fix error for non string camp.shortTitle

### DIFF
--- a/common/helpers/__tests__/campShortTitle.spec.js
+++ b/common/helpers/__tests__/campShortTitle.spec.js
@@ -37,6 +37,15 @@ describe('campShortTitle', () => {
     [{ shortTitle: undefined, title: null }, ''],
     [{ shortTitle: '0', title: 'Sola24' }, '0'],
     [{ shortTitle: '', title: 'Sola24' }, 'SoLa24'],
+
+    //error cases
+    [{ shortTitle: 0, title: 'Sola24' }, '0'],
+    [{ shortTitle: false, title: 'Sola24' }, 'false'],
+    [{ shortTitle: true, title: 'Sola24' }, 'true'],
+    [{ shortTitle: {}, title: 'Sola24' }, '[object Object]'],
+    [{ shortTitle: Symbol('foo'), title: 'Sola24' }, 'SoLa24'],
+    [{ shortTitle: [], title: 'Sola24' }, ''],
+    [{ shortTitle: /test/, title: 'Sola24' }, '/test/'],
     [null, ''],
     [undefined, ''],
   ])('maps "%s" to "%s"', (input, expected) => {

--- a/common/helpers/campShortTitle.js
+++ b/common/helpers/campShortTitle.js
@@ -48,8 +48,8 @@ const ADDITIONAL_SHORTNERS = [
 ]
 
 function campShortTitle(camp) {
-  if (camp?.shortTitle != null && camp.shortTitle !== '') {
-    return camp.shortTitle.substring(0, 16)
+  if (camp?.shortTitle != null && camp.shortTitle !== '' && typeof camp.shortTitle !== 'symbol') {
+    return `${camp.shortTitle}`.substring(0, 16)
   }
 
   let title = camp?.title ?? ''


### PR DESCRIPTION
Fixes [#6363](https://github.com/ecamp/ecamp3/issues/6360)