### PR TITLE
fix(frontend): fixes dayjs locales

### DIFF
--- a/common/helpers/dayjs.js
+++ b/common/helpers/dayjs.js
@@ -35,6 +35,7 @@ export const dayjsLocaleMap = {
   en: 'en-gb',
   it: 'it-ch',
   fr: 'fr-ch',
+  rm: 'de-ch',
 }
 
 /**

--- a/common/helpers/dayjs.js
+++ b/common/helpers/dayjs.js
@@ -38,6 +38,13 @@ export const dayjsLocaleMap = {
   rm: 'de-ch',
 }
 
+export function toDayjsLocale(locale) {
+  const twoLetterLocale = locale.substring(0, 2);
+  return Object.keys(dayjsLocaleMap).includes(twoLetterLocale)
+    ? dayjsLocaleMap[twoLetterLocale]
+    : locale;
+}
+
 /**
  * @typedef {import('dayjs').Dayjs} Dayjs
  * @property {Dayjs} utc

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -245,7 +245,7 @@
   "global": {
     "datetime": {
       "dateLong": "dd L",
-      "dateShort": "dd M/D",
+      "dateShort": "dd D/M",
       "dateTimeLong": "dd L LT",
       "duration": {
         "daysAndHours": "{days} d {hours} h",

--- a/frontend/src/components/print/print-client/renderPdf.worker.js
+++ b/frontend/src/components/print/print-client/renderPdf.worker.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser'
 import { renderPdf } from './renderPdf.js'
-import dayjs, { dayjsLocaleMap } from '@/common/helpers/dayjs.js'
+import dayjs, { toDayjsLocale } from '@/common/helpers/dayjs.js'
 
 // Work around an incompatibility between comlink, vite and react-pdf...
 // Comlink works with a globally defined function 'start'. And apparently the way we import
@@ -26,12 +26,7 @@ export const renderPdfInWorker = async (data) => {
 
   // We need to set the locale again here. Otherwise dayjs falls back to the default
   // on production deployments
-  const twoLetterLocale = lang.substring(0, 2)
-  dayjs.locale(
-    Object.keys(dayjsLocaleMap).includes(twoLetterLocale)
-      ? dayjsLocaleMap[twoLetterLocale]
-      : lang
-  )
+  dayjs.locale(toDayjsLocale(lang))
 
   const result = { ...(await renderPdf(data)) }
   if (result.error) {

--- a/frontend/src/components/print/print-client/renderPdf.worker.js
+++ b/frontend/src/components/print/print-client/renderPdf.worker.js
@@ -26,7 +26,12 @@ export const renderPdfInWorker = async (data) => {
 
   // We need to set the locale again here. Otherwise dayjs falls back to the default
   // on production deployments
-  dayjs.locale(Object.keys(dayjsLocaleMap).includes(lang) ? dayjsLocaleMap[lang] : lang)
+  const twoLetterLocale = lang.substring(0, 2)
+  dayjs.locale(
+    Object.keys(dayjsLocaleMap).includes(twoLetterLocale)
+      ? dayjsLocaleMap[twoLetterLocale]
+      : lang
+  )
 
   const result = { ...(await renderPdf(data)) }
   if (result.error) {

--- a/frontend/src/plugins/store/lang.js
+++ b/frontend/src/plugins/store/lang.js
@@ -23,8 +23,11 @@ export const mutations = {
 
     state.language = lang
     VueI18n.locale = lang
+    const twoLetterLocale = lang.substring(0, 2)
     Vue.dayjs.locale(
-      Object.keys(dayjsLocaleMap).includes(lang) ? dayjsLocaleMap[lang] : lang
+      Object.keys(dayjsLocaleMap).includes(twoLetterLocale)
+        ? dayjsLocaleMap[twoLetterLocale]
+        : lang
     )
     localeChanged()
     axios.defaults.headers.common['Accept-Language'] = lang

--- a/frontend/src/plugins/store/lang.js
+++ b/frontend/src/plugins/store/lang.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 import axios from 'axios'
 import VueI18n from '@/plugins/i18n'
 import { localeChanged } from 'vee-validate'
-import { dayjsLocaleMap } from '@/common/helpers/dayjs.js'
+import { toDayjsLocale } from '@/common/helpers/dayjs.js'
 
 const LANG_KEY = 'language'
 
@@ -23,12 +23,7 @@ export const mutations = {
 
     state.language = lang
     VueI18n.locale = lang
-    const twoLetterLocale = lang.substring(0, 2)
-    Vue.dayjs.locale(
-      Object.keys(dayjsLocaleMap).includes(twoLetterLocale)
-        ? dayjsLocaleMap[twoLetterLocale]
-        : lang
-    )
+    Vue.dayjs.locale(toDayjsLocale(lang))
     localeChanged()
     axios.defaults.headers.common['Accept-Language'] = lang
     document.querySelector('html').setAttribute('lang', lang)

--- a/print/pages/index.vue
+++ b/print/pages/index.vue
@@ -16,6 +16,8 @@
 </template>
 
 <script setup>
+import { dayjsLocaleMap } from '@/common/helpers/dayjs.js'
+
 // parse query config
 const route = useRoute()
 const query = route.query
@@ -26,7 +28,14 @@ const { setLocale, fallbackLocale } = useI18n()
 const { $date } = useNuxtApp()
 const locale = config.language || fallbackLocale.value
 await setLocale(locale) // i18n
-$date.locale(locale) //dayjs
+
+//dayjs
+const twoLetterLocale = locale.substring(0, 2)
+$date.locale(
+  Object.keys(dayjsLocaleMap).includes(twoLetterLocale)
+    ? dayjsLocaleMap[twoLetterLocale]
+    : locale
+)
 
 // load camp
 const { $api } = useNuxtApp()

--- a/print/pages/index.vue
+++ b/print/pages/index.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup>
-import { dayjsLocaleMap } from '@/common/helpers/dayjs.js'
+import { toDayjsLocale } from '@/common/helpers/dayjs.js'
 
 // parse query config
 const route = useRoute()
@@ -30,12 +30,7 @@ const locale = config.language || fallbackLocale.value
 await setLocale(locale) // i18n
 
 //dayjs
-const twoLetterLocale = locale.substring(0, 2)
-$date.locale(
-  Object.keys(dayjsLocaleMap).includes(twoLetterLocale)
-    ? dayjsLocaleMap[twoLetterLocale]
-    : locale
-)
+$date.locale(toDayjsLocale(locale))
 
 // load camp
 const { $api } = useNuxtApp()


### PR DESCRIPTION
Fixes #7631 

- Fix wrong M/D date format
- Fix logic to map our own i18n locales to available dayjs locales
  - always use en-gb for English, which by default uses 24h time format
  - use de-ch as fallback for rm-* 