### PR TITLE
Improve generated pdf names

### DIFF
--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -409,7 +409,7 @@ export default {
       return {
         camp: this.camp._meta.self,
         language: this.$store.state.lang.language,
-        documentName: this.activity.title + '.pdf',
+        documentName: this.activity.title,
         contents: [
           {
             type: 'Activity',

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -154,6 +154,7 @@ import {
   transformValuesToHalId,
 } from '@/helpers/querySyncHelper.js'
 import { filterMatchScheduleEntry } from '@/common/helpers/filterMatchScheduleEntry.js'
+import campShortTitle from '@/common/helpers/campShortTitle.js'
 
 export default {
   name: 'CampProgram',
@@ -206,7 +207,7 @@ export default {
       return {
         camp: this.camp._meta.self,
         language: this.$store.state.lang.language,
-        documentName: this.camp.title + '-picasso.pdf',
+        documentName: campShortTitle(this.camp) + '-' + this.period.description,
         contents: [
           {
             type: 'Picasso',

--- a/frontend/src/views/camp/Story.vue
+++ b/frontend/src/views/camp/Story.vue
@@ -39,6 +39,7 @@ import DownloadClientPdf from '@/components/print/print-client/DownloadClientPdf
 import LockButton from '@/components/generic/LockButton.vue'
 import LockUnlockListItem from '@/components/generic/LockUnlockListItem.vue'
 import PeriodSwitcher from '@/components/program/PeriodSwitcher.vue'
+import campShortTitle from '@/common/helpers/campShortTitle.js'
 
 export default {
   name: 'Story',
@@ -66,7 +67,8 @@ export default {
       return {
         camp: this.camp._meta.self,
         language: this.$store.state.lang.language,
-        documentName: this.camp.title + '-StorySummary.pdf',
+        documentName:
+          campShortTitle(this.camp) + '-' + this.$tc('views.camp.story.title'),
         contents: [
           {
             type: 'Story',


### PR DESCRIPTION
| PDF export | PDF filename before this PR (example) | PDF filename after this PR (example) | Comment |
| ------------- | ------------- | -- | -- |
| Activity detail | Stadtgame-pdf.pdf | Stadtgame.pdf | removed duplicate pdf extension |
| Story overview | GRGR-StorySummary-pdf.pdf | PfiLa-2023-Geschichte.pdf | changed to short title, removed duplicate pdf extension, replaced english term by translated term |
| Picasso | GRGR-picasso-pdf.pdf | PfiLa-2023-Hauptlager.pdf | changed to short title, removed duplicate pdf extension, replaced generic english term by period description |
| Print configurator | PfiLa-2023.pdf | PfiLa-2023.pdf | unchanged |

The .pdf extension is added later in the generatePDFMixins, so we don't need to add it to the initial value of documentName.