### PR TITLE
api_deployment.yaml: set GOMEMLIMIT variable

### DIFF
--- a/.helm/ecamp3/templates/api_deployment.yaml
+++ b/.helm/ecamp3/templates/api_deployment.yaml
@@ -141,6 +141,8 @@ spec:
                   name: {{ include "api.name" . }}
                   key: oauth-jubladb-base-url
             {{- end }}
+            - name: GOMEMLIMIT
+              value: "{{ .Values.api.resources.requests.memory }}B"
           volumeMounts:
             - mountPath: /app/config/jwt/public.pem
               name: jwt-keypair


### PR DESCRIPTION
See https://pkg.go.dev/runtime#hdr-Environment_Variables
from https://frankenphp.dev/docs/performance/#go-runtime-configuration

For now to the same value as requests memory.