### PR TITLE
api: remove separate sql query count tests

### DIFF
--- a/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
+++ b/api/tests/Api/CampCollaborations/ListCampCollaborationsTest.php
@@ -108,12 +108,4 @@ class ListCampCollaborationsTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('campCollaboration1campPrototype')],
         ], $response->toArray()['_links']['items']);
     }
-
-    public function testSqlQueryCount() {
-        $client = static::createClientWithCredentials();
-        $client->enableProfiler();
-        $client->request('GET', '/camp_collaborations');
-
-        $this->assertSqlQueryCount($client, 22);
-    }
 }

--- a/api/tests/Api/CampCollaborations/ReadCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/ReadCampCollaborationTest.php
@@ -117,15 +117,4 @@ class ReadCampCollaborationTest extends ECampApiTestCase {
             ],
         ]);
     }
-
-    public function testSqlQueryCount() {
-        /** @var CampCollaboration $campCollaboration */
-        $campCollaboration = static::getFixture('campCollaboration1manager');
-
-        $client = static::createClientWithCredentials();
-        $client->enableProfiler();
-        $client->request('GET', '/camp_collaborations/'.$campCollaboration->getId());
-
-        $this->assertSqlQueryCount($client, 14);
-    }
 }

--- a/api/tests/Api/ECampApiTestCase.php
+++ b/api/tests/Api/ECampApiTestCase.php
@@ -18,7 +18,6 @@ use App\Metadata\Resource\OperationHelper;
 use App\Repository\ProfileRepository;
 use App\Tests\HttpCache\CacheManagerMock;
 use App\Util\ArrayDeepSort;
-use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use Doctrine\ORM\EntityManagerInterface;
 use FOS\HttpCacheBundle\CacheManager;
 use Hautelook\AliceBundle\PhpUnit\FixtureStore;
@@ -321,17 +320,6 @@ abstract class ECampApiTestCase extends ApiTestCase {
 
         $this->assertEquals($propertyName, $responseArray['violations'][0]['propertyPath']);
         $this->assertStringStartsWith('Provided JSON doesn\'t match required schema', $responseArray['violations'][0]['message']);
-    }
-
-    /**
-     * Validates the number of executed SqlQueries.
-     * requieres $client->enableProfiler().
-     */
-    protected function assertSqlQueryCount(Client $client, int $expected) {
-        /** @var DoctrineDataCollector $collector */
-        $collector = $client->getProfile()->getCollector('db');
-
-        $this->assertEquals($expected, $collector->getQueryCount());
     }
 
     /**


### PR DESCRIPTION
We have the EndpointPerformanceTest which measures this.