### PR TITLE
Frontend: load root contentNodes with one request in useMaterialViewHelper.js

### DIFF
--- a/frontend/src/components/material/useMaterialViewHelper.js
+++ b/frontend/src/components/material/useMaterialViewHelper.js
@@ -123,8 +123,17 @@ export function useMaterialViewHelper(camp, list) {
   const downloadXlsx = downloadMaterialList(camp, collection, computedList.value?.name)
   const openPeriods = loadPeriods(camp)
 
-  onMounted(() => {
-    collection.value.map(({ materialItems }) => materialItems.$reload())
+  onMounted(async () => {
+    await Promise.all([
+      apiStore
+        .get()
+        .contentNodes({
+          isRoot: 'true',
+          camp: camp._meta.self,
+        })
+        .$loadItems(),
+      ...collection.value.map(({ materialItems }) => materialItems.$reload()),
+    ])
   })
 
   return {


### PR DESCRIPTION
They are not embedded anymore, now we need
to load them smart.

This reduces the load time of the material overview.

hal-json-vuex loads the whole root columnlayout, but we  only need the iri for comparison.
Now we at least load the columlayouts in one request.