### PR TITLE
renovate.json: move lock file maintenance to Wednesday and Thursday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "rebaseWhen": "conflicted",
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["on tuesday and wednesday"]
+    "schedule": ["on wednesday and thursday"]
   },
   "vulnerabilityAlerts": {
     "automerge": true


### PR DESCRIPTION
Our meeting is often on tuesday, and we don't want renovate active then.
If we disable renovate, we take away lock file maintenance time.