### PR TITLE
docker-compose.yml: add cache sidecar to log the requests on http-cache

### DIFF
--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -64,7 +64,7 @@ jobs:
       - run: docker compose -f docker-compose.yml run --rm api migrate-database
 
       # start necessary containers
-      - run: docker compose -f docker-compose.yml up -d api frontend pdf print browserless database docker-host http-cache mail pg-admin reverse-proxy
+      - run: docker compose -f docker-compose.yml up -d api frontend pdf print browserless database docker-host http-cache http-cache-logs mail pg-admin reverse-proxy
 
       # pull cypress while container are starting up
       - run: docker compose pull e2e

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,11 +62,21 @@ services:
       - api
     volumes:
       - ./api/docker/varnish/vcl/:/etc/varnish/:ro
+      - varnish_data:/var/lib/varnish
     command: -a :8081,HTTP -p http_max_hdr=96
     environment:
       - COOKIE_PREFIX=localhost_
       - SEND_XKEY_HEADERS_DOWNSTREAM=${SEND_XKEY_HEADERS_DOWNSTREAM:-true}
       - VARNISH_HTTP_PORT=8080
+  
+  http-cache-logs:
+    image: varnish:7.6.1
+    container_name: 'ecamp3-http-cache-log'
+    depends_on:
+      - http-cache
+    volumes:
+      - varnish_data:/var/lib/varnish:ro
+    command: varnishncsa
 
   pdf:
     image: node:22.14.0
@@ -215,3 +225,4 @@ volumes:
   db-data-postgres: null
   caddy_data:
   caddy_config:
+  varnish_data:


### PR DESCRIPTION
That we maybe can see why the e2e tests fail sometimes.
This seems to be the way to get logging out of varnish.
https://varnish-cache.org/docs/trunk/users-guide/operation-logging.html
https://superuser.com/questions/1713850/outputting-logging-with-varnish-when-using-docker-compose-docker-desktop