### PR TITLE
e2e: add cypress-terminal-report

### DIFF
--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -68,6 +68,8 @@ jobs:
 
       # pull cypress while container are starting up
       - run: docker compose pull e2e
+        
+      - run: docker compose run --entrypoint="npm ci" --rm e2e
 
       - run: sh -x wait-for-container-startup.sh
 

--- a/e2e/cypress.config.js
+++ b/e2e/cypress.config.js
@@ -16,6 +16,13 @@ module.exports = defineConfig({
         deleteDownloads: () => deleteDownloads(config),
         moveDownloads: (destSubDir) => moveDownloads(config, destSubDir),
       })
+      const cypressTerminalReportOptions = {
+        printLogsToConsole: 'always',
+      }
+      require('cypress-terminal-report/src/installLogsPrinter')(
+        on,
+        cypressTerminalReportOptions
+      )
     },
     specPattern: 'specs/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: 'support/index.js',

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -11,6 +11,7 @@
         "@eslint/eslintrc": "3.3.0",
         "@eslint/js": "9.22.0",
         "cypress": "13.16.1",
+        "cypress-terminal-report": "7.1.0",
         "eslint": "9.22.0",
         "eslint-config-prettier": "10.1.1",
         "eslint-plugin-cypress": "4.2.0",
@@ -1326,6 +1327,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1420,6 +1428,41 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress-terminal-report": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-7.1.0.tgz",
+      "integrity": "sha512-CBXxY19HNX2VFcZ0uifomzs0kuYKCTb2pPgJmluiHI5XHvvbHPFufHAAacM8z/pSOtHoovo/WU+fxE5KcZ8C4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "compare-versions": "^6.1.1",
+        "fs-extra": "^10.1.0",
+        "process": "^0.11.10",
+        "superstruct": "0.14.2"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "cypress": ">=10.0.0"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/cypress/node_modules/semver": {
@@ -3545,6 +3588,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/superstruct": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
+      "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -17,6 +17,7 @@
     "@eslint/eslintrc": "3.3.0",
     "@eslint/js": "9.22.0",
     "cypress": "13.16.1",
+    "cypress-terminal-report": "7.1.0",
     "eslint": "9.22.0",
     "eslint-config-prettier": "10.1.1",
     "eslint-plugin-cypress": "4.2.0",

--- a/e2e/support/index.js
+++ b/e2e/support/index.js
@@ -15,6 +15,11 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector'
+
+installLogsCollector({
+  commandTimings: 'seconds',
+})
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
That we see something in the output of our e2e tests in the terminal.
This should help with debugging.
Before:
![image](https://github.com/user-attachments/assets/95b80c5a-76ae-4f61-9c09-98705ff92487)

After:
![image](https://github.com/user-attachments/assets/ce10cea5-44e9-4662-9164-681eb84fb54a)
