### PR TITLE
e2e: finish switch to flat eslint config

### DIFF
--- a/e2e/eslint.config.mjs
+++ b/e2e/eslint.config.mjs
@@ -1,25 +1,20 @@
+import cypressEslint from 'eslint-plugin-cypress/flat'
 import { includeIgnoreFile } from '@eslint/compat'
 import globals from 'globals'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import js from '@eslint/js'
-import { FlatCompat } from '@eslint/eslintrc'
+import prettierRecommended from 'eslint-plugin-prettier/recommended'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
-})
+
 const gitignorePath = path.resolve(__dirname, '.gitignore')
 
 export default [
-  ...compat.extends(
-    'eslint:recommended',
-    'plugin:cypress/recommended',
-    'plugin:prettier/recommended'
-  ),
+  js.configs.recommended,
+  cypressEslint.configs.recommended,
+  prettierRecommended,
   {
     ignores: ['data/'],
   },

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,7 +8,6 @@
       "devDependencies": {
         "@babel/eslint-parser": "7.28.0",
         "@eslint/compat": "1.3.2",
-        "@eslint/eslintrc": "3.3.1",
         "@eslint/js": "9.33.0",
         "cypress": "14.5.2",
         "cypress-terminal-report": "7.2.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.28.0",
     "@eslint/compat": "1.3.2",
-    "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.33.0",
     "cypress": "14.5.2",
     "cypress-terminal-report": "7.2.1",


### PR DESCRIPTION
We still need eslint/compat for the .gitignore file. https://eslint.org/docs/latest/use/configure/ignore#including-gitignore-files