### PR TITLE
api: embed preferredContentTypes in the category when requested as subresource

### DIFF
--- a/api/src/Entity/Category.php
+++ b/api/src/Entity/Category.php
@@ -68,7 +68,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             ],
             extraProperties: [
                 'filter_by_current_user' => false,
-            ]
+            ],
+            normalizationContext: self::COLLECTION_NORMALIZATION_CONTEXT,
         ),
     ],
     denormalizationContext: ['groups' => ['write']],
@@ -82,6 +83,14 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
     use HasRootContentNodeTrait;
 
     public const CAMP_SUBRESOURCE_URI_TEMPLATE = '/camps/{campId}/categories{._format}';
+
+    public const array COLLECTION_NORMALIZATION_CONTEXT = [
+        'groups' => [
+            'read',
+            'Category:PreferredContentTypes',
+        ],
+        'swagger_definition_name' => 'read',
+    ];
 
     public const ITEM_NORMALIZATION_CONTEXT = [
         'groups' => [

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
@@ -6920,6 +6920,88 @@ components:
         - preferredContentTypes
         - short
       type: object
+    Category-read_Category.PreferredContentTypes:
+      deprecated: false
+      description: |-
+        A type of programme, such as sports activities or meal times, is called a category. A category
+        determines color and numbering scheme of the associated activities, and is used for marking
+        "similar" activities. A category may contain some skeleton programme which is used as a blueprint
+        when creating a new activity in the category.
+      properties:
+        camp:
+          description: 'The camp to which this category belongs. May not be changed once the category is created.'
+          example: /camps/1a2b3c4d
+          format: iri-reference
+          type: string
+        color:
+          description: 'The color of the activities in this category, as a hex color string.'
+          example: '#4DBB52'
+          maxLength: 8
+          pattern: '^(#[0-9a-zA-Z]{6})$'
+          type: string
+        contentNodes:
+          description: 'All the content nodes that make up the tree of programme content.'
+          example: '["/content_nodes/1a2b3c4d"]'
+          items:
+            example: 'https://example.com/'
+            format: iri-reference
+            type: string
+          readOnly: true
+          type: array
+        id:
+          description: 'An internal, unique, randomly generated identifier of this entity.'
+          example: 1a2b3c4d
+          maxLength: 16
+          readOnly: true
+          type: string
+        name:
+          description: 'The full name of the category.'
+          example: Lagersport
+          maxLength: 32
+          type: string
+        numberingStyle:
+          default: '1'
+          description: |-
+            Specifies whether the schedule entries of the activities in this category should be numbered
+            using arabic numbers, roman numerals or letters.
+          enum:
+            - '-'
+            - '1'
+            - A
+            - I
+            - a
+            - i
+          example: '1'
+          maxLength: 1
+          type: string
+        preferredContentTypes:
+          items:
+            $ref: '#/components/schemas/ContentType-read_Category.PreferredContentTypes'
+          readOnly: true
+          type: array
+        rootContentNode:
+          description: |-
+            The programme contents, organized as a tree of content nodes. The root content node cannot be
+            exchanged, but all the contents attached to it can.
+          example: /content_nodes/1a2b3c4d
+          format: iri-reference
+          readOnly: true
+          type: string
+        short:
+          description: |-
+            An abbreviated name of the category, for display in tight spaces, often together with the day and
+            schedule entry number, e.g. LS 3.a, where LS is the category's short name.
+          example: LS
+          maxLength: 16
+          type: string
+      required:
+        - camp
+        - color
+        - name
+        - numberingStyle
+        - preferredContentTypes
+        - short
+      type: object
     Category-read_Category.PreferredContentTypes_Category.ContentNodes:
       deprecated: false
       description: |-
@@ -7380,6 +7462,97 @@ components:
         - preferredContentTypes
         - short
       type: object
+    Category.jsonhal-read_Category.PreferredContentTypes:
+      deprecated: false
+      description: |-
+        A type of programme, such as sports activities or meal times, is called a category. A category
+        determines color and numbering scheme of the associated activities, and is used for marking
+        "similar" activities. A category may contain some skeleton programme which is used as a blueprint
+        when creating a new activity in the category.
+      properties:
+        _links:
+          properties:
+            self:
+              properties:
+                href:
+                  format: iri-reference
+                  type: string
+              type: object
+          type: object
+        camp:
+          description: 'The camp to which this category belongs. May not be changed once the category is created.'
+          example: /camps/1a2b3c4d
+          format: iri-reference
+          type: string
+        color:
+          description: 'The color of the activities in this category, as a hex color string.'
+          example: '#4DBB52'
+          maxLength: 8
+          pattern: '^(#[0-9a-zA-Z]{6})$'
+          type: string
+        contentNodes:
+          description: 'All the content nodes that make up the tree of programme content.'
+          example: '["/content_nodes/1a2b3c4d"]'
+          items:
+            example: 'https://example.com/'
+            format: iri-reference
+            type: string
+          readOnly: true
+          type: array
+        id:
+          description: 'An internal, unique, randomly generated identifier of this entity.'
+          example: 1a2b3c4d
+          maxLength: 16
+          readOnly: true
+          type: string
+        name:
+          description: 'The full name of the category.'
+          example: Lagersport
+          maxLength: 32
+          type: string
+        numberingStyle:
+          default: '1'
+          description: |-
+            Specifies whether the schedule entries of the activities in this category should be numbered
+            using arabic numbers, roman numerals or letters.
+          enum:
+            - '-'
+            - '1'
+            - A
+            - I
+            - a
+            - i
+          example: '1'
+          maxLength: 1
+          type: string
+        preferredContentTypes:
+          items:
+            $ref: '#/components/schemas/ContentType.jsonhal-read_Category.PreferredContentTypes'
+          readOnly: true
+          type: array
+        rootContentNode:
+          description: |-
+            The programme contents, organized as a tree of content nodes. The root content node cannot be
+            exchanged, but all the contents attached to it can.
+          example: /content_nodes/1a2b3c4d
+          format: iri-reference
+          readOnly: true
+          type: string
+        short:
+          description: |-
+            An abbreviated name of the category, for display in tight spaces, often together with the day and
+            schedule entry number, e.g. LS 3.a, where LS is the category's short name.
+          example: LS
+          maxLength: 16
+          type: string
+      required:
+        - camp
+        - color
+        - name
+        - numberingStyle
+        - preferredContentTypes
+        - short
+      type: object
     Category.jsonhal-read_Category.PreferredContentTypes_Category.ContentNodes:
       deprecated: false
       description: |-
@@ -7717,6 +7890,94 @@ components:
             example: 'https://example.com/'
             format: iri-reference
             type: string
+          type: array
+        rootContentNode:
+          description: |-
+            The programme contents, organized as a tree of content nodes. The root content node cannot be
+            exchanged, but all the contents attached to it can.
+          example: /content_nodes/1a2b3c4d
+          format: iri-reference
+          readOnly: true
+          type: string
+        short:
+          description: |-
+            An abbreviated name of the category, for display in tight spaces, often together with the day and
+            schedule entry number, e.g. LS 3.a, where LS is the category's short name.
+          example: LS
+          maxLength: 16
+          type: string
+      required:
+        - camp
+        - color
+        - name
+        - numberingStyle
+        - preferredContentTypes
+        - short
+      type: object
+    Category.jsonld-read_Category.PreferredContentTypes:
+      deprecated: false
+      description: |-
+        A type of programme, such as sports activities or meal times, is called a category. A category
+        determines color and numbering scheme of the associated activities, and is used for marking
+        "similar" activities. A category may contain some skeleton programme which is used as a blueprint
+        when creating a new activity in the category.
+      properties:
+        '@id':
+          readOnly: true
+          type: string
+        '@type':
+          readOnly: true
+          type: string
+        camp:
+          description: 'The camp to which this category belongs. May not be changed once the category is created.'
+          example: /camps/1a2b3c4d
+          format: iri-reference
+          type: string
+        color:
+          description: 'The color of the activities in this category, as a hex color string.'
+          example: '#4DBB52'
+          maxLength: 8
+          pattern: '^(#[0-9a-zA-Z]{6})$'
+          type: string
+        contentNodes:
+          description: 'All the content nodes that make up the tree of programme content.'
+          example: '["/content_nodes/1a2b3c4d"]'
+          items:
+            example: 'https://example.com/'
+            format: iri-reference
+            type: string
+          readOnly: true
+          type: array
+        id:
+          description: 'An internal, unique, randomly generated identifier of this entity.'
+          example: 1a2b3c4d
+          maxLength: 16
+          readOnly: true
+          type: string
+        name:
+          description: 'The full name of the category.'
+          example: Lagersport
+          maxLength: 32
+          type: string
+        numberingStyle:
+          default: '1'
+          description: |-
+            Specifies whether the schedule entries of the activities in this category should be numbered
+            using arabic numbers, roman numerals or letters.
+          enum:
+            - '-'
+            - '1'
+            - A
+            - I
+            - a
+            - i
+          example: '1'
+          maxLength: 1
+          type: string
+        preferredContentTypes:
+          items:
+            $ref: '#/components/schemas/ContentType.jsonld-read_Category.PreferredContentTypes'
+          readOnly: true
           type: array
         rootContentNode:
           description: |-
@@ -11249,6 +11510,40 @@ components:
         - active
         - name
       type: object
+    ContentType-read_Category.PreferredContentTypes:
+      deprecated: false
+      description: ''
+      properties:
+        active:
+          default: true
+          description: 'Whether this content type is still maintained and recommended for use in new camps.'
+          example: 'true'
+          readOnly: true
+          type: boolean
+        contentNodes:
+          description: 'API endpoint link for creating new entities of type entityClass.'
+          example: '/content_node/column_layouts?contentType=%2Fcontent_types%2F1a2b3c4d'
+          format: iri-reference
+          readOnly: true
+          type: array
+        id:
+          description: 'An internal, unique, randomly generated identifier of this entity.'
+          example: 1a2b3c4d
+          maxLength: 16
+          readOnly: true
+          type: string
+        name:
+          description: |-
+            A name in UpperCamelCase of the content type. This value may be used as a technical
+            identifier of this content type, it is guaranteed to stay fixed.
+          example: SafetyConsiderations
+          maxLength: 32
+          readOnly: true
+          type: string
+      required:
+        - active
+        - name
+      type: object
     ContentType-read_Category.PreferredContentTypes_Category.ContentNodes:
       deprecated: false
       description: ''
@@ -11410,6 +11705,49 @@ components:
         - active
         - name
       type: object
+    ContentType.jsonhal-read_Category.PreferredContentTypes:
+      deprecated: false
+      description: ''
+      properties:
+        _links:
+          properties:
+            self:
+              properties:
+                href:
+                  format: iri-reference
+                  type: string
+              type: object
+          type: object
+        active:
+          default: true
+          description: 'Whether this content type is still maintained and recommended for use in new camps.'
+          example: 'true'
+          readOnly: true
+          type: boolean
+        contentNodes:
+          description: 'API endpoint link for creating new entities of type entityClass.'
+          example: '/content_node/column_layouts?contentType=%2Fcontent_types%2F1a2b3c4d'
+          format: iri-reference
+          readOnly: true
+          type: array
+        id:
+          description: 'An internal, unique, randomly generated identifier of this entity.'
+          example: 1a2b3c4d
+          maxLength: 16
+          readOnly: true
+          type: string
+        name:
+          description: |-
+            A name in UpperCamelCase of the content type. This value may be used as a technical
+            identifier of this content type, it is guaranteed to stay fixed.
+          example: SafetyConsiderations
+          maxLength: 32
+          readOnly: true
+          type: string
+      required:
+        - active
+        - name
+      type: object
     ContentType.jsonhal-read_Category.PreferredContentTypes_Category.ContentNodes:
       deprecated: false
       description: ''
@@ -11459,6 +11797,63 @@ components:
         Defines a type of content that can be present in a content node tree. A content type
         determines what data can be stored in content nodes of this type, as well as validation,
         available slots and jsonConfig settings.
+      properties:
+        '@context':
+          oneOf:
+            -
+              additionalProperties: true
+              properties:
+                '@vocab':
+                  type: string
+                hydra:
+                  enum: ['http://www.w3.org/ns/hydra/core#']
+                  type: string
+              required:
+                - '@vocab'
+                - hydra
+              type: object
+            -
+              type: string
+          readOnly: true
+        '@id':
+          readOnly: true
+          type: string
+        '@type':
+          readOnly: true
+          type: string
+        active:
+          default: true
+          description: 'Whether this content type is still maintained and recommended for use in new camps.'
+          example: 'true'
+          readOnly: true
+          type: boolean
+        contentNodes:
+          description: 'API endpoint link for creating new entities of type entityClass.'
+          example: '/content_node/column_layouts?contentType=%2Fcontent_types%2F1a2b3c4d'
+          format: iri-reference
+          readOnly: true
+          type: array
+        id:
+          description: 'An internal, unique, randomly generated identifier of this entity.'
+          example: 1a2b3c4d
+          maxLength: 16
+          readOnly: true
+          type: string
+        name:
+          description: |-
+            A name in UpperCamelCase of the content type. This value may be used as a technical
+            identifier of this content type, it is guaranteed to stay fixed.
+          example: SafetyConsiderations
+          maxLength: 32
+          readOnly: true
+          type: string
+      required:
+        - active
+        - name
+      type: object
+    ContentType.jsonld-read_Category.PreferredContentTypes:
+      deprecated: false
+      description: ''
       properties:
         '@context':
           oneOf:
@@ -24916,7 +25311,7 @@ paths:
             application/hal+json:
               schema:
                 properties:
-                  _embedded: { anyOf: [{ properties: { item: { items: { $ref: '#/components/schemas/Category.jsonhal-read' }, type: array } }, type: object }, { type: object }] }
+                  _embedded: { anyOf: [{ properties: { item: { items: { $ref: '#/components/schemas/Category.jsonhal-read_Category.PreferredContentTypes' }, type: array } }, type: object }, { type: object }] }
                   _links: { properties: { first: { properties: { href: { format: iri-reference, type: string } }, type: object }, last: { properties: { href: { format: iri-reference, type: string } }, type: object }, next: { properties: { href: { format: iri-reference, type: string } }, type: object }, previous: { properties: { href: { format: iri-reference, type: string } }, type: object }, self: { properties: { href: { format: iri-reference, type: string } }, type: object } }, type: object }
                   itemsPerPage: { minimum: 0, type: integer }
                   totalItems: { minimum: 0, type: integer }
@@ -24927,12 +25322,12 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/Category-read'
+                  $ref: '#/components/schemas/Category-read_Category.PreferredContentTypes'
                 type: array
             application/ld+json:
               schema:
                 properties:
-                  member: { items: { $ref: '#/components/schemas/Category.jsonld-read' }, type: array }
+                  member: { items: { $ref: '#/components/schemas/Category.jsonld-read_Category.PreferredContentTypes' }, type: array }
                   search: { properties: { '@type': { type: string }, mapping: { items: { properties: { '@type': { type: string }, property: { type: ['null', string] }, required: { type: boolean }, variable: { type: string } }, type: object }, type: array }, template: { type: string }, variableRepresentation: { type: string } }, type: object }
                   totalItems: { minimum: 0, type: integer }
                   view: { example: { '@id': string, first: string, last: string, next: string, previous: string, type: string }, properties: { '@id': { format: iri-reference, type: string }, '@type': { type: string }, first: { format: iri-reference, type: string }, last: { format: iri-reference, type: string }, next: { format: iri-reference, type: string }, previous: { format: iri-reference, type: string } }, type: object }
@@ -24947,7 +25342,7 @@ paths:
             text/html:
               schema:
                 items:
-                  $ref: '#/components/schemas/Category-read'
+                  $ref: '#/components/schemas/Category-read_Category.PreferredContentTypes'
                 type: array
           description: 'Category collection'
       summary: 'Retrieves the collection of Category resources.'

--- a/e2e/specs/httpCache/categories.cy.js
+++ b/e2e/specs/httpCache/categories.cy.js
@@ -9,17 +9,19 @@ import {
 } from '../constants'
 import collectionResponse from './responses/categories_collection.json'
 
+const grgrLACategoryId = '1a869b162875'
+
 const collectionXKeys =
   /* campCollaboration for bipiUser */
   'b0bdb7202a9d ' +
   /* Category ES */
-  'ebfd46a1c181 ebfd46a1c181#camp ebfd46a1c181#preferredContentTypes ebfd46a1c181#rootContentNode ebfd46a1c181#contentNodes ' +
+  'ebfd46a1c181 ebfd46a1c181#camp ebfd46a1c181#preferredContentTypes ebfd46a1c181#rootContentNode ebfd46a1c181#embeddedPreferredContentTypes ebfd46a1c181#contentNodes ' +
   /* Category LA */
-  '1a869b162875 1a869b162875#camp 1a869b162875#preferredContentTypes 1a869b162875#rootContentNode 1a869b162875#contentNodes ' +
+  '1a869b162875 1a869b162875#camp 1a869b162875#preferredContentTypes 1a869b162875#rootContentNode f17470519474 1a0f84e322c8 3ef17bd1df72 4f0c657fecef a4211c112939 44dcc7493c65 cfccaecd4bad 318e064ea0c9 1a869b162875#embeddedPreferredContentTypes 1a869b162875#contentNodes ' +
   /* Category LP */
-  'dfa531302823 dfa531302823#camp dfa531302823#preferredContentTypes dfa531302823#rootContentNode dfa531302823#contentNodes ' +
+  'dfa531302823 dfa531302823#camp dfa531302823#preferredContentTypes dfa531302823#rootContentNode dfa531302823#embeddedPreferredContentTypes dfa531302823#contentNodes ' +
   /* Category LS */
-  'a023e85227ac a023e85227ac#camp a023e85227ac#preferredContentTypes a023e85227ac#rootContentNode a023e85227ac#contentNodes ' +
+  'a023e85227ac a023e85227ac#camp a023e85227ac#preferredContentTypes a023e85227ac#rootContentNode a023e85227ac#embeddedPreferredContentTypes a023e85227ac#contentNodes ' +
   /* collection URI (for detecting addition of new categories) */
   '/api/camps/3c79b99ab424/categories'
 
@@ -169,6 +171,81 @@ describe('cache test: /camps/{campId}/categories', () => {
       cy.wait('@invitations')
       cy.visit('/camps')
       cy.contains('GRGR')
+    })
+  })
+
+  describe('invalidates /camps/{campId}/categories', () => {
+    let categoryBefore
+    function preferredContentTypeIrisBefore() {
+      return categoryBefore._embedded.preferredContentTypes.map(
+        (contentType) => contentType._links.self.href
+      )
+    }
+
+    beforeEach(() => {
+      cy.login(bipiUser)
+
+      cy.apiGet(`/api/categories/${grgrLACategoryId}`).then((response) => {
+        categoryBefore = response.body
+        expect(preferredContentTypeIrisBefore()).to.not.be.empty
+      })
+    })
+
+    afterEach(() => {
+      cy.login(bipiUser)
+
+      cy.apiPatch(`/api/categories/${grgrLACategoryId}`, {
+        preferredContentTypes: preferredContentTypeIrisBefore(),
+        short: categoryBefore.short,
+        name: categoryBefore.name,
+        color: categoryBefore.color,
+        numberingStyle: categoryBefore.numberingStyle,
+      }).then((response) => {
+        expect(response.status).to.eq(200)
+      })
+    })
+
+    it('when preferredContentTypes are removed', () => {
+      const uri = `/api/camps/${grgrCampId}/categories`
+
+      Cypress.session.clearAllSavedSessions()
+      cy.login(bipiUser)
+
+      // warm up cache
+      cy.expectCacheMiss(uri)
+      cy.expectCacheHit(uri)
+
+      // set the preferredContentTypes to empty
+      cy.apiPatch(`/api/categories/${grgrLACategoryId}`, {
+        preferredContentTypes: [],
+      }).then(() => {
+        // ensure cache was invalidated
+        cy.waitForCacheMiss(uri)
+        cy.expectCacheHit(uri)
+      })
+    })
+
+    it('when preferredContentType is added', () => {
+      const uri = `/api/camps/${grgrCampId}/categories`
+
+      Cypress.session.clearAllSavedSessions()
+      cy.login(bipiUser)
+
+      // warm up cache
+      cy.expectCacheMiss(uri)
+      cy.expectCacheHit(uri)
+
+      // add new preferredContentType
+      cy.apiPatch(`/api/categories/${grgrLACategoryId}`, {
+        preferredContentTypes: [
+          ...preferredContentTypeIrisBefore(),
+          '/api/content_types/a4211c11211c',
+        ],
+      }).then(() => {
+        // ensure cache was invalidated
+        cy.waitForCacheMiss(uri)
+        cy.expectCacheHit(uri)
+      })
     })
   })
 })

