### PR TITLE
Reduce line-height and create nicer text-wrap for 2-line texts

### DIFF
--- a/frontend/src/views/camp/navigation/mobile/NavBottombar.vue
+++ b/frontend/src/views/camp/navigation/mobile/NavBottombar.vue
@@ -73,5 +73,8 @@ export default {
   width: 100%;
   word-break: break-word;
   text-align: center;
+  text-wrap: balance;
+  line-height: 1 !important;
+  padding-bottom: 5px;
 }
 </style>


### PR DESCRIPTION
| before: | after: |
|---|---|
| <img width="364" alt="Bildschirmfoto 2025-05-29 um 11 55 09" src="https://github.com/user-attachments/assets/9ffa7637-126d-48e6-8792-aa7382618f80" /> | <img width="363" alt="Bildschirmfoto 2025-05-29 um 11 55 50" src="https://github.com/user-attachments/assets/a603f351-e808-44be-9db0-80f8b954d010" /> |