### PR TITLE
RelatedCollectionLinkNormalizer performance improved

### DIFF
--- a/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
+++ b/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
@@ -119,7 +119,7 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
             //     continue;
             // }
 
-            list ($ok, $href) = $this->getRelatedCollectionHref($data, $rel, $context);
+            list($ok, $href) = $this->getRelatedCollectionHref($data, $rel, $context);
             if ($ok) {
                 $normalized_data['_links'][$rel] = ['href' => $href];
             }
@@ -182,12 +182,11 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
         $lookupKey = $relatedResourceClass.':'.$relatedFilterName;
         if (isset($this->exactSearchFilterExistsCache[$lookupKey])) {
             $result = $this->exactSearchFilterExistsCache[$lookupKey];
-
         } else {
             $result = [null, ''];
             $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($relatedResourceClass);
             $operation = OperationHelper::findOneByType($resourceMetadataCollection, GetCollection::class);
-            
+
             if (!$operation) {
                 $result = [null, 'The resource '.$relatedResourceClass.' does not implement GetCollection() operation.'];
             } else {
@@ -203,9 +202,9 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
 
         if ($result[0] instanceof Operation) {
             return [true, $this->router->generate($result[0]->getName(), [$relatedFilterName => urlencode($this->iriConverter->getIriFromResource($object))], UrlGeneratorInterface::ABS_PATH)];
-        } else {
-            return [false, $result[1]];
         }
+
+        return [false, $result[1]];
     }
 
     protected function getRelatedCollectionLinkAnnotation(string $className, string $propertyName): ?RelatedCollectionLink {

--- a/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
+++ b/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
@@ -82,7 +82,10 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
     use PropertyHelperTrait;
     use ClassInfoTrait;
 
-    private $exactSearchFilterExistsCache = [];
+    /**
+     * @var (Operation|string)[]
+     */
+    private array $exactSearchFilterExistsOperationCache = [];
 
     public function __construct(
         private NormalizerInterface $decorated,
@@ -121,10 +124,10 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
                 continue;
             }
 
-            list($ok, $href) = $this->getRelatedCollectionHref($data, $rel, $context);
-            if ($ok) {
-                $normalized_data['_links'][$rel] = ['href' => $href];
+            if (!$this->getRelatedCollectionHref($data, $rel, $context, $result)) {
+                continue;
             }
+            $normalized_data['_links'][$rel] = ['href' => $result];
         }
 
         return $normalized_data;
@@ -144,7 +147,7 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
         }
     }
 
