### PR TITLE
frontend: finish switch to flat eslint config

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -2,27 +2,21 @@ import vueEslintConfigPrettier from '@vue/eslint-config-prettier'
 
 import { includeIgnoreFile } from '@eslint/compat'
 import localRules from 'eslint-plugin-local-rules'
+import vueEslint from 'eslint-plugin-vue'
+import vueScopedCssEslint from 'eslint-plugin-vue-scoped-css'
 import globals from 'globals'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import js from '@eslint/js'
-import { FlatCompat } from '@eslint/eslintrc'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
-})
 const gitignorePath = path.resolve(__dirname, '.gitignore')
 export default [
-  ...compat.extends(
-    'plugin:vue/recommended',
-    'plugin:vue/vue3-recommended',
-    'plugin:vue-scoped-css/vue3-recommended',
-    'eslint:recommended'
-  ),
+  ...vueEslint.configs['flat/vue2-recommended'],
+  ...vueEslint.configs['flat/recommended'],
+  ...vueScopedCssEslint.configs['flat/recommended'],
+  js.configs.recommended,
   {
     ignores: ['data/', 'dist/', 'public/twemoji/'],
   },
@@ -42,7 +36,7 @@ export default [
       },
 
       parserOptions: {
-        ecmaVersion: '6',
+        ecmaVersion: 2022,
         parser: '@babel/eslint-parser',
       },
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -73,7 +73,6 @@
       "devDependencies": {
         "@babel/eslint-parser": "7.28.0",
         "@eslint/compat": "1.3.1",
-        "@eslint/eslintrc": "3.3.1",
         "@eslint/js": "9.32.0",
         "@sentry/vite-plugin": "3.6.1",
         "@testing-library/jest-dom": "6.6.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,7 +86,6 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.28.0",
     "@eslint/compat": "1.3.1",
-    "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.32.0",
     "@sentry/vite-plugin": "3.6.1",
     "@testing-library/jest-dom": "6.6.4",


### PR DESCRIPTION
We still need eslint/compat for the .gitignore file. https://eslint.org/docs/latest/use/configure/ignore#including-gitignore-files

The tests now need an ecmaVersion 2022.