### PR TITLE
print: increase --max-header-size for development

### DIFF
--- a/print/package.json
+++ b/print/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "nuxt dev",
-    "dev-debug": "node --inspect node_modules/.bin/nuxt",
+    "dev": "NODE_OPTIONS='--max-http-header-size=128000' nuxt dev",
+    "dev-debug": "NODE_OPTIONS='--max-http-header-size=128000' node --inspect node_modules/.bin/nuxt",
     "build": "nuxt build",
-    "start": "nuxt start",
+    "start": "NODE_OPTIONS='--max-http-header-size=128000' nuxt start",
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "lint:eslint": "eslint --fix .",
     "lint:prettier": "prettier --write --ignore-path .gitignore **/*.{css,scss,json,md}",


### PR DESCRIPTION
The http module of node has a max header size for the http server and the client.
When we send an http request to the api and get too many xkey entries,
the client request fails with: "Parse Error: Header overflow".
Both values are configured with the --max-http-header command line option.

Don't set this parameter in production, because there we don't emit the XKey headers to the clients.
And there we want to see if we accidentally generate too large headers.