### PR TITLE
Use original state of CampCollaboration to vote on CampRole

### DIFF
--- a/api/src/Doctrine/Orm/GetOriginalEntityData.php
+++ b/api/src/Doctrine/Orm/GetOriginalEntityData.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Doctrine\Orm;
+
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\EntityManagerInterface;
+
+readonly class GetOriginalEntityData {
+    public function __construct(
+        private EntityManagerInterface $em
+    ) {}
+
+    public function getOriginal(object $entity): object {
+        $uow = $this->em->getUnitOfWork();
+        $changeSet = $uow->getEntityChangeSet($entity);
+        $classMetadata = $this->em->getClassMetadata(ClassUtils::getClass($entity));
+
+        $originalEntity = clone $entity;
+        $this->em->detach($originalEntity);
+        foreach ($changeSet as $key => $value) {
+            $classMetadata->setFieldValue($originalEntity, $key, $value[0]);
+        }
+
+        return $originalEntity;
+    }
+}

--- a/api/src/HttpCache/PurgeHttpCacheListener.php
+++ b/api/src/HttpCache/PurgeHttpCacheListener.php
@@ -24,11 +24,11 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use ApiPlatform\Metadata\Util\ClassInfoTrait;
+use App\Doctrine\Orm\GetOriginalEntityData;
 use App\Entity\BaseEntity;
 use App\Entity\HasId;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -39,12 +39,20 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 /**
  * Purges responses containing modified entities from the proxy cache.
  */