--- a/e2e/specs/httpCache/responses/categories_collection.json
+++ b/e2e/specs/httpCache/responses/categories_collection.json
@@ -39,6 +39,9 @@
             "href": "/api/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F9d7b3a220fb4"
           }
         },
+        "_embedded": {
+          "preferredContentTypes": []
+        },
         "short": "ES",
         "name": "Essen",
         "color": "#BBBBBB",
@@ -62,6 +65,114 @@
           "contentNodes": {
             "href": "/api/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fbe9b6b7f23f6"
           }
+        },
+        "_embedded": {
+          "preferredContentTypes": [
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/f17470519474"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/column_layouts?contentType=%2Fapi%2Fcontent_types%2Ff17470519474"
+                }
+              },
+              "name": "ColumnLayout",
+              "active": true,
+              "id": "f17470519474"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/1a0f84e322c8"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/multi_selects?contentType=%2Fapi%2Fcontent_types%2F1a0f84e322c8"
+                }
+              },
+              "name": "LAThematicArea",
+              "active": true,
+              "id": "1a0f84e322c8"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/3ef17bd1df72"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/material_nodes?contentType=%2Fapi%2Fcontent_types%2F3ef17bd1df72"
+                }
+              },
+              "name": "Material",
+              "active": true,
+              "id": "3ef17bd1df72"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/4f0c657fecef"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F4f0c657fecef"
+                }
+              },
+              "name": "Notes",
+              "active": true,
+              "id": "4f0c657fecef"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/a4211c112939"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/responsive_layouts?contentType=%2Fapi%2Fcontent_types%2Fa4211c112939"
+                }
+              },
+              "name": "ResponsiveLayout",
+              "active": true,
+              "id": "a4211c112939"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/44dcc7493c65"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F44dcc7493c65"
+                }
+              },
+              "name": "SafetyConsiderations",
+              "active": true,
+              "id": "44dcc7493c65"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/cfccaecd4bad"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/storyboards?contentType=%2Fapi%2Fcontent_types%2Fcfccaecd4bad"
+                }
+              },
+              "name": "Storyboard",
+              "active": true,
+              "id": "cfccaecd4bad"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/318e064ea0c9"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F318e064ea0c9"
+                }
+              },
+              "name": "Storycontext",
+              "active": true,
+              "id": "318e064ea0c9"
+            }
+          ]
         },
         "short": "LA",
         "name": "Lageraktivität",
