### PR TITLE
pdf: finish switch to flat eslint config

### DIFF
--- a/pdf/eslint.config.mjs
+++ b/pdf/eslint.config.mjs
@@ -2,23 +2,19 @@ import vueEslintConfigPrettier from '@vue/eslint-config-prettier'
 
 import { includeIgnoreFile } from '@eslint/compat'
 import localRules from 'eslint-plugin-local-rules'
+import vueEslint from 'eslint-plugin-vue'
 import globals from 'globals'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import js from '@eslint/js'
-import { FlatCompat } from '@eslint/eslintrc'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
-})
 const gitignorePath = path.resolve(__dirname, '.gitignore')
 
 export default [
-  ...compat.extends('plugin:vue/vue3-recommended', 'eslint:recommended'),
+  js.configs.recommended,
+  ...vueEslint.configs['flat/recommended'],
   {
     ignores: ['dist/*.mjs'],
   },

--- a/pdf/package-lock.json
+++ b/pdf/package-lock.json
@@ -13,7 +13,6 @@
       "devDependencies": {
         "@babel/eslint-parser": "7.28.0",
         "@eslint/compat": "1.3.1",
-        "@eslint/eslintrc": "3.3.1",
         "@eslint/js": "9.32.0",
         "@intlify/core": "11.1.11",
         "@rushstack/eslint-patch": "1.12.0",

--- a/pdf/package.json
+++ b/pdf/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.28.0",
     "@eslint/compat": "1.3.1",
-    "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.32.0",
     "@intlify/core": "11.1.11",
     "@rushstack/eslint-patch": "1.12.0",


### PR DESCRIPTION
We still need eslint/compat for the .gitignore file.
https://eslint.org/docs/latest/use/configure/ignore#including-gitignore-files

Now using the flat configs of the plugins.