### PR TITLE
frontend: fix package-lock.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,7 @@
         "@tiptap/extension-underline": "2.11.7",
         "@tiptap/pm": "2.11.7",
         "@tiptap/vue-2": "2.11.7",
-        "@unhead/vue": "^1.11.20",
+        "@unhead/vue": "1.11.20",
         "@zxcvbn-ts/core": "3.0.4",
         "@zxcvbn-ts/language-common": "3.0.4",
         "@zxcvbn-ts/language-de": "3.0.2",


### PR DESCRIPTION
package.json was changed without updating package-lock.json. I don't know why npm ci still worked.
But now i don't have unrelated local changes anymore.