### PR TITLE
chore(deps): update node to 24.3.0

### DIFF
--- a/.ops/ecamp3-logging/values.yaml
+++ b/.ops/ecamp3-logging/values.yaml
@@ -56,7 +56,7 @@ elasticsearch:
         storage: ${ELASTIC_NODE_STORAGE_SIZE}
   removeOldIndexes:
     maxIndexAge: ${ELASTIC_NODE_MAX_INDEX_AGE}
-    image: node:22.17.0
+    image: node:24.3.0
 
 kibana:
   name: kibana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   frontend:
-    image: node:22.17.0
+    image: node:24.3.0
     container_name: 'ecamp3-frontend'
     ports:
       - '9229:9229' # jest debug
@@ -79,7 +79,7 @@ services:
     command: varnishncsa
 
   pdf:
-    image: node:22.17.0
+    image: node:24.3.0
     container_name: 'ecamp3-pdf'
     stdin_open: true
     tty: true
@@ -98,7 +98,7 @@ services:
       - CI=${CI}
 
   print:
-    image: node:22.17.0
+    image: node:24.3.0
     container_name: 'ecamp3-print'
     user: ${USER_ID:-1000}
     volumes:
@@ -210,7 +210,7 @@ services:
         protocol: tcp
 
   translation:
-    image: node:22.17.0
+    image: node:24.3.0
     profiles: ['translation']
     container_name: 'ecamp3-translation'
     volumes:


### PR DESCRIPTION
Where renovate did not pick it up.

Print was already broken with v22.
- https://github.com/ecamp/ecamp3/issues/7742