### PR TITLE
aws-setup: finish switch to flat config

### DIFF
--- a/.ops/aws-setup/eslint.config.mjs
+++ b/.ops/aws-setup/eslint.config.mjs
@@ -3,22 +3,18 @@ import globals from 'globals'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import js from '@eslint/js'
-import { FlatCompat } from '@eslint/eslintrc'
+import prettierRecommended from 'eslint-plugin-prettier/recommended'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
-})
 const gitignorePath = path.resolve(__dirname, '.gitignore')
 
 export default [
   {
     files: ['**/*.ts'],
   },
-  ...compat.extends('eslint:recommended', 'plugin:prettier/recommended', 'prettier'),
+  js.configs.recommended,
+  prettierRecommended,
 
   includeIgnoreFile(gitignorePath),
 

--- a/.ops/aws-setup/package-lock.json
+++ b/.ops/aws-setup/package-lock.json
@@ -13,7 +13,6 @@
             "devDependencies": {
                 "@babel/eslint-parser": "7.28.0",
                 "@eslint/compat": "1.3.1",
-                "@eslint/eslintrc": "3.3.1",
                 "@eslint/js": "9.32.0",
                 "@types/node": "22.16.3",
                 "eslint": "9.32.0",

--- a/.ops/aws-setup/package.json
+++ b/.ops/aws-setup/package.json
@@ -17,7 +17,6 @@
     "devDependencies": {
         "@babel/eslint-parser": "7.28.0",
         "@eslint/compat": "1.3.1",
-        "@eslint/eslintrc": "3.3.1",
         "@eslint/js": "9.32.0",
         "@types/node": "22.16.3",
         "eslint": "9.32.0",


### PR DESCRIPTION
We still need eslint/compat for the .gitignore file. https://eslint.org/docs/latest/use/configure/ignore#including-gitignore-files