### PR TITLE
Fix caddy deprecation warning

### DIFF
--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -18,9 +18,7 @@
 	# due to https://github.com/caddyserver/caddy/commit/f5ccb904a3db2bffd980feee685afaa762224cb2
 	admin 0.0.0.0:2019
 	# enable Prometheus metrics endpoint https://caddyserver.com/docs/metrics
-	servers {
-		metrics
-	}
+	metrics
 }
 
 {$CADDY_EXTRA_CONFIG}


### PR DESCRIPTION
Fixes the following warning from cluttering up our api logs (at least locally):
```
{"level":"warn","ts":1746632851.2260025,"msg":"The nested 'metrics' option inside `servers` is deprecated and will be removed in the next major version. Use the global 'metrics' option instead."}
```

See https://github.com/caddyserver/caddy/pull/6606