### PR TITLE
.docker-hub: make context for varnish smaller

### DIFF
--- a/.docker-hub/docker-compose.yml
+++ b/.docker-hub/docker-compose.yml
@@ -24,5 +24,5 @@ services:
   varnish-image:
     image: ${REGISTRY:-docker.io}/${REPO_OWNER:-ecamp}/ecamp3-varnish:${VERSION:-latest}
     build:
-      context: ../
-      dockerfile: .docker-hub/varnish/Dockerfile
+      context: varnish
+      dockerfile: Dockerfile


### PR DESCRIPTION
That we don't have to build the image when it did not change. We don't copy anything into the image, so we use no context.