### PR TITLE
httpCache.cy.js: fix unstable 'invalidates /camp/{campId}/categories for new category'

### DIFF
--- a/e2e/specs/httpCache.cy.js
+++ b/e2e/specs/httpCache.cy.js
@@ -141,41 +141,37 @@ describe('HTTP cache tests', () => {
     })
   })
 
-  it(
-    'invalidates /camp/{campId}/categories for new category',
-    { retries: { runMode: 3 } },
-    () => {
-      const uri = '/api/camps/3c79b99ab424/categories'
+  it('invalidates /camp/{campId}/categories for new category', () => {
+    const uri = '/api/camps/3c79b99ab424/categories'
 
-      Cypress.session.clearAllSavedSessions()
-      cy.login('test@example.com')
-        .then(() => cy.expectCacheMiss(uri))
-        .then(() => cy.expectCacheHit(uri))
-        .then(() =>
-          cy.apiPost('/api/categories', {
-            camp: '/api/camps/3c79b99ab424',
-            short: 'new',
-            name: 'new Category',
-            color: '#000000',
-            numberingStyle: '1',
-          })
-        )
-        .then((response) => {
-          // add new category to camp
-          const newContentNodeUri = response.body._links.self.href
-
-          // ensure cache was invalidated
-          cy.expectCacheMiss(uri)
-          cy.expectCacheHit(uri)
-
-          // delete newly created contentNode
-          cy.apiDelete(newContentNodeUri)
-
-          // ensure cache was invalidated
-          cy.expectCacheMiss(uri)
+    Cypress.session.clearAllSavedSessions()
+    cy.login('test@example.com')
+      .then(() => cy.expectCacheMiss(uri))
+      .then(() => cy.expectCacheHit(uri))
+      .then(() =>
+        cy.apiPost('/api/categories', {
+          camp: '/api/camps/3c79b99ab424',
+          short: 'new',
+          name: 'new Category',
+          color: '#000000',
+          numberingStyle: '1',
         })
-    }
-  )
+      )
+      .then((response) => {
+        // add new category to camp
+        const newContentNodeUri = response.body._links.self.href
+
+        // ensure cache was invalidated
+        cy.expectCacheMiss(uri)
+        cy.expectCacheHit(uri)
+
+        // delete newly created contentNode
+        cy.apiDelete(newContentNodeUri)
+
+        // ensure cache was invalidated
+        cy.expectCacheMiss(uri)
+      })
+  })
 
   it('invalidates cached data when user leaves a camp', () => {
     Cypress.session.clearAllSavedSessions()

--- a/e2e/specs/httpCache.cy.js
+++ b/e2e/specs/httpCache.cy.js
@@ -149,31 +149,31 @@ describe('HTTP cache tests', () => {
 
       Cypress.session.clearAllSavedSessions()
       cy.login('test@example.com')
+        .then(() => cy.expectCacheMiss(uri))
+        .then(() => cy.expectCacheHit(uri))
+        .then(() =>
+          cy.apiPost('/api/categories', {
+            camp: '/api/camps/3c79b99ab424',
+            short: 'new',
+            name: 'new Category',
+            color: '#000000',
+            numberingStyle: '1',
+          })
+        )
+        .then((response) => {
+          // add new category to camp
+          const newContentNodeUri = response.body._links.self.href
 
-      // warm up cache
-      cy.expectCacheMiss(uri)
-      cy.expectCacheHit(uri)
+          // ensure cache was invalidated
+          cy.expectCacheMiss(uri)
+          cy.expectCacheHit(uri)
 
-      // add new category to camp
-      cy.apiPost('/api/categories', {
-        camp: '/api/camps/3c79b99ab424',
-        short: 'new',
-        name: 'new Category',
-        color: '#000000',
-        numberingStyle: '1',
-      }).then((response) => {
-        const newContentNodeUri = response.body._links.self.href
+          // delete newly created contentNode
+          cy.apiDelete(newContentNodeUri)
 
-        // ensure cache was invalidated
-        cy.expectCacheMiss(uri)
-        cy.expectCacheHit(uri)
-
-        // delete newly created contentNode
-        cy.apiDelete(newContentNodeUri)
-
-        // ensure cache was invalidated
-        cy.expectCacheMiss(uri)
-      })
+          // ensure cache was invalidated
+          cy.expectCacheMiss(uri)
+        })
     }
   )
 


### PR DESCRIPTION
In cypress the overall model for assertions is
auto waiting, and this works well enough by just
using sequential statements.
But for requests where auto retry or waiting is impossible or even
maybe even dangerous, you need to model the dependencies directly with "then".

expectCacheMiss is also a special assertion because it uses
a request (it's GET, a retry could be implemented), but we want
the cache invalidation to be synchronous, und thus want
to test the cache logic after the login request is completed.
(And not wait until the cache status switches to MISS for one request).

Issue: #5493

---

Revert "httpCache.cy.js: retry 'invalidates /camp/{campId}/categories for new category' in runMode"

This reverts commit 1c9d51ef487e34a946018a747a4b08d75e571436.
And
- https://github.com/ecamp/ecamp3/pull/6260

----

Here is the build with 300 times the e2e tests: https://github.com/BacLuc/ecamp3/actions/runs/13617064849

It seems to not a lot better than main without retry :disappointed: https://github.com/BacLuc/ecamp3/actions/runs/13617523467

PR
- https://github.com/ecamp/ecamp3/pull/6953

And this PR should be exclusive.

The one with more upvotes (and no changes requested) will be merged.