### PR TITLE
The period filter is single-select

### DIFF
--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -270,8 +270,9 @@ export default {
 
     this.camp.periods()._meta.load.then(({ allItems }) => {
       const collection = allItems.map((entry) => entry._meta.self)
-      this.filter.period =
-        this.filter.period?.filter((value) => collection.includes(value)) ?? null
+      if (!collection.includes(this.filter.period)) {
+        this.filter.period = null
+      }
       this.loadingEndpoints.periods = false
     })
   },


### PR DESCRIPTION
Fixes #7773

To reproduce the error, visit Dev: https://dev.ecamp3.ch/camps/6973c230d6b1/Sola-2023/dashboard?period=fe47dfd2b541
To check the fix, visit the same URL on an instance with the fix.

Error state before the fix (stays like this forever):
<img width="900" height="225" alt="image" src="https://github.com/user-attachments/assets/d1f293e6-0220-4b2a-8dac-f6e77b17e704" />
