### PR TITLE
frontend: reload camp list accepting Invitation in PersonalInvitations

### DIFF
--- a/frontend/src/components/personal_invitations/PersonalInvitations.vue
+++ b/frontend/src/components/personal_invitations/PersonalInvitations.vue
@@ -109,6 +109,7 @@ export default {
         )
         .then(() => {
           this.invitations.$reload()
+          this.api.get().camps().$reload()
         })
         .catch((e) => this.$toast.error(errorToMultiLineToast(e)))
     },


### PR DESCRIPTION
Because we are sure that there is at least one camp more.