### PR TITLE
performance-test: enable running tests against e.g. dev.ecamp3.ch

### DIFF
--- a/.ops/performance-test/.env.example
+++ b/.ops/performance-test/.env.example
@@ -1,0 +1,1 @@
+#API_ROOT_URL=https://dev.ecamp3.ch/

--- a/.ops/performance-test/.gitignore
+++ b/.ops/performance-test/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.env

--- a/.ops/performance-test/docker-compose.yml
+++ b/.ops/performance-test/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     user: ${USER_ID:-1000}
     network_mode: host
     working_dir: /app
-#    environment:
-#      - K6_WEB_DASHBOARD=true
+    env_file:
+      - path: .env
+        required: false
     ports:
       - '5665:5665'


### PR DESCRIPTION
Phpstorm does not yet know the docker compose syntax to make .env file not required.
But it works.