### PR TITLE
frontend: also pre-optimize vite-plugin-comlink/symbol

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -100,6 +100,7 @@ export default defineConfig(({ mode }) => ({
       'lodash/size.js',
       'runes',
       'vee-validate',
+      'vite-plugin-comlink/symbol',
       'vue',
       'vuedraggable',
       'vue-toastification',


### PR DESCRIPTION
That we don't have the re-optimization when we switch to the print view.