### PR TITLE
print: load all columnLayouts in ActivityList

### DIFF
--- a/print/components/config/ActivityList.vue
+++ b/print/components/config/ActivityList.vue
@@ -31,6 +31,11 @@ const { data: periods, error } = await useAsyncData(
       props.camp.periods().$loadItems(),
       props.camp.activities().$loadItems(),
       props.camp.categories().$loadItems(),
+      Promise.all(
+        props.options.periods.map((period) =>
+          $api.get().columnLayouts({ period }).$loadItems()
+        )
+      ),
       props.camp.checklists().$loadItems(),
       $api
         .get()


### PR DESCRIPTION
Else they are loaded one by one which leads to a lot of requests. The columLayout is loaded when contentNode.root() is called in ActivityListScheduleEntry.

To find the culprit, you can insert
console.log((new Error()).stack)
into the interceptors of hal-json-vuex.js