### PR TITLE
Fix local dev setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
   
   http-cache-logs:
     image: varnish:7.7.0
-    container_name: 'ecamp3-http-cache-log'
+    container_name: 'ecamp3-http-cache-logs'
     depends_on:
       - http-cache
     volumes:


### PR DESCRIPTION
When following the setup instructions from scratch, the jwt folder needs to exist already. Otherwise, Docker will create it as the root user, leading to permission problems later when the container tries to create the JWT keys.

I tested this on a Linux machine by checking out a fresh copy of the repo and using `docker system prune -a --volumes` beforehand. Can't test it on Windows or Mac right now.

The dev setup being broken has previously been reported on discord.