### PR TITLE
opt out from FilterByUserExtension for subresources

### DIFF
--- a/api/src/Doctrine/FilterByCurrentUserExtension.php
+++ b/api/src/Doctrine/FilterByCurrentUserExtension.php
@@ -22,6 +22,11 @@ final class FilterByCurrentUserExtension implements QueryCollectionExtensionInte
     }
 
     public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, ?string $resourceClass = null, ?Operation $operation = null, array $context = []): void {
+        $extraProperties = $operation->getExtraProperties();
+        if (array_key_exists('filter_by_current_user', $extraProperties) && false === $extraProperties['filter_by_current_user']) {
+            return;
+        }
+
         $this->addWhere($queryBuilder, $queryNameGenerator, $resourceClass);
     }
 

--- a/api/src/Entity/Activity.php
+++ b/api/src/Entity/Activity.php
@@ -58,6 +58,9 @@ use Symfony\Component\Validator\Constraints as Assert;
             ],
             normalizationContext: self::COLLECTION_NORMALIZATION_CONTEXT,
             security: 'is_fully_authenticated()',
+            extraProperties: [
+                'filter_by_current_user' => false,
+            ]
         ),
         new Post(
             processor: ActivityCreateProcessor::class,

--- a/api/src/Entity/ActivityProgressLabel.php
+++ b/api/src/Entity/ActivityProgressLabel.php
@@ -54,6 +54,9 @@ use Symfony\Component\Validator\Constraints as Assert;
                 ),
             ],
             security: 'is_fully_authenticated()',
+            extraProperties: [
+                'filter_by_current_user' => false,
+            ]
         ),
         new Post(
             validationContext: ['groups' => ['Default', 'create']],

--- a/api/src/Entity/Category.php
+++ b/api/src/Entity/Category.php
@@ -66,6 +66,9 @@ use Symfony\Component\Validator\Constraints as Assert;
                     security: 'is_granted("CAMP_COLLABORATOR", camp) or is_granted("CAMP_IS_PROTOTYPE", camp)'
                 ),
             ],
+            extraProperties: [
+                'filter_by_current_user' => false,
+            ]
         ),
     ],
     denormalizationContext: ['groups' => ['write']],

--- a/api/src/Entity/Checklist.php
+++ b/api/src/Entity/Checklist.php
@@ -65,6 +65,9 @@ use Symfony\Component\Validator\Constraints as Assert;
                     security: 'is_granted("CAMP_COLLABORATOR", camp) or is_granted("CAMP_IS_PROTOTYPE", camp)'
                 ),
             ],
+            extraProperties: [
+                'filter_by_current_user' => false,
+            ]
         ),
     ],
     denormalizationContext: ['groups' => ['write']],

--- a/api/src/Entity/ChecklistItem.php
+++ b/api/src/Entity/ChecklistItem.php
@@ -68,6 +68,9 @@ use Symfony\Component\Validator\Constraints as Assert;
                                is_granted("CAMP_COLLABORATOR", checklist)'
                 ),
             ],
+            extraProperties: [
+                'filter_by_current_user' => false,
+            ]
         ),
     ],
     denormalizationContext: ['groups' => ['write']],

--- a/api/src/Entity/Day.php
+++ b/api/src/Entity/Day.php
@@ -45,6 +45,9 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
             ],
             normalizationContext: self::COLLECTION_NORMALIZATION_CONTEXT,
             security: 'is_fully_authenticated()',
+            extraProperties: [
+                'filter_by_current_user' => false,
+            ]
         ),
     ],
     denormalizationContext: ['groups' => ['write']],

--- a/api/src/Entity/DayResponsible.php
+++ b/api/src/Entity/DayResponsible.php
@@ -41,6 +41,9 @@ use Symfony\Component\Validator\Constraints as Assert;
                     security: 'is_granted("CAMP_COLLABORATOR", day) or is_granted("CAMP_IS_PROTOTYPE", day)'
                 ),
             ],
+            extraProperties: [
+                'filter_by_current_user' => false,
+            ]
         ),
         new Post(
             securityPostDenormalize: 'is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object) or object.day === null'

--- a/api/src/Entity/ScheduleEntry.php
+++ b/api/src/Entity/ScheduleEntry.php
@@ -54,6 +54,9 @@ use Symfony\Component\Validator\Constraints as Assert;
                 ),
             ],
             security: 'is_fully_authenticated()',
+            extraProperties: [
+                'filter_by_current_user' => false,
+            ]
         ),
         new Post(
             denormalizationContext: ['groups' => ['write', 'create']],

--- a/api/tests/Api/Activities/ListActivitiesTest.php
+++ b/api/tests/Api/Activities/ListActivitiesTest.php
@@ -59,7 +59,7 @@ class ListActivitiesTest extends ECampApiTestCase {
         ], $response->toArray()['_links']['items']);
     }
 
-    public function testListActivitiesByCampSubresourceIsAllowedForCollaborator() {
+    public function testListActivitiesAsCampSubresourceIsAllowedForCollaborator() {
         $camp = static::getFixture('camp1');
         $response = static::createClientWithCredentials()->request('GET', "/camps/{$camp->getId()}/activities");
         $this->assertResponseStatusCodeSame(200);
@@ -76,6 +76,12 @@ class ListActivitiesTest extends ECampApiTestCase {
             ['href' => $this->getIriFor('activity1')],
             ['href' => $this->getIriFor('activity2')],
         ], $response->toArray()['_links']['items']);
+    }
+
+    public function testListActivitiesAsCampSubresourceIsDeniedForUnrelatedUser() {
+        $camp = static::getFixture('camp1');
+        $response = static::createClientWithCredentials(['email' => static::$fixtures['user4unrelated']->getEmail()])->request('GET', "/camps/{$camp->getId()}/activities");
+        $this->assertResponseStatusCodeSame(404);
     }
 
     public function testListActivitiesFilteredByCampIsDeniedForUnrelatedUser() {

--- a/api/tests/Api/ActivityProgressLabel/ListActivityProgressLabelTest.php
+++ b/api/tests/Api/ActivityProgressLabel/ListActivityProgressLabelTest.php
@@ -86,6 +86,14 @@ class ListActivityProgressLabelTest extends ECampApiTestCase {
         ], $response->toArray()['_links']['items']);
     }
 
+    public function testListActivityProgressLabelsAsSubresourceOfCampIsDeniedForUnrelatedUser() {
+        $camp = static::getFixture('camp1');
+        $response = static::createClientWithCredentials(['email' => static::$fixtures['user4unrelated']->getEmail()])
+            ->request('GET', "/camps/{$camp->getId()}/activity_progress_labels")
+        ;
+        $this->assertResponseStatusCodeSame(404);
+    }
+
     public function testListActivityProgressLabelsFilteredByCampIsDeniedForUnrelatedUser() {
         $camp = static::getFixture('camp1');
         $response = static::createClientWithCredentials(['email' => static::$fixtures['user4unrelated']->getEmail()])


### PR DESCRIPTION
When using subresources, we don't need FilterByUserExtension anymore, as the security check is done by the link handler

See also:
https://github.com/ecamp/ecamp3/pull/4968#issuecomment-2094638068

This simplifies the database queries (no lookup anymore via view_user_camps)