### PR TITLE
npm: replace stylus with github package

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11062,8 +11062,7 @@
     },
     "node_modules/stylus": {
       "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.57.0.tgz",
-      "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
+      "resolved": "git+ssh://git@github.com/stylus/stylus.git#bc1404aa1f6c03341bd76529c8cf4beb4f3d99f7",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,6 +123,7 @@
     "vue-template-compiler": "2.7.15"
   },
   "overrides": {
+    "stylus": "github:stylus/stylus#0.57.0",
     "uri-js": "npm:uri-js-replace"
   },
   "postcss": {

--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -18829,8 +18829,7 @@
     },
     "node_modules/stylus": {
       "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.57.0.tgz",
-      "integrity": "sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==",
+      "resolved": "git+ssh://git@github.com/stylus/stylus.git#bc1404aa1f6c03341bd76529c8cf4beb4f3d99f7",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/print/package.json
+++ b/print/package.json
@@ -63,6 +63,7 @@
     "vue": "3.5.17"
   },
   "overrides": {
+    "stylus": "github:stylus/stylus#0.57.0",
     "uri-js": "npm:uri-js-replace"
   }
 }


### PR DESCRIPTION
It was probably wrongly flagged as security risk
because of a name clash.
See:
https://github.com/stylus/stylus/issues/2938
https://www.npmjs.com/package/stylus

Tag 0.57.0 seems unchanged, so i propose to stick with that until github responded.
Best way would be to remove this package, i don't think we need that.