### PR TITLE
Fix checklist node in client print

### DIFF
--- a/api/src/Entity/ContentNode/ChecklistNode.php
+++ b/api/src/Entity/ContentNode/ChecklistNode.php
@@ -53,7 +53,7 @@ class ChecklistNode extends ContentNode {
     /**
      * List of selected ChecklistItems.
      */
-    #[ApiProperty(example: '["/checklist_items/1a2b3c4d"]')]
+    #[ApiProperty(example: '["/checklist_items/1a2b3c4d"]', readableLink: true)]
     #[Groups(['read'])]
     #[ORM\ManyToMany(targetEntity: ChecklistItem::class, inversedBy: 'checklistNodes')]
     #[ORM\JoinTable(name: 'checklistnode_checklistitem')]

--- a/api/src/Entity/ContentNode/ChecklistNode.php
+++ b/api/src/Entity/ContentNode/ChecklistNode.php
@@ -53,7 +53,7 @@ class ChecklistNode extends ContentNode {
     /**
      * List of selected ChecklistItems.
      */
-    #[ApiProperty(example: '["/checklist_items/1a2b3c4d"]', readableLink: true)]
+    #[ApiProperty(example: '["/checklist_items/1a2b3c4d"]')]
     #[Groups(['read'])]
     #[ORM\ManyToMany(targetEntity: ChecklistItem::class, inversedBy: 'checklistNodes')]
     #[ORM\JoinTable(name: 'checklistnode_checklistitem')]

--- a/pdf/src/campPrint/scheduleEntry/ScheduleEntry.vue
+++ b/pdf/src/campPrint/scheduleEntry/ScheduleEntry.vue
@@ -18,12 +18,20 @@ export default {
   name: 'ScheduleEntry',
   components: { ScheduleEntryTitle, ContentNode },
   extends: PdfComponent,
+  provide() {
+    return {
+      camp: this.camp,
+    }
+  },
   props: {
     scheduleEntry: { type: Object, required: true },
   },
   computed: {
     activity() {
       return this.scheduleEntry.activity()
+    },
+    camp() {
+      return this.activity.camp()
     },
   },
 }

--- a/pdf/src/campPrint/scheduleEntry/contentNode/Checklist.vue
+++ b/pdf/src/campPrint/scheduleEntry/contentNode/Checklist.vue
@@ -19,6 +19,7 @@
 <script setup>
 import uniqWith from 'lodash-es/uniqWith.js'
 import sortBy from 'lodash-es/sortBy.js'
+import { inject } from 'vue'
 
 const props = defineProps({
   contentNode: { type: Object, required: true },
@@ -31,18 +32,27 @@ function calculateItemNumber(item) {
 
   return calculateItemNumber(item.parent()) + '.' + (item.position + 1)
 }
-const items = props.contentNode.checklistItems().items.map((item) => {
-  const number = calculateItemNumber(item)
-  return {
-    ...item,
-    number,
-  }
-})
+
+const camp = inject('camp')
+const allChecklists = camp.checklists().items
+const allItems = allChecklists.flatMap((checklist) => checklist.checklistItems().items)
+const items = allItems
+  .filter((item) => {
+    const connectedChecklistNodes = item
+      .checklistNodes()
+      .items.map((checklistNode) => checklistNode._meta.self)
+    return connectedChecklistNodes.includes(props.contentNode._meta.self)
+  })
+  .map((item) => {
+    const number = calculateItemNumber(item)
+    return {
+      ...item,
+      number,
+    }
+  })
 
 const checklists = uniqWith(
-  props.contentNode
-    .checklistItems()
-    .items.map((checklistItem) => checklistItem.checklist()),
+  items.map((checklistItem) => checklistItem.checklist()),
   function (checklist1, checklist2) {
     return checklist1._meta.self === checklist2._meta.self
   }

--- a/pdf/src/prepareInMainThread.js
+++ b/pdf/src/prepareInMainThread.js
@@ -93,7 +93,14 @@ export async function prepareInMainThread(config) {
         }),
       camp.materialLists().$loadItems(),
       config.apiGet().contentTypes().$loadItems(),
-      camp.checklists().$loadItems(),
+      camp
+        .checklists()
+        .$loadItems()
+        .then((checklists) => {
+          return Promise.all(
+            checklists.items.map((checklist) => checklist.checklistItems()._meta.load)
+          )
+        }),
       config
         .apiGet()
         .checklistItems({


### PR DESCRIPTION
Problem: I noticed that when reloading the print configurator page and then client printing a program with some activities with checklist nodes in it, the checklist nodes remain blank.

I then found out that inside client print some data is not properly preloaded before printing. Inside each checklist node, there is a _linked collection `checklistItems: { href: /api/checklist_items?checklistNodes=/api/content_node/checklist_nodes/1a2b3c4d }`. Although all individual checklist items are present in the store, this filtered collection is missing. For material nodes and their attached material items, we don't have this problem.

Detailed problem 1: In client print, we need this missing data to render the PDF correctly. This PR is an attempt to fix this problem, so that PDFs can be rendered complete with all content. I am doing this by embedding the checklist items in each checklist node, just like we already do with material items in material nodes.

Detailed problem 2: Currently, client print does not fail and report the error, but silently renders an empty Vue component, leaving an empty space in the PDF. This is due to Vue 3 aggressively catching errors which happen in `setup` functions, and not escalating them to outside the Vue app by default. This will be tackled in a separate PR #8128, so we get all errors in client print in sentry.

If we first solved detailed problem 2, then exporting pdfs would break. Therefore, I am first opening this PR and later a fix for detailed problem 2.