### PR TITLE
Remove obsolete bitnami reference

### DIFF
--- a/.helm/ecamp3/values.yaml
+++ b/.helm/ecamp3/values.yaml
@@ -145,7 +145,6 @@ mail:
       cpu: 10m
       memory: 10Mi
 
-# Full configuration: https://github.com/bitnami/charts/tree/master/bitnami/postgresql
 postgresql:
   url:
   dropDBOnUninstall: false


### PR DESCRIPTION
Since 80117985fa25317cfb7fb08e33d8349b082d7298 we don't support the bitnami postgres image anymore. Now bitnami is disabling free access to many of their images: https://github.com/bitnami/containers/issues/83267 This commit should remove the last reference to bitnami from our project.