### PR TITLE
reverse-proxy-nginx.conf: use upstreams for the proxy_pass directives

### DIFF
--- a/reverse-proxy-nginx.conf
+++ b/reverse-proxy-nginx.conf
@@ -20,12 +20,37 @@ http {
   access_log /var/log/nginx/access.log  main;
   sendfile on;
   keepalive_timeout 65;
+  
+  upstream frontend {
+      server frontend:3000;
+  }
+  
+  upstream api {
+      server api:3001;
+  }
+  
+  upstream http-cache {
+      server http-cache:8080;
+  }
+  
+  upstream print {
+      server print:3003;
+  }
+  
+  upstream mail {
+      server mail:1080;
+  }
+  
+  upstream pgadmin {
+      server pg-admin:80;
+  }
+  
   server {
     listen 3000;
     server_name localhost;
 
     location / {
-      proxy_pass http://frontend:3000;
+      proxy_pass http://frontend;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }
@@ -37,19 +62,19 @@ http {
       proxy_buffers 4 256k;
       proxy_busy_buffers_size 256k;
       proxy_set_header X-Forwarded-Prefix /api;
-      proxy_pass http://api:3001/;
+      proxy_pass http://api/;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }
     
     location /print {
-      proxy_pass http://print:3003;
+      proxy_pass http://print;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }
     
     location /mail {
-      proxy_pass http://mail:1080;
+      proxy_pass http://mail;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }
@@ -57,7 +82,7 @@ http {
     location /pgadmin/ {
       proxy_set_header X-Script-Name /pgadmin;
       proxy_set_header Host $host;
-      proxy_pass http://pg-admin:80/;
+      proxy_pass http://pg-admin/;
       proxy_redirect off;
     }
   }
@@ -66,7 +91,7 @@ http {
     server_name localhost;
 
     location / {
-      proxy_pass http://frontend:3000;
+      proxy_pass http://frontend;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }
@@ -78,19 +103,19 @@ http {
       proxy_buffers 4 256k;
       proxy_busy_buffers_size 256k;
       proxy_set_header X-Forwarded-Prefix /api;
-      proxy_pass http://http-cache:8080/;
+      proxy_pass http://http-cache/;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }
     
     location /print {
-      proxy_pass http://print:3003;
+      proxy_pass http://print;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }
     
     location /mail {
-      proxy_pass http://mail:1080;
+      proxy_pass http://mail;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
     }


### PR DESCRIPTION
nginx seems to better retry failed upstreams again if they are defined as upstreams.
Without the paid subscription we don't have a health_checks or even new resolves https://docs.nginx.com/nginx/admin-guide/load-balancer/http-health-check/ https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#configuring-http-load-balancing-using-dns