### PR TITLE
.ops/ingress: fix log-format-upstream

### DIFF
--- a/.ops/ingress/values.yaml
+++ b/.ops/ingress/values.yaml
@@ -8,4 +8,5 @@ ingress-nginx:
       "prometheus.io/port": "10254"
     config:
       log-format-escape-json: true
-      log-format-upstream: {"timestamp":"$time_iso8601","requestID":"$req_id","proxyUpstreamName":"$proxy_upstream_name","proxyAlternativeUpstreamName":"$proxy_alternative_upstream_name","upstreamStatus":$upstream_status,"upstreamAddr":"$upstream_addr","httpRequest":{"requestMethod":"$request_method","requestUrl":"$host$request_uri","status":$status,"requestSize":"$request_length","responseSize":"$upstream_response_length","userAgent":"$http_user_agent","remoteIp":"$remote_addr","referer":"$http_referer","request_time_seconds":$upstream_response_time,"protocol":"$server_protocol"}}
+      log-format-upstream: |
+        {"timestamp":"$time_iso8601","requestID":"$req_id","proxyUpstreamName":"$proxy_upstream_name","proxyAlternativeUpstreamName":"$proxy_alternative_upstream_name","upstreamStatus":$upstream_status,"upstreamAddr":"$upstream_addr","httpRequest":{"requestMethod":"$request_method","requestUrl":"$host$request_uri","status":$status,"requestSize":"$request_length","responseSize":"$upstream_response_length","userAgent":"$http_user_agent","remoteIp":"$remote_addr","referer":"$http_referer","request_time_seconds":$upstream_response_time,"protocol":"$server_protocol"}}


### PR DESCRIPTION
You need to put the json into a string (or in this case: multi line string).
Else it gets interpreted as yaml and does no good.