### PR TITLE
Add option for setting helm timeout during deployments

### DIFF
--- a/.github/workflows/reusable-dev-deployment.yml
+++ b/.github/workflows/reusable-dev-deployment.yml
@@ -131,7 +131,8 @@ jobs:
             --set recaptcha.secret='${{ secrets.RECAPTCHA_SECRET }}' \
             --set frontend.loginInfoTextKey=${{ vars.LOGIN_INFO_TEXT_KEY }} \
             --set featureToggle.developer=true \
-            --set featureToggle.checklist=${{ vars.FEATURE_CHECKLIST || 'false' }}
+            --set featureToggle.checklist=${{ vars.FEATURE_CHECKLIST || 'false' }} \
+            --timeout ${{ vars.HELM_TIMEOUT || '5m0s' }}
 
       - name: Finish the GitHub deployment
         uses: bobheadxi/deployments@v1.5.0

--- a/.github/workflows/reusable-stage-prod-deployment.yml
+++ b/.github/workflows/reusable-stage-prod-deployment.yml
@@ -111,7 +111,8 @@ jobs:
             --set print.resources.requests.memory=${{ vars.PRINT_MEMORY || '150Mi' }} \
             --set autoscaling.enabled=true \
             --set autoscaling.targetCPUUtilizationPercentage=90 \
-            --set featureToggle.checklist=${{ vars.FEATURE_CHECKLIST || 'false' }}
+            --set featureToggle.checklist=${{ vars.FEATURE_CHECKLIST || 'false' }} \
+            --timeout ${{ vars.HELM_TIMEOUT || '5m0s' }}
 
       - name: Finish the GitHub deployment
         uses: bobheadxi/deployments@v1.5.0


### PR DESCRIPTION
https://helm.sh/docs/intro/using_helm/#helpful-options-for-installupgraderollback

From the output of `helm upgrade --help`:
```
--timeout duration    time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
```