### PR TITLE
api: revert workaround for update to doctrine/orm 3

### DIFF
--- a/.github/workflows/continuous-integration-optional.yml
+++ b/.github/workflows/continuous-integration-optional.yml
@@ -136,5 +136,5 @@ jobs:
       - run: php bin/console doctrine:migrations:migrate --no-interaction -e test
         working-directory: api
 
-      - run: php bin/console doctrine:schema:validate --skip-sync -e test && php bin/console doctrine:migrations:up-to-date -e test && ! php bin/console doctrine:migrations:diff -e test --namespace DoctrineMigrations
+      - run: php bin/console doctrine:schema:validate -v -e test
         working-directory: api


### PR DESCRIPTION
Reverts commit 43ede76.
This was fixed with https://github.com/doctrine/DoctrineMigrationsBundle/releases/tag/3.4.0 I don't know how, but it seems fixed:
https://github.com/doctrine/migrations/issues/1406#issuecomment-2596839269

Test that a field is missing: https://github.com/BacLuc/ecamp3/actions/runs/18043972874/job/51350027199
Test that a migration is missing: https://github.com/BacLuc/ecamp3/actions/runs/18043962155/job/51349986629