### PR TITLE
Allow managers to delete camp

### DIFF
--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -42,7 +42,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
         new Delete(
             processor: CampRemoveProcessor::class,
-            security: 'object.owner == user'
+            security: 'is_granted("CAMP_MANAGER", object)',
         ),
         new GetCollection(
             security: 'is_authenticated()'

--- a/api/tests/Api/Camps/DeleteCampTest.php
+++ b/api/tests/Api/Camps/DeleteCampTest.php
@@ -43,9 +43,9 @@ class DeleteCampTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testDeleteCampIsDeniedForCollaboratorThatIsNotOwner() {
-        $camp = static::getFixture('camp2');
-        static::createClientWithCredentials()->request('DELETE', '/camps/'.$camp->getId());
+    public function testDeleteCampIsDeniedForMember() {
+        $camp = static::getFixture('camp1');
+        static::createClientWithCredentials(['email' => static::$fixtures['campCollaboration2member']->getEmail()])->request('DELETE', '/camps/'.$camp->getId());
         $this->assertResponseStatusCodeSame(403);
         $this->assertJsonContains([
             'title' => 'An error occurred',
@@ -53,8 +53,8 @@ class DeleteCampTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testDeleteCampIsAllowedForCampOwner() {
-        $camp = static::getFixture('camp1');
+    public function testDeleteCampIsAllowedForManager() {
+        $camp = static::getFixture('camp2');
         static::createClientWithCredentials()->request('DELETE', '/camps/'.$camp->getId());
         $this->assertResponseStatusCodeSame(204);
         $this->assertNull(static::getContainer()->get(CampRepository::class)->findOneBy(['id' => $camp->getId()]));


### PR DESCRIPTION
Fixes #2423 
We can also discuss this again, but the frontend already displays the danger zone to all managers (the owner isn't even exposed through the API).