@@ -87,6 +198,101 @@
             "href": "/api/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F63cbc734fa04"
           }
         },
+        "_embedded": {
+          "preferredContentTypes": [
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/f17470519474"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/column_layouts?contentType=%2Fapi%2Fcontent_types%2Ff17470519474"
+                }
+              },
+              "name": "ColumnLayout",
+              "active": true,
+              "id": "f17470519474"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/3ef17bd1df72"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/material_nodes?contentType=%2Fapi%2Fcontent_types%2F3ef17bd1df72"
+                }
+              },
+              "name": "Material",
+              "active": true,
+              "id": "3ef17bd1df72"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/4f0c657fecef"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F4f0c657fecef"
+                }
+              },
+              "name": "Notes",
+              "active": true,
+              "id": "4f0c657fecef"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/a4211c112939"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/responsive_layouts?contentType=%2Fapi%2Fcontent_types%2Fa4211c112939"
+                }
+              },
+              "name": "ResponsiveLayout",
+              "active": true,
+              "id": "a4211c112939"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/44dcc7493c65"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F44dcc7493c65"
+                }
+              },
+              "name": "SafetyConsiderations",
+              "active": true,
+              "id": "44dcc7493c65"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/cfccaecd4bad"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/storyboards?contentType=%2Fapi%2Fcontent_types%2Fcfccaecd4bad"
+                }
+              },
+              "name": "Storyboard",
+              "active": true,
+              "id": "cfccaecd4bad"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/318e064ea0c9"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F318e064ea0c9"
+                }
+              },
+              "name": "Storycontext",
+              "active": true,
+              "id": "318e064ea0c9"
+            }
+          ]
+        },
         "short": "LP",
         "name": "Lagerprogramm",
         "color": "#90B7E4",
