### PR TITLE
Performance: ContentNodeCampFilter, remove unnecessary joins

### DIFF
--- a/api/src/Doctrine/Filter/ContentNodeCampFilter.php
+++ b/api/src/Doctrine/Filter/ContentNodeCampFilter.php
@@ -64,9 +64,7 @@ final class ContentNodeCampFilter extends AbstractFilter {
 
         // generate alias to avoid interference with other filters
         $campParameterName = $queryNameGenerator->generateParameterName($property);
-        $periodJoinAlias = $queryNameGenerator->generateJoinAlias('period');
         $activityJoinAlias = $queryNameGenerator->generateJoinAlias('activity');
-        $scheduleEntryJoinAlias = $queryNameGenerator->generateJoinAlias('scheduleEntry');
 
         $rootAlias = $queryBuilder->getRootAliases()[0];
 
@@ -74,9 +72,7 @@ final class ContentNodeCampFilter extends AbstractFilter {
         $rootQry
             ->select("identity({$activityJoinAlias}.rootContentNode)")
             ->from(Activity::class, $activityJoinAlias)
-            ->join("{$activityJoinAlias}.scheduleEntries", $scheduleEntryJoinAlias)
-            ->join("{$scheduleEntryJoinAlias}.period", $periodJoinAlias)
-            ->where($queryBuilder->expr()->eq("{$periodJoinAlias}.camp", ":{$campParameterName}"))
+            ->where($queryBuilder->expr()->eq("{$activityJoinAlias}.camp", ":{$campParameterName}"))
         ;
 
         $queryBuilder->andWhere($queryBuilder->expr()->in("{$rootAlias}.root", $rootQry->getDQL()));


### PR DESCRIPTION
Camp-Filter on ContentNode

**Auswirkung**
auf /api/content_node/checklist_nodes?camp=/camps/_camp_id_

Old: (cost=**348.72..348.73** rows=1 width=1453)
New: (cost=**191.43..191.43** rows=2 width=1453)


**Old:**
Filter via `Activity -> ScheduleEntry -> Period -> Camp`
```
 ContentNode.Root  in  (
    select Activity.RootContentNode
    from   Activity
    join   ScheduleEntry
    join   Period
    where  Period.Camp = [FilterValue]
 )
```

<details>
<summary>Explain query</summary>

```
Sort  (cost=348.72..348.73 rows=1 width=1453)
  Sort Key: c0_.createtime DESC, c5_."position"
  ->  Nested Loop Semi Join  (cost=221.45..348.71 rows=1 width=1453)
        Join Filter: ((c0_.rootid)::text = (a.rootcontentnodeid)::text)
        ->  Nested Loop Semi Join  (cost=220.48..317.83 rows=1 width=1466)
              Join Filter: ((c0_.rootid)::text = (a7_.rootcontentnodeid)::text)
              ->  Nested Loop Left Join  (cost=220.17..300.60 rows=17 width=1453)
                    ->  Hash Join  (cost=220.03..297.19 rows=17 width=1375)
                          Hash Cond: ((c0_.contenttypeid)::text = (c4_.id)::text)
                          ->  Hash Right Join  (cost=202.60..279.72 rows=17 width=1162)
                                Hash Cond: ((c2_.id)::text = (c0_.parentid)::text)
                                ->  Seq Scan on content_node c2_  (cost=0.00..65.12 rows=793 width=278)
                                      Filter: ((strategy)::text = ANY ('{contentnode,checklistnode,columnlayout,storyboard,responsivelayout,singletext,materialnode,multiselect}'::text[]))
                                ->  Hash  (cost=202.39..202.39 rows=17 width=884)
                                      ->  Hash Left Join  (cost=134.15..202.39 rows=17 width=884)
                                            Hash Cond: ((c0_.rootid)::text = (c1_.id)::text)
                                            ->  Hash Right Join  (cost=74.84..143.03 rows=17 width=606)
                                                  Hash Cond: ((c3_.parentid)::text = (c0_.id)::text)
                                                  ->  Seq Scan on content_node c3_  (cost=0.00..65.12 rows=793 width=278)
                                                        Filter: ((strategy)::text = ANY ('{contentnode,checklistnode,columnlayout,storyboard,responsivelayout,singletext,materialnode,multiselect}'::text[]))
                                                  ->  Hash  (cost=74.63..74.63 rows=17 width=328)
                                                        ->  Hash Right Join  (cost=56.66..74.63 rows=17 width=328)
                                                              Hash Cond: ((c6_.checklistnode_id)::text = (c0_.id)::text)
                                                              ->  Seq Scan on checklistnode_checklistitem c6_  (cost=0.00..16.30 rows=630 width=100)
                                                              ->  Hash  (cost=56.45..56.45 rows=17 width=278)
                                                                    ->  Seq Scan on content_node c0_  (cost=0.00..56.45 rows=17 width=278)
                                                                          Filter: ((strategy)::text = 'checklistnode'::text)
                                            ->  Hash  (cost=56.45..56.45 rows=229 width=278)
                                                  ->  Seq Scan on content_node c1_  (cost=0.00..56.45 rows=229 width=278)
                                                        Filter: ((strategy)::text = 'columnlayout'::text)
                          ->  Hash  (cost=13.30..13.30 rows=330 width=213)
                                ->  Seq Scan on content_type c4_  (cost=0.00..13.30 rows=330 width=213)
                    ->  Index Scan using checklist_item_pkey on checklist_item c5_  (cost=0.14..0.20 rows=1 width=128)
                          Index Cond: ((id)::text = (c6_.checklistitem_id)::text)
              ->  Materialize  (cost=0.30..16.98 rows=1 width=13)
                    ->  Nested Loop  (cost=0.30..16.98 rows=1 width=13)
                          ->  Nested Loop  (cost=0.16..16.74 rows=1 width=13)
                                ->  Seq Scan on schedule_entry s8_  (cost=0.00..6.77 rows=277 width=26)
                                ->  Memoize  (cost=0.16..0.35 rows=1 width=50)
                                      Cache Key: s8_.periodid
                                      Cache Mode: logical
                                      ->  Index Scan using period_pkey on period p9_  (cost=0.15..0.34 rows=1 width=50)
                                            Index Cond: ((id)::text = (s8_.periodid)::text)
                                            Filter: ((campid)::text = '6973c230d6b1'::text)
                          ->  Index Scan using activity_pkey on activity a7_  (cost=0.14..0.23 rows=1 width=26)
                                Index Cond: ((id)::text = (s8_.activityid)::text)
        ->  Hash Join  (cost=0.97..30.87 rows=1 width=36)
              Hash Cond: ((c.id)::text = (a.campid)::text)
              ->  Append  (cost=0.14..29.19 rows=61 width=132)
                    ->  Nested Loop  (cost=0.14..20.11 rows=60 width=132)
                          ->  Index Only Scan using user_pkey on "user" u  (cost=0.14..8.16 rows=1 width=50)
                                Index Cond: (id = '9145944210a7'::text)
                          ->  Seq Scan on camp c  (cost=0.00..11.20 rows=60 width=50)
                                Filter: isprototype
                    ->  Subquery Scan on "*SELECT* 2"  (cost=0.14..8.17 rows=1 width=132)
                          ->  Index Scan using idx_c93898a7b00651c on camp_collaboration cc  (cost=0.14..8.16 rows=1 width=150)
                                Index Cond: ((status)::text = 'established'::text)
                                Filter: ((userid)::text = '9145944210a7'::text)
              ->  Hash  (cost=0.81..0.81 rows=2 width=72)
                    ->  Append  (cost=0.14..0.81 rows=2 width=72)
                          ->  Index Scan using uniq_ac74095af886581c on activity a  (cost=0.14..0.30 rows=1 width=26)
                                Index Cond: ((rootcontentnodeid)::text = (a7_.rootcontentnodeid)::text)
                          ->  Index Scan using uniq_64c19c1f886581c on category ca  (cost=0.14..0.50 rows=1 width=100)
                                Index Cond: ((rootcontentnodeid)::text = (a7_.rootcontentnodeid)::text)
```
</details>

**New:**
Filter direct `Activity -> Camp`
```
 ContentNode.Root  in  (
    select Activity.RootContentNode
    from   Activity
    where  Activity.Camp = [FilterValue]
 )
```

<details>
<summary>Explain query</summary>

```
Sort  (cost=191.43..191.43 rows=2 width=1453)
  Sort Key: c0_.createtime DESC, c5_."position"
  ->  Hash Semi Join  (cost=60.90..191.42 rows=2 width=1453)
        Hash Cond: ((c0_.rootid)::text = (a.rootcontentnodeid)::text)
        ->  Nested Loop Left Join  (cost=7.76..138.23 rows=3 width=1466)
              ->  Nested Loop Left Join  (cost=7.62..137.62 rows=3 width=1388)
                    ->  Nested Loop  (cost=7.47..128.45 rows=3 width=1338)
                          ->  Nested Loop Left Join  (cost=7.32..119.47 rows=3 width=1125)
                                ->  Nested Loop Left Join  (cost=5.84..94.71 rows=3 width=847)
                                      ->  Nested Loop Left Join  (cost=5.56..78.25 rows=3 width=569)
                                            ->  Hash Join  (cost=5.29..61.78 rows=3 width=291)
                                                  Hash Cond: ((c0_.rootid)::text = (a7_.rootcontentnodeid)::text)
                                                  ->  Seq Scan on content_node c0_  (cost=0.00..56.45 rows=17 width=278)
                                                        Filter: ((strategy)::text = 'checklistnode'::text)
                                                  ->  Hash  (cost=4.80..4.80 rows=39 width=13)
                                                        ->  Seq Scan on activity a7_  (cost=0.00..4.80 rows=39 width=13)
                                                              Filter: ((campid)::text = '6973c230d6b1'::text)
                                            ->  Index Scan using content_node_pkey on content_node c1_  (cost=0.28..5.47 rows=1 width=278)
                                                  Index Cond: ((id)::text = (c0_.rootid)::text)
                                                  Filter: ((strategy)::text = 'columnlayout'::text)
                                      ->  Index Scan using content_node_pkey on content_node c2_  (cost=0.28..5.48 rows=1 width=278)
                                            Index Cond: ((id)::text = (c0_.parentid)::text)
                                            Filter: ((strategy)::text = ANY ('{contentnode,checklistnode,columnlayout,storyboard,responsivelayout,singletext,materialnode,multiselect}'::text[]))
                                ->  Bitmap Heap Scan on content_node c3_  (cost=1.48..8.24 rows=2 width=278)
                                      Recheck Cond: ((c0_.id)::text = (parentid)::text)
                                      Filter: ((strategy)::text = ANY ('{contentnode,checklistnode,columnlayout,storyboard,responsivelayout,singletext,materialnode,multiselect}'::text[]))
                                      ->  Bitmap Index Scan on idx_481d058010ee4cee  (cost=0.00..1.48 rows=3 width=0)
                                            Index Cond: ((parentid)::text = (c0_.id)::text)
                          ->  Index Scan using content_type_pkey on content_type c4_  (cost=0.15..2.99 rows=1 width=213)
                                Index Cond: ((id)::text = (c0_.contenttypeid)::text)
                    ->  Index Scan using idx_5a2b5b31de6b6f00 on checklistnode_checklistitem c6_  (cost=0.15..3.03 rows=3 width=100)
                          Index Cond: ((checklistnode_id)::text = (c0_.id)::text)
              ->  Index Scan using checklist_item_pkey on checklist_item c5_  (cost=0.14..0.20 rows=1 width=128)
                    Index Cond: ((id)::text = (c6_.checklistitem_id)::text)
        ->  Hash  (cost=51.71..51.71 rows=114 width=36)
              ->  Hash Join  (cost=30.56..51.71 rows=114 width=36)
                    Hash Cond: ((a.campid)::text = (v9_.campid)::text)
                    ->  Append  (cost=0.00..18.61 rows=374 width=72)
                          ->  Seq Scan on activity a  (cost=0.00..4.44 rows=144 width=26)
                          ->  Seq Scan on category ca  (cost=0.00..12.30 rows=230 width=100)
                    ->  Hash  (cost=29.80..29.80 rows=61 width=50)
                          ->  Subquery Scan on v9_  (cost=0.14..29.80 rows=61 width=50)
                                ->  Append  (cost=0.14..29.19 rows=61 width=132)
                                      ->  Nested Loop  (cost=0.14..20.11 rows=60 width=132)
                                            ->  Index Only Scan using user_pkey on "user" u  (cost=0.14..8.16 rows=1 width=50)
                                                  Index Cond: (id = '9145944210a7'::text)
                                            ->  Seq Scan on camp c  (cost=0.00..11.20 rows=60 width=50)
                                                  Filter: isprototype
                                      ->  Subquery Scan on "*SELECT* 2"  (cost=0.14..8.17 rows=1 width=132)
                                            ->  Index Scan using idx_c93898a7b00651c on camp_collaboration cc  (cost=0.14..8.16 rows=1 width=150)
                                                  Index Cond: ((status)::text = 'established'::text)
                                                  Filter: ((userid)::text = '9145944210a7'::text)
```
</details>