### PR TITLE
e2e: wait for the requests to either have cache 'HIT', 'MISS', 'PASS'

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -12,6 +12,7 @@
         "@eslint/js": "9.22.0",
         "cypress": "13.16.1",
         "cypress-terminal-report": "7.1.0",
+        "cypress-wait-until": "3.0.2",
         "eslint": "9.22.0",
         "eslint-config-prettier": "10.1.1",
         "eslint-plugin-cypress": "4.2.0",
@@ -1464,6 +1465,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/cypress-wait-until": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-3.0.2.tgz",
+      "integrity": "sha512-iemies796dD5CgjG5kV0MnpEmKSH+s7O83ZoJLVzuVbZmm4lheMsZqAVT73hlMx4QlkwhxbyUzhOBUOZwoOe0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cypress/node_modules/semver": {
       "version": "7.7.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -18,6 +18,7 @@
     "@eslint/js": "9.22.0",
     "cypress": "13.16.1",
     "cypress-terminal-report": "7.1.0",
+    "cypress-wait-until": "3.0.2",
     "eslint": "9.22.0",
     "eslint-config-prettier": "10.1.1",
     "eslint-plugin-cypress": "4.2.0",

--- a/e2e/specs/httpCache.cy.js
+++ b/e2e/specs/httpCache.cy.js
@@ -93,7 +93,7 @@ describe('HTTP cache tests', () => {
     })
 
     // warm up cache
-    cy.expectCacheMiss(uri)
+    cy.waitForCacheMiss(uri)
     cy.expectCacheHit(uri)
 
     cy.login('felicity@smoak.com')
@@ -106,7 +106,9 @@ describe('HTTP cache tests', () => {
     })
 
     // ensure cache was invalidated
-    cy.expectCacheMiss(uri)
+    cy.waitForCacheMiss(uri)
+    cy.expectCacheHit(uri)
+
     cy.login('bruce@wayne.com')
     cy.expectCacheMiss(uri)
   })
@@ -130,14 +132,15 @@ describe('HTTP cache tests', () => {
       const newContentNodeUri = response.body._links.self.href
 
       // ensure cache was invalidated
-      cy.expectCacheMiss(uri)
+      cy.waitForCacheMiss(uri)
       cy.expectCacheHit(uri)
 
       // delete newly created contentNode
       cy.apiDelete(newContentNodeUri)
 
       // ensure cache was invalidated
-      cy.expectCacheMiss(uri)
+      cy.waitForCacheMiss(uri)
+      cy.expectCacheHit(uri)
     })
   })
 
@@ -162,14 +165,15 @@ describe('HTTP cache tests', () => {
       const newContentNodeUri = response.body._links.self.href
 
       // ensure cache was invalidated
-      cy.expectCacheMiss(uri)
+      cy.waitForCacheMiss(uri)
       cy.expectCacheHit(uri)
 
       // delete newly created contentNode
       cy.apiDelete(newContentNodeUri)
 
       // ensure cache was invalidated
-      cy.expectCacheMiss(uri)
+      cy.waitForCacheMiss(uri)
+      cy.expectCacheHit(uri)
     })
   })
 

--- a/e2e/specs/httpCache.cy.js
+++ b/e2e/specs/httpCache.cy.js
@@ -141,41 +141,37 @@ describe('HTTP cache tests', () => {
     })
   })
 
