### PR TITLE
api: rename parameter $object to $data for Normalizer

### DIFF
--- a/api/src/Serializer/Normalizer/CircularReferenceDetectingHalItemNormalizer.php
+++ b/api/src/Serializer/Normalizer/CircularReferenceDetectingHalItemNormalizer.php
@@ -40,13 +40,15 @@ final class CircularReferenceDetectingHalItemNormalizer extends AbstractItemNorm
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-suppress ParamNameMismatch
      */
-    public function normalize($object, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
-        if ($this->isHalCircularReference($object, $context)) {
-            return $this->handleHalCircularReference($object, $format, $context);
+    public function normalize($data, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
+        if ($this->isHalCircularReference($data, $context)) {
+            return $this->handleHalCircularReference($data, $format, $context);
         }
 
-        return $this->decorated->normalize($object, $format, $context);
+        return $this->decorated->normalize($data, $format, $context);
     }
 
     public function setSerializer(SerializerInterface $serializer): void {

--- a/api/src/Serializer/Normalizer/CollectionItemsNormalizer.php
+++ b/api/src/Serializer/Normalizer/CollectionItemsNormalizer.php
@@ -20,20 +20,20 @@ class CollectionItemsNormalizer implements NormalizerInterface, NormalizerAwareI
         return $this->decorated->supportsNormalization($data, $format, $context);
     }
 
-    public function normalize($object, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
-        $data = $this->decorated->normalize($object, $format, $context);
+    public function normalize($data, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
+        $normalized_data = $this->decorated->normalize($data, $format, $context);
 
-        if (isset($data['_embedded'], $data['_embedded']['item'])) {
-            $data['_embedded']['items'] = $data['_embedded']['item'];
-            unset($data['_embedded']['item']);
+        if (isset($normalized_data['_embedded'], $normalized_data['_embedded']['item'])) {
+            $normalized_data['_embedded']['items'] = $normalized_data['_embedded']['item'];
+            unset($normalized_data['_embedded']['item']);
 
-            $data['_links']['items'] = $data['_links']['item'];
-            unset($data['_links']['item']);
-        } elseif (isset($data['totalItems']) && 0 === $data['totalItems']) {
-            $data['_embedded']['items'] = [];
+            $normalized_data['_links']['items'] = $normalized_data['_links']['item'];
+            unset($normalized_data['_links']['item']);
+        } elseif (isset($normalized_data['totalItems']) && 0 === $normalized_data['totalItems']) {
+            $normalized_data['_embedded']['items'] = [];
         }
 
-        return $data;
+        return $normalized_data;
     }
 
     public function getSupportedTypes(?string $format): array {

--- a/api/src/Serializer/Normalizer/ContentTypeNormalizer.php
+++ b/api/src/Serializer/Normalizer/ContentTypeNormalizer.php
@@ -25,22 +25,22 @@ class ContentTypeNormalizer implements NormalizerInterface, SerializerAwareInter
         return $this->decorated->supportsNormalization($data, $format, $context);
     }
 
-    public function normalize($object, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
-        $data = $this->decorated->normalize($object, $format, $context);
+    public function normalize($data, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
+        $normalized_data = $this->decorated->normalize($data, $format, $context);
 
-        if ($object instanceof ContentType && isset($object->entityClass)) {
+        if ($data instanceof ContentType && isset($data->entityClass)) {
             // get uri for the respective ContentNode entity and add ContentType as query parameter
-            [$uriTemplate, $templated] = $this->uriTemplateFactory->createFromResourceClass($object->entityClass);
-            $uri = $this->uriTemplate->expand($uriTemplate, ['contentType' => $this->iriConverter->getIriFromResource($object)]);
+            [$uriTemplate, $templated] = $this->uriTemplateFactory->createFromResourceClass($data->entityClass);
+            $uri = $this->uriTemplate->expand($uriTemplate, ['contentType' => $this->iriConverter->getIriFromResource($data)]);
 
             // add uri as HAL link
-            $data['_links']['contentNodes']['href'] = $uri;
+            $normalized_data['_links']['contentNodes']['href'] = $uri;
 
             // unset the property itself (property definition was only needed to ensure proper API documentation)
-            unset($data['contentNodes']);
+            unset($normalized_data['contentNodes']);
         }
 
-        return $data;
+        return $normalized_data;
     }
 
     public function getSupportedTypes(?string $format): array {

--- a/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
+++ b/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
@@ -98,28 +98,28 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
         return $this->decorated->supportsNormalization($data, $format, $context);
     }
 
-    public function normalize($object, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
-        $data = $this->decorated->normalize($object, $format, $context);
+    public function normalize($data, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
+        $normalized_data = $this->decorated->normalize($data, $format, $context);
 
-        if (!isset($data['_links'])) {
-            return $data;
+        if (!isset($normalized_data['_links'])) {
+            return $normalized_data;
         }
 
-        foreach ($data['_links'] as $rel => $link) {
+        foreach ($normalized_data['_links'] as $rel => $link) {
             // Only consider array rels (i.e. OneToMany and ManyToMany)
             if (isset($link['href'])) {
                 continue;
             }
 
             try {
-                $data['_links'][$rel] = ['href' => $this->getRelatedCollectionHref($object, $rel, $context)];
+                $normalized_data['_links'][$rel] = ['href' => $this->getRelatedCollectionHref($data, $rel, $context)];
             } catch (UnsupportedRelationException $e) {
                 // The relation is not supported, or there is no matching filter defined on the related entity
                 continue;
             }
         }
 
-        return $data;
+        return $normalized_data;
     }
 
     public function getSupportedTypes(?string $format): array {

--- a/api/src/Serializer/Normalizer/TranslationConstraintViolationListNormalizer.php
+++ b/api/src/Serializer/Normalizer/TranslationConstraintViolationListNormalizer.php
@@ -24,15 +24,15 @@ class TranslationConstraintViolationListNormalizer implements NormalizerInterfac
         return $this->getNormalizerCollection()->exists(fn ($_, $elem) => $elem->supportsNormalization($data, $format, $context));
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
-        $normalizer = $this->getNormalizerCollection()->filter(fn ($elem) => $elem->supportsNormalization($object, $format, $context))->first();
+    public function normalize(mixed $data, ?string $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
+        $normalizer = $this->getNormalizerCollection()->filter(fn ($elem) => $elem->supportsNormalization($data, $format, $context))->first();
         if (false === $normalizer) {
             throw new \RuntimeException("Did not find a normalizer to normalize response to format {$format}");
         }
-        $result = $normalizer->normalize($object, $format, $context);
+        $result = $normalizer->normalize($data, $format, $context);
 
-        /** @var ConstraintViolationList $object */
-        foreach ($object as $violation) {
+        /** @var ConstraintViolationList $data */
+        foreach ($data as $violation) {
             foreach ($result['violations'] as &$resultItem) {
                 $code = $resultItem['code'] ?? null;
                 $propertyPath = $resultItem['propertyPath'];

--- a/api/src/Serializer/Normalizer/UriTemplateNormalizer.php
+++ b/api/src/Serializer/Normalizer/UriTemplateNormalizer.php
@@ -23,8 +23,8 @@ class UriTemplateNormalizer implements NormalizerInterface {
         return $this->decorated->supportsNormalization($data, $format, $context);
     }
 
-    public function normalize($object, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
-        $result = $this->decorated->normalize($object, $format, $context);
+    public function normalize($data, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string {
+        $result = $this->decorated->normalize($data, $format, $context);
 
         foreach ($result['_links'] as $rel => $link) {
             if ('self' === $rel) {

--- a/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests\Serializer\Normalizer;
 
-use ApiPlatform\Api\FilterInterface;
+use ApiPlatform\Doctrine\Common\Filter\SearchFilterInterface;
 use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiResource;
@@ -48,7 +48,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
     private MockObject|PropertyAccessorInterface $propertyAccessor;
     private EntityManagerInterface|MockObject $entityManager;
 
-    private ?FilterInterface $filterInstance;
+    private null|DateFilter|SearchFilterInterface $filterInstance;
 
     protected function setUp(): void {
         $this->filterLocatorMock = $this->createMock(ServiceLocator::class);


### PR DESCRIPTION
This fixes the psalm error
- Argument 1 of App\Serializer\Normalizer\CircularReferenceDetectingHalItemNormalizer::normalize has wrong name $object, expecting $data as defined by Symfony\Component\Serializer\Normalizer\NormalizerInterface::normalize (see https://psalm.dev/230) public function normalize($object, $format = null, array $context = []): null|array|\ArrayObject|bool|float|int|string { } After 6bdbd2e0.