### PR TITLE
Update hal-json-vuex in frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,7 @@
         "deepmerge": "4.3.1",
         "emoji-regex": "10.4.0",
         "file-saver": "2.0.5",
-        "hal-json-vuex": "2.0.0-alpha.16",
+        "hal-json-vuex": "3.0.0-alpha.9",
         "inter-ui": "3.19.3",
         "js-cookie": "3.0.5",
         "linkify-it": "5.0.0",
@@ -7205,35 +7205,62 @@
       "license": "ISC"
     },
     "node_modules/hal-json-normalizer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hal-json-normalizer/-/hal-json-normalizer-4.2.0.tgz",
-      "integrity": "sha512-TnlN4OzP/RPTCRC/+Zy9qjt9mefSHEjQrI2RQPERahBsOh5gPnUnpuH2DfIM3NiMdlCNQaTQuyhU1oJ0L4vNEg==",
-      "license": "MIT",
+      "version": "5.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/hal-json-normalizer/-/hal-json-normalizer-5.0.0-alpha.0.tgz",
+      "integrity": "sha512-c/7LnUA63PZ/i+Jx6ueUNzTfr05cWzaiFIO2/aoQ8LCIpY37INfflHtYTlQiSi9FfAQDI/CTeExUrbU6U1uEnw==",
       "dependencies": {
-        "lodash": "^4.17.15"
+        "lodash-es": "^4.17.15"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 18.17.0"
       }
     },
     "node_modules/hal-json-vuex": {
-      "version": "2.0.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/hal-json-vuex/-/hal-json-vuex-2.0.0-alpha.16.tgz",
-      "integrity": "sha512-7OtQtJLr9Od4giw27ryINOYlM/6dvNZlcQiiseINq8qKrpc5dV9hLo4QOvKy8YGgnQOXYnCMSJ55/7XM+qiPGg==",
-      "license": "MIT",
+      "version": "3.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/hal-json-vuex/-/hal-json-vuex-3.0.0-alpha.9.tgz",
+      "integrity": "sha512-DgQmQ3ddu9P3PKzBKSvxEf4EhO9Tu30TQms3V8BT8+97tEqDzek8J41KsyAVbk5vCt4nxsj7v8lm5gp4JzokgQ==",
       "dependencies": {
-        "hal-json-normalizer": "^4.2.0",
-        "url-template": "^2.0.8"
+        "hal-json-normalizer": "^5.0.0-alpha.0",
+        "url-template": "^3.1.1",
+        "vue-demi": "^0.14.10"
       },
       "engines": {
-        "node": ">=14.0.0 <19.0.0"
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^2.0.0 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
-    "node_modules/hal-json-vuex/node_modules/url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
-      "license": "BSD"
+    "node_modules/hal-json-vuex/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
@@ -8494,6 +8521,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "deepmerge": "4.3.1",
     "emoji-regex": "10.4.0",
     "file-saver": "2.0.5",
-    "hal-json-vuex": "2.0.0-alpha.16",
+    "hal-json-vuex": "3.0.0-alpha.9",
     "inter-ui": "3.19.3",
     "js-cookie": "3.0.5",
     "linkify-it": "5.0.0",


### PR DESCRIPTION
Use new version of hal-json-vuex also in vue 2 frontend (yet without using [typing functionality](https://github.com/ecamp/ecamp3/pull/6032))