### PR TITLE
ecamp3-logging: pin fluent-operator container tag

### DIFF
--- a/.ops/ecamp3-logging/values.yaml
+++ b/.ops/ecamp3-logging/values.yaml
@@ -3,6 +3,8 @@ fluent-operator:
   operator: 
     annotations: 
       trigger-recreate: ${RANDOM_STRING}
+    container: 
+      tag: 3.3.0
   fluentbit:
     enable: true
     input:


### PR DESCRIPTION
This currently runs into CrashLoopBackoff on prod sometimes. This was changed to latest in
- https://github.com/fluent/fluent-operator/pull/208 line:
- https://github.com/fluent/fluent-operator/pull/208/files#diff-c8382299239a550c6747ba79bff00ed81780ea6a5639d69cf192c0ea3a269bc6R15

This way we at least test the same in dev that we will deploy on prod.