### PR TITLE
chore: change varnish log output to escapedUrl format

### DIFF
--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -234,7 +234,7 @@ apiCache:
       memory: 100Mi
   logging:
     enabled: true
-    customOutput: '{ "received_at": "%t", "varnish_side": "%{Varnish:side}x", "method": "%m", "url": "%U", "query": "%q", "response_bytes": %b, "time_taken": %D, "status": %s, "handling": "%{Varnish:handling}x", "response_reason": "%{VSL:RespReason}x", "fetch_error": "%{VSL:FetchError}x", "httpRequest": { "requestMethod": "%m", "requestUrl": "%U%q", "status": "%s" } }'
+    customOutput: '{ "received_at": "%t", "varnish_side": "%{Varnish:side}x", "method": "%m", "host": "%h", "url": "%U", "query": "%q", "response_bytes": %b, "time_taken": %D, "status": %s, "handling": "%{Varnish:handling}x", "response_reason": "%{VSL:RespReason}x", "fetch_error": "%{VSL:FetchError}x", "httpRequest": { "requestMethod": "%m", "requestUrl": "%{Host}i%U%q", "status": "%s" } }'
     customOutputJsonFormat: true
     # Timeout before returning error on initial VSM connection.
     # If set the VSM connection is retried every 0.5 seconds for this many seconds.

--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -234,12 +234,12 @@ apiCache:
       memory: 100Mi
   logging:
     enabled: true
-    customOutput: '{ "received_at": "%t", "varnish_side": "%{Varnish:side}x", "method": "%m", "url": "%U", "query": "%q", "response_bytes": %b, "time_taken": %D, "status": %s, "handling": "%{Varnish:handling}x", "response_reason": "%{VSL:RespReason}x", "fetch_error": "%{VSL:FetchError}x" }'
+    customOutput: '{ "received_at": "%t", "varnish_side": "%{Varnish:side}x", "method": "%m", "url": "%U", "query": "%q", "response_bytes": %b, "time_taken": %D, "status": %s, "handling": "%{Varnish:handling}x", "response_reason": "%{VSL:RespReason}x", "fetch_error": "%{VSL:FetchError}x", "httpRequest": { "requestMethod": "%m", "requestUrl": "%U%q", "status": "%s" } }'
     customOutputJsonFormat: true
     # Timeout before returning error on initial VSM connection.
     # If set the VSM connection is retried every 0.5 seconds for this many seconds.
     # If zero the connection is attempted only once and will fail immediately if unsuccessful.
-    # If set to "off", the connection will not fail, allowing the utility to start and wait indefinetely for the Varnish instance to appear.
+    # If set to "off", the connection will not fail, allowing the utility to start and wait indefinitely for the Varnish instance to appear.
     # Defaults to "off" in this case.
     timeout: "off"
     resources:


### PR DESCRIPTION
We want to see the hit/miss/pass rate. To group this by escapedUrl we adjust the log format, so that the fluentd clusterfilter adds an additional requestUrl