### PR TITLE
Proposal helmfile for deployment

### DIFF
--- a/.github/actions/setup-helmfile/action.yaml
+++ b/.github/actions/setup-helmfile/action.yaml
@@ -1,0 +1,13 @@
+name: 'Setup helmfile'
+description: 'Sets up helmfile in /usr/local/bin/helmfile'
+runs:
+  using: "composite"
+  steps:
+    - name: install helmfile
+      run: |
+        curl -L https://github.com/helmfile/helmfile/releases/download/v1.1.3/helmfile_1.1.3_linux_amd64.tar.gz -o helmfile.tar.gz
+        tar -xvf /tmp/helmfile.tar.gz
+        mv helmfile /usr/local/bin
+        chmod +x /usr/local/bin/helmfile
+      working-directory: /tmp
+      shell: bash

--- a/.github/workflows/deploy-ecamp3-logging.yml
+++ b/.github/workflows/deploy-ecamp3-logging.yml
@@ -4,9 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Choose environment'
+        description: "Choose environment"
         type: environment
         required: true
+      action:
+        description: "Choose action"
+        type: choice
+        required: true
+        default: diff
+        options:
+          - diff
+          - deploy
 
 jobs:
   deploy-ecamp3-logging:
@@ -61,6 +69,7 @@ jobs:
         working-directory: .ops/ecamp3-logging
 
       - name: Deploy
+        if: ${{ github.event.inputs.action == 'deploy' }}
         run: |
           ./deploy.sh deploy
         working-directory: .ops/ecamp3-logging

--- a/.github/workflows/deploy-ecamp3-logging.yml
+++ b/.github/workflows/deploy-ecamp3-logging.yml
@@ -25,36 +25,39 @@ jobs:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-      - name: Dump secrets to .env
+      - name: Dump secrets to /tmp/secrets.yaml
         run: |
-          echo '${{ toJSON(secrets) }}' | jq -r 'keys[] as $k | select(.[$k] |contains("\n") | not) | "\($k)=\"\(.[$k])\""' >> .env
-        working-directory: .ops/ecamp3-logging
+          cat << 'EOF' | tee -a /tmp/secrets.yaml
+          ${{ toJSON(secrets) }}
+          EOF
+          jq '.' /tmp/secrets.yaml
 
-      - name: Dump variables to .env
+      - name: Dump variables to /tmp/env.yaml
         run: |
-          echo '${{ toJSON(vars) }}' | jq -r 'keys[] as $k | select(.[$k] |contains("\n") | not) | "\($k)=\"\(.[$k])\""' >> .env
-        working-directory: .ops/ecamp3-logging
+          cat << 'EOF' | tee -a /tmp/env.yaml
+          ${{ toJSON(vars) }}
+          EOF
+          jq '.' /tmp/env.yaml
 
-      - name: Show .env for debugging
-        run: echo "$(cat .env | sort)"
+      - name: Merge secrets and variables
+        run: |
+          jq -s '.[0] + .[1]' /tmp/secrets.yaml /tmp/env.yaml > env.yaml
+          jq '.' env.yaml
         working-directory: .ops/ecamp3-logging
 
       - name: Setup helm
         run: |
           mkdir ~/.kube && echo '${{ secrets.KUBECONFIG }}' > ~/.kube/config && chmod go-r ~/.kube/config
 
-      - name: Add helm repositories
-        run: |
-          helm repo add fluent https://fluent.github.io/helm-charts
-          helm repo update
+      - uses: ./.github/actions/setup-helmfile
 
       - name: Diff deployment
         run: |
           ./deploy.sh diff || true
         working-directory: .ops/ecamp3-logging
 
-      - name: Show values.out.yaml
-        run: cat values.out.yaml
+      - name: Show values.yaml
+        run: cat values.yaml
         working-directory: .ops/ecamp3-logging
 
       - name: Deploy

--- a/.ops/ecamp3-logging/.gitignore
+++ b/.ops/ecamp3-logging/.gitignore
@@ -1,3 +1,4 @@
 .env
