### PR TITLE
Reverse time ordering for past camps

### DIFF
--- a/frontend/src/views/Camps.vue
+++ b/frontend/src/views/Camps.vue
@@ -132,7 +132,9 @@ export default {
     pastCamps() {
       return Object.values(
         groupBy(
-          this.periods.items.filter((p) => !dayjs(p.end).endOf('day').isAfter(dayjs())),
+          this.periods.items
+            .filter((p) => !dayjs(p.end).endOf('day').isAfter(dayjs()))
+            .sort((p1, p2) => dayjs(p2.start).unix() - dayjs(p1.start).unix()),
           (p) => p.camp()._meta.self
         )
       )


### PR DESCRIPTION
Most recent past camps are the most interesting for copying activities, so they should be listed on top of the past camps list (IMO). eCamp v2 did it the same way.