### PR TITLE
frontend: load root contentNodes with one request in ChecklistDetail.vue

### DIFF
--- a/frontend/src/components/checklist/ChecklistDetail.vue
+++ b/frontend/src/components/checklist/ChecklistDetail.vue
@@ -109,6 +109,15 @@ export default {
       return this.checklist.checklistItems().items.filter((item) => !item.parent)
     },
   },
+  async mounted() {
+    await this.api
+      .get()
+      .contentNodes({
+        isRoot: 'true',
+        camp: this.camp._meta.self,
+      })
+      .$loadItems()
+  },
   methods: {
     makeChecklistNameEditable() {
       this.editChecklistName = true


### PR DESCRIPTION
They are not embedded anymore, now we need
to load them smart.