### PR TITLE
Fix rendering number emoji

### DIFF
--- a/pdf/src/CampPrint.vue
+++ b/pdf/src/CampPrint.vue
@@ -88,7 +88,10 @@ const registerFonts = async () => {
       // https://github.com/twitter/twemoji/issues/419#issuecomment-637360325
       const filename = code.includes('200d')
         ? code
-        : code.replaceAll('fe0f', '').replaceAll(/--|^-|-$/g, '')
+        : code
+            .split('-')
+            .filter((part) => part && part !== 'fe0f')
+            .join('-')
       return '/twemoji/assets/72x72/' + filename + '.png'
     },
   })


### PR DESCRIPTION
Offending example emoji: 1️⃣

I have no reason to believe that this has affected any users yet. But maybe we could write a test iterating over all twemoji checking they can be printed..?