### PR TITLE
api: reduce db queries for activities and categories

### DIFF
--- a/api/src/Entity/HasRootContentNodeTrait.php
+++ b/api/src/Entity/HasRootContentNodeTrait.php
@@ -7,6 +7,7 @@ use App\Entity\ContentNode\ColumnLayout;
 use App\Serializer\Normalizer\RelatedCollectionLink;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Attribute\SerializedName;
 use Symfony\Component\Validator\Constraints as Assert;
 
 trait HasRootContentNodeTrait {
@@ -35,15 +36,20 @@ trait HasRootContentNodeTrait {
         return $this->rootContentNode;
     }
 
+    public function getContentNodes(): array {
+        return $this->rootContentNode?->getRootDescendants() ?? [];
+    }
+
     /**
      * All the content nodes that make up the tree of programme content.
      *
      * @return ContentNode[]
      */
-    #[ApiProperty(example: '["/content_nodes/1a2b3c4d"]')]
+    #[ApiProperty(example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d')]
+    #[SerializedName('contentNodes')]
     #[Groups(['read'])]
     #[RelatedCollectionLink(ContentNode::class, ['root' => 'rootContentNode'])]
-    public function getContentNodes(): array {
-        return $this->rootContentNode?->getRootDescendants() ?? [];
+    public function getEmptyContentNodesForIriGeneration(): array {
+        return [];
     }
 }

--- a/api/tests/Api/SnapshotTests/EndpointPerformanceTest.php
+++ b/api/tests/Api/SnapshotTests/EndpointPerformanceTest.php
@@ -60,6 +60,13 @@ class EndpointPerformanceTest extends ECampApiTestCase {
             $queryExecutionTime[$url] = $executionTimeSeconds;
         }
 
+        foreach ($this->getSubresourceUrls() as $url => $id) {
+            list($statusCode, $queryCount, $executionTimeSeconds) = $this->measurePerformanceFor(preg_replace('/\{id}/', $id, $url));
+            $responseCodes[$url] = $statusCode;
+            $numberOfQueries[$url] = $queryCount;
+            $queryExecutionTime[$url] = $executionTimeSeconds;
+        }
+
         $not200Responses = array_filter($responseCodes, fn ($value) => 200 != $value);
         assertThat($not200Responses, equalTo([]));
 
@@ -255,6 +262,25 @@ class EndpointPerformanceTest extends ECampApiTestCase {
             '/material_lists?camp=' => urlencode($this->getIriFor('camp1')),
             '/profiles?user.collaboration.camp=' => urlencode($this->getIriFor('camp1')),
             '/schedule_entries?period=' => urlencode($this->getIriFor('period1')),
+        ];
+    }
+
+    private function getSubresourceUrls(): array {
+        $camp1Id = $this->getFixture('camp1')->getId();
+        $checklist1Id = $this->getFixture('checklist1')->getId();
+        $dayId = $this->getFixture('day1period1')->getId();
+        $periodId = $this->getFixture('period1')->getId();
+
+        return [
+            '/camps/{id}/activities' => $camp1Id,
+            '/camps/{id}/activity_progress_labels' => $camp1Id,
+            '/camps/{id}/camp_collaborations' => $camp1Id,
+            '/camps/{id}/categories' => $camp1Id,
+            '/camps/{id}/checklists' => $camp1Id,
+            '/checklists/{id}/checklist_items' => $checklist1Id,
+            '/days/{id}/day_responsibles' => $dayId,
+            '/periods/{id}/days' => $periodId,
+            '/periods/{id}/schedule_entries' => $periodId,
         ];
     }
 

--- a/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
+++ b/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
@@ -10,6 +10,7 @@ use App\Tests\Spatie\Snapshots\Driver\ECampYamlSnapshotDriver;
 use App\Util\ArrayDeepSort;
 use Hautelook\AliceBundle\PhpUnit\FixtureStore;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
@@ -215,6 +216,32 @@ class ResponseSnapshotTest extends ECampApiTestCase {
                 default => true,
             };
         });
