### PR TITLE
Fix broken activity layout

### DIFF
--- a/frontend/src/components/activity/content/checklist/ChecklistItems.vue
+++ b/frontend/src/components/activity/content/checklist/ChecklistItems.vue
@@ -44,8 +44,7 @@ export default {
 <style scoped>
 .e-checklist-item-parent-name {
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: wrap;
 }
 
 .ec-checklist--item-title {

--- a/frontend/src/components/activity/content/checklist/ChecklistItems.vue
+++ b/frontend/src/components/activity/content/checklist/ChecklistItems.vue
@@ -5,7 +5,7 @@
       <v-list-item
         v-for="{ item, parents } in items"
         :key="item._meta.self"
-        class="min-h-0"
+        class="min-h-0 d-grid"
         :disabled="layoutMode"
       >
         <v-list-item-content class="py-2">
@@ -44,7 +44,8 @@ export default {
 <style scoped>
 .e-checklist-item-parent-name {
   min-width: 0;
-  white-space: wrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ec-checklist--item-title {


### PR DESCRIPTION
Fixes #7774
The parent checklist item was set to white-space: nowrap, which led to the layout being broken when the text is long.

Setting a max width on the element did not help, and the existing ellipsis CSS also did not work. I am not sure why. But breaking the text looks okay, so that's the easiest fix I could find:
<img width="508" height="348" alt="image" src="https://github.com/user-attachments/assets/915a1bc5-745d-47f3-ad59-f7db540c9e52" />

