### PR TITLE
Wait a bit before installing new package versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   },
   "automergeType": "branch",
   "rebaseWhen": "conflicted",
+  "minimumReleaseAge": "7 days",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["on wednesday and thursday"]


### PR DESCRIPTION
There has been a series of attacks on npm packages recently:
https://decipher.sc/2025/09/08/targeted-attack-compromises-popular-npm-packages/
https://www.aikido.dev/blog/s1ngularity-nx-attackers-strike-again

This leads to compromising the machines of devs, and from there automatically infects npm packages to which the dev (or CI pipeline) has publishing access, or GitHub push access. This commit is a band-aid quick fix, so we don't install the bleeding edge new package the minute it comes out. So far, package maintainers and NPM have been relatively quick to find and yank the infected packages. This is not guaranteed to protect us, but it should make it harder for us to automatically get infected.

For reference, the renovate docs on this option:
https://docs.renovatebot.com/configuration-options/#minimumreleaseage