-    public function getRelatedCollectionHref($object, $rel, array $context = []): array {
+    protected function getRelatedCollectionHref($object, $rel, array $context, &$href): bool {
         $resourceClass = $this->getObjectClass($object);
 
         if ($this->nameConverter instanceof NameConverterInterface) {
@@ -157,7 +160,9 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
             $params = $this->extractUriParams($object, $annotation->getParams());
             [$uriTemplate] = $this->uriTemplateFactory->createFromResourceClass($annotation->getRelatedEntity());
 
-            return [true, $this->uriTemplate->expand($uriTemplate, $params)];
+            $href = $this->uriTemplate->expand($uriTemplate, $params);
+
+            return true;
         }
 
         try {
@@ -169,7 +174,8 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
 
             $relationMetadata = $classMetadata->getAssociationMapping($rel);
         } catch (MappingException) {
-            return [false, $resourceClass.'#'.$rel.' is not a Doctrine association. Embedding non-Doctrine collections is currently not implemented.'];
+            // $resourceClass # $rel is not a Doctrine association. Embedding non-Doctrine collections is currently not implemented
+            return false;
         }
 
         $relatedResourceClass = $relationMetadata['targetEntity'];
@@ -178,35 +184,38 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
         $relatedFilterName ??= $relationMetadata['inversedBy'];
 
         if (empty($relatedResourceClass) || empty($relatedFilterName)) {
-            return [false, 'The '.$resourceClass.'#'.$rel.' relation does not have both a targetEntity and a mappedBy or inversedBy property'];
+            // The $resourceClass # $rel relation does not have both a targetEntity and a mappedBy or inversedBy property
+            return false;
         }
 
         $lookupKey = $relatedResourceClass.':'.$relatedFilterName;
-        if (isset($this->exactSearchFilterExistsCache[$lookupKey])) {
-            $result = $this->exactSearchFilterExistsCache[$lookupKey];
+        if (isset($this->exactSearchFilterExistsOperationCache[$lookupKey])) {
+            $result = $this->exactSearchFilterExistsOperationCache[$lookupKey];
         } else {
-            $result = [null, ''];
+            $result = 'No Operation';
             $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($relatedResourceClass);
             $operation = OperationHelper::findOneByType($resourceMetadataCollection, GetCollection::class);
 
             if (!$operation) {
-                $result = [null, 'The resource '.$relatedResourceClass.' does not implement GetCollection() operation.'];
+                // The resource $relatedResourceClass does not implement GetCollection() operation
             } else {
                 $filterExists = $this->exactSearchFilterExists($relatedResourceClass, $relatedFilterName);
                 if (!$filterExists) {
-                    $result = [null, 'The resource '.$relatedResourceClass.' does not have a search filter for the relation '.$relatedFilterName.'.'];
+                    // The resource $relatedResourceClass does not have a search filter for the relation $relatedFilterName
                 } else {
-                    $result = [$operation, ''];
+                    $result = $operation;
                 }
             }
-            $this->exactSearchFilterExistsCache[$lookupKey] = $result;
+            $this->exactSearchFilterExistsOperationCache[$lookupKey] = $result;
         }
 
-        if ($result[0] instanceof Operation) {
-            return [true, $this->router->generate($result[0]->getName(), [$relatedFilterName => urlencode($this->iriConverter->getIriFromResource($object))], UrlGeneratorInterface::ABS_PATH)];
+        if ($result instanceof Operation) {
+            $href = $this->router->generate($result->getName(), [$relatedFilterName => urlencode($this->iriConverter->getIriFromResource($object))], UrlGeneratorInterface::ABS_PATH);
+
+            return true;
         }
 
-        return [false, $result[1]];
+        return false;
     }
 
     protected function getRelatedCollectionLinkAnnotation(string $className, string $propertyName): ?RelatedCollectionLink {

--- a/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
+++ b/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
@@ -114,9 +114,10 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
                 continue;
             }
             // Only consider relations with non-null value (object or collection)
-            if (property_exists($data, $rel) && !isset($data->$rel)) {
-                continue;
-            }
+            // (does not yet work, some properties are private and cannot be read out)
+            // if (property_exists($data, $rel) && !isset($data->$rel)) {
+            //     continue;
+            // }
 
             list ($ok, $href) = $this->getRelatedCollectionHref($data, $rel, $context);
             if ($ok) {

--- a/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
+++ b/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
@@ -8,6 +8,7 @@ use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\IriConverterInterface;
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use App\Entity\BaseEntity;
@@ -81,6 +82,8 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
     use PropertyHelperTrait;
     use ClassInfoTrait;
 
+    private $exactSearchFilterExistsCache = [];
+
     public function __construct(
         private NormalizerInterface $decorated,
         private ServiceLocator $filterLocator,
@@ -110,12 +113,14 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
             if (isset($link['href'])) {
                 continue;
             }
-
-            try {
-                $normalized_data['_links'][$rel] = ['href' => $this->getRelatedCollectionHref($data, $rel, $context)];
-            } catch (UnsupportedRelationException $e) {
-                // The relation is not supported, or there is no matching filter defined on the related entity
+            // Only consider relations with non-null value (object or collection)
+            if (property_exists($data, $rel) && !isset($data->$rel)) {
                 continue;
+            }
+
+            list ($ok, $href) = $this->getRelatedCollectionHref($data, $rel, $context);
+            if ($ok) {
+                $normalized_data['_links'][$rel] = ['href' => $href];
             }
         }
 
@@ -136,7 +141,7 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
         }
     }
 
-    public function getRelatedCollectionHref($object, $rel, array $context = []): string {
+    public function getRelatedCollectionHref($object, $rel, array $context = []): array {
         $resourceClass = $this->getObjectClass($object);
 
         if ($this->nameConverter instanceof NameConverterInterface) {
@@ -149,7 +154,7 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
             $params = $this->extractUriParams($object, $annotation->getParams());
             [$uriTemplate] = $this->uriTemplateFactory->createFromResourceClass($annotation->getRelatedEntity());
 
-            return $this->uriTemplate->expand($uriTemplate, $params);
+            return [true, $this->uriTemplate->expand($uriTemplate, $params)];
         }
 
         try {
@@ -161,7 +166,7 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
 
             $relationMetadata = $classMetadata->getAssociationMapping($rel);
         } catch (MappingException) {
-            throw new UnsupportedRelationException($resourceClass.'#'.$rel.' is not a Doctrine association. Embedding non-Doctrine collections is currently not implemented.');
+            return [false, $resourceClass.'#'.$rel.' is not a Doctrine association. Embedding non-Doctrine collections is currently not implemented.'];
         }
 
         $relatedResourceClass = $relationMetadata['targetEntity'];
@@ -170,21 +175,36 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
         $relatedFilterName ??= $relationMetadata['inversedBy'];
 
         if (empty($relatedResourceClass) || empty($relatedFilterName)) {
-            throw new UnsupportedRelationException('The '.$resourceClass.'#'.$rel.' relation does not have both a targetEntity and a mappedBy or inversedBy property');
+            return [false, 'The '.$resourceClass.'#'.$rel.' relation does not have both a targetEntity and a mappedBy or inversedBy property'];
         }
 
-        $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($relatedResourceClass);
-        $operation = OperationHelper::findOneByType($resourceMetadataCollection, GetCollection::class);
+        $lookupKey = $relatedResourceClass.':'.$relatedFilterName;
+        if (isset($this->exactSearchFilterExistsCache[$lookupKey])) {
+            $result = $this->exactSearchFilterExistsCache[$lookupKey];
 
-        if (!$operation) {
-            throw new UnsupportedRelationException('The resource '.$relatedResourceClass.' does not implement GetCollection() operation.');
+        } else {
+            $result = [null, ''];
+            $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($relatedResourceClass);
+            $operation = OperationHelper::findOneByType($resourceMetadataCollection, GetCollection::class);
+            
+            if (!$operation) {
+                $result = [null, 'The resource '.$relatedResourceClass.' does not implement GetCollection() operation.'];
+            } else {
+                $filterExists = $this->exactSearchFilterExists($relatedResourceClass, $relatedFilterName);
+                if (!$filterExists) {
+                    $result = [null, 'The resource '.$relatedResourceClass.' does not have a search filter for the relation '.$relatedFilterName.'.'];
+                } else {
+                    $result = [$operation, ''];
+                }
+            }
+            $this->exactSearchFilterExistsCache[$lookupKey] = $result;
         }
 
-        if (!$this->exactSearchFilterExists($relatedResourceClass, $relatedFilterName)) {
-            throw new UnsupportedRelationException('The resource '.$relatedResourceClass.' does not have a search filter for the relation '.$relatedFilterName.'.');
+        if ($result[0] instanceof Operation) {
+            return [true, $this->router->generate($result[0]->getName(), [$relatedFilterName => urlencode($this->iriConverter->getIriFromResource($object))], UrlGeneratorInterface::ABS_PATH)];
+        } else {
+            return [false, $result[1]];
         }
-
-        return $this->router->generate($operation->getName(), [$relatedFilterName => urlencode($this->iriConverter->getIriFromResource($object))], UrlGeneratorInterface::ABS_PATH);
     }
 
     protected function getRelatedCollectionLinkAnnotation(string $className, string $propertyName): ?RelatedCollectionLink {

--- a/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
+++ b/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
@@ -113,11 +113,13 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
             if (isset($link['href'])) {
                 continue;
             }
-            // Only consider relations with non-null value (object or collection)
-            // (does not yet work, some properties are private and cannot be read out)
-            // if (property_exists($data, $rel) && !isset($data->$rel)) {
-            //     continue;
-            // }
+
+            // If relation is a public property, this property can be checked to be a non-null value
+            $values = get_object_vars($data);
+            if (array_key_exists($rel, $values) && null == $values[$rel]) {
+                // target-value is NULL
+                continue;
+            }
 
             list($ok, $href) = $this->getRelatedCollectionHref($data, $rel, $context);
             if ($ok) {


### PR DESCRIPTION
Function `getRelatedCollectionHref` is called several times for the same relation 
- try-catch removed 
- cache per relation if no URI can be calculated for it anyway (instead of trying again and again)

## Old:
- all activities
![image](https://github.com/user-attachments/assets/d2c2f034-39f3-41c1-be81-3cd556774047)
- activities of one camp
![image](https://github.com/user-attachments/assets/0e4f2597-4cb4-4140-afda-094db8753f53)

## New:
- all activities
![image](https://github.com/user-attachments/assets/52744cec-7055-4ad5-8e2f-27f0dc3df4aa)
- activities of one camp
![image](https://github.com/user-attachments/assets/1f347e82-b893-4716-80ec-752fd3dbc56f)

## New2:
- all activities
![image](https://github.com/user-attachments/assets/8955674f-ae79-4131-b24f-5ed175416005)
- activities of one camp
![image](https://github.com/user-attachments/assets/e799813c-58f1-4c3b-97dd-e659c1a3ef6b)


#6461