### PR TITLE
reverse-proxy-nginx.conf: switch to cached endpoint by default

### DIFF
--- a/e2e/cypress.config.js
+++ b/e2e/cypress.config.js
@@ -24,6 +24,5 @@ module.exports = defineConfig({
   env: {
     PRINT_URL: 'http://localhost:3000/print',
     API_ROOT_URL: 'http://localhost:3000/api',
-    API_ROOT_URL_CACHED: 'http://localhost:3004',
   },
 })

--- a/e2e/specs/httpCache.cy.js
+++ b/e2e/specs/httpCache.cy.js
@@ -6,7 +6,7 @@ describe('HTTP cache tests', () => {
     cy.login('test@example.com')
 
     // first request is a cache miss
-    cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+    cy.request(`${uri}.jsonhal`).then((response) => {
       const headers = response.headers
       expect(headers.xkey).to.eq(
         'a4211c11211c c462edd869f3 5e2028c55ee4 a4211c112939 f17470519474 1a0f84e322c8 3ef17bd1df72 4f0c657fecef 44dcc7493c65 cfccaecd4bad 318e064ea0c9 /api/content_types'
@@ -32,7 +32,7 @@ describe('HTTP cache tests', () => {
     cy.login('test@example.com')
 
     // first request is a cache miss
-    cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+    cy.request(`${uri}.jsonhal`).then((response) => {
       const headers = response.headers
       expect(headers.xkey).to.eq('318e064ea0c9')
       expect(headers['x-cache']).to.eq('MISS')
@@ -52,7 +52,7 @@ describe('HTTP cache tests', () => {
     cy.login('test@example.com')
 
     // first request is a cache miss
-    cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+    cy.request(`${uri}.jsonhal`).then((response) => {
       const headers = response.headers
       expect(headers.xkey).to.eq(
         /* campCollaboration for test@example.com */
@@ -200,7 +200,7 @@ describe('HTTP cache tests', () => {
     // ensure cache was invalidated
     cy.login('castor@example.com')
     cy.request({
-      url: Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal',
+      url: `${uri}.jsonhal`,
       failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(404)

--- a/e2e/support/commands.js
+++ b/e2e/support/commands.js
@@ -39,21 +39,21 @@ Cypress.Commands.add('moveDownloads', () => {
 })
 
 Cypress.Commands.add('expectCacheHit', (uri) => {
-  cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+  cy.request(`${uri}.jsonhal`).then((response) => {
     const headers = response.headers
     expect(headers['x-cache']).to.eq('HIT')
   })
 })
 
 Cypress.Commands.add('expectCacheMiss', (uri) => {
-  cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+  cy.request(`${uri}.jsonhal`).then((response) => {
     const headers = response.headers
     expect(headers['x-cache']).to.eq('MISS')
   })
 })
 
 Cypress.Commands.add('expectCachePass', (uri) => {
-  cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+  cy.request(`${uri}.jsonhal`).then((response) => {
     const headers = response.headers
     expect(headers['x-cache']).to.eq('PASS')
   })
@@ -62,7 +62,7 @@ Cypress.Commands.add('expectCachePass', (uri) => {
 Cypress.Commands.add('apiPatch', (uri, body) => {
   cy.request({
     method: 'PATCH',
-    url: Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal',
+    url: `${uri}.jsonhal`,
     body,
     headers: {
       'Content-Type': 'application/merge-patch+json',
@@ -73,7 +73,7 @@ Cypress.Commands.add('apiPatch', (uri, body) => {
 Cypress.Commands.add('apiPost', (uri, body) => {
   cy.request({
     method: 'POST',
-    url: Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal',
+    url: `${uri}.jsonhal`,
     body,
     headers: {
       'Content-Type': 'application/hal+json',
@@ -84,6 +84,6 @@ Cypress.Commands.add('apiPost', (uri, body) => {
 Cypress.Commands.add('apiDelete', (uri) => {
   cy.request({
     method: 'DELETE',
-    url: Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal',
+    url: `${uri}.jsonhal`,
   })
 })

--- a/reverse-proxy-nginx.conf
+++ b/reverse-proxy-nginx.conf
@@ -37,7 +37,7 @@ http {
       proxy_buffers 4 256k;
       proxy_busy_buffers_size 256k;
       proxy_set_header X-Forwarded-Prefix /api;
-      proxy_pass http://api:3001/;
+      proxy_pass http://http-cache:8080/;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }
@@ -78,7 +78,7 @@ http {
       proxy_buffers 4 256k;
       proxy_busy_buffers_size 256k;
       proxy_set_header X-Forwarded-Prefix /api;
-      proxy_pass http://http-cache:8080/;
+      proxy_pass http://api:3001/;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }


### PR DESCRIPTION
Now that we rolled out caching, we should use it locally to maybe detect the error with caching earlier.