### PR TITLE
Performance: Reuse existing joins in QueryBuilder

### DIFF
--- a/api/src/Repository/ActivityResponsibleRepository.php
+++ b/api/src/Repository/ActivityResponsibleRepository.php
@@ -3,12 +3,10 @@
 namespace App\Repository;
 
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
-use App\Entity\Activity;
 use App\Entity\ActivityResponsible;
 use App\Entity\User;
-use App\Entity\UserCamp;
+use App\Util\QueryBuilderHelper;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -26,14 +24,7 @@ class ActivityResponsibleRepository extends ServiceEntityRepository implements C
     }
 
     public function filterByUser(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, User $user): void {
-        $activityQry = $this->getEntityManager()->createQueryBuilder();
-        $activityQry->select('a');
-        $activityQry->from(Activity::class, 'a');
-        $activityQry->join(UserCamp::class, 'uc', Join::WITH, 'a.camp = uc.camp');
-        $activityQry->where('uc.user = :current_user');
-
-        $rootAlias = $queryBuilder->getRootAliases()[0];
-        $queryBuilder->andWhere($queryBuilder->expr()->in("{$rootAlias}.activity", $activityQry->getDQL()));
-        $queryBuilder->setParameter('current_user', $user);
+        $activity = QueryBuilderHelper::findOrAddInnerRootJoinAlias($queryBuilder, $queryNameGenerator, 'activity');
+        $this->filterByCampCollaboration($queryBuilder, $user, "{$activity}.camp");
     }
 }

--- a/api/src/Repository/DayRepository.php
+++ b/api/src/Repository/DayRepository.php
@@ -4,11 +4,9 @@ namespace App\Repository;
 
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use App\Entity\Day;
-use App\Entity\Period;
 use App\Entity\User;
-use App\Entity\UserCamp;
+use App\Util\QueryBuilderHelper;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -26,14 +24,7 @@ class DayRepository extends ServiceEntityRepository implements CanFilterByUserIn
     }
 
     public function filterByUser(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, User $user): void {
-        $periodQry = $this->getEntityManager()->createQueryBuilder();
-        $periodQry->select('p');
-        $periodQry->from(Period::class, 'p');
-        $periodQry->join(UserCamp::class, 'uc', Join::WITH, 'p.camp = uc.camp');
-        $periodQry->where('uc.user = :current_user');
-
-        $rootAlias = $queryBuilder->getRootAliases()[0];
-        $queryBuilder->andWhere($queryBuilder->expr()->in("{$rootAlias}.period", $periodQry->getDQL()));
-        $queryBuilder->setParameter('current_user', $user);
+        $period = QueryBuilderHelper::findOrAddInnerRootJoinAlias($queryBuilder, $queryNameGenerator, 'period');
+        $this->filterByCampCollaboration($queryBuilder, $user, "{$period}.camp");
     }
 }

--- a/api/src/Repository/DayResponsibleRepository.php
+++ b/api/src/Repository/DayResponsibleRepository.php
@@ -3,12 +3,10 @@
 namespace App\Repository;
 
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
-use App\Entity\Day;
 use App\Entity\DayResponsible;
 use App\Entity\User;
-use App\Entity\UserCamp;
+use App\Util\QueryBuilderHelper;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -26,15 +24,9 @@ class DayResponsibleRepository extends ServiceEntityRepository implements CanFil
     }
 
     public function filterByUser(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, User $user): void {
-        $dayQry = $this->getEntityManager()->createQueryBuilder();
-        $dayQry->select('d');
-        $dayQry->from(Day::class, 'd');
-        $dayQry->join('d.period', 'p');
-        $dayQry->join(UserCamp::class, 'uc', Join::WITH, 'p.camp = uc.camp');
-        $dayQry->where('uc.user = :current_user');
+        $day = QueryBuilderHelper::findOrAddInnerRootJoinAlias($queryBuilder, $queryNameGenerator, 'day');
+        $period = QueryBuilderHelper::findOrAddInnerJoinAlias($queryBuilder, $queryNameGenerator, $day, 'period');
 
-        $rootAlias = $queryBuilder->getRootAliases()[0];
-        $queryBuilder->andWhere($queryBuilder->expr()->in("{$rootAlias}.day", $dayQry->getDQL()));
-        $queryBuilder->setParameter('current_user', $user);
+        $this->filterByCampCollaboration($queryBuilder, $user, "{$period}.camp");
     }
 }

--- a/api/src/Repository/FiltersByCampCollaboration.php
+++ b/api/src/Repository/FiltersByCampCollaboration.php
@@ -2,7 +2,6 @@
 
 namespace App\Repository;
 
