### PR TITLE
Fix rendering combined emoji 🧙‍♂️ in the PDF

### DIFF
--- a/pdf/src/CampPrint.vue
+++ b/pdf/src/CampPrint.vue
@@ -75,8 +75,15 @@ const registerFonts = async () => {
   })
 
   Font.registerEmojiSource({
-    formag: 'png',
-    url: '/twemoji/assets/72x72/',
+    withVariationSelectors: true,
+    builder(code) {
+      // If the code point does not contain 200d, remove any fe0f
+      // https://github.com/twitter/twemoji/issues/419#issuecomment-637360325
+      const filename = code.includes('200d')
+        ? code
+        : code.replaceAll('fe0f', '').replaceAll(/--|^-|-$/g, '')
+      return '/twemoji/assets/72x72/' + filename + '.png'
+    },
   })
 
   return await Promise.all([


### PR DESCRIPTION
Fixes https://ecamp.sentry.io/issues/6353794860/?project=5602507&query=is%3Aunresolved%20image&referrer=issue-stream

The twemoji library strips one code point from the emoji file names in some cases, see https://github.com/twitter/twemoji/issues/419#issuecomment-637360325

Specifically, the male mage emoji 🧙‍♂️ consists of [4 code points](https://apps.timwhitlock.info/unicode/inspect?s=%F0%9F%A7%99%E2%80%8D%E2%99%82%EF%B8%8F):
- 1f9d9 mage
- 200d  zero width joiner
- 2642  male sign
- fe0f  variation selector 16
And the correct twemoji filename is: `/twemoji/assets/72x72/1f9d9-200d-2642-fe0f.png`

On the other hand, the dove emoji 🕊️ consists of [2 code points](https://apps.timwhitlock.info/unicode/inspect?s=%F0%9F%95%8A%EF%B8%8F):
- 1f54a dove
- fe0f  variation selector 16 
And the correct twemoji filename is: `/twemoji/assets/72x72/1f54a.png` (note the omitted variation selector)

In the twemoji library, according to the linked comment, the variation selector is removed in simple emoji without a zero width joiner, but preserved in combined emoji with a zero width joiner. Therefore, we need to mirror this transformation.

Different emoji libraries can handle this differently, which is why it can't really be fixed on the react-pdf side.