### PR TITLE
Activity filter counts

### DIFF
--- a/common/helpers/__tests__/filterMatchScheduleEntry.spec.js
+++ b/common/helpers/__tests__/filterMatchScheduleEntry.spec.js
@@ -36,8 +36,6 @@ describe('filterMatchScheduleEntry', () => {
     [{ category: ['/categories/00000000', '/categories/1a2b3c4d'] }, true],
     [{ responsible: undefined }, true],
     [{ responsible: null }, true],
-    [{ responsible: '/camp_collaborations/1a2b3c4d' }, true],
-    [{ responsible: '/camp_collaborations/00000000' }, true], // Non-array filter value is treated as absent filter value
     [{ responsible: ['/camp_collaborations/1a2b3c4d'] }, true],
     [{ responsible: ['/camp_collaborations/00000000'] }, false],
     [{ responsible: ['/camp_collaborations/1a2b3c4d', '/camp_collaborations/00000000'] }, false],

--- a/common/helpers/__tests__/filterMatchScheduleEntry.spec.js
+++ b/common/helpers/__tests__/filterMatchScheduleEntry.spec.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { filterMatchScheduleEntry } from '../filterMatchScheduleEntry.js'
+
+const scheduleEntry = {
+  period: () => ({ _meta: { self: '/periods/1a2b3c4d' } }),
+  activity: () => ({
+    category: () => ({ _meta: { self: '/categories/1a2b3c4d' } }),
+    activityResponsibles: () => ({
+      items: [
+        { campCollaboration: () => ({ _meta: { self: '/camp_collaborations/1a2b3c4d' } }) },
+        { campCollaboration: () => ({ _meta: { self: '/camp_collaborations/ffffffff' } }) },
+      ]
+    }),
+    progressLabel: () => ({ _meta: { self: '/progress_labels/1a2b3c4d' } })
+  }),
+}
+
+describe('filterMatchScheduleEntry', () => {
+  it.each([
+    [null, true],
+    [undefined, true],
+    ['wrong input', true],
+    [{}, true],
+    [{ period: undefined }, true],
+    [{ period: null }, true],
+    [{ period: '/periods/1a2b3c4d' }, true],
+    [{ period: '/periods/00000000' }, false],
+    [{ period: ['/periods/1a2b3c4d'] }, false], // an array of periods is currently not supported
+    [{ category: undefined }, true],
+    [{ category: null }, true],
+    [{ category: '/categories/1a2b3c4d' }, true],
+    [{ category: '/categories/00000000' }, false],
+    [{ category: ['/categories/1a2b3c4d'] }, true],
+    [{ category: ['/categories/00000000'] }, false],
+    [{ category: ['/categories/1a2b3c4d', '/categories/00000000'] }, true],
+    [{ category: ['/categories/00000000', '/categories/1a2b3c4d'] }, true],
+    [{ responsible: undefined }, true],
+    [{ responsible: null }, true],
+    [{ responsible: '/camp_collaborations/1a2b3c4d' }, true],
+    [{ responsible: '/camp_collaborations/00000000' }, true], // Non-array filter value is treated as absent filter value
+    [{ responsible: ['/camp_collaborations/1a2b3c4d'] }, true],
+    [{ responsible: ['/camp_collaborations/00000000'] }, false],
+    [{ responsible: ['/camp_collaborations/1a2b3c4d', '/camp_collaborations/00000000'] }, false],
+    [{ responsible: ['/camp_collaborations/00000000', '/camp_collaborations/1a2b3c4d'] }, false],
+    [{ responsible: ['/camp_collaborations/1a2b3c4d', '/camp_collaborations/ffffffff'] }, true],
+    [{ responsible: ['/camp_collaborations/ffffffff', '/camp_collaborations/1a2b3c4d'] }, true],
+    [{ progressLabel: undefined }, true],
+    [{ progressLabel: null }, true],
+    [{ progressLabel: '/progress_labels/1a2b3c4d' }, true],
+    [{ progressLabel: '/progress_labels/00000000' }, false],
+    [{ progressLabel: ['/progress_labels/1a2b3c4d'] }, true],
+    [{ progressLabel: ['/progress_labels/00000000'] }, false],
+    [{ progressLabel: ['/progress_labels/1a2b3c4d', '/progress_labels/00000000'] }, true],
+    [{ progressLabel: ['/progress_labels/00000000', '/progress_labels/1a2b3c4d'] }, true],
+  ])('maps %o to %s', (filter, expected) => {
+    expect(filterMatchScheduleEntry(scheduleEntry, filter)).toEqual(expected)
+  })
+})

--- a/common/helpers/__tests__/filterMatchScheduleEntry.spec.js
+++ b/common/helpers/__tests__/filterMatchScheduleEntry.spec.js
@@ -50,6 +50,60 @@ describe('filterMatchScheduleEntry', () => {
     [{ progressLabel: ['/progress_labels/00000000'] }, false],
     [{ progressLabel: ['/progress_labels/1a2b3c4d', '/progress_labels/00000000'] }, true],
     [{ progressLabel: ['/progress_labels/00000000', '/progress_labels/1a2b3c4d'] }, true],
+    [{
+      period: '/periods/1a2b3c4d',
+      category: ['/categories/1a2b3c4d'],
+      responsible: ['/camp_collaborations/1a2b3c4d'],
+      progressLabel: ['/progress_labels/1a2b3c4d'],
+    }, true],
+    [{
+      period: null,
+      category: ['/categories/1a2b3c4d'],
+      responsible: ['/camp_collaborations/1a2b3c4d'],
+      progressLabel: ['/progress_labels/1a2b3c4d'],
+    }, true],
+    [{
+      period: '/periods/1a2b3c4d',
+      category: null,
+      responsible: ['/camp_collaborations/1a2b3c4d'],
+      progressLabel: ['/progress_labels/1a2b3c4d'],
+    }, true],
+    [{
+      period: '/periods/1a2b3c4d',
+      category: ['/categories/1a2b3c4d'],
+      responsible: null,
+      progressLabel: ['/progress_labels/1a2b3c4d'],
+    }, true],
+    [{
+      period: '/periods/1a2b3c4d',
+      category: ['/categories/1a2b3c4d'],
+      responsible: ['/camp_collaborations/1a2b3c4d'],
+      progressLabel: null,
+    }, true],
+    [{
+      period: '/periods/00000000',
+      category: ['/categories/1a2b3c4d'],
+      responsible: ['/camp_collaborations/1a2b3c4d'],
+      progressLabel: ['/progress_labels/1a2b3c4d'],
+    }, false],
+    [{
+      period: '/periods/1a2b3c4d',
+      category: ['/categories/00000000'],
+      responsible: ['/camp_collaborations/1a2b3c4d'],
+      progressLabel: ['/progress_labels/1a2b3c4d'],
+    }, false],
+    [{
+      period: '/periods/1a2b3c4d',
+      category: ['/categories/1a2b3c4d'],
+      responsible: ['/camp_collaborations/00000000'],
+      progressLabel: ['/progress_labels/1a2b3c4d'],
+    }, false],
+    [{
+      period: '/periods/1a2b3c4d',
+      category: ['/categories/1a2b3c4d'],
+      responsible: ['/camp_collaborations/1a2b3c4d'],
+      progressLabel: ['/progress_labels/00000000'],
+    }, false],
   ])('maps %o to %s', (filter, expected) => {
     expect(filterMatchScheduleEntry(scheduleEntry, filter)).toEqual(expected)
   })

--- a/common/helpers/filterMatchScheduleEntry.js
+++ b/common/helpers/filterMatchScheduleEntry.js
@@ -15,15 +15,14 @@ const filterMatchScheduleEntry = (scheduleEntry, filter) => {
     (filter.category === null ||
       filter.category === undefined ||
       filter.category.length === 0 ||
-      filter.category?.includes(
+      filter.category.includes(
         scheduleEntry.activity().category()._meta.self
       )) &&
     // filter by responsibles: AND filter
     (filter.responsible === null ||
       filter.responsible === undefined ||
       filter.responsible.length === 0 ||
-      typeof filter.responsible?.every !== 'function' ||
-      filter.responsible?.every((responsible) => {
+      filter.responsible.every((responsible) => {
         return scheduleEntry
           .activity()
           .activityResponsibles()
@@ -35,7 +34,7 @@ const filterMatchScheduleEntry = (scheduleEntry, filter) => {
     (filter.progressLabel === null ||
       filter.progressLabel === undefined ||
       filter.progressLabel.length === 0 ||
-      filter.progressLabel?.includes(
+      filter.progressLabel.includes(
         scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
       ))
   )

--- a/common/helpers/filterMatchScheduleEntry.js
+++ b/common/helpers/filterMatchScheduleEntry.js
@@ -1,0 +1,44 @@
+/**
+ * Filtering of schedule entries by various criteria.
+ * Only the matcher function for matching a single scheduleEntry with
+ * a set of filter criteria is implemented here, because this can be
+ * used more flexibly in the application.
+ */
+const filterMatchScheduleEntry = (scheduleEntry, filter) => {
+  if (!filter) return true
+  return (
+    // filter by period
+    (filter.period === null ||
+      filter.period === undefined ||
+      scheduleEntry.period()._meta.self === filter.period) &&
+    // filter by categories: OR filter
+    (filter.category === null ||
+      filter.category === undefined ||
+      filter.category.length === 0 ||
+      filter.category?.includes(
+        scheduleEntry.activity().category()._meta.self
+      )) &&
+    // filter by responsibles: AND filter
+    (filter.responsible === null ||
+      filter.responsible === undefined ||
+      filter.responsible.length === 0 ||
+      typeof filter.responsible?.every !== 'function' ||
+      filter.responsible?.every((responsible) => {
+        return scheduleEntry
+          .activity()
+          .activityResponsibles()
+          .items.map((responsible) => responsible.campCollaboration()._meta.self)
+          .includes(responsible)
+      }) ||
+      (filter.responsible[0] === 'none' &&
+        scheduleEntry.activity().activityResponsibles().items.length === 0)) &&
+    (filter.progressLabel === null ||
+      filter.progressLabel === undefined ||
+      filter.progressLabel.length === 0 ||
+      filter.progressLabel?.includes(
+        scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
+      ))
+  )
+}
+
+export { filterMatchScheduleEntry }

--- a/frontend/src/components/dashboard/BooleanFilter.vue
+++ b/frontend/src/components/dashboard/BooleanFilter.vue
@@ -1,11 +1,13 @@
 <template>
-  <v-chip
-    label
-    outlined
-    :color="value ? 'primary' : null"
-    @click="$emit('input', !value)"
-    >{{ label }}</v-chip
-  >
+  <v-chip label outlined :color="value ? 'primary' : null" @click="$emit('input', !value)"
+    >{{ label }}
+    <v-badge
+      v-if="resultCount !== null"
+      inline
+      bordered
+      color="#e8e8e8"
+      :content="resultCount"
+  /></v-chip>
 </template>
 
 <script>
@@ -14,8 +16,13 @@ export default {
   props: {
     value: Boolean,
     label: { type: String, required: true },
+    resultCount: { type: Number, default: null },
   },
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+::v-deep(.v-badge__badge) {
+  color: #000 !important;
+}
+</style>

--- a/frontend/src/components/dashboard/BooleanFilter.vue
+++ b/frontend/src/components/dashboard/BooleanFilter.vue
@@ -1,18 +1,15 @@
 <template>
   <v-chip label outlined :color="value ? 'primary' : null" @click="$emit('input', !value)"
-    >{{ label }}
-    <v-badge
-      v-if="resultCount !== null"
-      inline
-      bordered
-      color="#e8e8e8"
-      :content="resultCount"
+    >{{ label }} <CountBadge v-if="resultCount !== null" :count="resultCount"
   /></v-chip>
 </template>
 
 <script>
+import CountBadge from '@/components/dashboard/CountBadge.vue'
+
 export default {
   name: 'BooleanFilter',
+  components: { CountBadge },
   props: {
     value: Boolean,
     label: { type: String, required: true },
@@ -20,9 +17,3 @@ export default {
   },
 }
 </script>
-
-<style scoped>
-::v-deep(.v-badge__badge) {
-  color: #000 !important;
-}
-</style>

--- a/frontend/src/components/dashboard/CountBadge.vue
+++ b/frontend/src/components/dashboard/CountBadge.vue
@@ -12,6 +12,7 @@ export default {
 </script>
 
 <style scoped>
+/* eslint-disable vue-scoped-css/no-unused-selector */
 .v-badge {
   margin-top: 0;
 }
@@ -39,4 +40,5 @@ export default {
   transform: none;
   border-color: #cfd8dc;
 }
+/* eslint-enable vue-scoped-css/no-unused-selector */
 </style>

--- a/frontend/src/components/dashboard/CountBadge.vue
+++ b/frontend/src/components/dashboard/CountBadge.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-badge inline bordered dark color="blue-grey lighten-5" :content="String(count)" />
+</template>
+
+<script>
+export default {
+  name: 'CountBadge',
+  props: {
+    count: { type: [Number, String], required: true },
+  },
+}
+</script>
+
+<style scoped>
+.v-badge {
+  margin-top: 0;
+}
+
+:deep(.v-badge__badge) {
+  color: currentcolor;
+  min-width: 18px;
+  font-weight: 500;
+  line-height: 12.5px;
+  margin-top: 0;
+}
+
+:is(.v-chip.primary, .v-list-item--active)
+  .v-badge--bordered
+  :deep(.v-badge__badge:after) {
+  border-color: currentcolor;
+}
+
+:is(.v-chip.primary, .v-list-item--active) .v-badge :deep(.v-badge__badge) {
+  background-color: #f2f9fc !important;
+}
+
+.v-badge--bordered :deep(.v-badge__badge:after) {
+  border-width: 1px;
+  transform: none;
+  border-color: #cfd8dc;
+}
+</style>

--- a/frontend/src/components/dashboard/SelectFilter.vue
+++ b/frontend/src/components/dashboard/SelectFilter.vue
@@ -28,13 +28,7 @@
       >
         <v-list-item-title>
           <slot name="item" v-bind="{ item, self }">{{ item.text }}</slot>
-          <v-badge
-            v-if="item.resultCount !== null"
-            inline
-            bordered
-            color="#e8e8e8"
-            :content="item.resultCount"
-          />
+          <CountBadge v-if="item.resultCount !== null" :count="item.resultCount" />
         </v-list-item-title>
         <v-list-item-action v-if="multiple && !item.exclusiveNone">
           <v-checkbox v-model="item.selected" dense />
@@ -51,9 +45,11 @@
 
 <script>
 import { get, keyBy } from 'lodash-es'
+import CountBadge from '@/components/dashboard/CountBadge.vue'
 
 export default {
   name: 'SelectFilter',
+  components: { CountBadge },
   props: {
     label: { type: String, required: true },
     multiple: { type: Boolean, default: false },
@@ -132,12 +128,3 @@ export default {
   },
 }
 </script>
-
-<style scoped>
-::v-deep(.v-badge) {
-  margin-top: 0;
-}
-::v-deep(.v-badge__badge) {
-  color: #000 !important;
-}
-</style>

--- a/frontend/src/components/dashboard/SelectFilter.vue
+++ b/frontend/src/components/dashboard/SelectFilter.vue
@@ -28,6 +28,7 @@
       >
         <v-list-item-title>
           <slot name="item" v-bind="{ item, self }">{{ item.text }}</slot>
+          <template v-if="item.resultCount !== null">({{ item.resultCount }})</template>
         </v-list-item-title>
         <v-list-item-action v-if="multiple && !item.exclusiveNone">
           <v-checkbox v-model="item.selected" dense />
@@ -65,11 +66,12 @@ export default {
         Object.values(this.items).map((item) => {
           const text = this.displayValue(item)
           const value = get(item, this.valueField)
+          const resultCount = get(item, 'resultCount', null)
           const exclusiveNone = get(item, 'exclusiveNone')
           const selected = this.multiple
             ? this.value?.includes(value)
             : this.value === value
-          return { text, value, selected, exclusiveNone }
+          return { text, resultCount, value, selected, exclusiveNone }
         }),
         'value'
       )

--- a/frontend/src/components/dashboard/SelectFilter.vue
+++ b/frontend/src/components/dashboard/SelectFilter.vue
@@ -28,7 +28,13 @@
       >
         <v-list-item-title>
           <slot name="item" v-bind="{ item, self }">{{ item.text }}</slot>
-          <template v-if="item.resultCount !== null">({{ item.resultCount }})</template>
+          <v-badge
+            v-if="item.resultCount !== null"
+            inline
+            bordered
+            color="#e8e8e8"
+            :content="item.resultCount"
+          />
         </v-list-item-title>
         <v-list-item-action v-if="multiple && !item.exclusiveNone">
           <v-checkbox v-model="item.selected" dense />
@@ -127,4 +133,11 @@ export default {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+::v-deep(.v-badge) {
+  margin-top: 0;
+}
+::v-deep(.v-badge__badge) {
+  color: #000 !important;
+}
+</style>

--- a/frontend/src/components/program/ScheduleEntries.vue
+++ b/frontend/src/components/program/ScheduleEntries.vue
@@ -41,7 +41,7 @@ export default {
   props: {
     period: { type: Object, required: true },
     showButton: { type: Boolean, required: true },
-    matchFn: { type: Function, required: false, default: () => true },
+    filterFn: { type: Function, required: false, default: () => true },
   },
   data() {
     return {
@@ -63,7 +63,7 @@ export default {
     filteredScheduleEntries() {
       return this.scheduleEntries.items.map((item) => ({
         ...item,
-        filterMatch: this.matchFn(item),
+        filterMatch: this.filterFn(item),
       }))
     },
     loading() {

--- a/frontend/src/components/program/ScheduleEntryFilters.vue
+++ b/frontend/src/components/program/ScheduleEntryFilters.vue
@@ -7,7 +7,12 @@
     <BooleanFilter
       v-if="loadingEndpoints !== true && loadingEndpoints.campCollaborations !== true"
       v-model="showOnlyMyActivities"
-      :label="$tc('components.program.scheduleEntryFilters.onlyMyActivities') + ' (' + myActivitiesCount + ')'"
+      :label="
+        $tc('components.program.scheduleEntryFilters.onlyMyActivities') +
+        ' (' +
+        myActivitiesCount +
+        ')'
+      "
     />
     <v-skeleton-loader
       v-else
@@ -159,15 +164,15 @@ export default {
     },
     filterFn: {
       type: Function,
-      default: () => []
+      default: () => [],
     },
   },
   computed: {
     periodItems() {
       return keyBy(
-        Object.values(this.periods).map(period => ({
+        Object.values(this.periods).map((period) => ({
           ...period,
-          resultCount: this.resultCountWithModifiedFilter('period', period._meta.self)
+          resultCount: this.resultCountWithModifiedFilter('period', period._meta.self),
         })),
         '_meta.self'
       )
@@ -192,20 +197,20 @@ export default {
           exclusiveNone: true,
           label: this.$tc('components.program.scheduleEntryFilters.responsibleNone'),
           _meta: { self: 'none' },
-          resultCount: this.resultCountWithModifiedFilter('responsible', ['none'])
+          resultCount: this.resultCountWithModifiedFilter('responsible', ['none']),
         },
         ...keyBy(
           sortBy(this.camp.campCollaborations().items, (u) =>
             campCollaborationDisplayName(u, this.$tc.bind(this)).toLowerCase()
-          ).map(campCollaboration => {
+          ).map((campCollaboration) => {
             return {
               ...campCollaboration,
-              resultCount: this.resultCountWithModifiedFilter('responsible', this.value.responsible?.includes('none') ? [
-                campCollaboration._meta.self,
-              ] : [
-                ...this.value.responsible,
-                campCollaboration._meta.self,
-              ])
+              resultCount: this.resultCountWithModifiedFilter(
+                'responsible',
+                this.value.responsible?.includes('none')
+                  ? [campCollaboration._meta.self]
+                  : [...this.value.responsible, campCollaboration._meta.self]
+              ),
             }
           }),
           '_meta.self'
@@ -214,10 +219,12 @@ export default {
     },
     categories() {
       return keyBy(
-        this.camp.categories().items.map(category => {
+        this.camp.categories().items.map((category) => {
           return {
             ...category,
-            resultCount: this.resultCountWithModifiedFilter('category', [category._meta.self])
+            resultCount: this.resultCountWithModifiedFilter('category', [
+              category._meta.self,
+            ]),
           }
         }),
         '_meta.self'
@@ -229,13 +236,15 @@ export default {
         none: {
           title: this.$tc('components.program.scheduleEntryFilters.progressLabelNone'),
           _meta: { self: 'none' },
-          resultCount: this.resultCountWithModifiedFilter('progressLabel', ['none'])
+          resultCount: this.resultCountWithModifiedFilter('progressLabel', ['none']),
         },
         ...keyBy(
-          labels.map(label => {
+          labels.map((label) => {
             return {
               ...label,
-              resultCount: this.resultCountWithModifiedFilter('progressLabel', [label._meta.self])
+              resultCount: this.resultCountWithModifiedFilter('progressLabel', [
+                label._meta.self,
+              ]),
             }
           }),
           '_meta.self'
@@ -273,7 +282,7 @@ export default {
         period: null,
         progressLabel: null,
       }).length
-    }
+    },
   },
   mounted() {
     if (this.loadingEndpoints !== true) {
@@ -311,7 +320,7 @@ export default {
         ...this.value,
         [filterName]: filterValue,
       }).length
-    }
+    },
   },
 }
 </script>

--- a/frontend/src/components/program/ScheduleEntryFilters.vue
+++ b/frontend/src/components/program/ScheduleEntryFilters.vue
@@ -7,7 +7,7 @@
     <BooleanFilter
       v-if="loadingEndpoints !== true && loadingEndpoints.campCollaborations !== true"
       v-model="showOnlyMyActivities"
-      :label="$tc('components.program.scheduleEntryFilters.onlyMyActivities')"
+      :label="$tc('components.program.scheduleEntryFilters.onlyMyActivities') + ' (' + myActivitiesCount + ')'"
     />
     <v-skeleton-loader
       v-else
@@ -22,7 +22,7 @@
         <SelectFilter
           v-if="multiplePeriods"
           v-model="value.period"
-          :items="periods"
+          :items="periodItems"
           display-field="description"
           :label="$tc('components.program.scheduleEntryFilters.period')"
         />
@@ -157,8 +157,21 @@ export default {
       type: [Boolean, Object],
       default: true,
     },
+    filterFn: {
+      type: Function,
+      default: () => []
+    },
   },
   computed: {
+    periodItems() {
+      return keyBy(
+        Object.values(this.periods).map(period => ({
+          ...period,
+          resultCount: this.resultCountWithModifiedFilter('period', period._meta.self)
+        })),
+        '_meta.self'
+      )
+    },
     multiplePeriods() {
       return this.periods && Object.keys(this.periods).length > 1
     },
@@ -179,17 +192,36 @@ export default {
           exclusiveNone: true,
           label: this.$tc('components.program.scheduleEntryFilters.responsibleNone'),
           _meta: { self: 'none' },
+          resultCount: this.resultCountWithModifiedFilter('responsible', ['none'])
         },
         ...keyBy(
           sortBy(this.camp.campCollaborations().items, (u) =>
             campCollaborationDisplayName(u, this.$tc.bind(this)).toLowerCase()
-          ),
+          ).map(campCollaboration => {
+            return {
+              ...campCollaboration,
+              resultCount: this.resultCountWithModifiedFilter('responsible', this.value.responsible?.includes('none') ? [
+                campCollaboration._meta.self,
+              ] : [
+                ...this.value.responsible,
+                campCollaboration._meta.self,
+              ])
+            }
+          }),
           '_meta.self'
         ),
       }
     },
     categories() {
-      return keyBy(this.camp.categories().items, '_meta.self')
+      return keyBy(
+        this.camp.categories().items.map(category => {
+          return {
+            ...category,
+            resultCount: this.resultCountWithModifiedFilter('category', [category._meta.self])
+          }
+        }),
+        '_meta.self'
+      )
     },
     progressLabels() {
       const labels = sortBy(this.camp.progressLabels().items, (l) => l.position)
@@ -197,8 +229,17 @@ export default {
         none: {
           title: this.$tc('components.program.scheduleEntryFilters.progressLabelNone'),
           _meta: { self: 'none' },
+          resultCount: this.resultCountWithModifiedFilter('progressLabel', ['none'])
         },
-        ...keyBy(labels, '_meta.self'),
+        ...keyBy(
+          labels.map(label => {
+            return {
+              ...label,
+              resultCount: this.resultCountWithModifiedFilter('progressLabel', [label._meta.self])
+            }
+          }),
+          '_meta.self'
+        ),
       }
     },
     filteredPropertiesCount() {
@@ -225,6 +266,14 @@ export default {
         this.value.progressLabel = null
       },
     },
+    myActivitiesCount() {
+      return this.filterFn({
+        responsible: [this.loggedInCampCollaboration],
+        category: [],
+        period: null,
+        progressLabel: null,
+      }).length
+    }
   },
   mounted() {
     if (this.loadingEndpoints !== true) {
@@ -257,6 +306,12 @@ export default {
     onResize({ height }) {
       this.$emit('height-changed', height)
     },
+    resultCountWithModifiedFilter(filterName, filterValue) {
+      return this.filterFn({
+        ...this.value,
+        [filterName]: filterValue,
+      }).length
+    }
   },
 }
 </script>

--- a/frontend/src/components/program/ScheduleEntryFilters.vue
+++ b/frontend/src/components/program/ScheduleEntryFilters.vue
@@ -7,12 +7,8 @@
     <BooleanFilter
       v-if="loadingEndpoints !== true && loadingEndpoints.campCollaborations !== true"
       v-model="showOnlyMyActivities"
-      :label="
-        $tc('components.program.scheduleEntryFilters.onlyMyActivities') +
-        ' (' +
-        myActivitiesCount +
-        ')'
-      "
+      :label="$tc('components.program.scheduleEntryFilters.onlyMyActivities')"
+      :result-count="myActivitiesCount"
     />
     <v-skeleton-loader
       v-else

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -148,6 +148,7 @@ import {
   processRouteQuery,
   transformValuesToHalId,
 } from '@/helpers/querySyncHelper.js'
+import { filterMatchScheduleEntry } from '@/common/helpers/filterMatchScheduleEntry.js'
 
 export default {
   name: 'CampProgram',
@@ -265,38 +266,7 @@ export default {
       this.showReminder = true
     },
     filterFn(scheduleEntry, filter) {
-      return (
-        // filter by period
-        (filter.period === null ||
-          filter.period === undefined ||
-          scheduleEntry.period()._meta.self === filter.period) &&
-        // filter by categories: OR filter
-        (filter.category === null ||
-          filter.category === undefined ||
-          filter.category.length === 0 ||
-          filter.category?.includes(
-            scheduleEntry.activity().category()._meta.self
-          )) &&
-        // filter by responsibles: AND filter
-        (filter.responsible === null ||
-          filter.responsible === undefined ||
-          filter.responsible.length === 0 ||
-          filter.responsible?.every((responsible) => {
-            return scheduleEntry
-              .activity()
-              .activityResponsibles()
-              .items.map((responsible) => responsible.campCollaboration()._meta.self)
-              .includes(responsible)
-          }) ||
-          (filter.responsible[0] === 'none' &&
-            scheduleEntry.activity().activityResponsibles().items.length === 0)) &&
-        (filter.progressLabel === null ||
-          filter.progressLabel === undefined ||
-          filter.progressLabel.length === 0 ||
-          filter.progressLabel?.includes(
-            scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
-          ))
-      )
+      return filterMatchScheduleEntry(scheduleEntry, filter)
     },
     persistRouterState() {
       const query = transformValuesToHalId(this.filter)

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -90,6 +90,7 @@ Show all activity schedule entries of a single period.
       class="ec-content-card__toolbar--border pb-4 justify-center"
       :loading-endpoints="loadingEndpoints"
       :camp="camp"
+      :filter-fn="(filter) => period.scheduleEntries().items.filter(scheduleEntry => filterFn(scheduleEntry, filter))"
       @height-changed="scheduleEntryFiltersHeightChanged"
     />
     <template v-if="loading">

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -90,12 +90,7 @@ Show all activity schedule entries of a single period.
       class="ec-content-card__toolbar--border pb-4 justify-center"
       :loading-endpoints="loadingEndpoints"
       :camp="camp"
-      :filter-fn="
-        (filter) =>
-          period
-            .scheduleEntries()
-            .items.filter((scheduleEntry) => filterFn(scheduleEntry, filter))
-      "
+      :filter-fn="filterFn"
       @height-changed="scheduleEntryFiltersHeightChanged"
     />
     <template v-if="loading">
@@ -105,7 +100,7 @@ Show all activity schedule entries of a single period.
       v-else
       :period="period"
       :show-button="isContributor"
-      :filter-fn="(scheduleEntry) => filterFn(scheduleEntry, filter)"
+      :filter-fn="filterMatchScheduleEntry"
     >
       <template #default="slotProps">
         <Picasso
@@ -236,6 +231,17 @@ export default {
     isFilterSet() {
       return this.filteredPropertiesCount > 0
     },
+    filterMatchScheduleEntry() {
+      return (scheduleEntry) => filterMatchScheduleEntry(scheduleEntry, this.filter)
+    },
+    filterFn() {
+      return (filter) =>
+        this.period
+          .scheduleEntries()
+          .items.filter((scheduleEntry) =>
+            filterMatchScheduleEntry(scheduleEntry, filter)
+          )
+    },
   },
   watch: {
     openFilter: {
@@ -269,9 +275,6 @@ export default {
         ? this.$tc('views.camp.campProgram.reminderLockedMove')
         : this.$tc('views.camp.campProgram.reminderLockedCreate')
       this.showReminder = true
-    },
-    filterFn(scheduleEntry, filter) {
-      return filterMatchScheduleEntry(scheduleEntry, filter)
     },
     persistRouterState() {
       const query = transformValuesToHalId(this.filter)

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -90,7 +90,12 @@ Show all activity schedule entries of a single period.
       class="ec-content-card__toolbar--border pb-4 justify-center"
       :loading-endpoints="loadingEndpoints"
       :camp="camp"
-      :filter-fn="(filter) => period.scheduleEntries().items.filter(scheduleEntry => filterFn(scheduleEntry, filter))"
+      :filter-fn="
+        (filter) =>
+          period
+            .scheduleEntries()
+            .items.filter((scheduleEntry) => filterFn(scheduleEntry, filter))
+      "
       @height-changed="scheduleEntryFiltersHeightChanged"
     />
     <template v-if="loading">

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -127,6 +127,7 @@ Show all activity schedule entries of a single period.
           class="pa-4"
           :loading-endpoints="loadingEndpoints"
           :camp="camp"
+          :filter-fn="filterFn"
         />
       </v-sheet>
     </v-bottom-sheet>

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -99,7 +99,7 @@ Show all activity schedule entries of a single period.
       v-else
       :period="period"
       :show-button="isContributor"
-      :match-fn="match"
+      :filter-fn="(scheduleEntry) => filterFn(scheduleEntry, filter)"
     >
       <template #default="slotProps">
         <Picasso
@@ -263,30 +263,38 @@ export default {
         : this.$tc('views.camp.campProgram.reminderLockedCreate')
       this.showReminder = true
     },
-    match(scheduleEntry) {
+    filterFn(scheduleEntry, filter) {
       return (
-        this.filteredPropertiesCount === 0 ||
-        ((this.filter.category === null ||
-          this.filter.category.length === 0 ||
-          this.filter.category.includes(
+        // filter by period
+        (filter.period === null ||
+          filter.period === undefined ||
+          scheduleEntry.period()._meta.self === filter.period) &&
+        // filter by categories: OR filter
+        (filter.category === null ||
+          filter.category === undefined ||
+          filter.category.length === 0 ||
+          filter.category?.includes(
             scheduleEntry.activity().category()._meta.self
           )) &&
-          (this.filter.responsible === null ||
-            this.filter.responsible.length === 0 ||
-            this.filter.responsible?.every((responsible) =>
-              scheduleEntry
-                .activity()
-                .activityResponsibles()
-                .items.map((responsible) => responsible.campCollaboration()._meta.self)
-                .includes(responsible)
-            ) ||
-            (this.filter.responsible[0] === 'none' &&
-              scheduleEntry.activity().activityResponsibles().items.length === 0)) &&
-          (this.filter.progressLabel === null ||
-            this.filter.progressLabel.length === 0 ||
-            this.filter.progressLabel?.includes(
-              scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
-            )))
+        // filter by responsibles: AND filter
+        (filter.responsible === null ||
+          filter.responsible === undefined ||
+          filter.responsible.length === 0 ||
+          filter.responsible?.every((responsible) => {
+            return scheduleEntry
+              .activity()
+              .activityResponsibles()
+              .items.map((responsible) => responsible.campCollaboration()._meta.self)
+              .includes(responsible)
+          }) ||
+          (filter.responsible[0] === 'none' &&
+            scheduleEntry.activity().activityResponsibles().items.length === 0)) &&
+        (filter.progressLabel === null ||
+          filter.progressLabel === undefined ||
+          filter.progressLabel.length === 0 ||
+          filter.progressLabel?.includes(
+            scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
+          ))
       )
     },
     persistRouterState() {

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -150,6 +150,7 @@ import {
 import AvatarRow from '@/components/generic/AvatarRow.vue'
 import ScheduleEntryFilters from '@/components/program/ScheduleEntryFilters.vue'
 import dayjs from '@/common/helpers/dayjs.js'
+import { filterMatchScheduleEntry } from '@/common/helpers/filterMatchScheduleEntry.js'
 
 export default {
   name: 'Dashboard',
@@ -289,38 +290,7 @@ export default {
       }
     },
     filterFn(scheduleEntry, filter) {
-      return (
-        // filter by period
-        (filter.period === null ||
-          filter.period === undefined ||
-          scheduleEntry.period()._meta.self === filter.period) &&
-        // filter by categories: OR filter
-        (filter.category === null ||
-          filter.category === undefined ||
-          filter.category.length === 0 ||
-          filter.category?.includes(
-            scheduleEntry.activity().category()._meta.self
-          )) &&
-        // filter by responsibles: AND filter
-        (filter.responsible === null ||
-          filter.responsible === undefined ||
-          filter.responsible.length === 0 ||
-          filter.responsible?.every((responsible) => {
-            return scheduleEntry
-              .activity()
-              .activityResponsibles()
-              .items.map((responsible) => responsible.campCollaboration()._meta.self)
-              .includes(responsible)
-          }) ||
-          (filter.responsible[0] === 'none' &&
-            scheduleEntry.activity().activityResponsibles().items.length === 0)) &&
-        (filter.progressLabel === null ||
-          filter.progressLabel === undefined ||
-          filter.progressLabel.length === 0 ||
-          filter.progressLabel?.includes(
-            scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
-          ))
-      )
+      return filterMatchScheduleEntry(scheduleEntry, filter)
     },
   },
 }

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -24,10 +24,7 @@
         :loading-endpoints="loadingEndpoints"
         :camp="camp"
         :periods="periods"
-        :filter-fn="
-          (filter) =>
-            scheduleEntries.filter((scheduleEntry) => filterFn(scheduleEntry, filter))
-        "
+        :filter-fn="filterFn"
       />
       <template v-if="!loading">
         <table
@@ -221,7 +218,7 @@ export default {
     },
     filteredScheduleEntries() {
       return this.scheduleEntries.filter((scheduleEntry) =>
-        this.filterFn(scheduleEntry, this.filter)
+        filterMatchScheduleEntry(scheduleEntry, this.filter)
       )
     },
     groupedScheduleEntries() {
@@ -234,6 +231,12 @@ export default {
           return scheduleEntry.day()._meta.self
         })
       )
+    },
+    filterFn() {
+      return (filter) =>
+        this.scheduleEntries.filter((scheduleEntry) =>
+          filterMatchScheduleEntry(scheduleEntry, filter)
+        )
     },
     ...mapGetters({
       loggedInUser: 'getLoggedInUser',
@@ -293,9 +296,6 @@ export default {
           behavior: 'smooth',
         })
       }
-    },
-    filterFn(scheduleEntry, filter) {
-      return filterMatchScheduleEntry(scheduleEntry, filter)
     },
   },
 }

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -24,7 +24,10 @@
         :loading-endpoints="loadingEndpoints"
         :camp="camp"
         :periods="periods"
-        :filter-fn="(filter) => scheduleEntries.filter(scheduleEntry => filterFn(scheduleEntry, filter))"
+        :filter-fn="
+          (filter) =>
+            scheduleEntries.filter((scheduleEntry) => filterFn(scheduleEntry, filter))
+        "
       />
       <template v-if="!loading">
         <table
@@ -217,7 +220,9 @@ export default {
       )
     },
     filteredScheduleEntries() {
-      return this.scheduleEntries.filter(scheduleEntry => this.filterFn(scheduleEntry, this.filter))
+      return this.scheduleEntries.filter((scheduleEntry) =>
+        this.filterFn(scheduleEntry, this.filter)
+      )
     },
     groupedScheduleEntries() {
       const groupedByPeriod = groupBy(

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -24,6 +24,7 @@
         :loading-endpoints="loadingEndpoints"
         :camp="camp"
         :periods="periods"
+        :filter-fn="(filter) => scheduleEntries.filter(scheduleEntry => filterFn(scheduleEntry, filter))"
       />
       <template v-if="!loading">
         <table

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -215,35 +215,7 @@ export default {
       )
     },
     filteredScheduleEntries() {
-      return this.scheduleEntries.filter(
-        (scheduleEntry) =>
-          // filter by period
-          (this.filter.period === null ||
-            scheduleEntry.period()._meta.self === this.filter.period) &&
-          // filter by categories: OR filter
-          (this.filter.category === null ||
-            this.filter.category.length === 0 ||
-            this.filter.category?.includes(
-              scheduleEntry.activity().category()._meta.self
-            )) &&
-          // filter by responsibles: AND filter
-          (this.filter.responsible === null ||
-            this.filter.responsible.length === 0 ||
-            this.filter.responsible?.every((responsible) => {
-              return scheduleEntry
-                .activity()
-                .activityResponsibles()
-                .items.map((responsible) => responsible.campCollaboration()._meta.self)
-                .includes(responsible)
-            }) ||
-            (this.filter.responsible[0] === 'none' &&
-              scheduleEntry.activity().activityResponsibles().items.length === 0)) &&
-          (this.filter.progressLabel === null ||
-            this.filter.progressLabel.length === 0 ||
-            this.filter.progressLabel?.includes(
-              scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
-            ))
-      )
+      return this.scheduleEntries.filter(scheduleEntry => this.filterFn(scheduleEntry, this.filter))
     },
     groupedScheduleEntries() {
       const groupedByPeriod = groupBy(
@@ -314,6 +286,40 @@ export default {
           behavior: 'smooth',
         })
       }
+    },
+    filterFn(scheduleEntry, filter) {
+      return (
+        // filter by period
+        (filter.period === null ||
+          filter.period === undefined ||
+          scheduleEntry.period()._meta.self === filter.period) &&
+        // filter by categories: OR filter
+        (filter.category === null ||
+          filter.category === undefined ||
+          filter.category.length === 0 ||
+          filter.category?.includes(
+            scheduleEntry.activity().category()._meta.self
+          )) &&
+        // filter by responsibles: AND filter
+        (filter.responsible === null ||
+          filter.responsible === undefined ||
+          filter.responsible.length === 0 ||
+          filter.responsible?.every((responsible) => {
+            return scheduleEntry
+              .activity()
+              .activityResponsibles()
+              .items.map((responsible) => responsible.campCollaboration()._meta.self)
+              .includes(responsible)
+          }) ||
+          (filter.responsible[0] === 'none' &&
+            scheduleEntry.activity().activityResponsibles().items.length === 0)) &&
+        (filter.progressLabel === null ||
+          filter.progressLabel === undefined ||
+          filter.progressLabel.length === 0 ||
+          filter.progressLabel?.includes(
+            scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
+          ))
+      )
     },
   },
 }

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -257,8 +257,8 @@ export default {
 
     this.camp.periods()._meta.load.then(({ allItems }) => {
       const collection = allItems.map((entry) => entry._meta.self)
-      this.filter.periods =
-        this.filter.periods?.filter((value) => collection.includes(value)) ?? null
+      this.filter.period =
+        this.filter.period?.filter((value) => collection.includes(value)) ?? null
       this.loadingEndpoints.periods = false
     })
   },


### PR DESCRIPTION
Adds counters indicating the number of results belonging to each filter option.
The counters adapt when more filters are added.
There is some complexity due to the different filter behaviours (AND vs OR, exclusive none, single vs. multiple), but I think I got the most intuitive version down for each filter.
Works both on the dashboard and on the picasso.

Also fixes #4951, and I moved the filtering logic to common, because of the following feature request: "Druckfilter (z.B. nur Blöcke wo ich Verantwortlich bin)". This PR is incidentally a first step in this direction.

![image](https://github.com/user-attachments/assets/7d0991cc-a05a-471a-addd-e24b0ddd7c20)
