### PR TITLE
api: disallow a guest to change his role to member/manager

### DIFF
--- a/api/src/State/CampCollaborationUpdateProcessor.php
+++ b/api/src/State/CampCollaborationUpdateProcessor.php
@@ -4,11 +4,13 @@ namespace App\State;
 
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\CampCollaboration;
+use App\Entity\User;
 use App\Service\MailService;
 use App\State\Util\AbstractPersistProcessor;
 use App\State\Util\PropertyChangeListener;
 use App\Util\IdGenerator;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 
 /**
@@ -29,9 +31,17 @@ class CampCollaborationUpdateProcessor extends AbstractPersistProcessor {
             afterAction: fn (CampCollaboration $data) => $this->onAfterStatusChange($data)
         );
 
+        $roleChangeListener = PropertyChangeListener::of(
+            extractProperty: fn (CampCollaboration $data) => $data->role,
+            beforeAction: fn (CampCollaboration $data, CampCollaboration $previous) => $this->onBeforeRoleChange($data, $previous),
+        );
+
         parent::__construct(
             $decorated,
-            propertyChangeListeners: [$statusChangeListener]
+            propertyChangeListeners: [
+                $statusChangeListener,
+                $roleChangeListener,
+            ]
         );
     }
 
@@ -42,6 +52,20 @@ class CampCollaborationUpdateProcessor extends AbstractPersistProcessor {
         }
 
         return $data;
+    }
+
+    public function onBeforeRoleChange(CampCollaboration $data, CampCollaboration $previous): CampCollaboration {
+        /** @var User $user */
+        $user = $this->security->getUser();
+        // If the update does not affect the own collaboration, the voter works.
+        if ($data->user->getId() !== $user->getId()) {
+            return $data;
+        }
+        if (in_array($previous->role, [CampCollaboration::ROLE_MANAGER, CampCollaboration::ROLE_MEMBER], true)) {
+            return $data;
+        }
+
+        throw new HttpException(403, 'Not authorized to change role');
     }
 
     public function onAfterStatusChange(CampCollaboration $data): void {

--- a/api/src/State/Util/AbstractPersistProcessor.php
+++ b/api/src/State/Util/AbstractPersistProcessor.php
@@ -39,7 +39,7 @@ abstract class AbstractPersistProcessor implements ProcessorInterface {
                 $propertyBefore = call_user_func($listener->getExtractProperty(), $dataBefore);
                 $propertyNow = call_user_func($listener->getExtractProperty(), $data);
                 if ($propertyBefore !== $propertyNow) {
-                    $data = call_user_func($listener->getBeforeAction(), $data);
+                    $data = call_user_func($listener->getBeforeAction(), $data, $dataBefore);
                 }
             }
         }
@@ -53,7 +53,7 @@ abstract class AbstractPersistProcessor implements ProcessorInterface {
                 $propertyBefore = call_user_func($listener->getExtractProperty(), $dataBefore);
                 $propertyNow = call_user_func($listener->getExtractProperty(), $data);
                 if ($propertyBefore !== $propertyNow) {
-                    call_user_func($listener->getAfterAction(), $data);
+                    call_user_func($listener->getAfterAction(), $data, $dataBefore);
                 }
             }
         }