@@ -110,6 +316,101 @@
           "contentNodes": {
             "href": "/api/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F2cce9e17a368"
           }
+        },
+        "_embedded": {
+          "preferredContentTypes": [
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/f17470519474"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/column_layouts?contentType=%2Fapi%2Fcontent_types%2Ff17470519474"
+                }
+              },
+              "name": "ColumnLayout",
+              "active": true,
+              "id": "f17470519474"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/3ef17bd1df72"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/material_nodes?contentType=%2Fapi%2Fcontent_types%2F3ef17bd1df72"
+                }
+              },
+              "name": "Material",
+              "active": true,
+              "id": "3ef17bd1df72"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/4f0c657fecef"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F4f0c657fecef"
+                }
+              },
+              "name": "Notes",
+              "active": true,
+              "id": "4f0c657fecef"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/a4211c112939"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/responsive_layouts?contentType=%2Fapi%2Fcontent_types%2Fa4211c112939"
+                }
+              },
+              "name": "ResponsiveLayout",
+              "active": true,
+              "id": "a4211c112939"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/44dcc7493c65"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F44dcc7493c65"
+                }
+              },
+              "name": "SafetyConsiderations",
+              "active": true,
+              "id": "44dcc7493c65"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/cfccaecd4bad"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/storyboards?contentType=%2Fapi%2Fcontent_types%2Fcfccaecd4bad"
+                }
+              },
+              "name": "Storyboard",
+              "active": true,
+              "id": "cfccaecd4bad"
+            },
+            {
+              "_links": {
+                "self": {
+                  "href": "/api/content_types/318e064ea0c9"
+                },
+                "contentNodes": {
+                  "href": "/api/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F318e064ea0c9"
+                }
+              },
+              "name": "Storycontext",
+              "active": true,
+              "id": "318e064ea0c9"
+            }
+          ]
         },
         "short": "LS",
         "name": "Lagersport",

--- a/e2e/support/commands.js
+++ b/e2e/support/commands.js
@@ -70,6 +70,13 @@ Cypress.Commands.add('waitForCacheMiss', (uri) => {
   ).then((result) => expect(result).to.eq(true))
 })
 
+Cypress.Commands.add('apiGet', (uri) => {
+  return cy.request({
+    method: 'GET',
+    url: Cypress.env('API_ROOT_URL_CACHED') + uri + '.jsonhal',
+  })
+})
+
 Cypress.Commands.add('apiPatch', (uri, body) => {
   cy.request({
     method: 'PATCH',


### PR DESCRIPTION
This leads currently to requests to
api/content_types?categories=%2Fapi%2Fcategories%2F{id}%2F which we cannot cache yet.
They are executed when you select a prototype while creating a camp. We also cannot prefetch all collection urls for the preferredContentTypes. The request somehow takes a while.
In a camp there are not many categories, and the amount of contentTypes that would be joined is also limited.
Currently, preferredContentTypes is anyway mostly empty.

Issue: #6461