### PR TITLE
remove usage of deprecated getMockForAbstractClass

### DIFF
--- a/api/tests/State/Util/AbstractPersistProcessorTest.php
+++ b/api/tests/State/Util/AbstractPersistProcessorTest.php
@@ -2,12 +2,14 @@
 
 namespace App\Tests\State\Util;
 
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\BaseEntity;
 use App\State\Util\AbstractPersistProcessor;
 use App\State\Util\PropertyChangeListener;
+use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -19,7 +21,14 @@ class AbstractPersistProcessorTest extends TestCase {
     private MockableClosure|MockObject $closure;
     private PropertyChangeListener $propertyChangeListener;
     private AbstractPersistProcessor|MockObject $processor;
+    private MockableClosure|MockObject $onBefore;
+    private MockableClosure|MockObject $onAfter;
 
+    /**
+     * @throws WarningException
+     * @throws Exception
+     * @throws \ReflectionException
+     */
     protected function setUp(): void {
         $this->decoratedProcessor = $this->createMock(ProcessorInterface::class);
         $this->decoratedProcessor->method('process')->willReturnArgument(0);
@@ -32,16 +41,18 @@ class AbstractPersistProcessorTest extends TestCase {
             afterAction: fn ($data) => $this->closure->call($data),
         );
 
-        $this->processor = $this->getMockForAbstractClass(
-            AbstractPersistProcessor::class,
-            [
-                $this->decoratedProcessor,
-                [$this->propertyChangeListener],
-            ],
-            mockedMethods: ['onBefore', 'onAfter']
-        );
+        $this->onBefore = $this->createMock(MockableClosure::class);
+        $this->onBefore->method('call')->willReturnArgument(0);
 
-        $this->processor->method('onBefore')->willReturnArgument(0);
+        $this->onAfter = $this->createMock(MockableClosure::class);
+        $this->onAfter->method('call');
+
+        $this->processor = new MyEntityPersistProcessor(
+            decorated: $this->decoratedProcessor,
+            propertyChangeListeners: [$this->propertyChangeListener],
+            onBefore: $this->onBefore,
+            onAfter: $this->onAfter,
+        );
 
         set_error_handler(
             /**
@@ -58,22 +69,20 @@ class AbstractPersistProcessorTest extends TestCase {
         restore_error_handler();
     }
 
+    /**
+     * @throws Exception
+     */
     public function testThrowsIfOnePropertyChangeListenerIsOfWrongType() {
         $this->expectException(\InvalidArgumentException::class);
-        $this->getMockForAbstractClass(
-            AbstractPersistProcessor::class,
-            [
-                $this->decoratedProcessor,
-                [$this->propertyChangeListener, new \stdClass()],
-            ]
-        );
+
+        new MyEntityPersistProcessor($this->createMock(ProcessorInterface::class), [$this->propertyChangeListener, new \stdClass()], $this->onBefore, $this->onAfter);
     }
 
     public function testCallsOnBeforeCreateAndOnAfterCreateOnPost() {
         $toPersist = new MyEntity();
 
-        $this->processor->expects(self::once())->method('onBefore')->willReturnArgument(0);
-        $this->processor->expects(self::once())->method('onAfter');
+        $this->onBefore->expects(self::once())->method('call')->willReturnArgument(0);
+        $this->onAfter->expects(self::once())->method('call');
         $this->decoratedProcessor->expects(self::once())->method('process')->willReturnArgument(0);
 
         $processResult = $this->processor->process($toPersist, new Post());
@@ -156,11 +165,30 @@ class AbstractPersistProcessorTest extends TestCase {
             ->method('call')
             ->willReturnOnConsecutiveCalls($newData, null)
         ;
-        $this->processor->expects(self::once())->method('onBefore')->willReturnArgument(0);
-        $this->processor->expects(self::once())->method('onAfter');
 
         $processResult = $this->processor->process($newData, new Patch(), [], $context);
         self::assertThat($processResult, self::equalTo($newData));
+    }
+}
+
+class MyEntityPersistProcessor extends AbstractPersistProcessor {
+    public function __construct(
+        ProcessorInterface $decorated,
+        array $propertyChangeListeners = [],
+        private readonly ?MockableClosure $onBefore = null,
+        private readonly ?MockableClosure $onAfter = null,
+    ) {
+        parent::__construct($decorated, $propertyChangeListeners);
+    }
+
+    public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []) {
+        // @noinspection PhpMethodParametersCountMismatchInspection
+        return $this->onBefore->call($data, $operation, $uriVariables, $context);
+    }
+
+    public function onAfter($data, Operation $operation, array $uriVariables = [], array $context = []): void {
+        // @noinspection PhpMethodParametersCountMismatchInspection
+        $this->onAfter->call($data, $operation, $uriVariables, $context);
     }
 }
 

--- a/api/tests/State/Util/AbstractRemoveProcessorTest.php
+++ b/api/tests/State/Util/AbstractRemoveProcessorTest.php
@@ -3,8 +3,10 @@
 namespace App\Tests\State\Util;
 
 use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\State\Util\AbstractRemoveProcessor;
+use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -15,23 +17,53 @@ class AbstractRemoveProcessorTest extends TestCase {
     private MockObject|ProcessorInterface $decoratedProcessor;
     private AbstractRemoveProcessor|MockObject $processor;
 
+    private MockableClosure|MockObject $onBefore;
+    private MockableClosure|MockObject $onAfter;
+
+    /**
+     * @throws Exception
+     */
     protected function setUp(): void {
         $this->decoratedProcessor = $this->createMock(ProcessorInterface::class);
 
-        $this->processor = $this->getMockForAbstractClass(
-            AbstractRemoveProcessor::class,
-            [
-                $this->decoratedProcessor,
-            ],
-            mockedMethods: ['onBefore', 'onAfter']
+        $this->onBefore = $this->createMock(MockableClosure::class);
+        $this->onBefore->method('call')->willReturnArgument(0);
+
+        $this->onAfter = $this->createMock(MockableClosure::class);
+        $this->onAfter->method('call');
+
+        $this->processor = new MyEntityRemoveProcessor(
+            decorated: $this->decoratedProcessor,
+            onBefore: $this->onBefore,
+            onAfter: $this->onAfter,
         );
     }
 
     public function testCallsOnBeforeAndOnAfterOnDelete() {
-        $this->processor->expects(self::once())->method('onBefore');
-        $this->processor->expects(self::once())->method('onAfter');
+        $this->onBefore->expects(self::once())->method('call');
+        $this->onAfter->expects(self::once())->method('call');
         $this->decoratedProcessor->expects(self::once())->method('process');
 
         $this->processor->process(new \stdClass(), new Delete());
+    }
+}
+
+class MyEntityRemoveProcessor extends AbstractRemoveProcessor {
+    public function __construct(
+        ProcessorInterface $decorated,
+        private readonly ?MockableClosure $onBefore = null,
+        private readonly ?MockableClosure $onAfter = null,
+    ) {
+        parent::__construct($decorated);
+    }
+
+    public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []): void {
+        // @noinspection PhpMethodParametersCountMismatchInspection
+        $this->onBefore->call($data, $operation, $uriVariables, $context);
+    }
+
+    public function onAfter($data, Operation $operation, array $uriVariables = [], array $context = []): void {
+        // @noinspection PhpMethodParametersCountMismatchInspection
+        $this->onAfter->call($data, $operation, $uriVariables, $context);
     }
 }

--- a/api/tests/Types/Doctrine/BaseDateTypeTestCase.php
+++ b/api/tests/Types/Doctrine/BaseDateTypeTestCase.php
@@ -7,21 +7,21 @@
 namespace App\Tests\Types\Doctrine;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 abstract class BaseDateTypeTestCase extends TestCase {
-    protected AbstractPlatform&MockObject $platform;
+    protected AbstractPlatform $platform;
     protected Type $type;
 
     /** @var non-empty-string */
     private string $currentTimezone;
 
     protected function setUp(): void {
-        $this->platform = $this->getMockForAbstractClass(AbstractPlatform::class);
+        $this->platform = new PostgreSQLPlatform();
         $this->currentTimezone = \date_default_timezone_get();
     }
 

--- a/api/tests/Types/Doctrine/UTCDateTimeTypeTest.php
+++ b/api/tests/Types/Doctrine/UTCDateTimeTypeTest.php
@@ -22,7 +22,7 @@ class UTCDateTimeTypeTest extends BaseDateTypeTestCase {
     public function testDateTimeConvertsToDatabaseValue(): void {
         $date = new \DateTime('1985-09-01 10:10:10');
 
-        $expected = $date->format($this->platform->getDateTimeTzFormatString());
+        $expected = $date->format($this->platform->getDateTimeFormatString());
         $actual = $this->type->convertToDatabaseValue($date, $this->platform);
 
         self::assertEquals($expected, $actual);


### PR DESCRIPTION
AbstractPersistProcessorTest: remove usage of deprecated getMockForAbstractClass

Replace the functionality we need in the test with injected callbacks.

Issue: #7594

---

AbstractRemoveProcessorTest: remove usage of deprecated getMockForAbstractClass

Replace the functionality we need in the test with injected callbacks.

Issue: #7594

---

Types/Doctrine: remove usage of deprecated getMockForAbstractClass

Just instantiate a concrete implementation, we did not verify the interactions.
The Postgres implementation does not return the TimeZone when converting
to DatabaseValue.

Issue: #7594