### PR TITLE
reverse-proxy-nginx.conf: forward X-Forwarded-Host header

### DIFF
--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -10,6 +10,7 @@ framework:
     # See https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers
     trusted_headers:
         - 'x-forwarded-for'
+        - 'x-forwarded-host'
         - 'x-forwarded-prefix'
         - 'x-forwarded-proto'
 

--- a/reverse-proxy-nginx.conf
+++ b/reverse-proxy-nginx.conf
@@ -61,6 +61,7 @@ http {
       proxy_buffer_size 128k;
       proxy_buffers 4 256k;
       proxy_busy_buffers_size 256k;
+      proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-Prefix /api;
       proxy_pass http://api/;
       proxy_set_header Upgrade $http_upgrade;
@@ -102,6 +103,7 @@ http {
       proxy_buffer_size 128k;
       proxy_buffers 4 256k;
       proxy_busy_buffers_size 256k;
+      proxy_set_header X-Forwarded-Host $http_host;
       proxy_set_header X-Forwarded-Prefix /api;
       proxy_pass http://http-cache/;
       proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
That the symfony toolbar works again.
fixes #7207

Do not change the ingress config yet because there we don't have a problem.