### PR TITLE
ecamp3-logging: make MAX_INDEX_AGE and STORAGE_SIZE configurable

### DIFF
--- a/.ops/ecamp3-logging/deploy.sh
+++ b/.ops/ecamp3-logging/deploy.sh
@@ -7,10 +7,17 @@ cd $SCRIPT_DIR
 
 ELASTIC_NODE_REQUESTS_MEMORY=1000Mi
 ELASTIC_NODE_LIMITS_MEMORY=1000Mi
+ELASTIC_NODE_MAX_INDEX_AGE=15
 RANDOM_STRING=$(uuidgen)
 
 if [ -f $SCRIPT_DIR/.env ]; then
   . $SCRIPT_DIR/.env
+fi
+
+if [ -z "${ELASTIC_NODE_STORAGE_SIZE}" ]; then
+  echo "Please define ELASTIC_NODE_STORAGE_SIZE. There is no good default value."
+  echo "It can also not be automatically enlarged, see: https://github.com/kubernetes/enhancements/pull/4651 and https://github.com/kubernetes/kubernetes/issues/68737"
+  exit 1
 fi
 
 envsubst < $SCRIPT_DIR/values.yaml > $SCRIPT_DIR/values.out.yaml

--- a/.ops/ecamp3-logging/values.yaml
+++ b/.ops/ecamp3-logging/values.yaml
@@ -51,9 +51,9 @@ elasticsearch:
     storageClassName: do-block-storage
     resources:
       requests:
-        storage: 10Gi
+        storage: ${ELASTIC_NODE_STORAGE_SIZE}
   removeOldIndexes:
-    maxIndexAge: 15
+    maxIndexAge: ${ELASTIC_NODE_MAX_INDEX_AGE}
     image: node:22.14.0
 
 kibana:


### PR DESCRIPTION
In prod the 10Gi were too small for sometimes even more than 1Gi logs per day for 15 days.

It is not possible to patch the size of a volumeClaimTemplate directly.
I had to perfom https://serverfault.com/questions/955293/how-to-increase-disk-size-in-a-stateful-set manually.
With this change, we can deploy ecamp3-logging now again on dev and on prod.

I increased the storage for prod now to 50 Gi, and set the index lifetime again to 15 days.