+    }
+
+    /**
+     * @throws RedirectionExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws ServerExceptionInterface
+     */
+    #[TestWith(['/camps', '/activities'], '/camps_{campId}_activities')]
+    #[TestWith(['/camps', '/activity_progress_labels'], '/camps_{campId}_activity_progress_labels')]
+    #[TestWith(['/camps', '/camp_collaborations'], '/camps_{campId}_camp_collaborations')]
+    #[TestWith(['/camps', '/checklists'], '/camps_{campId}_checklists')]
+    #[TestWith(['/camps', '/categories'], '/camps_{campId}_categories')]
+    #[TestWith(['/checklists', '/checklist_items'], '/checklists_{campId}_checklist_items')]
+    #[TestWith(['/days', '/day_responsibles'], '/days_{campId}_day_responsibles')]
+    #[TestWith(['/periods', '/days'], '/periods_{campId}_days')]
+    #[TestWith(['/periods', '/schedule_entries'], '/periods_{campId}_schedule_entries')]
+    public function testSubResourceUrlMatchesSnapshot(string $endpoint, string $subresource) {
+        $fixture = $this->getFixtureFor($endpoint);
+        $uri = "{$endpoint}/{$fixture->getId()}{$subresource}";
+
+        $response = static::createClientWithCredentials()->request('GET', $uri);
+
+        assertThat($response->getStatusCode(), equalTo(200));
+        $this->assertMatchesEscapedResponseSnapshot($response);
     }
 
     private function getFixtureFor(string $collectionEndpoint) {

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
@@ -32,7 +32,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -114,7 +114,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -189,7 +189,7 @@ components:
           readOnly: true
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -267,7 +267,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -423,7 +423,7 @@ components:
           type: array
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -440,6 +440,10 @@ components:
                   maxLength: 16
                   readOnly: true
                   type: string
+                contentNodes:
+                  items: { type: unknown_type }
+                  readOnly: true
+                  type: array
                 location:
                   default: ''
                   description: "The physical location where this activity's programme will be carried out."
@@ -465,8 +469,6 @@ components:
                   properties: { data: { properties: { id: { format: iri-reference, type: string }, type: { type: string } }, type: object } }
                 category:
                   properties: { data: { properties: { id: { format: iri-reference, type: string }, type: { type: string } }, type: object } }
-                contentNodes:
-                  properties: { data: { items: { properties: { id: { format: iri-reference, type: string }, type: { type: string } }, type: object }, type: array } }
                 progressLabel:
                   properties: { data: { properties: { id: { format: iri-reference, type: string }, type: { type: string } }, type: object } }
                 rootContentNode:
@@ -490,7 +492,6 @@ components:
             url: 'https://jsonapi.org/format/#fetching-includes'
           items:
             anyOf:
-              - []
               -
                 $ref: '#/components/schemas/ScheduleEntry.jsonapi'
               -
@@ -547,7 +548,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -638,7 +639,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -722,7 +723,7 @@ components:
           readOnly: true
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -809,7 +810,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -979,7 +980,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -1067,7 +1068,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -1165,7 +1166,7 @@ components:
           readOnly: true
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -1266,7 +1267,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -6793,7 +6794,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -6856,7 +6857,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -6941,7 +6942,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -7023,7 +7024,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -7233,6 +7234,12 @@ components:
                   maxLength: 8
                   pattern: '^(#[0-9a-zA-Z]{6})$'
                   type: string
+                contentNodes:
+                  description: 'All the content nodes that make up the tree of programme content.'
+                  example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
+                  items: { example: 'https://example.com/', format: iri-reference, type: string }
+                  readOnly: true
+                  type: array
                 name:
                   description: 'The full name of the category.'
                   example: Lagersport
@@ -7266,8 +7273,6 @@ components:
               properties:
                 camp:
                   properties: { data: { properties: { id: { format: iri-reference, type: string }, type: { type: string } }, type: object } }
-                contentNodes:
-                  properties: { data: { items: { properties: { id: { format: iri-reference, type: string }, type: { type: string } }, type: object }, type: array } }
                 preferredContentTypes:
                   properties: { data: { items: { properties: { id: { format: iri-reference, type: string }, type: { type: string } }, type: object }, type: array } }
                 rootContentNode:
@@ -7288,7 +7293,6 @@ components:
             url: 'https://jsonapi.org/format/#fetching-includes'
           items:
             anyOf:
-              - []
               -
                 $ref: '#/components/schemas/Camp.jsonapi'
               -
@@ -7326,7 +7330,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -7398,7 +7402,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -7492,7 +7496,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -7583,7 +7587,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -7764,7 +7768,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -7850,7 +7854,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -7941,7 +7945,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference
@@ -8046,7 +8050,7 @@ components:
           type: string
         contentNodes:
           description: 'All the content nodes that make up the tree of programme content.'
-          example: '["/content_nodes/1a2b3c4d"]'
+          example: '/content_nodes?root=%2Fcontent_node%2Fcolumn_layouts%2F1a2b3c4d'
           items:
             example: 'https://example.com/'
             format: iri-reference

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set camps_campId_activities__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set camps_campId_activities__1.json
@@ -1,0 +1,206 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "activityResponsibles": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ],
+                    "progressLabel": "escaped_value",
+                    "scheduleEntries": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayNumber": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "left": "escaped_value",
+                            "number": "escaped_value",
+                            "scheduleEntryNumber": "escaped_value",
+                            "start": "escaped_value",
+                            "width": "escaped_value"
+                        },
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayNumber": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "left": "escaped_value",
+                            "number": "escaped_value",
+                            "scheduleEntryNumber": "escaped_value",
+                            "start": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "activityResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "category": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "progressLabel": "escaped_value",
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "location": "escaped_value",
+                "title": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "activityResponsibles": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ],
+                    "progressLabel": {
+                        "_links": {
+                            "camp": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "id": "escaped_value",
+                        "position": "escaped_value",
+                        "title": "escaped_value"
+                    },
+                    "scheduleEntries": [
+                        {
+                            "_links": {
+                                "activity": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "period": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "dayNumber": "escaped_value",
+                            "end": "escaped_value",
+                            "id": "escaped_value",
+                            "left": "escaped_value",
+                            "number": "escaped_value",
+                            "scheduleEntryNumber": "escaped_value",
+                            "start": "escaped_value",
+                            "width": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "activityResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "category": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "progressLabel": {
+                        "href": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "location": "escaped_value",
+                "title": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set camps_campId_activity_progress_labels__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set camps_campId_activity_progress_labels__1.json
@@ -1,0 +1,46 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "title": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "title": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set camps_campId_camp_collaborations__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set camps_campId_camp_collaborations__1.json
@@ -1,0 +1,527 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "checklists": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "shortTitle": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": "escaped_value"
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": "escaped_value"
+                },
+                "abbreviation": "escaped_value",
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "checklists": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "shortTitle": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "abbreviation": "escaped_value",
+                        "color": "escaped_value",
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "abbreviation": "escaped_value",
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "checklists": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "shortTitle": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "abbreviation": "escaped_value",
+                        "color": "escaped_value",
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "abbreviation": "escaped_value",
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "checklists": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "shortTitle": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "abbreviation": "escaped_value",
+                        "color": "escaped_value",
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "abbreviation": "escaped_value",
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "checklists": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "shortTitle": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "abbreviation": "escaped_value",
+                        "color": "escaped_value",
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "abbreviation": "escaped_value",
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "camp": {
+                        "_links": {
+                            "activities": {
+                                "href": "escaped_value"
+                            },
+                            "campCollaborations": {
+                                "href": "escaped_value"
+                            },
+                            "categories": {
+                                "href": "escaped_value"
+                            },
+                            "checklists": {
+                                "href": "escaped_value"
+                            },
+                            "creator": {
+                                "href": "escaped_value"
+                            },
+                            "materialLists": {
+                                "href": "escaped_value"
+                            },
+                            "periods": {
+                                "href": "escaped_value"
+                            },
+                            "profiles": {
+                                "href": "escaped_value"
+                            },
+                            "progressLabels": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "addressCity": "escaped_value",
+                        "addressName": "escaped_value",
+                        "addressStreet": "escaped_value",
+                        "addressZipcode": "escaped_value",
+                        "coachName": "escaped_value",
+                        "courseKind": "escaped_value",
+                        "courseNumber": "escaped_value",
+                        "id": "escaped_value",
+                        "isPrototype": "escaped_value",
+                        "kind": "escaped_value",
+                        "motto": "escaped_value",
+                        "organizer": "escaped_value",
+                        "printYSLogoOnPicasso": "escaped_value",
+                        "shortTitle": "escaped_value",
+                        "title": "escaped_value",
+                        "trainingAdvisorName": "escaped_value"
+                    },
+                    "user": {
+                        "_links": {
+                            "profile": {
+                                "href": "escaped_value"
+                            },
+                            "self": {
+                                "href": "escaped_value"
+                            }
+                        },
+                        "abbreviation": "escaped_value",
+                        "color": "escaped_value",
+                        "displayName": "escaped_value",
+                        "id": "escaped_value"
+                    }
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    },
+                    "user": {
+                        "href": "escaped_value"
+                    }
+                },
+                "abbreviation": "escaped_value",
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "inviteEmail": "escaped_value",
+                "role": "escaped_value",
+                "status": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set camps_campId_categories__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set camps_campId_categories__1.json
@@ -1,0 +1,118 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "preferredContentTypes": []
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "preferredContentTypes": {
+                        "href": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value",
+                "numberingStyle": "escaped_value",
+                "short": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "preferredContentTypes": []
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "preferredContentTypes": {
+                        "href": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value",
+                "numberingStyle": "escaped_value",
+                "short": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "preferredContentTypes": [
+                        {
+                            "_links": {
+                                "contentNodes": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "active": "escaped_value",
+                            "id": "escaped_value",
+                            "name": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "contentNodes": {
+                        "href": "escaped_value"
+                    },
+                    "preferredContentTypes": {
+                        "href": "escaped_value"
+                    },
+                    "rootContentNode": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "color": "escaped_value",
+                "id": "escaped_value",
+                "name": "escaped_value",
+                "numberingStyle": "escaped_value",
+                "short": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set camps_campId_checklists__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set camps_campId_checklists__1.json
@@ -1,0 +1,52 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "checklistItems": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "isPrototype": "escaped_value",
+                "name": "escaped_value"
+            },
+            {
+                "_links": {
+                    "camp": {
+                        "href": "escaped_value"
+                    },
+                    "checklistItems": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "isPrototype": "escaped_value",
+                "name": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set checklists_campId_checklist_items__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set checklists_campId_checklist_items__1.json
@@ -1,0 +1,106 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "checklist": {
+                        "href": "escaped_value"
+                    },
+                    "checklistNodes": [],
+                    "children": [],
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "text": "escaped_value"
+            },
+            {
+                "_links": {
+                    "checklist": {
+                        "href": "escaped_value"
+                    },
+                    "checklistNodes": [],
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "parent": "escaped_value",
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "text": "escaped_value"
+            },
+            {
+                "_links": {
+                    "checklist": {
+                        "href": "escaped_value"
+                    },
+                    "checklistNodes": [],
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "text": "escaped_value"
+            },
+            {
+                "_links": {
+                    "checklist": {
+                        "href": "escaped_value"
+                    },
+                    "checklistNodes": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "children": [],
+                    "parent": "escaped_value",
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "text": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set days_campId_day_responsibles__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set days_campId_day_responsibles__1.json
@@ -1,0 +1,31 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "campCollaboration": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set periods_campId_days__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set periods_campId_days__1.json
@@ -1,0 +1,125 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "dayResponsibles": []
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "dayResponsibles": [
+                        {
+                            "_links": {
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            },
+            {
+                "_embedded": {
+                    "dayResponsibles": [
+                        {
+                            "_links": {
+                                "campCollaboration": {
+                                    "href": "escaped_value"
+                                },
+                                "day": {
+                                    "href": "escaped_value"
+                                },
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "id": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "dayResponsibles": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "scheduleEntries": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayOffset": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "number": "escaped_value",
+                "start": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set periods_campId_schedule_entries__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testSubResourceUrlMatchesSnapshot with data set periods_campId_schedule_entries__1.json
@@ -1,0 +1,95 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            },
+            {
+                "_links": {
+                    "activity": {
+                        "href": "escaped_value"
+                    },
+                    "day": {
+                        "href": "escaped_value"
+                    },
+                    "period": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "dayNumber": "escaped_value",
+                "end": "escaped_value",
+                "id": "escaped_value",
+                "left": "escaped_value",
+                "number": "escaped_value",
+                "scheduleEntryNumber": "escaped_value",
+                "start": "escaped_value",
+                "width": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
@@ -45,3 +45,12 @@
 '/material_lists?camp=': 7
 '/profiles?user.collaboration.camp=': 6
 '/schedule_entries?period=': 13
+'/camps/{id}/activities': 15
+'/camps/{id}/activity_progress_labels': 8
+'/camps/{id}/camp_collaborations': 11
+'/camps/{id}/categories': 11
+'/camps/{id}/checklists': 8
+'/checklists/{id}/checklist_items': 8
+'/days/{id}/day_responsibles': 9
+'/periods/{id}/days': 14
+'/periods/{id}/schedule_entries': 14

--- a/api/tests/Api/SnapshotTests/__snapshots__/test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/test_EndpointPerformanceTest__testPerformanceDidNotChangeForStableEndpoints__1.yml
@@ -1,5 +1,5 @@
-/activities: 21
-/activities/item: 37
+/activities: 17
+/activities/item: 35
 /activity_progress_labels: 6
 /activity_progress_labels/item: 7
 /activity_responsibles: 6
@@ -8,7 +8,7 @@
 /camps/item: 19
 /camp_collaborations: 16
 /camp_collaborations/item: 7
-/categories: 11
+/categories: 6
 /categories/item: 11
 /checklists: 6
 /checklists/item: 7
@@ -29,14 +29,14 @@
 /profiles: 6
 /profiles/item: 6
 /schedule_entries: 23
-/schedule_entries/item: 19
+/schedule_entries/item: 17
 /users/item: 6
-'/activities?camp=': 13
+'/activities?camp=': 11
 '/activity_progress_labels?camp=': 6
 '/activity_responsibles?activity.camp=': 6
 '/camp_collaborations?camp=': 10
 '/camp_collaborations?activityResponsibles.activity=': 9
-'/categories?camp=': 9
+'/categories?camp=': 6
 '/content_types?categories=': 6
 '/day_responsibles?day.period=': 6
 '/material_items?materialList=': 7
@@ -45,10 +45,10 @@
 '/material_lists?camp=': 7
 '/profiles?user.collaboration.camp=': 6
 '/schedule_entries?period=': 13
-'/camps/{id}/activities': 15
+'/camps/{id}/activities': 13
 '/camps/{id}/activity_progress_labels': 8
 '/camps/{id}/camp_collaborations': 11
-'/camps/{id}/categories': 11
+'/camps/{id}/categories': 8
 '/camps/{id}/checklists': 8
 '/checklists/{id}/checklist_items': 8
 '/days/{id}/day_responsibles': 9

--- a/e2e/specs/httpCache/activities.cy.js
+++ b/e2e/specs/httpCache/activities.cy.js
@@ -28,7 +28,7 @@ const collectionXKeys =
   /* embedded activitiy responsibles: */
   '06743ccfeedd 06743ccfeedd#activity 06743ccfeedd#campCollaboration ' +
   '21bc6661c569 21bc6661c569#activity 21bc6661c569#campCollaboration ' +
-  'a13fadc97610#embeddedActivityResponsibles a13fadc97610#contentNodes ' +
+  'a13fadc97610#embeddedActivityResponsibles a13fadc97610#emptyContentNodesForIriGeneration ' +
   /**
    * activity "Skifahren"
    */
@@ -43,7 +43,7 @@ const collectionXKeys =
   /* embedded activitiy responsibles: */
   'b29d387cc403#embeddedScheduleEntries ' +
   'a9a760e36fd8 a9a760e36fd8#activity a9a760e36fd8#campCollaboration b29d387cc403#embeddedActivityResponsibles ' +
-  'b29d387cc403#contentNodes ' +
+  'b29d387cc403#emptyContentNodesForIriGeneration ' +
   /* collection URI (for detecting addition of new activities) */
   '/api/camps/70ca971c992f/activities'
 

--- a/e2e/specs/httpCache/categories.cy.js
+++ b/e2e/specs/httpCache/categories.cy.js
@@ -15,13 +15,13 @@ const collectionXKeys =
   /* campCollaboration for bipiUser */
   'b0bdb7202a9d ' +
   /* Category ES */
-  'ebfd46a1c181 ebfd46a1c181#camp ebfd46a1c181#preferredContentTypes ebfd46a1c181#rootContentNode ebfd46a1c181#embeddedPreferredContentTypes ebfd46a1c181#contentNodes ' +
+  'ebfd46a1c181 ebfd46a1c181#camp ebfd46a1c181#preferredContentTypes ebfd46a1c181#rootContentNode ebfd46a1c181#embeddedPreferredContentTypes ebfd46a1c181#emptyContentNodesForIriGeneration ' +
   /* Category LA */
-  '1a869b162875 1a869b162875#camp 1a869b162875#preferredContentTypes 1a869b162875#rootContentNode f17470519474 1a0f84e322c8 3ef17bd1df72 4f0c657fecef a4211c112939 44dcc7493c65 cfccaecd4bad 318e064ea0c9 1a869b162875#embeddedPreferredContentTypes 1a869b162875#contentNodes ' +
+  '1a869b162875 1a869b162875#camp 1a869b162875#preferredContentTypes 1a869b162875#rootContentNode f17470519474 1a0f84e322c8 3ef17bd1df72 4f0c657fecef a4211c112939 44dcc7493c65 cfccaecd4bad 318e064ea0c9 1a869b162875#embeddedPreferredContentTypes 1a869b162875#emptyContentNodesForIriGeneration ' +
   /* Category LP */
-  'dfa531302823 dfa531302823#camp dfa531302823#preferredContentTypes dfa531302823#rootContentNode dfa531302823#embeddedPreferredContentTypes dfa531302823#contentNodes ' +
+  'dfa531302823 dfa531302823#camp dfa531302823#preferredContentTypes dfa531302823#rootContentNode dfa531302823#embeddedPreferredContentTypes dfa531302823#emptyContentNodesForIriGeneration ' +
   /* Category LS */
-  'a023e85227ac a023e85227ac#camp a023e85227ac#preferredContentTypes a023e85227ac#rootContentNode a023e85227ac#embeddedPreferredContentTypes a023e85227ac#contentNodes ' +
+  'a023e85227ac a023e85227ac#camp a023e85227ac#preferredContentTypes a023e85227ac#rootContentNode a023e85227ac#embeddedPreferredContentTypes a023e85227ac#emptyContentNodesForIriGeneration ' +
   /* collection URI (for detecting addition of new categories) */
   '/api/camps/3c79b99ab424/categories'
 


### PR DESCRIPTION
That we track these now too.
~~Do not yet add the categories subresource, because it is changed right now: https://github.com/ecamp/ecamp3/pull/7751~~

That we can later improve the performance but know what we changed.

----

api: dont fetch contentNodes when relation iri is the output in HasRootContentNodeTrait

This saves us a lot of database queries whose results wont be used anyway.
For the json api the output is not correct, but the performance gain
is so big (from 300 queries to 11 in one prod camp) that this can be accepted.



Issue: #6461