### PR TITLE
Print configurator: Preselect period in single-period camps

### DIFF
--- a/frontend/src/components/form/base/ESelect.vue
+++ b/frontend/src/components/form/base/ESelect.vue
@@ -17,6 +17,8 @@
       :error-messages="veeErrors.concat(errorMessages)"
       :label="labelOrEntityFieldLabel"
       :class="[inputClass]"
+      :readonly="readonly"
+      :append-icon="readonly ? null : '$dropdown'"
       v-on="$listeners"
     >
       <!-- passing through all slots -->
@@ -40,6 +42,7 @@ export default {
   props: {
     immediateValidation: { type: Boolean, default: false },
     skipIfEmpty: { type: Boolean, default: true },
+    readonly: { type: Boolean, default: false },
   },
 }
 </script>

--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -39,7 +39,7 @@
             @click="
               addContent({
                 type: idx,
-                options: component.defaultOptions(),
+                options: component.defaultOptions(camp),
               })
             "
           >

--- a/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
+++ b/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
@@ -21,6 +21,20 @@ describe('repairConfig', () => {
       ],
     }),
   }
+  const multiPeriodCamp = {
+    _meta: { self: '/camps/1a2b3c4d' },
+    shortTitle: 'test camp',
+    periods: () => ({
+      items: [
+        {
+          _meta: { self: '/periods/1a2b3c4d' },
+        },
+        {
+          _meta: { self: '/periods/11223344' },
+        },
+      ],
+    }),
+  }
   const availableLocales = ['en-GB', 'de-CH', 'de-CH-scout']
   const componentRepairers = Object.fromEntries(
     [
@@ -38,6 +52,13 @@ describe('repairConfig', () => {
     { type: 'Picasso', options: { periods: ['/periods/1a2b3c4d'], orientation: 'L' } },
   ]
   const args = [camp, availableLocales, 'en', componentRepairers, defaultContents]
+  const multiPeriodArgs = [
+    multiPeriodCamp,
+    availableLocales,
+    'en',
+    componentRepairers,
+    defaultContents,
+  ]
 
   test('fills empty config with default data', async () => {
     // given
@@ -567,7 +588,7 @@ describe('repairConfig', () => {
       }
 
       // when
-      const result = repairConfig(config, ...args)
+      const result = repairConfig(config, ...multiPeriodArgs)
 
       // then
       expect(result).toEqual({
@@ -576,6 +597,40 @@ describe('repairConfig', () => {
           {
             type: 'Picasso',
             options: { periods: [], orientation: 'L' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en-GB',
+      })
+    })
+
+    test('does not allow empty periods if there is only one period in the camp', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: { periods: [], orientation: 'L' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en-GB',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Picasso',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              orientation: 'L',
+            },
           },
         ],
         documentName: 'test camp',
@@ -771,7 +826,7 @@ describe('repairConfig', () => {
       }
 
       // when
-      const result = repairConfig(config, ...args)
+      const result = repairConfig(config, ...multiPeriodArgs)
 
       // then
       expect(result).toEqual({
@@ -780,6 +835,43 @@ describe('repairConfig', () => {
           {
             type: 'Program',
             options: { periods: [], dayOverview: true },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en-GB',
+      })
+    })
+
+    test('does not allow empty periods if there is only one period in the camp', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              dayOverview: true,
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en-GB',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Program',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              dayOverview: true,
+            },
           },
         ],
         documentName: 'test camp',
@@ -874,7 +966,7 @@ describe('repairConfig', () => {
       }
 
       // when
-      const result = repairConfig(config, ...args)
+      const result = repairConfig(config, ...multiPeriodArgs)
 
       // then
       expect(result).toEqual({
@@ -883,6 +975,43 @@ describe('repairConfig', () => {
           {
             type: 'Story',
             options: { periods: [], contentType: 'Storycontext' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en-GB',
+      })
+    })
+
+    test('does not allow empty periods if there is only one period in the camp', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Story',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              contentType: 'Storycontext',
+            },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en-GB',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'Story',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              contentType: 'Storycontext',
+            },
           },
         ],
         documentName: 'test camp',
@@ -1014,7 +1143,7 @@ describe('repairConfig', () => {
       }
 
       // when
-      const result = repairConfig(config, ...args)
+      const result = repairConfig(config, ...multiPeriodArgs)
 
       // then
       expect(result).toEqual({
@@ -1023,6 +1152,40 @@ describe('repairConfig', () => {
           {
             type: 'SafetyConsiderations',
             options: { periods: [], contentType: 'SafetyConsiderations' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en-GB',
+      })
+    })
+
+    test('does not allow empty period when there is only one period in the camp', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'SafetyConsiderations',
+            options: { periods: [], contentType: 'SafetyConsiderations' },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en-GB',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'SafetyConsiderations',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              contentType: 'SafetyConsiderations',
+            },
           },
         ],
         documentName: 'test camp',
@@ -1186,7 +1349,7 @@ describe('repairConfig', () => {
       }
 
       // when
-      const result = repairConfig(config, ...args)
+      const result = repairConfig(config, ...multiPeriodArgs)
 
       // then
       expect(result).toEqual({
@@ -1195,6 +1358,39 @@ describe('repairConfig', () => {
           {
             type: 'ActivityList',
             options: { periods: [] },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en-GB',
+      })
+    })
+
+    test('does not allow empty period if there is only one period in the camp', async () => {
+      // given
+      const config = {
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'ActivityList',
+            options: { periods: [] },
+          },
+        ],
+        documentName: 'test camp',
+        language: 'en-GB',
+      }
+
+      // when
+      const result = repairConfig(config, ...args)
+
+      // then
+      expect(result).toEqual({
+        camp: '/camps/1a2b3c4d',
+        contents: [
+          {
+            type: 'ActivityList',
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+            },
           },
         ],
         documentName: 'test camp',

--- a/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
+++ b/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
@@ -479,7 +479,10 @@ describe('repairConfig', () => {
         contents: [
           {
             type: 'Picasso',
-            options: { periods: [], orientation: 'L' },
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              orientation: 'L',
+            },
           },
         ],
         documentName: 'test camp',
@@ -670,7 +673,7 @@ describe('repairConfig', () => {
           {
             type: 'Program',
             options: {
-              periods: [],
+              periods: ['/periods/1a2b3c4d'],
               dayOverview: true,
             },
           },
@@ -845,7 +848,10 @@ describe('repairConfig', () => {
         contents: [
           {
             type: 'Story',
-            options: { periods: [], contentType: 'Storycontext' },
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              contentType: 'Storycontext',
+            },
           },
         ],
         documentName: 'test camp',
@@ -982,7 +988,10 @@ describe('repairConfig', () => {
         contents: [
           {
             type: 'SafetyConsiderations',
-            options: { periods: [], contentType: 'SafetyConsiderations' },
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+              contentType: 'SafetyConsiderations',
+            },
           },
         ],
         documentName: 'test camp',
@@ -1152,7 +1161,9 @@ describe('repairConfig', () => {
         contents: [
           {
             type: 'ActivityList',
-            options: { periods: [] },
+            options: {
+              periods: ['/periods/1a2b3c4d'],
+            },
           },
         ],
         documentName: 'test camp',

--- a/frontend/src/components/print/config/ActivityListConfig.vue
+++ b/frontend/src/components/print/config/ActivityListConfig.vue
@@ -6,6 +6,7 @@
       :label="$tc('print.config.periods')"
       multiple
       :filled="false"
+      :readonly="periods.length === 1"
       @input="$emit('input')"
     />
   </div>
@@ -34,9 +35,10 @@ export default {
       }))
     },
   },
-  defaultOptions() {
+  defaultOptions(camp) {
     return {
-      periods: [],
+      periods:
+        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : [],
     }
   },
   design: {

--- a/frontend/src/components/print/config/ActivityListConfig.vue
+++ b/frontend/src/components/print/config/ActivityListConfig.vue
@@ -46,7 +46,10 @@ export default {
   },
   repairConfig(config, camp) {
     if (!config.options) config.options = {}
-    if (!config.options.periods) config.options.periods = []
+    if (!config.options.periods) {
+      config.options.periods =
+        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : []
+    }
     const knownPeriods = camp.periods().items.map((p) => p._meta.self)
     config.options.periods = config.options.periods.filter((period) => {
       return knownPeriods.includes(period)

--- a/frontend/src/components/print/config/ActivityListConfig.vue
+++ b/frontend/src/components/print/config/ActivityListConfig.vue
@@ -46,14 +46,15 @@ export default {
   },
   repairConfig(config, camp) {
     if (!config.options) config.options = {}
-    if (!config.options.periods) {
-      config.options.periods =
-        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : []
+    if (camp.periods().items.length === 1) {
+      config.options.periods = [camp.periods().items[0]._meta.self]
+    } else {
+      if (!config.options.periods) config.options.periods = []
+      const knownPeriods = camp.periods().items.map((p) => p._meta.self)
+      config.options.periods = config.options.periods.filter((period) => {
+        return knownPeriods.includes(period)
+      })
     }
-    const knownPeriods = camp.periods().items.map((p) => p._meta.self)
-    config.options.periods = config.options.periods.filter((period) => {
-      return knownPeriods.includes(period)
-    })
     return config
   },
 }

--- a/frontend/src/components/print/config/PicassoConfig.vue
+++ b/frontend/src/components/print/config/PicassoConfig.vue
@@ -6,6 +6,7 @@
       :items="periods"
       multiple
       :filled="false"
+      :readonly="periods.length === 1"
       @input="$emit('input')"
     />
     <e-select
@@ -59,9 +60,10 @@ export default {
       }))
     },
   },
-  defaultOptions() {
+  defaultOptions(camp) {
     return {
-      periods: [],
+      periods:
+        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : [],
       orientation: 'L',
     }
   },

--- a/frontend/src/components/print/config/PicassoConfig.vue
+++ b/frontend/src/components/print/config/PicassoConfig.vue
@@ -72,14 +72,15 @@ export default {
   },
   repairConfig(config, camp) {
     if (!config.options) config.options = {}
-    if (!config.options.periods) {
-      config.options.periods =
-        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : []
+    if (camp.periods().items.length === 1) {
+      config.options.periods = [camp.periods().items[0]._meta.self]
+    } else {
+      if (!config.options.periods) config.options.periods = []
+      const knownPeriods = camp.periods().items.map((p) => p._meta.self)
+      config.options.periods = config.options.periods.filter((period) => {
+        return knownPeriods.includes(period)
+      })
     }
-    const knownPeriods = camp.periods().items.map((p) => p._meta.self)
-    config.options.periods = config.options.periods.filter((period) => {
-      return knownPeriods.includes(period)
-    })
     if (!ORIENTATIONS.map((o) => o.value).includes(config.options.orientation)) {
       config.options.orientation = 'L'
     }

--- a/frontend/src/components/print/config/PicassoConfig.vue
+++ b/frontend/src/components/print/config/PicassoConfig.vue
@@ -72,7 +72,10 @@ export default {
   },
   repairConfig(config, camp) {
     if (!config.options) config.options = {}
-    if (!config.options.periods) config.options.periods = []
+    if (!config.options.periods) {
+      config.options.periods =
+        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : []
+    }
     const knownPeriods = camp.periods().items.map((p) => p._meta.self)
     config.options.periods = config.options.periods.filter((period) => {
       return knownPeriods.includes(period)

--- a/frontend/src/components/print/config/ProgramConfig.vue
+++ b/frontend/src/components/print/config/ProgramConfig.vue
@@ -6,6 +6,7 @@
       :label="$tc('print.config.periods')"
       multiple
       :filled="false"
+      :readonly="periods.length === 1"
       @input="$emit('input')"
     />
     <e-checkbox
@@ -39,9 +40,10 @@ export default {
       }))
     },
   },
-  defaultOptions() {
+  defaultOptions(camp) {
     return {
-      periods: [],
+      periods:
+        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : [],
       dayOverview: true,
     }
   },

--- a/frontend/src/components/print/config/ProgramConfig.vue
+++ b/frontend/src/components/print/config/ProgramConfig.vue
@@ -52,14 +52,15 @@ export default {
   },
   repairConfig(config, camp) {
     if (!config.options) config.options = {}
-    if (!config.options.periods) {
-      config.options.periods =
-        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : []
+    if (camp.periods().items.length === 1) {
+      config.options.periods = [camp.periods().items[0]._meta.self]
+    } else {
+      if (!config.options.periods) config.options.periods = []
+      const knownPeriods = camp.periods().items.map((p) => p._meta.self)
+      config.options.periods = config.options.periods.filter((period) => {
+        return knownPeriods.includes(period)
+      })
     }
-    const knownPeriods = camp.periods().items.map((p) => p._meta.self)
-    config.options.periods = config.options.periods.filter((period) => {
-      return knownPeriods.includes(period)
-    })
     if (typeof config.options.dayOverview !== 'boolean') config.options.dayOverview = true
     return config
   },

--- a/frontend/src/components/print/config/ProgramConfig.vue
+++ b/frontend/src/components/print/config/ProgramConfig.vue
@@ -52,7 +52,10 @@ export default {
   },
   repairConfig(config, camp) {
     if (!config.options) config.options = {}
-    if (!config.options.periods) config.options.periods = []
+    if (!config.options.periods) {
+      config.options.periods =
+        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : []
+    }
     const knownPeriods = camp.periods().items.map((p) => p._meta.self)
     config.options.periods = config.options.periods.filter((period) => {
       return knownPeriods.includes(period)

--- a/frontend/src/components/print/config/SafetyConsiderationsConfig.vue
+++ b/frontend/src/components/print/config/SafetyConsiderationsConfig.vue
@@ -31,7 +31,10 @@ export default {
   },
   repairConfig(config, camp) {
     if (!config.options) config.options = {}
-    if (!config.options.periods) config.options.periods = []
+    if (!config.options.periods) {
+      config.options.periods =
+        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : []
+    }
     if (!config.options.contentType) config.options.contentType = 'SafetyConsiderations'
     const knownPeriods = camp.periods().items.map((p) => p._meta.self)
     config.options.periods = config.options.periods.filter((period) => {

--- a/frontend/src/components/print/config/SafetyConsiderationsConfig.vue
+++ b/frontend/src/components/print/config/SafetyConsiderationsConfig.vue
@@ -6,6 +6,7 @@
       :label="$tc('print.config.periods')"
       multiple
       :filled="false"
+      :readonly="periods.length === 1"
       @input="$emit('input')"
     />
   </div>
@@ -18,9 +19,10 @@ import { SUMMARY_CONTENTTYPES } from '@/components/print/config/SummaryConfig.vu
 export default {
   name: 'SafetyConsiderationsConfig',
   extends: SummaryConfig,
-  defaultOptions() {
+  defaultOptions(camp) {
     return {
-      periods: [],
+      periods:
+        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : [],
       contentType: 'SafetyConsiderations',
     }
   },

--- a/frontend/src/components/print/config/SafetyConsiderationsConfig.vue
+++ b/frontend/src/components/print/config/SafetyConsiderationsConfig.vue
@@ -31,17 +31,18 @@ export default {
   },
   repairConfig(config, camp) {
     if (!config.options) config.options = {}
-    if (!config.options.periods) {
-      config.options.periods =
-        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : []
-    }
     if (!config.options.contentType) config.options.contentType = 'SafetyConsiderations'
-    const knownPeriods = camp.periods().items.map((p) => p._meta.self)
-    config.options.periods = config.options.periods.filter((period) => {
-      return knownPeriods.includes(period)
-    })
     if (!SUMMARY_CONTENTTYPES.includes(config.options.contentType)) {
       config.options.contentType = 'SafetyConsiderations'
+    }
+    if (camp.periods().items.length === 1) {
+      config.options.periods = [camp.periods().items[0]._meta.self]
+    } else {
+      if (!config.options.periods) config.options.periods = []
+      const knownPeriods = camp.periods().items.map((p) => p._meta.self)
+      config.options.periods = config.options.periods.filter((period) => {
+        return knownPeriods.includes(period)
+      })
     }
     return config
   },

--- a/frontend/src/components/print/config/StoryConfig.vue
+++ b/frontend/src/components/print/config/StoryConfig.vue
@@ -31,7 +31,10 @@ export default {
   },
   repairConfig(config, camp) {
     if (!config.options) config.options = {}
-    if (!config.options.periods) config.options.periods = []
+    if (!config.options.periods) {
+      config.options.periods =
+        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : []
+    }
     if (!config.options.contentType) config.options.contentType = 'Storycontext'
     const knownPeriods = camp.periods().items.map((p) => p._meta.self)
     config.options.periods = config.options.periods.filter((period) => {

--- a/frontend/src/components/print/config/StoryConfig.vue
+++ b/frontend/src/components/print/config/StoryConfig.vue
@@ -6,6 +6,7 @@
       :label="$tc('print.config.periods')"
       multiple
       :filled="false"
+      :readonly="periods.length === 1"
       @input="$emit('input')"
     />
   </div>
@@ -18,9 +19,10 @@ import { SUMMARY_CONTENTTYPES } from '@/components/print/config/SummaryConfig.vu
 export default {
   name: 'StoryConfig',
   extends: SummaryConfig,
-  defaultOptions() {
+  defaultOptions(camp) {
     return {
-      periods: [],
+      periods:
+        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : [],
       contentType: 'Storycontext',
     }
   },

--- a/frontend/src/components/print/config/StoryConfig.vue
+++ b/frontend/src/components/print/config/StoryConfig.vue
@@ -31,17 +31,18 @@ export default {
   },
   repairConfig(config, camp) {
     if (!config.options) config.options = {}
-    if (!config.options.periods) {
-      config.options.periods =
-        camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : []
-    }
     if (!config.options.contentType) config.options.contentType = 'Storycontext'
-    const knownPeriods = camp.periods().items.map((p) => p._meta.self)
-    config.options.periods = config.options.periods.filter((period) => {
-      return knownPeriods.includes(period)
-    })
     if (!SUMMARY_CONTENTTYPES.includes(config.options.contentType)) {
       config.options.contentType = 'Storycontext'
+    }
+    if (camp.periods().items.length === 1) {
+      config.options.periods = [camp.periods().items[0]._meta.self]
+    } else {
+      if (!config.options.periods) config.options.periods = []
+      const knownPeriods = camp.periods().items.map((p) => p._meta.self)
+      config.options.periods = config.options.periods.filter((period) => {
+        return knownPeriods.includes(period)
+      })
     }
     return config
   },


### PR DESCRIPTION
Also sets the period selection dropdown to readonly, with appropriate style (hide the caret).

![Screenshot_20250522-140939_Firefox (1).jpg](https://github.com/user-attachments/assets/f6fa57d6-422c-4702-b009-56a22f33aedd)

~~This has a small risk of some users still having print configs in their local storage with some empty period selection. However, our prints can handle this, and the users can easily fix their print config themselves if needed.~~ Fixed

Todo:
- [x] When auto-repairing a config, make sure to also select the sole period