### PR TITLE
frontend: silence deprecations inherited from vuetify

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -149,11 +149,13 @@ export default defineConfig(({ mode }) => ({
         // support for legacy api will be removed in vite 7. https://vite.dev/guide/migration.html#sass-now-uses-modern-api-by-default
         api: 'legacy',
         additionalData: '@import "./node_modules/vuetify/src/styles/styles.sass";\n', // original default variables from vuetify
+        silenceDeprecations: ['slash-div', 'mixed-decls'],
       },
       sass: {
         // support for legacy api will be removed in vite 7. https://vite.dev/guide/migration.html#sass-now-uses-modern-api-by-default
         api: 'legacy',
         additionalData: '@import "./src/scss/variables.scss"\n', // vuetify variable overrides
+        silenceDeprecations: ['slash-div', 'mixed-decls'],
       },
     },
   },


### PR DESCRIPTION
It helps nobody when we see them.

See https://github.com/ecamp/ecamp3/actions/runs/17700081924/job/50304629252?pr=8179
vs https://github.com/ecamp/ecamp3/actions/runs/17637342875/job/50116232917