### PR TITLE
CI: do not run continuous-integration.yml on stage and prod

### DIFF
--- a/.github/workflows/deployment-stage-prod.yml
+++ b/.github/workflows/deployment-stage-prod.yml
@@ -11,13 +11,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  continuous-integration:
-    name: 'Continuous integration'
-    uses: ./.github/workflows/continuous-integration.yml
-
   build-and-push:
     name: Build and push docker images
-    needs: continuous-integration
     uses: ./.github/workflows/reusable-build-and-push.yml
     with:
       tag: ${{ github.ref_name }}


### PR DESCRIPTION
Usually, they it already ran on devel.
If you do manual branching and pushing, you can run the workflow by yourself with workflow-dispatch.