### PR TITLE
chore(api): remove normalization_context from api_platform.defaults

### DIFF
--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -34,8 +34,6 @@ api_platform:
             get: ~
             post:
                 input_formats: [ 'jsonld', 'jsonapi', 'json' ]
-        normalization_context:
-            skip_null_values: false
 
     # On API-Platform Update - test, if this config is still needed.
     # See PR 5948: https://github.com/ecamp/ecamp3/pull/5948


### PR DESCRIPTION
in api/config/packages/api_platform.yaml.
skip_null_values is already set in SerializerContextBuilder.

I also tried to just use the defaults, but OpenApi does not seem to use the OperationDefaultsTrait
See https://github.com/BacLuc/ecamp3/tree/api-remove-serializercontextbuilder

Now the configuration is just in one place.