### PR TITLE
Fix phpunit warnings

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -113,7 +113,7 @@
         "cs-fix": "php-cs-fixer fix",
         "test": [
             "Composer\\Config::disableProcessTimeout",
-            "bin/phpunit -d memory_limit=-1"
+            "bin/phpunit -d memory_limit=-1 -c phpunit.xml.dist"
         ],
         "paratest": [
             "Composer\\Config::disableProcessTimeout",

--- a/api/phpunit.nodocker.xml
+++ b/api/phpunit.nodocker.xml
@@ -14,7 +14,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <server name="SHELL_VERBOSITY" value="-1"/>
         <server name="SYMFONY_PHPUNIT_REMOVE" value=""/>
-        <server name="SYMFONY_PHPUNIT_VERSION" value="10.4.2"/>
+        <server name="SYMFONY_PHPUNIT_VERSION" value="11.4.3"/>
         <env name="DATABASE_URL" value="postgresql://ecamp3:ecamp3@localhost:5432/ecamp3dev?serverVersion=15%26charset=utf8" force="true" />
         <env name="TEST_DATABASE_URL" value="postgresql://ecamp3:ecamp3@localhost:5432/ecamp3dev?serverVersion=15%26charset=utf8" force="true" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="quiet[]=indirect&amp;max[total]=999999"/>

--- a/api/phpunit.performance_test.xml.dist
+++ b/api/phpunit.performance_test.xml.dist
@@ -14,7 +14,7 @@
     <server name="APP_ENV" value="performance_test" force="true"/>
     <server name="SHELL_VERBOSITY" value="-1"/>
     <server name="SYMFONY_PHPUNIT_REMOVE" value=""/>
-    <server name="SYMFONY_PHPUNIT_VERSION" value="10.4.2"/>
+    <server name="SYMFONY_PHPUNIT_VERSION" value="11.4.3"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="quiet[]=indirect&amp;max[total]=999999"/>
     <!-- if "Other deprecation notices" ever gets annoying: 
           <env name="SYMFONY_DEPRECATIONS_HELPER"

--- a/api/phpunit.xml.dist
+++ b/api/phpunit.xml.dist
@@ -14,7 +14,7 @@
     <server name="APP_ENV" value="test" force="true"/>
     <server name="SHELL_VERBOSITY" value="-1"/>
     <server name="SYMFONY_PHPUNIT_REMOVE" value=""/>
-    <server name="SYMFONY_PHPUNIT_VERSION" value="10.4.2"/>
+    <server name="SYMFONY_PHPUNIT_VERSION" value="11.4.3"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="quiet[]=indirect&amp;max[total]=999999"/>
     <!-- if "Other deprecation notices" ever gets annoying: 
           <env name="SYMFONY_DEPRECATIONS_HELPER"

--- a/api/tests/bootstrap.php
+++ b/api/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\ErrorHandler\ErrorHandler;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
@@ -11,3 +12,7 @@ if (method_exists(Dotenv::class, 'bootEnv')) {
 if ($_SERVER['APP_DEBUG']) {
     umask(0000);
 }
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+set_exception_handler([new ErrorHandler(), 'handleException']);


### PR DESCRIPTION
api: pull setting exception handler up to boostrap.php

As suggested in https://github.com/symfony/symfony/issues/53812#issuecomment-1962740145

This seems like a temporary fix, until symfony has figured out
what to do with https://github.com/sebastianbergmann/phpunit/pull/5619

Issue: #6407

---
api: explicitly set path to phpunit.xml.dist

phpunit 11 does not seem to find it by itself.

---

api: also update phpunit version of phpunit.*.xml

Was forgotten in f761b09.