### PR TITLE
Do not use FETCH_EAGER

### DIFF
--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -53,6 +53,11 @@ services:
         tags:
             - 'app.input_filter'
 
+    api_platform.doctrine.orm.query_extension.filter_eager_loading:
+        class: ApiPlatform\Doctrine\Orm\Extension\FilterEagerLoadingExtension
+        arguments:
+            - false
+
     App\Serializer\Normalizer\RelatedCollectionLinkNormalizer:
         decorates: 'api_platform.hal.normalizer.item'
         arguments:

--- a/api/src/Entity/ScheduleEntry.php
+++ b/api/src/Entity/ScheduleEntry.php
@@ -88,7 +88,7 @@ class ScheduleEntry extends BaseEntity implements BelongsToCampInterface {
     #[AssertBelongsToSameCamp]
     #[ApiProperty(example: '/periods/1a2b3c4d')]
     #[Groups(['read', 'write'])]
-    #[ORM\ManyToOne(targetEntity: Period::class, inversedBy: 'scheduleEntries', fetch: 'EAGER')]
+    #[ORM\ManyToOne(targetEntity: Period::class, inversedBy: 'scheduleEntries')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'cascade')]
     public ?Period $period = null;
 

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -162,7 +162,7 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
         ]
     )]
     #[Groups(['create'])]
-    #[ORM\OneToOne(targetEntity: Profile::class, inversedBy: 'user', cascade: ['persist'], fetch: 'EAGER')]
+    #[ORM\OneToOne(targetEntity: Profile::class, inversedBy: 'user', cascade: ['persist'])]
     #[ORM\JoinColumn(nullable: false, unique: true, onDelete: 'restrict')]
     public Profile $profile;
 

--- a/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
+++ b/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
@@ -114,6 +114,6 @@ class ListCampCollaborationsTest extends ECampApiTestCase {
         $client->enableProfiler();
         $client->request('GET', '/camp_collaborations');
 
-        $this->assertSqlQueryCount($client, 22);
+        $this->assertSqlQueryCount($client, 28);
     }
 }

--- a/api/tests/Api/SnapshotTests/__snapshots__/performance_test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/performance_test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
@@ -1,12 +1,12 @@
-/activities: 221
+/activities: 223
 /activities/item: 236
 /activity_progress_labels: 6
 /activity_progress_labels/item: 7
 /activity_responsibles: 6
 /activity_responsibles/item: 8
 /camps: 36
-/camps/item: 31
-/camp_collaborations: 22
+/camps/item: 45
+/camp_collaborations: 38
 /camp_collaborations/item: 24
 /categories: 11
 /categories/item: 9
@@ -34,7 +34,7 @@
 '/activities?camp=': 213
 '/activity_progress_labels?camp=': 6
 '/activity_responsibles?activity.camp=': 6
-'/camp_collaborations?camp=': 12
+'/camp_collaborations?camp=': 25
 '/camp_collaborations?activityResponsibles.activity=': 24
 '/categories?camp=': 9
 '/content_types?categories=': 6

--- a/api/tests/Api/SnapshotTests/__snapshots__/test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
@@ -1,12 +1,12 @@
-/activities: 21
+/activities: 23
 /activities/item: 36
 /activity_progress_labels: 6
 /activity_progress_labels/item: 7
 /activity_responsibles: 6
 /activity_responsibles/item: 8
 /camps: 26
-/camps/item: 21
-/camp_collaborations: 22
+/camps/item: 25
+/camp_collaborations: 28
 /camp_collaborations/item: 14
 /categories: 11
 /categories/item: 9
@@ -34,7 +34,7 @@
 '/activities?camp=': 13
 '/activity_progress_labels?camp=': 6
 '/activity_responsibles?activity.camp=': 6
-'/camp_collaborations?camp=': 12
+'/camp_collaborations?camp=': 15
 '/camp_collaborations?activityResponsibles.activity=': 14
 '/categories?camp=': 9
 '/content_types?categories=': 6


### PR DESCRIPTION
Solves the same problem as #6720 - but differently. 

We can completely dispense with eager-fetch, so that `FilterEagerLoadingsExtension` has no effect.
This way we don't have to undermine the ApiPlatform code.

**Affected endpoints:**
- /camp/{campId}/categories
- /camp/{campId}/checklists
- /checklists/{checklistId}/checklist_items
- /periods/{periodId}/days
- /periods/{periodId}/schedule_entries
- /days/{dayId}/day_responsibles