### PR TITLE
Use default print config in nuxtPrint e2e

### DIFF
--- a/e2e/specs/nuxtPrint.cy.js
+++ b/e2e/specs/nuxtPrint.cy.js
@@ -10,28 +10,42 @@ describe('Nuxt print test', () => {
       const body = response.body
       const camp = body._embedded.items.filter((c) => c.motto)[0]
       const campUri = camp._links.self.href
+      const campPeriodsLink = camp._links.periods.href
+      cy.request(Cypress.env('API_ROOT_URL') + campPeriodsLink.replace('/api', '')).then(
+        (periodsResponse) => {
+          const period = periodsResponse.body._embedded.items[0]
+          const periodUri = period._links.self.href
 
-      const printConfig = {
-        language: 'en',
-        documentName: 'camp',
-        camp: campUri,
-        contents: [
-          {
-            type: 'Cover',
-            options: {},
-          },
-        ],
-      }
+          const printConfig = {
+            language: 'en',
+            documentName: 'camp',
+            camp: campUri,
+            contents: [
+              {
+                type: 'Cover',
+                options: {},
+              },
+              {
+                type: 'Story',
+                options: {
+                  periods: [periodUri],
+                  contentType: 'Storycontext',
+                },
+              },
+            ],
+          }
 
-      cy.visit(
-        Cypress.env('PRINT_URL') +
-          '/?config=' +
-          encodeURIComponent(JSON.stringify(printConfig))
+          cy.visit(
+            Cypress.env('PRINT_URL') +
+              '/?config=' +
+              encodeURIComponent(JSON.stringify(printConfig))
+          )
+          cy.contains(camp.title)
+          cy.contains(camp.motto)
+
+          cy.get('#content_0_cover').should('have.css', 'font-size', '50px') // this ensures Tailwind is properly built and integrated
+        }
       )
-      cy.contains(camp.title)
-      cy.contains(camp.motto)
-
-      cy.get('#content_0_cover').should('have.css', 'font-size', '50px') // this ensures Tailwind is properly built and integrated
     })
   })
 

--- a/e2e/specs/nuxtPrint.cy.js
+++ b/e2e/specs/nuxtPrint.cy.js
@@ -26,11 +26,29 @@ describe('Nuxt print test', () => {
                 options: {},
               },
               {
+                type: 'Picasso',
+                options: {
+                  periods: [periodUri],
+                  orientation: 'L',
+                },
+              },
+              {
                 type: 'Story',
                 options: {
                   periods: [periodUri],
                   contentType: 'Storycontext',
                 },
+              },
+              {
+                type: 'Program',
+                options: {
+                  periods: [periodUri],
+                  dayOverview: true,
+                },
+              },
+              {
+                type: 'Toc',
+                options: {},
               },
             ],
           }

--- a/e2e/specs/nuxtPrint.cy.js
+++ b/e2e/specs/nuxtPrint.cy.js
@@ -6,64 +6,62 @@ describe('Nuxt print test', () => {
   it('shows print preview', () => {
     cy.login('test@example.com')
 
-    cy.request(Cypress.env('API_ROOT_URL') + '/camps.jsonhal').then((response) => {
+    cy.request('/api/camps.jsonhal').then((response) => {
       const body = response.body
       const camp = body._embedded.items.filter((c) => c.motto)[0]
       const campUri = camp._links.self.href
       const campPeriodsLink = camp._links.periods.href
-      cy.request(Cypress.env('API_ROOT_URL') + campPeriodsLink.replace('/api', '')).then(
-        (periodsResponse) => {
-          const period = periodsResponse.body._embedded.items[0]
-          const periodUri = period._links.self.href
+      cy.request(campPeriodsLink).then((periodsResponse) => {
+        const period = periodsResponse.body._embedded.items[0]
+        const periodUri = period._links.self.href
 
-          const printConfig = {
-            language: 'en',
-            documentName: 'camp',
-            camp: campUri,
-            contents: [
-              {
-                type: 'Cover',
-                options: {},
+        const printConfig = {
+          language: 'en',
+          documentName: 'camp',
+          camp: campUri,
+          contents: [
+            {
+              type: 'Cover',
+              options: {},
+            },
+            {
+              type: 'Picasso',
+              options: {
+                periods: [periodUri],
+                orientation: 'L',
               },
-              {
-                type: 'Picasso',
-                options: {
-                  periods: [periodUri],
-                  orientation: 'L',
-                },
+            },
+            {
+              type: 'Story',
+              options: {
+                periods: [periodUri],
+                contentType: 'Storycontext',
               },
-              {
-                type: 'Story',
-                options: {
-                  periods: [periodUri],
-                  contentType: 'Storycontext',
-                },
+            },
+            {
+              type: 'Program',
+              options: {
+                periods: [periodUri],
+                dayOverview: true,
               },
-              {
-                type: 'Program',
-                options: {
-                  periods: [periodUri],
-                  dayOverview: true,
-                },
-              },
-              {
-                type: 'Toc',
-                options: {},
-              },
-            ],
-          }
-
-          cy.visit(
-            Cypress.env('PRINT_URL') +
-              '/?config=' +
-              encodeURIComponent(JSON.stringify(printConfig))
-          )
-          cy.contains(camp.title)
-          cy.contains(camp.motto)
-
-          cy.get('#content_0_cover').should('have.css', 'font-size', '50px') // this ensures Tailwind is properly built and integrated
+            },
+            {
+              type: 'Toc',
+              options: {},
+            },
+          ],
         }
-      )
+
+        cy.visit(
+          Cypress.env('PRINT_URL') +
+            '/?config=' +
+            encodeURIComponent(JSON.stringify(printConfig))
+        )
+        cy.contains(camp.title)
+        cy.contains(camp.motto)
+
+        cy.get('#content_0_cover').should('have.css', 'font-size', '50px') // this ensures Tailwind is properly built and integrated
+      })
     })
   })
 


### PR DESCRIPTION
So that some more complex content is tested instead of only the title  page. This should help catch future regressions.

With this change the test would have failed after #6988 (which regressed the nuxt print).