### PR TITLE
print: finish switch to flat eslint config

### DIFF
--- a/print/eslint.config.mjs
+++ b/print/eslint.config.mjs
@@ -1,31 +1,26 @@
 import { includeIgnoreFile } from '@eslint/compat'
 import localRules from 'eslint-plugin-local-rules'
+import vueEslint from 'eslint-plugin-vue'
+import vueScopedCssEslint from 'eslint-plugin-vue-scoped-css'
+import { createConfigForNuxt } from '@nuxt/eslint-config/flat'
+import prettierRecommended from 'eslint-plugin-prettier/recommended'
 import globals from 'globals'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import js from '@eslint/js'
-import { FlatCompat } from '@eslint/eslintrc'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
-})
 const gitignorePath = path.resolve(__dirname, '.gitignore')
 
-export default [
+export default createConfigForNuxt().append([
   {
     files: ['**/*.ts'],
   },
-  ...compat.extends(
-    'plugin:vue/vue3-recommended',
-    'plugin:vue-scoped-css/vue3-recommended',
-    '@nuxt/eslint-config',
-    'eslint:recommended',
-    'plugin:prettier/recommended'
-  ),
+  ...vueEslint.configs['flat/recommended'],
+  ...vueScopedCssEslint.configs['flat/recommended'],
+  js.configs.recommended,
+  prettierRecommended,
   {
     ignores: ['common/**/*', '.nuxt/', '.output/', 'coverage/'],
   },
@@ -45,6 +40,7 @@ export default [
     },
 
     rules: {
+      'import/first': 'off',
       'no-undef': 'off',
       'no-console': 'off',
       'prettier/prettier': 'error',
@@ -61,4 +57,4 @@ export default [
       ],
     },
   },
-]
+])

--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -22,7 +22,6 @@
       },
       "devDependencies": {
         "@eslint/compat": "1.3.1",
-        "@eslint/eslintrc": "3.3.1",
         "@eslint/js": "9.32.0",
         "@nuxt/eslint": "1.7.1",
         "@nuxt/eslint-config": "0.7.6",

--- a/print/package.json
+++ b/print/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@eslint/compat": "1.3.1",
-    "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.32.0",
     "@nuxt/eslint": "1.7.1",
     "@nuxt/eslint-config": "0.7.6",


### PR DESCRIPTION
We still need eslint/compat for the .gitignore file. https://eslint.org/docs/latest/use/configure/ignore#including-gitignore-files

Like this we have a new rule 'import/first'.
Maybe we enable the rule in another PR.

Now using the flat configs of the plugins.