+/env.yaml
 /charts
-/values.out.yaml
+/values.yaml

--- a/.ops/ecamp3-logging/.helmignore
+++ b/.ops/ecamp3-logging/.helmignore
@@ -1,3 +1,5 @@
 .env
 /deploy.sh
-/values.out.yaml
+/values.yaml
+/values.yaml.gotmpl
+/env.yaml

--- a/.ops/ecamp3-logging/README.md
+++ b/.ops/ecamp3-logging/README.md
@@ -5,12 +5,7 @@ ecamp3 is running.
 
 ## Prerequisites
 
-You need to add the fluent helm repository:
-
-```shell
-helm repo add fluent https://fluent.github.io/helm-charts 
-helm repo update
-```
+You need the helmfile in addition to kubectl and helm.
 
 ## Provisioning of Kibana Configuration
 

--- a/.ops/ecamp3-logging/deploy.sh
+++ b/.ops/ecamp3-logging/deploy.sh
@@ -5,24 +5,14 @@ set -ea
 SCRIPT_DIR=$(realpath "$(dirname "$0")")
 cd $SCRIPT_DIR
 
-ELASTIC_NODE_REQUESTS_MEMORY=1000Mi
-ELASTIC_NODE_LIMITS_MEMORY=1000Mi
-ELASTIC_NODE_MAX_INDEX_AGE=15
-RANDOM_STRING=$(uuidgen)
-
 if [ -f $SCRIPT_DIR/.env ]; then
   . $SCRIPT_DIR/.env
 fi
 
-if [ -z "${ELASTIC_NODE_STORAGE_SIZE}" ]; then
-  echo "Please define ELASTIC_NODE_STORAGE_SIZE. There is no good default value."
-  echo "It can also not be automatically enlarged, see: https://github.com/kubernetes/enhancements/pull/4651 and https://github.com/kubernetes/kubernetes/issues/68737"
-  exit 1
-fi
+echo "ELASTIC_NODE_STORAGE_SIZE can not be automatically enlarged, see: https://github.com/kubernetes/enhancements/pull/4651 and https://github.com/kubernetes/kubernetes/issues/68737"
 
-envsubst < $SCRIPT_DIR/values.yaml > $SCRIPT_DIR/values.out.yaml
-
-helm dep build
+helmfile deps
+helmfile write-values --environment default --output-file-template values.yaml
 
 if [ $1 = "deploy" ]; then
   # to debug: --dry-run --debug
@@ -30,14 +20,14 @@ if [ $1 = "deploy" ]; then
       --namespace ecamp3-logging \
       --create-namespace \
       $SCRIPT_DIR \
-      --values $SCRIPT_DIR/values.out.yaml
+      --values $SCRIPT_DIR/values.yaml
   exit 0
 fi
 
 if [ $1 = "diff" ]; then
   helm template \
-      --namespace ecamp3-logging --no-hooks --skip-tests ecamp3-logging  \
+      --namespace ecamp3-logging --no-hooks --skip-tests ecamp3-logging \
       $SCRIPT_DIR \
-      --values $SCRIPT_DIR/values.out.yaml | kubectl diff --namespace ecamp3-logging -f -
+      --values $SCRIPT_DIR/values.yaml | kubectl diff --namespace ecamp3-logging -f -
   exit 0
 fi

--- a/.ops/ecamp3-logging/helmfile.yaml
+++ b/.ops/ecamp3-logging/helmfile.yaml
@@ -1,0 +1,14 @@
+environments:
+  default:
+    values:
+      - ./env.yaml
+---
+repositories:
+  - name: fluent
+    url: https://fluent.github.io/helm-charts
+
+releases:
+  - name: ""
+    chart: .
+    values:
+      - ./values.yaml.gotmpl

--- a/.ops/ecamp3-logging/values.yaml.gotmpl
+++ b/.ops/ecamp3-logging/values.yaml.gotmpl
@@ -1,9 +1,9 @@
 fluent-operator:
   containerRuntime: containerd
   operator: 
