### PR TITLE
Load root contentNodes smarter in StoryPeriod and ChecklistOverview

### DIFF
--- a/frontend/src/components/story/StoryPeriod.vue
+++ b/frontend/src/components/story/StoryPeriod.vue
@@ -77,6 +77,13 @@ export default {
         this.period.days().$loadItems(),
         this.period.camp().activities().$loadItems(),
         this.period.camp().categories().$loadItems(),
+        this.api
+          .get()
+          .contentNodes({
+            isRoot: 'true',
+            period: this.period._meta.self,
+          })
+          .$loadItems(),
       ])
 
       this.loading = false

--- a/frontend/src/views/camp/checklistOverview/ChecklistOverview.vue
+++ b/frontend/src/views/camp/checklistOverview/ChecklistOverview.vue
@@ -90,6 +90,13 @@ export default {
           this.processChecklistItems(items)
           this.loading = false
         }),
+      this.api
+        .get()
+        .contentNodes({
+          isRoot: 'true',
+          camp: this.camp._meta.self,
+        })
+        .$loadItems(),
     ])
   },
   methods: {


### PR DESCRIPTION
hal-json-vuex loads the whole root columnlayout, but we  only need the iri for comparison.
Now we at least load the columlayouts in one request.