### PR TITLE
reusable-build-and-push.yml: use the source branch to build the images for a pr

### DIFF
--- a/.github/workflows/reusable-build-and-push.yml
+++ b/.github/workflows/reusable-build-and-push.yml
@@ -40,6 +40,8 @@ jobs:
             return context.repo.owner.toLowerCase()
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{ inputs.sha }}
 
       - name: Set nightly tag if commit was on main
         id: add-nightly-tag
@@ -122,6 +124,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
+          ref: ${{ inputs.sha }}
           fetch-depth: 100
 
       - run: |


### PR DESCRIPTION
Else use the HEAD of the current branch.
We did not see this when writing/reviewing the pr. See https://github.com/ecamp/ecamp3/pull/7898/files#r2319901379

See the result here: https://github.com/ecamp/ecamp3/pull/8096