### PR TITLE
api: fix  "Symfony\Component\PropertyInfo\Type" class is deprecated

### DIFF
--- a/api/src/Doctrine/Filter/ContentNodeCampFilter.php
+++ b/api/src/Doctrine/Filter/ContentNodeCampFilter.php
@@ -12,8 +12,8 @@ use App\Repository\FiltersByCampCollaboration;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\TypeInfo\Type;
 
 final class ContentNodeCampFilter extends AbstractFilter {
     use FiltersByCampCollaboration;
@@ -34,7 +34,7 @@ final class ContentNodeCampFilter extends AbstractFilter {
     public function getDescription(string $resourceClass): array {
         return ['camp' => [
             'property' => self::CAMP_QUERY_NAME,
-            'type' => Type::BUILTIN_TYPE_STRING,
+            'type' => Type::string()->__toString(),
             'required' => false,
         ]];
     }

--- a/api/src/Doctrine/Filter/ContentNodeIsRootFilter.php
+++ b/api/src/Doctrine/Filter/ContentNodeIsRootFilter.php
@@ -9,8 +9,8 @@ use App\Entity\ContentNode;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\TypeInfo\Type;
 
 final class ContentNodeIsRootFilter extends AbstractFilter {
     public const IS_ROOT_QUERY_NAME = 'isRoot';
@@ -28,7 +28,7 @@ final class ContentNodeIsRootFilter extends AbstractFilter {
     public function getDescription(string $resourceClass): array {
         return ['isRoot' => [
             'property' => self::IS_ROOT_QUERY_NAME,
-            'type' => Type::BUILTIN_TYPE_BOOL,
+            'type' => Type::bool()->__toString(),
             'required' => false,
         ]];
     }

--- a/api/src/Doctrine/Filter/ContentNodePeriodFilter.php
+++ b/api/src/Doctrine/Filter/ContentNodePeriodFilter.php
@@ -13,8 +13,8 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\TypeInfo\Type;
 
 final class ContentNodePeriodFilter extends AbstractFilter {
     use FiltersByCampCollaboration;
@@ -35,7 +35,7 @@ final class ContentNodePeriodFilter extends AbstractFilter {
     public function getDescription(string $resourceClass): array {
         return ['period' => [
             'property' => self::PERIOD_QUERY_NAME,
-            'type' => Type::BUILTIN_TYPE_STRING,
+            'type' => Type::string()->__toString(),
             'required' => false,
         ]];
     }

--- a/api/src/Doctrine/Filter/MaterialItemPeriodFilter.php
+++ b/api/src/Doctrine/Filter/MaterialItemPeriodFilter.php
@@ -11,8 +11,8 @@ use App\Entity\PeriodMaterialItem;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\TypeInfo\Type;
 
 final class MaterialItemPeriodFilter extends AbstractFilter {
     public const PERIOD_QUERY_NAME = 'period';
@@ -31,7 +31,7 @@ final class MaterialItemPeriodFilter extends AbstractFilter {
     public function getDescription(string $resourceClass): array {
         return ['period' => [
             'property' => self::PERIOD_QUERY_NAME,
-            'type' => Type::BUILTIN_TYPE_STRING,
+            'type' => Type::string()->__toString(),
             'required' => false,
         ]];
     }

--- a/api/tests/Serializer/PreventAutomaticEmbeddingPropertyMetadataFactoryTest.php
+++ b/api/tests/Serializer/PreventAutomaticEmbeddingPropertyMetadataFactoryTest.php
@@ -6,7 +6,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use App\Serializer\PreventAutomaticEmbeddingPropertyMetadataFactory;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\PropertyInfo\Type as PropertyInfoType;
+use Symfony\Component\TypeInfo\Type;
 
 /**
  * @internal
@@ -35,7 +35,7 @@ class PreventAutomaticEmbeddingPropertyMetadataFactoryTest extends TestCase {
             security: true,
             securityPostDenormalize: 'securityPostDenormalize',
             types: ['types'],
-            builtinTypes: [new PropertyInfoType(builtinType: PropertyInfoType::BUILTIN_TYPE_INT)],
+            builtinTypes: [Type::int()],
             schema: ['schema'],
             initializable: true,
             iris: ['iris'],


### PR DESCRIPTION
Use "Symfony\Component\TypeInfo\Type" class from "symfony/type-info" instead.