-use App\Entity\Camp;
 use App\Entity\User;
 use App\Entity\UserCamp;
 use Doctrine\ORM\QueryBuilder;
@@ -14,7 +13,7 @@ trait FiltersByCampCollaboration {
      * Assumes the queryBuilder already knows how to get to the corresponding camp. You can pass
      * the alias of the camp as the third argument if it's anything other than "camp".
      */
-    public function filterByCampCollaboration(QueryBuilder $queryBuilder, User $user, string $campAlias = 'camp'): void {
+    protected function filterByCampCollaboration(QueryBuilder $queryBuilder, User $user, string $campAlias = 'camp'): void {
         $campsQry = $queryBuilder->getEntityManager()->createQueryBuilder();
         $campsQry->select('identity(uc.camp)');
         $campsQry->from(UserCamp::class, 'uc');

--- a/api/src/Repository/MaterialItemRepository.php
+++ b/api/src/Repository/MaterialItemRepository.php
@@ -4,11 +4,9 @@ namespace App\Repository;
 
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use App\Entity\MaterialItem;
-use App\Entity\MaterialList;
 use App\Entity\User;
-use App\Entity\UserCamp;
+use App\Util\QueryBuilderHelper;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -19,19 +17,14 @@ use Doctrine\Persistence\ManagerRegistry;
  * @method MaterialItem[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
 class MaterialItemRepository extends ServiceEntityRepository implements CanFilterByUserInterface {
+    use FiltersByCampCollaboration;
+
     public function __construct(ManagerRegistry $registry) {
         parent::__construct($registry, MaterialItem::class);
     }
 
     public function filterByUser(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, User $user): void {
-        $materialListQry = $this->getEntityManager()->createQueryBuilder();
-        $materialListQry->select('ml');
-        $materialListQry->from(MaterialList::class, 'ml');
-        $materialListQry->join(UserCamp::class, 'uc', Join::WITH, 'ml.camp = uc.camp');
-        $materialListQry->where('uc.user = :current_user');
-
-        $rootAlias = $queryBuilder->getRootAliases()[0];
-        $queryBuilder->andWhere($queryBuilder->expr()->in("{$rootAlias}.materialList", $materialListQry->getDQL()));
-        $queryBuilder->setParameter('current_user', $user);
+        $materialList = QueryBuilderHelper::findOrAddInnerRootJoinAlias($queryBuilder, $queryNameGenerator, 'materialList');
+        $this->filterByCampCollaboration($queryBuilder, $user, "{$materialList}.camp");
     }
 }

--- a/api/src/Repository/ScheduleEntryRepository.php
+++ b/api/src/Repository/ScheduleEntryRepository.php
@@ -3,12 +3,10 @@
 namespace App\Repository;
 
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
-use App\Entity\Activity;
 use App\Entity\ScheduleEntry;
 use App\Entity\User;
-use App\Entity\UserCamp;
+use App\Util\QueryBuilderHelper;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -38,14 +36,7 @@ class ScheduleEntryRepository extends ServiceEntityRepository implements CanFilt
     }
 
     public function filterByUser(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, User $user): void {
-        $activityQry = $this->getEntityManager()->createQueryBuilder();
-        $activityQry->select('a');
-        $activityQry->from(Activity::class, 'a');
-        $activityQry->join(UserCamp::class, 'uc', Join::WITH, 'a.camp = uc.camp');
-        $activityQry->where('uc.user = :current_user');
-
-        $rootAlias = $queryBuilder->getRootAliases()[0];
-        $queryBuilder->andWhere($queryBuilder->expr()->in("{$rootAlias}.activity", $activityQry->getDQL()));
-        $queryBuilder->setParameter('current_user', $user);
+        $activity = QueryBuilderHelper::findOrAddInnerRootJoinAlias($queryBuilder, $queryNameGenerator, 'activity');
+        $this->filterByCampCollaboration($queryBuilder, $user, "{$activity}.camp");
     }
 }

--- a/api/src/Util/QueryBuilderHelper.php
+++ b/api/src/Util/QueryBuilderHelper.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Util;
+
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+
+class QueryBuilderHelper {
+    public static function findOrAddInnerRootJoinAlias(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $association) {
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+
+        return QueryBuilderHelper::findOrAddInnerJoinAlias($queryBuilder, $queryNameGenerator, $rootAlias, $association);
+    }
+
+    public static function findOrAddInnerJoinAlias(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $alias, string $association) {
+        $allJoins = $queryBuilder->getDQLPart('join');
+
+        /** @var array $joins */
+        $joins = array_filter(
+            $allJoins[$alias] ?? [],
+            fn ($j) => 'INNER' == $j->getJoinType() && $j->getJoin() == "{$alias}.{$association}"
+        );
+
+        if (empty($joins)) {
+            $innerAlias = $queryNameGenerator->generateJoinAlias($association);
+            $queryBuilder->join("{$alias}.{$association}", $innerAlias);
+        } else {
+            $join = reset($joins);
+            $innerAlias = $join->getAlias();
+        }
+
+        return $innerAlias;
+    }
+}

--- a/api/tests/Util/QueryBuilderHelperTest.php
+++ b/api/tests/Util/QueryBuilderHelperTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Tests\Util;
+
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use App\Entity\Day;
+use App\Util\QueryBuilderHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @internal
+ */
+class QueryBuilderHelperTest extends KernelTestCase {
+    private EntityManagerInterface $entityManager;
+    private MockObject|QueryNameGeneratorInterface $queryNameGeneratorInterfaceMock;
+
+    protected function setUp(): void {
+        static::bootKernel();
+
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->queryNameGeneratorInterfaceMock = $this->createMock(QueryNameGeneratorInterface::class);
+
+        $this->queryNameGeneratorInterfaceMock
+            ->method('generateJoinAlias')
+            ->willReturnCallback(fn ($field) => $field.'_alias')
+        ;
+    }
+
+    public function testAddMissingJoin() {
+        // given
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->from(Day::class, 'd');
+
+        // when
+        $p = QueryBuilderHelper::findOrAddInnerRootJoinAlias($qb, $this->queryNameGeneratorInterfaceMock, 'period');
+
+        // then
+        $this->assertEquals('period_alias', $p);
+
+        $joins = $qb->getDQLPart('join');
+        $this->assertCount(1, $joins);
+        $this->assertArrayHasKey('d', $joins);
+        $this->assertEquals('period_alias', $joins['d'][0]->getAlias());
+    }
+
+    public function testFindExistingJoin() {
+        // given
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->from(Day::class, 'd');
+        $qb->join('d.period', 'p');
+
+        // when
+        $p = QueryBuilderHelper::findOrAddInnerRootJoinAlias($qb, $this->queryNameGeneratorInterfaceMock, 'period');
+
+        // then
+        $this->assertEquals('p', $p);
+
+        $joins = $qb->getDQLPart('join');
+        $this->assertCount(1, $joins);
+        $this->assertArrayHasKey('d', $joins);
+        $this->assertEquals('p', $joins['d'][0]->getAlias());
+    }
+
+    public function testAddJoinIfExistingIsNotInner() {
+        // given
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->from(Day::class, 'd');
+        $qb->leftJoin('d.period', 'p');
+
+        // when
+        $p = QueryBuilderHelper::findOrAddInnerRootJoinAlias($qb, $this->queryNameGeneratorInterfaceMock, 'period');
+
+        // then
+        $this->assertEquals('period_alias', $p);
+
+        $joins = $qb->getDQLPart('join');
+        $this->assertCount(1, $joins);
+        $this->assertArrayHasKey('d', $joins);
+        $this->assertCount(2, $joins['d']);
+    }
+}


### PR DESCRIPTION
**before:**
SQL:
```sql
SELECT
  d0_.id AS id_0,
  d0_.createTime AS createtime_1,
  d0_.updateTime AS updatetime_2,
  d0_.dayOffset AS dayoffset_3,
  p1_.id AS id_4,
  p1_.createTime AS createtime_5,
  p1_.updateTime AS updatetime_6,
  p1_.description AS description_7,
  p1_.start AS start_8,
  p1_."end" AS end_9,
  d0_.periodId AS periodid_10,
  p1_.campId AS campid_11
FROM
  day d0_
  INNER JOIN period p1_ ON d0_.periodId = p1_.id
WHERE
  d0_.periodId IN (
    SELECT
      p2_.id
    FROM
      period p2_
      INNER JOIN view_user_camps v3_ ON (p2_.campId = v3_.campId)
    WHERE
      v3_.userId = ?
  )
ORDER BY
  d0_.createTime DESC,
  p1_.start ASC,
  d0_.dayOffset ASC
```

ExplainPlan:
```
Sort  (cost=94.93..95.35 rows=167 width=276)
  Sort Key: d0_.createtime DESC, p1_.start, d0_.dayoffset
  ->  Hash Join  (cost=69.53..88.77 rows=167 width=276)
        Hash Cond: ((d0_.periodid)::text = (p1_.id)::text)
        ->  Hash Semi Join  (cost=49.62..68.43 rows=167 width=170)
              Hash Cond: ((d0_.periodid)::text = (p2_.id)::text)
              ->  Seq Scan on day d0_  (cost=0.00..15.50 rows=550 width=120)
              ->  Hash  (cost=47.95..47.95 rows=134 width=50)
                    ->  Hash Join  (cost=30.56..47.95 rows=134 width=50)
                          Hash Cond: ((p2_.campid)::text = (v3_.campid)::text)
                          ->  Seq Scan on period p2_  (cost=0.00..14.40 rows=440 width=100)
                          ->  Hash  (cost=29.80..29.80 rows=61 width=50)
                                ->  Subquery Scan on v3_  (cost=0.14..29.80 rows=61 width=50)
                                      ->  Append  (cost=0.14..29.19 rows=61 width=132)
                                            ->  Nested Loop  (cost=0.14..20.11 rows=60 width=132)
                                                  ->  Index Only Scan using user_pkey on "user" u  (cost=0.14..8.16 rows=1 width=50)
                                                        Index Cond: (id = '9145944210a7'::text)
                                                  ->  Seq Scan on camp c  (cost=0.00..11.20 rows=60 width=50)
                                                        Filter: isprototype
                                            ->  Subquery Scan on "*SELECT* 2"  (cost=0.14..8.17 rows=1 width=132)
                                                  ->  Index Scan using idx_c93898a7b00651c on camp_collaboration cc  (cost=0.14..8.16 rows=1 width=150)
                                                        Index Cond: ((status)::text = 'established'::text)
                                                        Filter: ((userid)::text = '9145944210a7'::text)
        ->  Hash  (cost=14.40..14.40 rows=440 width=156)
              ->  Seq Scan on period p1_  (cost=0.00..14.40 rows=440 width=156)
```


**after:**
SQL:
```sql
SELECT
  d0_.id AS id_0,
  d0_.createTime AS createtime_1,
  d0_.updateTime AS updatetime_2,
  d0_.dayOffset AS dayoffset_3,
  p1_.id AS id_4,
  p1_.createTime AS createtime_5,
  p1_.updateTime AS updatetime_6,
  p1_.description AS description_7,
  p1_.start AS start_8,
  p1_."end" AS end_9,
  d0_.periodId AS periodid_10,
  p1_.campId AS campid_11
FROM
  day d0_
  INNER JOIN period p1_ ON d0_.periodId = p1_.id
WHERE
  p1_.campId IN (
    SELECT
      v2_.campId AS sclr_12
    FROM
      view_user_camps v2_
    WHERE
      v2_.userId = ?
  )
ORDER BY
  d0_.createTime DESC,
  p1_.start ASC,
  d0_.dayOffset ASC
```

ExplainPlan:
```
Sort  (cost=74.73..75.15 rows=168 width=276)
  Sort Key: d0_.createtime DESC, p1_.start, d0_.dayoffset
  ->  Hash Join  (cost=49.28..68.52 rows=168 width=276)
        Hash Cond: ((d0_.periodid)::text = (p1_.id)::text)
        ->  Seq Scan on day d0_  (cost=0.00..15.50 rows=550 width=120)
        ->  Hash  (cost=47.61..47.61 rows=134 width=156)
              ->  Hash Semi Join  (cost=30.56..47.61 rows=134 width=156)
                    Hash Cond: ((p1_.campid)::text = (v2_.campid)::text)
                    ->  Seq Scan on period p1_  (cost=0.00..14.40 rows=440 width=156)
                    ->  Hash  (cost=29.80..29.80 rows=61 width=50)
                          ->  Subquery Scan on v2_  (cost=0.14..29.80 rows=61 width=50)
                                ->  Append  (cost=0.14..29.19 rows=61 width=132)
                                      ->  Nested Loop  (cost=0.14..20.11 rows=60 width=132)
                                            ->  Index Only Scan using user_pkey on "user" u  (cost=0.14..8.16 rows=1 width=50)
                                                  Index Cond: (id = '9145944210a7'::text)
                                            ->  Seq Scan on camp c  (cost=0.00..11.20 rows=60 width=50)
                                                  Filter: isprototype
                                      ->  Subquery Scan on "*SELECT* 2"  (cost=0.14..8.17 rows=1 width=132)
                                            ->  Index Scan using idx_c93898a7b00651c on camp_collaboration cc  (cost=0.14..8.16 rows=1 width=150)
                                                  Index Cond: ((status)::text = 'established'::text)
                                                  Filter: ((userid)::text = '9145944210a7'::text)
```