--- a/api/src/State/Util/PropertyChangeListener.php
+++ b/api/src/State/Util/PropertyChangeListener.php
@@ -26,11 +26,11 @@ class PropertyChangeListener {
         if (self::hasOneParameter($extractProperty)) {
             throw new \InvalidArgumentException('extractProperty must have exactly one parameter');
         }
-        if (self::hasOneParameter($beforeAction)) {
-            throw new \InvalidArgumentException('afterAction must have exactly one parameter');
+        if (self::hasAtMostTwoParameter($beforeAction)) {
+            throw new \InvalidArgumentException('afterAction must have between 1 and 2 parameters');
         }
-        if (self::hasOneParameter($afterAction)) {
-            throw new \InvalidArgumentException('afterAction must have exactly one parameter');
+        if (self::hasAtMostTwoParameter($afterAction)) {
+            throw new \InvalidArgumentException('afterAction must have between 1 and 2 parameters');
         }
 
         return new PropertyChangeListener($extractProperty, $beforeAction, $afterAction);
@@ -55,5 +55,16 @@ class PropertyChangeListener {
         $beforeActionReflectionFunction = new \ReflectionFunction($beforeAction);
 
         return 1 != $beforeActionReflectionFunction->getNumberOfParameters();
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    private static function hasAtMostTwoParameter(?\Closure $beforeAction): bool {
+        $beforeActionReflectionFunction = new \ReflectionFunction($beforeAction);
+
+        $numberOfParameters = $beforeActionReflectionFunction->getNumberOfParameters();
+
+        return $numberOfParameters < 1 || $numberOfParameters > 2;
     }
 }

--- a/api/tests/Api/CampCollaborations/UpdateCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/UpdateCampCollaborationTest.php
@@ -6,6 +6,11 @@ use App\Entity\CampCollaboration;
 use App\Entity\User;
 use App\Tests\Api\ECampApiTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 /**
  * @internal
@@ -26,7 +31,7 @@ class UpdateCampCollaborationTest extends ECampApiTestCase {
 
     public function testPatchCampCollaborationIsDeniedForUnrelatedUser() {
         $campCollaboration = static::getFixture('campCollaboration1manager');
-        static::createClientWithCredentials(['email' => static::$fixtures['user4unrelated']->getEmail()])
+        static::createClientWithCredentials(['email' => static::getFixture('user4unrelated')->getEmail()])
             ->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
                 'status' => 'inactive',
                 'role' => 'guest',
@@ -41,7 +46,7 @@ class UpdateCampCollaborationTest extends ECampApiTestCase {
 
     public function testPatchCampCollaborationIsDeniedForInactiveCollaborator() {
         $campCollaboration = static::getFixture('campCollaboration1manager');
-        static::createClientWithCredentials(['email' => static::$fixtures['user5inactive']->getEmail()])
+        static::createClientWithCredentials(['email' => static::getFixture('user5inactive')->getEmail()])
             ->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
                 'status' => 'inactive',
                 'role' => 'guest',
@@ -56,7 +61,7 @@ class UpdateCampCollaborationTest extends ECampApiTestCase {
 
     public function testPatchCampCollaborationIsDeniedForGuest() {
         $campCollaboration = static::getFixture('campCollaboration1manager');
-        static::createClientWithCredentials(['email' => static::$fixtures['user3guest']->getEmail()])
+        static::createClientWithCredentials(['email' => static::getFixture('user3guest')->getEmail()])
             ->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
                 'status' => 'inactive',
                 'role' => 'guest',
@@ -69,9 +74,9 @@ class UpdateCampCollaborationTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testOwnPatchCampCollaborationIsAllowedForGuest() {
+    public function testPatchOwnCampCollaborationIsAllowedForGuest() {
         $campCollaboration = static::getFixture('campCollaboration3guest');
-        static::createClientWithCredentials(['email' => static::$fixtures['user3guest']->getEmail()])
+        static::createClientWithCredentials(['email' => $campCollaboration->getEmail()])
             ->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
                 'status' => 'inactive',
                 'role' => 'guest',
@@ -82,11 +87,31 @@ class UpdateCampCollaborationTest extends ECampApiTestCase {
             'status' => 'inactive',
             'role' => 'guest',
         ]);
+    }
+
+    public function testPatchOwnCampCollaborationToMemberIsRejectedForGuest() {
+        $campCollaboration = static::getFixture('campCollaboration3guest');
+        static::createClientWithCredentials(['email' => $campCollaboration->getEmail()])
+            ->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
+                'role' => 'member',
+            ], 'headers' => ['Content-Type' => 'application/merge-patch+json']])
+        ;
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testPatchOwnCampCollaborationToManagerIsRejectedForGuest() {
+        $campCollaboration = static::getFixture('campCollaboration3guest');
+        static::createClientWithCredentials(['email' => $campCollaboration->getEmail()])
+            ->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
+                'role' => 'manager',
+            ], 'headers' => ['Content-Type' => 'application/merge-patch+json']])
+        ;
+        $this->assertResponseStatusCodeSame(403);
     }
 
     public function testPatchCampCollaborationIsAllowedForMember() {
         $campCollaboration = static::getFixture('campCollaboration1manager');
-        static::createClientWithCredentials(['email' => static::$fixtures['user2member']->getEmail()])
+        static::createClientWithCredentials(['email' => static::getFixture('user2member')->getEmail()])
             ->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
                 'status' => 'inactive',
                 'role' => 'guest',
@@ -99,8 +124,86 @@ class UpdateCampCollaborationTest extends ECampApiTestCase {
         ]);
     }
 
-    public function testPatchCampCollaborationIsAllowedForManager() {
+    /**
+     * Silly, but for now members can change the collaborations in the api.
+     *
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws DecodingExceptionInterface|TransportExceptionInterface
+     */
+    public function testPatchOwnCampCollaborationToManagerIsAllowedForMember() {
+        $campCollaboration = static::getFixture('campCollaboration2member');
+        static::createClientWithCredentials(['email' => $campCollaboration->getEmail()])
+            ->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
+                'role' => 'manager',
+            ], 'headers' => ['Content-Type' => 'application/merge-patch+json']])
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'role' => 'manager',
+        ]);
+    }
+
+    public function testPatchOwnStatusOfCampCollaborationIsAllowedForManager() {
         $campCollaboration = static::getFixture('campCollaboration1manager');
+        static::createClientWithCredentials()->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
+            'status' => 'inactive',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'status' => 'inactive',
+        ]);
+    }
+
+    public function testPatchOwnRoleToMemberOfCampCollaborationIsAllowedForManager() {
+        $campCollaboration = static::getFixture('campCollaboration1manager');
+        static::createClientWithCredentials()->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
+            'role' => 'member',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'role' => 'member',
+        ]);
+    }
+
+    public function testPatchOwnRoleToGuestOfCampCollaborationIsAllowedForMember() {
+        $campCollaboration = static::getFixture('campCollaboration1manager');
+        static::createClientWithCredentials()->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
+            'role' => CampCollaboration::ROLE_GUEST,
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'role' => 'guest',
+        ]);
+    }
+
+    public function testPatchOwnRoleToGuestOfCampCollaborationIsAllowedForManager() {
+        $campCollaboration = static::getFixture('campCollaboration1manager');
+        static::createClientWithCredentials()->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
+            'role' => 'guest',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'role' => 'guest',
+        ]);
+    }
+
+    public function testPatchOwnStatusAndRoleCampCollaborationIsAcceptedForManager() {
+        $campCollaboration = static::getFixture('campCollaboration1manager');
+        static::createClientWithCredentials()->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
+            'status' => 'inactive',
+            'role' => 'guest',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains([
+            'status' => 'inactive',
+            'role' => 'guest',
+        ]);
+    }
+
+    public function testPatchOwnStatusAndRoleOfCampCollaborationIsAcceptedForMember() {
+        $campCollaboration = static::getFixture('campCollaboration2member');
         static::createClientWithCredentials()->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [
             'status' => 'inactive',
             'role' => 'guest',


### PR DESCRIPTION
Fix it in CampCollaborationUpdateProcessor for now, because that's the only place this is a problem now.
Maybe we should later fix this in the CampRoleVoter. It only is a problem when the own campCollaboration is changed.