-    annotations: 
-      trigger-recreate: ${RANDOM_STRING}
-    container: 
+    annotations:
+      trigger-recreate: {{ exec "uuidgen" (list) }}
+    container:
       tag: 3.3.0
   fluentbit:
     enable: true
@@ -26,7 +26,7 @@ fluent-operator:
       - ingress-nginx
     envVars: 
       - name: TRIGGER_FLUENTD_RECREATE
-        value: ${RANDOM_STRING}
+        value: {{ exec "uuidgen" (list) }}
     enable: true
 
 fluentd:
@@ -46,16 +46,16 @@ elasticsearch:
   elasticNode:
     resources:
       requests:
-        memory: ${ELASTIC_NODE_REQUESTS_MEMORY}
+        memory: {{ .Environment.Values | get "ELASTIC_NODE_REQUESTS_MEMORY" "1000Mi" }}
       limits:
-        memory: ${ELASTIC_NODE_LIMITS_MEMORY}
+        memory: {{ .Environment.Values | get "ELASTIC_NODE_LIMITS_MEMORY" "1000Mi"}}
   persistence:
     storageClassName: do-block-storage
     resources:
       requests:
-        storage: ${ELASTIC_NODE_STORAGE_SIZE}
+        storage: {{ .Environment.Values | get "ELASTIC_NODE_STORAGE_SIZE" nil | required "Please define ELASTIC_NODE_STORAGE_SIZE. There is no good default value." }}
   removeOldIndexes:
-    maxIndexAge: ${ELASTIC_NODE_MAX_INDEX_AGE}
+    maxIndexAge: {{ .Environment.Values | get "ELASTIC_NODE_MAX_INDEX_AGE" "15" }}
     image: node:24.8.0
 
 kibana:


### PR DESCRIPTION
Since a long time i am unhappy with the the way we set the variables in our helm deployment for ecamp3.
e.g.:
```bash
            --set imageTag=${{ github.sha }} \
            --set frontend.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-frontend' \
            --set print.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-print' \
            --set api.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-api' \
            --set apiCache.image.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-varnish' \
            --set postgresql.dbBackupRestoreImage.repository='docker.io/${{ vars.DOCKER_HUB_USERNAME }}/ecamp3-db-backup-restore' \
            --set termsOfServiceLinkTemplate='https://ecamp3.ch/{lang}/tos' \
            --set newsLink='https://ecamp3.ch/blog' \
            --set helpLink='https://ecamp3.ch/faq' \
            --set domain=${{ env.domain }} \
```

The problems:
- It is difficult to read
- It is error prone during refactoring (renaming or moving a key)
- It is currently duplicated and the staging workflow can more or less only be tested in staging
- you can make a typo for the var/secret and a typo for the variable yamlPath
- If you don't do proper null handling you accidentally overwrite the default value
- If you forget the quotes and you have a multi line secret you have an error
- If you forget the backslash at the end of the line you have an error
- If you have a backslash on the last line you have an error

The cons against helmfile and "changing something"
- it works and we don't change it much
- with helmfile we have another abstraction more

My vision:
We have a deploy script for all resources we deploy (currently all with helm, and then with helmfile if needed)
which can be run locally to develop.
The same script is executed for all environments, so it can be tested already in development and in the feature branch deployment.
The script has a diff mode where you just see what would be changed, so have the ci jobs.
We don't run the tests for the staging and prod deployment, they already ran on devel.
To add a new configurable part to the helmfile you just need to add it in the helmfile, you don't have to repeat the yamlPath in the CI script.

Default values:
the default values are if possible:
1. In the application code
2. In the Containerfile

If the dev values differ from prod
then the default value for prod is in the values file template.

For dev, feature branch deployments and staging the values to change have to be overridden.
(it would be possible to have multiple sets of default values, but i don't think we need that.)

This here is just the example for ecamp3-logging