### PR TITLE
Disable FilterEagerLoadingsExtension for better performance

### DIFF
--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -53,6 +53,9 @@ services:
         tags:
             - 'app.input_filter'
 
+    App\Doctrine\Orm\Extension\FilterEagerLoadingsExtension:
+        decorates: 'api_platform.doctrine.orm.query_extension.filter_eager_loading'
+
     App\Serializer\Normalizer\RelatedCollectionLinkNormalizer:
         decorates: 'api_platform.hal.normalizer.item'
         arguments:

--- a/api/src/Doctrine/Orm/Extension/FilterEagerLoadingsExtension.php
+++ b/api/src/Doctrine/Orm/Extension/FilterEagerLoadingsExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Doctrine\Orm\Extension;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+final class FilterEagerLoadingsExtension implements QueryCollectionExtensionInterface {
+    public function __construct(private QueryCollectionExtensionInterface $decorated) {}
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        ?string $resourceClass = null,
+        ?Operation $operation = null,
+        array $context = []
+    ): void {
+        // Manipulates $queryBuilder
+
+        // Orig:
+        //  select
+        //  from        category c0_
+        //  inner join  camp c1_       ON c0_.campId = c1_.id
+        //  ...
+        //  where       c1_.id = ?
+
+        // New:
+        //  select      ...
+        //  from        category c0_
+        //  inner join  camp c1_       ON c0_.campId = c1_.id
+        //  ...
+        //  where       c0_.id IN (
+        //                  SELECT c9_.id
+        //                  FROM category c9_
+        //                  INNER JOIN camp c10_ ON c9_.campId = c10_.id
+        //                  WHERE c10_.id = ?
+        //              )
+
+        // Not clear, why ApiPlatform is doing this.
+        // Orig-Verison performs better.
+        // FilterEagerLoadingExtension is disabled.
+
+        $this->decorated->applyToCollection($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
+    }
+}

--- a/api/src/Doctrine/Orm/Extension/FilterEagerLoadingsExtension.php
+++ b/api/src/Doctrine/Orm/Extension/FilterEagerLoadingsExtension.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\Operation;
 use Doctrine\ORM\QueryBuilder;
 
 final class FilterEagerLoadingsExtension implements QueryCollectionExtensionInterface {
+    // @phpstan-ignore property.onlyWritten
     public function __construct(private QueryCollectionExtensionInterface $decorated) {}
 
     public function applyToCollection(
@@ -42,6 +43,6 @@ final class FilterEagerLoadingsExtension implements QueryCollectionExtensionInte
         // Orig-Verison performs better.
         // FilterEagerLoadingExtension is disabled.
 
-        $this->decorated->applyToCollection($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
+        // $this->decorated->applyToCollection($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
     }
 }


### PR DESCRIPTION
It is not clear to me what the filter `FilterEagerLoadingsExtension` is supposed to do. 
In our case, it ensures that the endpoint `/camps/111/categories` does not perform well.

The filter rebuilds the SQL 
from:
```sql
select      ...
from        category c0_ 
inner join  camp c1_       ON c0_.campId = c1_.id
...
where       c1_.id = ?
```

to:
```sql
select      ...
from        category c0_ 
inner join  camp c1_       ON c0_.campId = c1_.id
...
where       c0_.id IN (
                SELECT c9_.id 
                FROM category c9_ 
                INNER JOIN camp c10_ ON c9_.campId = c10_.id 
                WHERE c10_.id = ?
            )
```