### PR TITLE
fix xls sheet name length

### DIFF
--- a/frontend/src/components/material/__tests__/useMaterialViewHelper.spec.js
+++ b/frontend/src/components/material/__tests__/useMaterialViewHelper.spec.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { toWorkbook } from '@/components/material/useMaterialViewHelper.js'
+
+describe('toWorkBook', () => {
+  it('replaces invalid characters', () => {
+    const sheets = createSheets('s?h*e[]e/t:1:')
+
+    const workbook = toWorkbook(sheets)
+
+    expect(workbook.SheetNames).toEqual(['sheet1'])
+  })
+
+  it('shortens sheets names with more than 31 characters', () => {
+    const sheetName = 'a'.repeat(32)
+    const sheets = createSheets(sheetName)
+
+    const workbook = toWorkbook(sheets)
+
+    expect(workbook.SheetNames).toEqual([sheetName.slice(0, 31)])
+  })
+
+  it('does not overwrite sheets when shortening them makes them not unique anymore', () => {
+    const sheets = [
+      ...createSheets('a'.repeat(32)),
+      ...createSheets('a'.repeat(33)),
+      ...createSheets('a'.repeat(34)),
+    ]
+    const workbook = toWorkbook(sheets)
+
+    expect(Object.entries(workbook.Sheets)).toHaveLength(sheets.length)
+    expect(workbook.SheetNames.filter((name) => name.length > 31)).toEqual([])
+  })
+
+  it('does not overwrite sheets when they have the same name', () => {
+    const sheets = [...createSheets('sheet1'), ...createSheets('sheet1')]
+    const workbook = toWorkbook(sheets)
+
+    expect(Object.entries(workbook.Sheets)).toHaveLength(sheets.length)
+  })
+})
+
+const data = [['row1']]
+
+function createSheets(sheetName) {
+  return [
+    {
+      sheetName: sheetName,
+      data,
+    },
+  ]
+}

--- a/frontend/src/components/material/useMaterialViewHelper.js
+++ b/frontend/src/components/material/useMaterialViewHelper.js
@@ -68,6 +68,21 @@ async function getSheets(camp, collection, materialList) {
 }
 
 /**
+ * @param sheets {array} array of {sheetName: string, data: array}
+ * @returns {object} an XLSX workbook
+ */
+function toWorkbook(sheets) {
+  const workbook = XLSX.utils.book_new();
+  sheets.forEach(({ sheetName, data }) => {
+    const worksheet = XLSX.utils.aoa_to_sheet(data);
+    const validSheetName = sheetName.replaceAll(/[?*[\]/\\:]/g, "");
+    workbook.SheetNames.push(validSheetName);
+    workbook.Sheets[validSheetName] = worksheet;
+  });
+  return workbook;
+}
+
+/**
  * @param {object} camp
  * @param {{value: {period: object, materialItems: {items: array}}[]}} collection
  * @param {string} materialList materialList name if set
@@ -76,14 +91,8 @@ function downloadMaterialList(camp, collection, materialList) {
   return async () => {
     await camp.activities().$loadItems()
 
-    const workbook = XLSX.utils.book_new()
     const sheets = await getSheets(camp, collection.value, materialList)
-    sheets.forEach(({ sheetName, data }) => {
-      const worksheet = XLSX.utils.aoa_to_sheet(data)
-      const validSheetName = sheetName.replaceAll(/[?*[\]/\\:]/g, '')
-      workbook.SheetNames.push(validSheetName)
-      workbook.Sheets[validSheetName] = worksheet
-    })
+    const workbook = toWorkbook(sheets);
     XLSX.writeFile(workbook, generateFilename(camp, materialList))
   }
 }

--- a/frontend/src/components/material/useMaterialViewHelper.js
+++ b/frontend/src/components/material/useMaterialViewHelper.js
@@ -67,19 +67,28 @@ async function getSheets(camp, collection, materialList) {
   )
 }
 
+function randomString(len) {
+  const p = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  return [...Array(len)].reduce((a) => a + p[~~(Math.random() * p.length)], '')
+}
+
 /**
  * @param sheets {array} array of {sheetName: string, data: array}
  * @returns {object} an XLSX workbook
  */
-function toWorkbook(sheets) {
-  const workbook = XLSX.utils.book_new();
+export function toWorkbook(sheets) {
+  const workbook = XLSX.utils.book_new()
   sheets.forEach(({ sheetName, data }) => {
-    const worksheet = XLSX.utils.aoa_to_sheet(data);
-    const validSheetName = sheetName.replaceAll(/[?*[\]/\\:]/g, "");
-    workbook.SheetNames.push(validSheetName);
-    workbook.Sheets[validSheetName] = worksheet;
-  });
-  return workbook;
+    const worksheet = XLSX.utils.aoa_to_sheet(data)
+    const validSheetName = sheetName.replaceAll(/[?*[\]/\\:]/g, '')
+    let slicedSheetName = validSheetName.slice(0, 31)
+    if (workbook.SheetNames.includes(slicedSheetName)) {
+      slicedSheetName = validSheetName.slice(0, 28) + randomString(3)
+    }
+    workbook.SheetNames.push(slicedSheetName)
+    workbook.Sheets[slicedSheetName] = worksheet
+  })
+  return workbook
 }
 
 /**
@@ -92,7 +101,7 @@ function downloadMaterialList(camp, collection, materialList) {
     await camp.activities().$loadItems()
 
     const sheets = await getSheets(camp, collection.value, materialList)
-    const workbook = toWorkbook(sheets);
+    const workbook = toWorkbook(sheets)
     XLSX.writeFile(workbook, generateFilename(camp, materialList))
   }
 }


### PR DESCRIPTION
frontend: extract method toWorkbook in useMaterialViewHelper.js

That we can test it in isolation.

---

frontend: trim sheetNames to 31 chars in useMaterialViewHelper.js

And replace the last 3 chars with random alphanumeric characters
on collision.

This also fixes the "duplicate sheet" error if 2 periods have the same name.

Closes: https://github.com/ecamp/ecamp3/issues/7184