### PR TITLE
renovate.json: remove dependency dashboard approval for sass

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,10 +51,6 @@
       "groupName": "vue-test-utils-frontend"
     },
     {
-      "matchDepNames": ["sass"],
-      "dependencyDashboardApproval": true
-    },
-    {
       "matchDepNames": ["php", "dunglas/frankenphp"],
       "automerge": false,
       "groupName": "php"


### PR DESCRIPTION
We accidentally updated it in commit db406c3 when merging
- https://github.com/ecamp/ecamp3/pull/6094

And it works, so we leave it at the higher version.