-final class PurgeHttpCacheListener {
+final readonly class PurgeHttpCacheListener {
     use ClassInfoTrait;
 
     public const IRI_RELATION_DELIMITER = '#';
 
-    public function __construct(private readonly IriConverterInterface $iriConverter, private readonly ResourceClassResolverInterface $resourceClassResolver, private readonly PropertyAccessorInterface $propertyAccessor, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly CacheManager $cacheManager) {}
+    public function __construct(
+        private IriConverterInterface $iriConverter,
+        private ResourceClassResolverInterface $resourceClassResolver,
+        private PropertyAccessorInterface $propertyAccessor,
+        private ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory,
+        private CacheManager $cacheManager,
+        private EntityManagerInterface $em,
+        private GetOriginalEntityData $getOriginalEntityData,
+    ) {}
 
     /**
      * Collects tags from the previous and the current version of the updated entities to purge related documents.
@@ -72,32 +80,27 @@ final class PurgeHttpCacheListener {
     /**
      * Collects tags from inserted, updated and deleted entities, including relations.
      */
-    public function onFlush(OnFlushEventArgs $eventArgs): void {
-        /** @var EntityManagerInterface */
-        $em = $eventArgs->getObjectManager();
-
-        if (!$em instanceof EntityManagerInterface) {
-            return;
-        }
-
-        $uow = $em->getUnitOfWork();
+    public function onFlush(): void {
+        $uow = $this->em->getUnitOfWork();
 
         foreach ($uow->getScheduledEntityInsertions() as $entity) {
-            $this->gatherResourceTags($em, $entity);
-            $this->gatherRelationTags($em, $entity);
+            $this->gatherResourceTags($entity);
+            $this->gatherRelationTags($entity);
         }
 
         foreach ($uow->getScheduledEntityUpdates() as $entity) {
-            $originalEntity = $this->getOriginalEntity($entity, $em);
+            /** @var BaseEntity $entity */
+            $originalEntity = $this->getOriginalEntityData->getOriginal($entity);
             $this->addTagForItem($entity);
-            $this->gatherResourceTags($em, $entity, $originalEntity);
+            $this->gatherResourceTags($entity, $originalEntity);
         }
 
         foreach ($uow->getScheduledEntityDeletions() as $entity) {
-            $originalEntity = $this->getOriginalEntity($entity, $em);
+            /** @var BaseEntity $entity */
+            $originalEntity = $this->getOriginalEntityData->getOriginal($entity);
             $this->addTagForItem($originalEntity);
-            $this->gatherResourceTags($em, $originalEntity);
-            $this->gatherRelationTags($em, $originalEntity);
+            $this->gatherResourceTags($originalEntity);
+            $this->gatherRelationTags($originalEntity);
         }
 
         // trigger cache purges for changes on many-to-many relations
@@ -136,29 +139,12 @@ final class PurgeHttpCacheListener {
     }
 
     /**
-     * Computes the original state of the entity based on the current entity and on the changeset.
-     */
-    private function getOriginalEntity($entity, $em) {
-        $uow = $em->getUnitOfWork();
-        $changeSet = $uow->getEntityChangeSet($entity);
-        $classMetadata = $em->getClassMetadata(ClassUtils::getClass($entity));
-
-        $originalEntity = clone $entity;
-        $em->detach($originalEntity);
-        foreach ($changeSet as $key => $value) {
-            $classMetadata->setFieldValue($originalEntity, $key, $value[0]);
-        }
-
-        return $originalEntity;
-    }
-
-    /**
      * Purges all collections (GetCollection operations), in which entity is listed on top level.
      *
      * If oldEntity is provided, purge is only done if the IRI of the collection has changed
      * (e.g. for updating period on a ScheduleEntry and the IRI changes from /periods/1/schedule_entries to /periods/2/schedule_entries)
      */
-    private function gatherResourceTags(EntityManagerInterface $em, object $entity, ?object $oldEntity = null): void {
+    private function gatherResourceTags(object $entity, ?object $oldEntity = null): void {
         $entityClass = $this->getObjectClass($entity);
         if (!$this->resourceClassResolver->isResourceClass($entityClass)) {
             return;
@@ -168,7 +154,7 @@ final class PurgeHttpCacheListener {
         $this->gatherResourceTagsForClass($resourceClass, $entity, $oldEntity);
 
         // also purge parent classes (e.g. /content_nodes)
-        $classMetadata = $em->getClassMetadata(ClassUtils::getClass($entity));
+        $classMetadata = $this->em->getClassMetadata(ClassUtils::getClass($entity));
         foreach ($classMetadata->parentClasses as $parentClass) {
             $this->gatherResourceTagsForClass($parentClass, $entity, $oldEntity);
         }
@@ -221,8 +207,8 @@ final class PurgeHttpCacheListener {
      *
      * @psalm-suppress UndefinedClass
      */
-    private function gatherRelationTags(EntityManagerInterface $em, object $entity): void {
-        $associationMappings = $em->getClassMetadata(ClassUtils::getClass($entity))->getAssociationMappings();
+    private function gatherRelationTags(object $entity): void {
+        $associationMappings = $this->em->getClassMetadata(ClassUtils::getClass($entity))->getAssociationMappings();
 
         foreach ($associationMappings as $property => $associationMapping) {
             if ($associationMapping instanceof AssociationMapping && ($associationMapping->targetEntity ?? null) && !$this->resourceClassResolver->isResourceClass($associationMapping->targetEntity)) {

--- a/api/src/Security/Voter/CampRoleVoter.php
+++ b/api/src/Security/Voter/CampRoleVoter.php
@@ -2,6 +2,7 @@
 
 namespace App\Security\Voter;
 
+use App\Doctrine\Orm\GetOriginalEntityData;
 use App\Entity\BelongsToCampInterface;
 use App\Entity\BelongsToContentNodeTreeInterface;
 use App\Entity\CampCollaboration;
@@ -27,7 +28,8 @@ class CampRoleVoter extends Voter {
 
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly ResponseTagger $responseTagger
+        private readonly ResponseTagger $responseTagger,
+        private readonly GetOriginalEntityData $getOriginalEntityData,
     ) {}
 
     protected function supports($attribute, $subject): bool {
@@ -48,6 +50,7 @@ class CampRoleVoter extends Voter {
         }
 
         $campCollaboration = $camp->collaborations
+            ->map(fn ($campCollaboration) => $this->getOriginalEntityData->getOriginal($campCollaboration))
             ->filter(self::withStatus(CampCollaboration::STATUS_ESTABLISHED))
             ->filter(self::ofUser($user))
             ->filter(self::withRole($attribute))

--- a/api/src/State/CampCollaborationUpdateProcessor.php
+++ b/api/src/State/CampCollaborationUpdateProcessor.php
@@ -4,13 +4,11 @@ namespace App\State;
 
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\CampCollaboration;
-use App\Entity\User;
 use App\Service\MailService;
 use App\State\Util\AbstractPersistProcessor;
 use App\State\Util\PropertyChangeListener;
 use App\Util\IdGenerator;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 
 /**
@@ -31,17 +29,9 @@ class CampCollaborationUpdateProcessor extends AbstractPersistProcessor {
             afterAction: fn (CampCollaboration $data) => $this->onAfterStatusChange($data)
         );
 
-        $roleChangeListener = PropertyChangeListener::of(
-            extractProperty: fn (CampCollaboration $data) => $data->role,
-            beforeAction: fn (CampCollaboration $data, CampCollaboration $previous) => $this->onBeforeRoleChange($data, $previous),
-        );
-
         parent::__construct(
             $decorated,
-            propertyChangeListeners: [
-                $statusChangeListener,
-                $roleChangeListener,
-            ]
+            propertyChangeListeners: [$statusChangeListener]
         );
     }
 
@@ -52,20 +42,6 @@ class CampCollaborationUpdateProcessor extends AbstractPersistProcessor {
         }
 
         return $data;
-    }
-
-    public function onBeforeRoleChange(CampCollaboration $data, CampCollaboration $previous): CampCollaboration {
-        /** @var User $user */
-        $user = $this->security->getUser();
-        // If the update does not affect the own collaboration, the voter works.
-        if ($data->user->getId() !== $user->getId()) {
-            return $data;
-        }
-        if (in_array($previous->role, [CampCollaboration::ROLE_MANAGER, CampCollaboration::ROLE_MEMBER], true)) {
-            return $data;
-        }
-
-        throw new HttpException(403, 'Not authorized to change role');
     }
 
     public function onAfterStatusChange(CampCollaboration $data): void {

--- a/api/src/State/Util/AbstractPersistProcessor.php
+++ b/api/src/State/Util/AbstractPersistProcessor.php
@@ -39,7 +39,7 @@ abstract class AbstractPersistProcessor implements ProcessorInterface {
                 $propertyBefore = call_user_func($listener->getExtractProperty(), $dataBefore);
                 $propertyNow = call_user_func($listener->getExtractProperty(), $data);
                 if ($propertyBefore !== $propertyNow) {
-                    $data = call_user_func($listener->getBeforeAction(), $data, $dataBefore);
+                    $data = call_user_func($listener->getBeforeAction(), $data);
                 }
             }
         }
@@ -53,7 +53,7 @@ abstract class AbstractPersistProcessor implements ProcessorInterface {
                 $propertyBefore = call_user_func($listener->getExtractProperty(), $dataBefore);
                 $propertyNow = call_user_func($listener->getExtractProperty(), $data);
                 if ($propertyBefore !== $propertyNow) {
-                    call_user_func($listener->getAfterAction(), $data, $dataBefore);
+                    call_user_func($listener->getAfterAction(), $data);
                 }
             }
         }

--- a/api/src/State/Util/PropertyChangeListener.php
+++ b/api/src/State/Util/PropertyChangeListener.php
@@ -26,11 +26,11 @@ class PropertyChangeListener {
         if (self::hasOneParameter($extractProperty)) {
             throw new \InvalidArgumentException('extractProperty must have exactly one parameter');
         }
-        if (self::hasAtMostTwoParameter($beforeAction)) {
-            throw new \InvalidArgumentException('afterAction must have between 1 and 2 parameters');
+        if (self::hasOneParameter($beforeAction)) {
+            throw new \InvalidArgumentException('afterAction must have exactly one parameter');
         }
-        if (self::hasAtMostTwoParameter($afterAction)) {
-            throw new \InvalidArgumentException('afterAction must have between 1 and 2 parameters');
+        if (self::hasOneParameter($afterAction)) {
+            throw new \InvalidArgumentException('afterAction must have exactly one parameter');
         }
 
         return new PropertyChangeListener($extractProperty, $beforeAction, $afterAction);
@@ -55,16 +55,5 @@ class PropertyChangeListener {
         $beforeActionReflectionFunction = new \ReflectionFunction($beforeAction);
 
         return 1 != $beforeActionReflectionFunction->getNumberOfParameters();
-    }
-
-    /**
-     * @throws \ReflectionException
-     */
-    private static function hasAtMostTwoParameter(?\Closure $beforeAction): bool {
-        $beforeActionReflectionFunction = new \ReflectionFunction($beforeAction);
-
-        $numberOfParameters = $beforeActionReflectionFunction->getNumberOfParameters();
-
-        return $numberOfParameters < 1 || $numberOfParameters > 2;
     }
 }

--- a/api/tests/Api/CampCollaborations/UpdateCampCollaborationTest.php
+++ b/api/tests/Api/CampCollaborations/UpdateCampCollaborationTest.php
@@ -338,6 +338,24 @@ class UpdateCampCollaborationTest extends ECampApiTestCase {
         $this->assertResponseStatusCodeSame(422);
     }
 
+    public function testRejectsPatchOwnCollaborationStatusFromInactiveToInvited() {
+        /** @var CampCollaboration $campCollaboration */
+        $campCollaboration = static::getFixture('campCollaboration5inactive');
+        static::createClientWithCredentials(credentials: ['email' => $campCollaboration->getEmail()])
+            ->request(
+                'PATCH',
+                '/camp_collaborations/'.$campCollaboration->getId(),
+                [
+                    'json' => [
+                        'status' => CampCollaboration::STATUS_INVITED,
+                    ],
+                    'headers' => ['Content-Type' => 'application/merge-patch+json'],
+                ]
+            )
+        ;
+        $this->assertResponseStatusCodeSame(404);
+    }
+
     public function testPatchCampCollaborationValidatesInvalidRole() {
         $campCollaboration = static::getFixture('campCollaboration1manager');
         static::createClientWithCredentials()->request('PATCH', '/camp_collaborations/'.$campCollaboration->getId(), ['json' => [

--- a/api/tests/Doctrine/Orm/GetOriginalDataIntegrationTest.php
+++ b/api/tests/Doctrine/Orm/GetOriginalDataIntegrationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Tests\Doctrine\Orm;
+
+use App\Doctrine\Orm\GetOriginalEntityData;
+use App\Entity\Profile;
+use App\Entity\User;
+use App\Tests\Api\ECampApiTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+
+use function PHPUnit\Framework\assertThat;
+use function PHPUnit\Framework\equalTo;
+use function PHPUnit\Framework\isFalse;
+use function PHPUnit\Framework\logicalNot;
+
+/**
+ * @internal
+ */
+class GetOriginalDataIntegrationTest extends ECampApiTestCase {
+    private EntityManagerInterface $em;
+    private GetOriginalEntityData $getOriginalEntityData;
+
+    public function setUp(): void {
+        parent::setUp();
+        $container = static::getContainer();
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->getOriginalEntityData = $container->get(GetOriginalEntityData::class);
+    }
+
+    public function testGetPreviousStateOfEntity() {
+        /** @var User $user */
+        $user = static::getFixture('user1manager');
+        $this->em->persist($user);
+        $previousState = $user->state;
+        assertThat($previousState, logicalNot(equalTo(User::STATE_NONREGISTERED)));
+
+        $user->state = User::STATE_NONREGISTERED;
+        $this->recomputeChangeSet($user);
+        $original = $this->getOriginalEntityData->getOriginal($user);
+
+        assertThat($original->state, equalTo($previousState));
+    }
+
+    public function testGetPreviousStateOfUnchangedEntity() {
+        /** @var User $user */
+        $user = static::getFixture('user1manager');
+        $this->em->persist($user);
+        $this->computeChangeSet($user);
+
+        $this->recomputeChangeSet($user);
+        $original = $this->getOriginalEntityData->getOriginal($user);
+
+        assertThat(isset($original->state), isFalse());
+    }
+
+    public function testGetPreviousStateOfNewEntity() {
+        $user = new User();
+        $user->profile = new Profile();
+        $user->profile->email = Uuid::uuid4().'@example.com';
+        $previousState = $user->state;
+        $this->em->persist($user);
+        $this->computeChangeSet($user);
+        assertThat($previousState, logicalNot(equalTo(User::STATE_REGISTERED)));
+
+        $user->state = User::STATE_REGISTERED;
+        $this->recomputeChangeSet($user);
+        $original = $this->getOriginalEntityData->getOriginal($user);
+
+        assertThat($original->state, equalTo($previousState));
+    }
+
+    public function testGetPreviousStateOfUnchangedNewEntity() {
+        $user = new User();
+        $user->profile = new Profile();
+        $user->profile->email = Uuid::uuid4().'@example.com';
+        $this->em->persist($user);
+        $this->computeChangeSet($user);
+
+        $this->recomputeChangeSet($user);
+        $original = $this->getOriginalEntityData->getOriginal($user);
+
+        assertThat(isset($original->state), isFalse());
+    }
+
+    private function computeChangeSet(User $user): void {
+        $this->em
+            ->getUnitOfWork()
+            ->computeChangeSet(
+                class: $this->em->getClassMetadata(get_class($user)),
+                entity: $user
+            )
+        ;
+    }
+
+    private function recomputeChangeSet(User $user): void {
+        $this->em
+            ->getUnitOfWork()
+            ->recomputeSingleEntityChangeSet(
+                class: $this->em->getClassMetadata(get_class($user)),
+                entity: $user
+            )
+        ;
+    }
+}

--- a/api/tests/HttpCache/PurgeHttpCacheListenerTest.php
+++ b/api/tests/HttpCache/PurgeHttpCacheListenerTest.php
@@ -23,6 +23,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
+use App\Doctrine\Orm\GetOriginalEntityData;
 use App\HttpCache\PurgeHttpCacheListener;
 use App\Tests\HttpCache\Entity\ContainNonResource;
 use App\Tests\HttpCache\Entity\Dummy;
@@ -60,7 +61,7 @@ class PurgeHttpCacheListenerTest extends TestCase {
 
     protected function setUp(): void {
         $this->cacheManagerProphecy = $this->prophesize(CacheManager::class);
-        $this->cacheManagerProphecy->flush(Argument::any())->willReturn(0);
+        $this->cacheManagerProphecy->flush()->willReturn(0);
 
         $this->resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
         $this->resourceClassResolverProphecy->isResourceClass(Argument::type('string'))->willReturn(true);
@@ -140,7 +141,7 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $cacheManagerProphecy->invalidateTags(['/dummies'])->willReturn($cacheManagerProphecy)->shouldBeCalled();
         $cacheManagerProphecy->invalidateTags(['/dummies/3'])->willReturn($cacheManagerProphecy)->shouldBeCalled();
         $cacheManagerProphecy->invalidateTags(['/dummies/4'])->willReturn($cacheManagerProphecy)->shouldBeCalled();
-        $cacheManagerProphecy->flush(Argument::any())->willReturn(0);
+        $cacheManagerProphecy->flush()->willReturn(0);
 
         $metadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $operation = (new GetCollection())->withShortName('Dummy')->withClass(Dummy::class);
@@ -184,7 +185,7 @@ class PurgeHttpCacheListenerTest extends TestCase {
 
         $emProphecy->getClassMetadata(Dummy::class)->willReturn($dummyClassMetadata)->shouldBeCalled();
         $emProphecy->getClassMetadata(DummyNoGetOperation::class)->willReturn(new ClassMetadata(DummyNoGetOperation::class))->shouldBeCalled();
-        $eventArgs = new OnFlushEventArgs($emProphecy->reveal());
+        $em = $emProphecy->reveal();
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->isReadable(Argument::type(Dummy::class), 'relatedDummy')->willReturn(true);
@@ -192,8 +193,16 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $propertyAccessorProphecy->getValue(Argument::type(Dummy::class), 'relatedDummy')->willReturn(null);
         $propertyAccessorProphecy->getValue(Argument::type(Dummy::class), 'relatedOwningDummy')->willReturn(null);
 
-        $listener = new PurgeHttpCacheListener($iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(), $metadataFactoryProphecy->reveal(), $cacheManagerProphecy->reveal());
-        $listener->onFlush($eventArgs);
+        $listener = new PurgeHttpCacheListener(
+            iriConverter: $iriConverterProphecy->reveal(),
+            resourceClassResolver: $resourceClassResolverProphecy->reveal(),
+            propertyAccessor: $propertyAccessorProphecy->reveal(),
+            resourceMetadataCollectionFactory: $metadataFactoryProphecy->reveal(),
+            cacheManager: $cacheManagerProphecy->reveal(),
+            em: $em,
+            getOriginalEntityData: new GetOriginalEntityData($em),
+        );
+        $listener->onFlush();
         $listener->postFlush();
     }
 
@@ -210,7 +219,7 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $cacheManagerProphecy = $this->prophesize(CacheManager::class);
         $cacheManagerProphecy->invalidateTags(['/related_dummies/old#dummies'])->shouldBeCalled()->willReturn($cacheManagerProphecy);
         $cacheManagerProphecy->invalidateTags(['/related_dummies/new#dummies'])->shouldBeCalled()->willReturn($cacheManagerProphecy);
-        $cacheManagerProphecy->flush(Argument::any())->willReturn(0);
+        $cacheManagerProphecy->flush()->willReturn(0);
 
         $metadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
 
@@ -228,11 +237,20 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $emProphecy->getClassMetadata(Dummy::class)->willReturn($classMetadata)->shouldBeCalled();
 
         $changeSet = ['relatedDummy' => [$oldRelatedDummy, $newRelatedDummy]];
-        $eventArgs = new PreUpdateEventArgs($dummy, $emProphecy->reveal(), $changeSet);
+        $em = $emProphecy->reveal();
+        $eventArgs = new PreUpdateEventArgs($dummy, $em, $changeSet);
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
 
-        $listener = new PurgeHttpCacheListener($iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(), $metadataFactoryProphecy->reveal(), $cacheManagerProphecy->reveal());
+        $listener = new PurgeHttpCacheListener(
+            iriConverter: $iriConverterProphecy->reveal(),
+            resourceClassResolver: $resourceClassResolverProphecy->reveal(),
+            propertyAccessor: $propertyAccessorProphecy->reveal(),
+            resourceMetadataCollectionFactory: $metadataFactoryProphecy->reveal(),
+            cacheManager: $cacheManagerProphecy->reveal(),
+            em: $em,
+            getOriginalEntityData: new GetOriginalEntityData($em),
+        );
         $listener->preUpdate($eventArgs);
         $listener->postFlush();
     }
@@ -246,7 +264,7 @@ class PurgeHttpCacheListenerTest extends TestCase {
 
         $cacheManagerProphecy = $this->prophesize(CacheManager::class);
         $cacheManagerProphecy->invalidateTags(Argument::any())->shouldNotBeCalled();
-        $cacheManagerProphecy->flush(Argument::any())->willReturn(0);
+        $cacheManagerProphecy->flush()->willReturn(0);
 
         $metadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
 
@@ -260,11 +278,20 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $emProphecy->getClassMetadata(DummyNoGetOperation::class)->willReturn($classMetadata)->shouldBeCalled();
 
         $changeSet = ['lorem' => 'ipsum'];
-        $eventArgs = new PreUpdateEventArgs($dummyNoGetOperation, $emProphecy->reveal(), $changeSet);
+        $em = $emProphecy->reveal();
+        $eventArgs = new PreUpdateEventArgs($dummyNoGetOperation, $em, $changeSet);
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
 
-        $listener = new PurgeHttpCacheListener($iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(), $metadataFactoryProphecy->reveal(), $cacheManagerProphecy->reveal());
+        $listener = new PurgeHttpCacheListener(
+            iriConverter: $iriConverterProphecy->reveal(),
+            resourceClassResolver: $resourceClassResolverProphecy->reveal(),
+            propertyAccessor: $propertyAccessorProphecy->reveal(),
+            resourceMetadataCollectionFactory: $metadataFactoryProphecy->reveal(),
+            cacheManager: $cacheManagerProphecy->reveal(),
+            em: $em,
+            getOriginalEntityData: new GetOriginalEntityData($em),
+        );
         $listener->preUpdate($eventArgs);
         $listener->postFlush();
     }
@@ -274,7 +301,7 @@ class PurgeHttpCacheListenerTest extends TestCase {
 
         $cacheManagerProphecy = $this->prophesize(CacheManager::class);
         $cacheManagerProphecy->invalidateTags(Argument::any())->shouldNotBeCalled();
-        $cacheManagerProphecy->flush(Argument::any())->willReturn(0);
+        $cacheManagerProphecy->flush()->willReturn(0);
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromResource($nonResource)->shouldNotBeCalled();
@@ -296,12 +323,21 @@ class PurgeHttpCacheListenerTest extends TestCase {
 
         $dummyClassMetadata = new ClassMetadata(ContainNonResource::class);
         $emProphecy->getClassMetadata(NotAResource::class)->willReturn($dummyClassMetadata);
-        $eventArgs = new OnFlushEventArgs($emProphecy->reveal());
+        $em = $emProphecy->reveal();
+        $eventArgs = new OnFlushEventArgs($em);
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
 
-        $listener = new PurgeHttpCacheListener($iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(), $metadataFactoryProphecy->reveal(), $cacheManagerProphecy->reveal());
-        $listener->onFlush($eventArgs);
+        $listener = new PurgeHttpCacheListener(
+            iriConverter: $iriConverterProphecy->reveal(),
+            resourceClassResolver: $resourceClassResolverProphecy->reveal(),
+            propertyAccessor: $propertyAccessorProphecy->reveal(),
+            resourceMetadataCollectionFactory: $metadataFactoryProphecy->reveal(),
+            cacheManager: $cacheManagerProphecy->reveal(),
+            em: $em,
+            getOriginalEntityData: new GetOriginalEntityData($em),
+        );
+        $listener->onFlush();
     }
 
     public function testPropertyIsNotAResourceClass(): void {
@@ -310,7 +346,7 @@ class PurgeHttpCacheListenerTest extends TestCase {
 
         $cacheManagerProphecy = $this->prophesize(CacheManager::class);
         $cacheManagerProphecy->invalidateTags(Argument::any())->shouldNotBeCalled();
-        $cacheManagerProphecy->flush(Argument::any())->willReturn(0);
+        $cacheManagerProphecy->flush()->willReturn(0);
 
         $metadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $metadataFactoryProphecy->create(ContainNonResource::class)->willReturn(new ResourceMetadataCollection('ContainNonResource', [
@@ -341,7 +377,8 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $dummyClassMetadata->mapManyToOne(['fieldName' => 'notAResource', 'targetEntity' => NotAResource::class, 'inversedBy' => 'resources']);
         $dummyClassMetadata->mapOneToMany(['fieldName' => 'collectionOfNotAResource', 'targetEntity' => NotAResource::class, 'mappedBy' => 'resource']);
         $emProphecy->getClassMetadata(ContainNonResource::class)->willReturn($dummyClassMetadata);
-        $eventArgs = new OnFlushEventArgs($emProphecy->reveal());
+        $em = $emProphecy->reveal();
+        $eventArgs = new OnFlushEventArgs($em);
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
         $propertyAccessorProphecy->isReadable(Argument::type(ContainNonResource::class), 'notAResource')->willReturn(true);
@@ -349,8 +386,16 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $propertyAccessorProphecy->getValue(Argument::type(ContainNonResource::class), 'notAResource')->shouldNotBeCalled();
         $propertyAccessorProphecy->getValue(Argument::type(ContainNonResource::class), 'collectionOfNotAResource')->shouldNotBeCalled();
 
-        $listener = new PurgeHttpCacheListener($iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(), $metadataFactoryProphecy->reveal(), $cacheManagerProphecy->reveal());
-        $listener->onFlush($eventArgs);
+        $listener = new PurgeHttpCacheListener(
+            iriConverter: $iriConverterProphecy->reveal(),
+            resourceClassResolver: $resourceClassResolverProphecy->reveal(),
+            propertyAccessor: $propertyAccessorProphecy->reveal(),
+            resourceMetadataCollectionFactory: $metadataFactoryProphecy->reveal(),
+            cacheManager: $cacheManagerProphecy->reveal(),
+            em: $em,
+            getOriginalEntityData: new GetOriginalEntityData($em),
+        );
+        $listener->onFlush();
     }
 
     /**
@@ -375,8 +420,18 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $this->cacheManagerProphecy->invalidateTags(['/related_dummies/100/dummies'])->willReturn($this->cacheManagerProphecy)->shouldBeCalled();
 
         // when
-        $listener = new PurgeHttpCacheListener($this->iriConverterProphecy->reveal(), $this->resourceClassResolverProphecy->reveal(), $this->propertyAccessorProphecy->reveal(), $this->metadataFactoryProphecy->reveal(), $this->cacheManagerProphecy->reveal());
-        $listener->onFlush(new OnFlushEventArgs($this->emProphecy->reveal()));
+
+        $em = $this->emProphecy->reveal();
+        $listener = new PurgeHttpCacheListener(
+            iriConverter: $this->iriConverterProphecy->reveal(),
+            resourceClassResolver: $this->resourceClassResolverProphecy->reveal(),
+            propertyAccessor: $this->propertyAccessorProphecy->reveal(),
+            resourceMetadataCollectionFactory: $this->metadataFactoryProphecy->reveal(),
+            cacheManager: $this->cacheManagerProphecy->reveal(),
+            em: $em,
+            getOriginalEntityData: new GetOriginalEntityData($em),
+        );
+        $listener->onFlush();
         $listener->postFlush();
     }
 
@@ -404,8 +459,18 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $this->cacheManagerProphecy->invalidateTags(['/related_dummies/100/dummies'])->willReturn($this->cacheManagerProphecy)->shouldBeCalled();
 
         // when
-        $listener = new PurgeHttpCacheListener($this->iriConverterProphecy->reveal(), $this->resourceClassResolverProphecy->reveal(), $this->propertyAccessorProphecy->reveal(), $this->metadataFactoryProphecy->reveal(), $this->cacheManagerProphecy->reveal());
-        $listener->onFlush(new OnFlushEventArgs($this->emProphecy->reveal()));
+
+        $em = $this->emProphecy->reveal();
+        $listener = new PurgeHttpCacheListener(
+            iriConverter: $this->iriConverterProphecy->reveal(),
+            resourceClassResolver: $this->resourceClassResolverProphecy->reveal(),
+            propertyAccessor: $this->propertyAccessorProphecy->reveal(),
+            resourceMetadataCollectionFactory: $this->metadataFactoryProphecy->reveal(),
+            cacheManager: $this->cacheManagerProphecy->reveal(),
+            em: $em,
+            getOriginalEntityData: new GetOriginalEntityData($em),
+        );
+        $listener->onFlush();
         $listener->postFlush();
     }
 
@@ -436,8 +501,18 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $this->cacheManagerProphecy->invalidateTags(['/related_dummies/99/dummies'])->willReturn($this->cacheManagerProphecy)->shouldBeCalled();
 
         // when
-        $listener = new PurgeHttpCacheListener($this->iriConverterProphecy->reveal(), $this->resourceClassResolverProphecy->reveal(), $this->propertyAccessorProphecy->reveal(), $this->metadataFactoryProphecy->reveal(), $this->cacheManagerProphecy->reveal());
-        $listener->onFlush(new OnFlushEventArgs($this->emProphecy->reveal()));
+
+        $em = $this->emProphecy->reveal();
+        $listener = new PurgeHttpCacheListener(
+            iriConverter: $this->iriConverterProphecy->reveal(),
+            resourceClassResolver: $this->resourceClassResolverProphecy->reveal(),
+            propertyAccessor: $this->propertyAccessorProphecy->reveal(),
+            resourceMetadataCollectionFactory: $this->metadataFactoryProphecy->reveal(),
+            cacheManager: $this->cacheManagerProphecy->reveal(),
+            em: $em,
+            getOriginalEntityData: new GetOriginalEntityData($em),
+        );
+        $listener->onFlush();
         $listener->postFlush();
     }
 }

--- a/api/tests/Security/Voter/CampRoleVoterTest.php
+++ b/api/tests/Security/Voter/CampRoleVoterTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Security\Voter;
 
+use App\Doctrine\Orm\GetOriginalEntityData;
 use App\Entity\Activity;
 use App\Entity\BaseEntity;
 use App\Entity\BelongsToContentNodeTreeInterface;
@@ -14,6 +15,7 @@ use App\HttpCache\ResponseTagger;
 use App\Security\Voter\CampRoleVoter;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -27,13 +29,29 @@ class CampRoleVoterTest extends TestCase {
     private MockObject|TokenInterface $token;
     private EntityManagerInterface|MockObject $em;
     private MockObject|ResponseTagger $responseTagger;
+    private GetOriginalEntityData|MockObject $getOriginalEntityData;
+
+    private ?object $getOriginalEntityReturnValue;
 
     public function setUp(): void {
         parent::setUp();
         $this->token = $this->createMock(TokenInterface::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
         $this->responseTagger = $this->createMock(ResponseTagger::class);
-        $this->voter = new CampRoleVoter($this->em, $this->responseTagger);
+        $unitOfWork = $this->createMock(UnitOfWork::class);
+        $this->em->method('getUnitOfWork')->willReturn($unitOfWork);
+        $this->getOriginalEntityData = self::createMock(GetOriginalEntityData::class);
+        $this->getOriginalEntityReturnValue = null;
+        $this->getOriginalEntityData->method('getOriginal')
+            ->willReturnCallback(function ($entity) {
+                if (null != $this->getOriginalEntityReturnValue) {
+                    return $this->getOriginalEntityReturnValue;
+                }
+
+                return $entity;
+            })
+        ;
+        $this->voter = new CampRoleVoter($this->em, $this->responseTagger, $this->getOriginalEntityData);
     }
 
     public function testDoesntVoteWhenAttributeWrong() {
@@ -211,6 +229,31 @@ class CampRoleVoterTest extends TestCase {
         $this->assertSame(VoterInterface::ACCESS_DENIED, $result);
     }
 
+    public function testDeniesAccessWhenMatchingCampCollaborationIsMemberBeforeTransaction() {
+        // given
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn('idFromTest');
+        $user2 = $this->createMock(User::class);
+        $user2->method('getId')->willReturn('idFromTest');
+        $this->token->method('getUser')->willReturn($user);
+        $collaboration = new CampCollaboration();
+        $collaboration->user = $user2;
+        $collaboration->status = CampCollaboration::STATUS_INVITED;
+        $collaboration->role = CampCollaboration::ROLE_MANAGER;
+        $this->getOriginalEntityReturnValue = clone $collaboration;
+        $this->getOriginalEntityReturnValue->role = CampCollaboration::ROLE_MEMBER;
+        $camp = new Camp();
+        $camp->collaborations->add($collaboration);
+        $subject = $this->createMock(Period::class);
+        $subject->method('getCamp')->willReturn($camp);
+
+        // when
+        $result = $this->voter->vote($this->token, $subject, ['CAMP_COLLABORATOR']);
+
+        // then
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $result);
+    }
+
     public function testGrantsAccessViaBelongsToCampInterface() {
         // given
         $user = $this->createMock(User::class);
@@ -231,6 +274,33 @@ class CampRoleVoterTest extends TestCase {
 
         // when
         $result = $this->voter->vote($this->token, $subject, ['CAMP_COLLABORATOR']);
+
+        // then
+        $this->assertSame(VoterInterface::ACCESS_GRANTED, $result);
+    }
+
+    public function testGrantsAccessViaBelongsToCampInterfaceWhenWasManagerBefore() {
+        // given
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn('idFromTest');
+        $user2 = $this->createMock(User::class);
+        $user2->method('getId')->willReturn('idFromTest');
+        $this->token->method('getUser')->willReturn($user);
+        $collaboration = new CampCollaboration();
+        $collaboration->user = $user2;
+        $collaboration->status = CampCollaboration::STATUS_ESTABLISHED;
+        $collaboration->role = CampCollaboration::ROLE_GUEST;
+        $this->getOriginalEntityReturnValue = clone $collaboration;
+        $this->getOriginalEntityReturnValue->role = CampCollaboration::ROLE_MANAGER;
+        $camp = new Camp();
+        $camp->collaborations->add($collaboration);
+        $subject = $this->createMock(Period::class);
+        $subject->method('getCamp')->willReturn($camp);
+
+        $this->responseTagger->expects($this->once())->method('addTags')->with([$collaboration->getId()]);
+
+        // when
+        $result = $this->voter->vote($this->token, $subject, ['CAMP_MANAGER']);
 
         // then
         $this->assertSame(VoterInterface::ACCESS_GRANTED, $result);


### PR DESCRIPTION
refactor/api: extract GetOriginalEntityData from PurgeHttpCacheListener

And inject the EntityManager via dependencyInjection.
This makes the tests and usage way easier.

---

api: use the previous state of CampCollaboration to check ACL

This is a better solution than doing this
in the UpdateProcessor.
Could not use UnitOfWork::getOriginalEntityData, this blocked until the process was interrupted in the tests.
This also reverts commit af316509f15d045d76825c7c806d5252fae061cf.

