### PR TITLE
api: increase default memory limit to 500M in development

### DIFF
--- a/api/docker/php/conf.d/api-platform.dev.ini
+++ b/api/docker/php/conf.d/api-platform.dev.ini
@@ -2,4 +2,5 @@
 ; See https://github.com/docker/for-linux/issues/264
 ; The `client_host` below may optionally be replaced with `discover_client_host=yes`
 ; Add `start_with_request=yes` to start debug session on each request
+memory_limit = ${PHP_MEMORY_LIMIT:-}
 xdebug.client_host = host.docker.internal

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,5 +24,6 @@ services:
       # This should correspond to the server declared in PHPStorm `Preferences | Languages & Frameworks | PHP | Servers`
       # Then PHPStorm will use the corresponding path mappings
       PHP_IDE_CONFIG: serverName=localhost
+      PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT:-500M}
       PERFORMANCE_TEST_DEBUG_OUTPUT: ${PERFORMANCE_TEST_DEBUG_OUTPUT:-}
     user: ${USER_ID:-1000}


### PR DESCRIPTION
With php 8.3 it got even cloud native and allows to set ini values from env vars: https://www.php.net/manual/en/configuration.file.php#example-33 Can be overridden in .env.
If the variable is not set, the php default (128M) is used.

I did not set the default in the api-platform.dev.ini because if I used the fallback empty string in the docker compose (that docker compose does not complain that it is not defined), the fallback in the php ini is not used.
Do not use api/.env to set the default value because we don't need that for prod. Another valid place to set the value would be the development stage in the docker build.

Issue: #8036

http://localhost:3000/api/_profiler/phpinfo
<img width="2382" height="84" alt="image" src="https://github.com/user-attachments/assets/26daf214-5d0a-410f-b2b1-a436a1094a18" />