-  it(
-    'invalidates /camp/{campId}/categories for new category',
-    { retries: { runMode: 3 } },
-    () => {
-      const uri = '/api/camps/3c79b99ab424/categories'
+  it('invalidates /camp/{campId}/categories for new category', () => {
+    const uri = '/api/camps/3c79b99ab424/categories'
 
-      Cypress.session.clearAllSavedSessions()
-      cy.login('test@example.com')
+    Cypress.session.clearAllSavedSessions()
+    cy.login('test@example.com')
 
-      // warm up cache
+    // warm up cache
+    cy.expectCacheMiss(uri)
+    cy.expectCacheHit(uri)
+
+    // add new category to camp
+    cy.apiPost('/api/categories', {
+      camp: '/api/camps/3c79b99ab424',
+      short: 'new',
+      name: 'new Category',
+      color: '#000000',
+      numberingStyle: '1',
+    }).then((response) => {
+      const newContentNodeUri = response.body._links.self.href
+
+      // ensure cache was invalidated
       cy.expectCacheMiss(uri)
       cy.expectCacheHit(uri)
 
-      // add new category to camp
-      cy.apiPost('/api/categories', {
-        camp: '/api/camps/3c79b99ab424',
-        short: 'new',
-        name: 'new Category',
-        color: '#000000',
-        numberingStyle: '1',
-      }).then((response) => {
-        const newContentNodeUri = response.body._links.self.href
+      // delete newly created contentNode
+      cy.apiDelete(newContentNodeUri)
 
-        // ensure cache was invalidated
-        cy.expectCacheMiss(uri)
-        cy.expectCacheHit(uri)
-
-        // delete newly created contentNode
-        cy.apiDelete(newContentNodeUri)
-
-        // ensure cache was invalidated
-        cy.expectCacheMiss(uri)
-      })
-    }
-  )
+      // ensure cache was invalidated
+      cy.expectCacheMiss(uri)
+    })
+  })
 
   it('invalidates cached data when user leaves a camp', () => {
     Cypress.session.clearAllSavedSessions()

--- a/e2e/support/commands.js
+++ b/e2e/support/commands.js
@@ -24,6 +24,8 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+import 'cypress-wait-until'
+
 Cypress.Commands.add('login', (identifier) => {
   cy.session(identifier, () => {
     cy.request({
@@ -39,24 +41,30 @@ Cypress.Commands.add('moveDownloads', () => {
 })
 
 Cypress.Commands.add('expectCacheHit', (uri) => {
-  cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
-    const headers = response.headers
-    expect(headers['x-cache']).to.eq('HIT')
-  })
+  cy.waitUntil(() =>
+    cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+      const headers = response.headers
+      return headers['x-cache'] === 'HIT'
+    })
+  ).then((result) => expect(result).to.eq(true))
 })
 
 Cypress.Commands.add('expectCacheMiss', (uri) => {
-  cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
-    const headers = response.headers
-    expect(headers['x-cache']).to.eq('MISS')
-  })
+  cy.waitUntil(() =>
+    cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+      const headers = response.headers
+      return headers['x-cache'] === 'MISS'
+    })
+  ).then((result) => expect(result).to.eq(true))
 })
 
 Cypress.Commands.add('expectCachePass', (uri) => {
-  cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
-    const headers = response.headers
-    expect(headers['x-cache']).to.eq('PASS')
-  })
+  cy.waitUntil(() =>
+    cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+      const headers = response.headers
+      return headers['x-cache'] === 'PASS'
+    })
+  ).then((result) => expect(result).to.eq(true))
 })
 
 Cypress.Commands.add('apiPatch', (uri, body) => {

--- a/e2e/support/commands.js
+++ b/e2e/support/commands.js
@@ -41,28 +41,31 @@ Cypress.Commands.add('moveDownloads', () => {
 })
 
 Cypress.Commands.add('expectCacheHit', (uri) => {
-  cy.waitUntil(() =>
-    cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
-      const headers = response.headers
-      return headers['x-cache'] === 'HIT'
-    })
-  ).then((result) => expect(result).to.eq(true))
+  cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+    const headers = response.headers
+    expect(headers['x-cache']).to.eq('HIT')
+  })
 })
 
 Cypress.Commands.add('expectCacheMiss', (uri) => {
+  cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+    const headers = response.headers
+    expect(headers['x-cache']).to.eq('MISS')
+  })
+})
+
+Cypress.Commands.add('expectCachePass', (uri) => {
+  cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
+    const headers = response.headers
+    expect(headers['x-cache']).to.eq('PASS')
+  })
+})
+
+Cypress.Commands.add('waitForCacheMiss', (uri) => {
   cy.waitUntil(() =>
     cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
       const headers = response.headers
       return headers['x-cache'] === 'MISS'
-    })
-  ).then((result) => expect(result).to.eq(true))
-})
-
-Cypress.Commands.add('expectCachePass', (uri) => {
-  cy.waitUntil(() =>
-    cy.request(Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal').then((response) => {
-      const headers = response.headers
-      return headers['x-cache'] === 'PASS'
     })
   ).then((result) => expect(result).to.eq(true))
 })


### PR DESCRIPTION
e2e: wait for the requests to either have cache 'HIT', 'MISS', 'PASS'

Because this is a distributed system, while a PATCH request is running,
other clients may still do a dirty read of the cached value to be invalidated.
Symfony also splits up the purge requests, so this may take a while.

As an observer from the point of the e2e tests (or any clients using our application),
it's possible (by design) to read the previous value, which is not valid anymore when
the PATCH, POST or DELETE request has ended.

Thus we don't need to assert this strictly in cypress, we can repeat the get
request for some time until we observe the desired behaviour.

This is better than retrying the whole test because the retry is very specific with
the request which should have a more or less strict defined caching behaviour.

Issue: #5493

-----

Revert "httpCache.cy.js: retry 'invalidates /camp/{campId}/categories for new category' in runMode"

This reverts commit 1c9d51ef487e34a946018a747a4b08d75e571436.
and
- https://github.com/ecamp/ecamp3/pull/6260

This makes it stable enough that we don't need retries on the test level anymore.

---

Here is the build with 300 times the e2e tests: https://github.com/BacLuc/ecamp3/actions/runs/13617092804

PR

- https://github.com/ecamp/ecamp3/pull/6954

And this PR should be exclusive.

The one with more upvotes (and no changes requested) will be merged.