### PR TITLE
Write summary to PR description instead of comment

### DIFF
--- a/.github/workflows/summarize-changes-on-staging-and-prod-prs.yml
+++ b/.github/workflows/summarize-changes-on-staging-and-prod-prs.yml
@@ -24,11 +24,11 @@ jobs:
           echo "$SUMMARY" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Comment summary on PR
-        uses: thollander/actions-comment-pull-request@v3
+      - name: Update PR description with summary
+        uses: kt3k/update-pr-description@8077af9ce93a5ea30878f27eb2d6f4ae02a211ba # v2
         with:
-          pr-number: ${{ github.event.pull_request.number }}
-          message: |
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_body: |
             ### <span aria-hidden="true">🏗️</span> Changes in this deployment
 
             Includes the following non-renovate PRs:
@@ -43,5 +43,3 @@ jobs:
             ```
 
             </details>
-
-          comment-tag: deployment-pr-summary


### PR DESCRIPTION
I noticed that in #7947, @BacLuc manually copied the summary text from the auto-generated comment to the PR description. We can do this with robots! :robot:

Caution: The whole PR description will be replaced completely on every push now. If we want to have the ability to add some human text, we can develop this further to only replace the part between some invisible markers (HTML comments).

The upside is that in various previews of a GH PR, the start of the description is already displayed. So our often very similar deployment PRs will become more distinguishable this way.