### PR TITLE
Tell Vue it's fine to admit errors, we can handle it

### DIFF
--- a/pdf/src/renderer/vueRenderer.js
+++ b/pdf/src/renderer/vueRenderer.js
@@ -22,6 +22,8 @@ export function renderVueToPdfStructure(root, props = {}, onProgress = async () 
     },
     props
   )
+  app.config.throwUnhandledErrorInProduction = true
+
   app.mount(container)
 
   return container.doc


### PR DESCRIPTION
This is the solution to the second detailed problem in #8126. Please merge this together with or after #8126, so that client print doesn't stop working due to missing the fix in #8126.

In client print, if an error happens during the Vue rendering, we want that error to be thrown out of the application. The error will then bubble up to the top level of the worker thread, be caught and relayed by Comlink and then in the main thread reported to Sentry and an error indicator displayed to the user.

However, Vue 3 by default catches all errors and logs them to the console, because normally a Vue app isn't embedded inside of another app. We now explicitely tell Vue to pass errors on without swallowing them.

I tested this locally with an error in a setup script and an error in a computed. Will try to test it on the feature branch deployment too, for a more realistic simulation of production.