### PR TITLE
Kill processes that don't want to listen to SIGTERM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - CI=${CI}
     working_dir: /app
     command: ./docker-setup.sh
+    stop_signal: SIGKILL
     depends_on:
       - pdf
 
@@ -91,6 +92,7 @@ services:
       - ./.cache/npm:/home/node/.npm
     working_dir: /app
     command: ./docker-setup.sh
+    stop_signal: SIGKILL
     environment:
       - NODE_ENV=development
       - NPM_CONFIG_UPDATE_NOTIFIER=false
@@ -118,6 +120,7 @@ services:
       - ./print/print.env
     working_dir: /app
     command: ./docker-setup.sh
+    stop_signal: SIGKILL
 
   database:
     image: postgres:15-alpine
@@ -208,6 +211,7 @@ services:
       - target: 3004
         published: 3004
         protocol: tcp
+    stop_signal: SIGKILL
 
   translation:
     image: node:24.8.0


### PR DESCRIPTION
Speeds up stopping the dev containers.

Before (>20s):
```
Gracefully stopping... (press Ctrl+C again to force)
[+] Stopping 12/12
 ✔ Container ecamp3-reverse-proxy          Stopped                                                                                     10.2s 
 ✔ Container ecamp3-print                  Stopped                                                                                     10.1s 
 ✔ Container ecamp3-browserless            Stopped                                                                                      0.2s 
 ✔ Container ecamp3-http-cache-logs        Stopped                                                                                      0.2s 
 ✔ Container ecamp3-pg-admin               Stopped                                                                                      1.5s 
 ✔ Container ecamp3-mail                   Stopped                                                                                      0.2s 
 ✔ Container ecamp3-http-cache             Stopped                                                                                      0.2s 
 ✔ Container ecamp3-frontend               Stopped                                                                                     10.2s 
 ✔ Container ecamp3-api                    Stopped                                                                                      0.2s 
 ✔ Container ecamp3-database               Stopped                                                                                      0.2s 
 ✔ Container ecamp3-docker-host-forwarder  Stopped                                                                                      0.1s 
 ✔ Container ecamp3-pdf                    Stopped                                                                                     10.2s
```

After (~2s):
```
Gracefully stopping... (press Ctrl+C again to force)
[+] Stopping 12/12
 ✔ Container ecamp3-browserless            Stopped                                                                                      0.3s 
 ✔ Container ecamp3-pg-admin               Stopped                                                                                      1.5s 
 ✔ Container ecamp3-http-cache-logs        Stopped                                                                                      0.2s 
 ✔ Container ecamp3-print                  Stopped                                                                                      0.4s 
 ✔ Container ecamp3-mail                   Stopped                                                                                      0.2s 
 ✔ Container ecamp3-reverse-proxy          Stopped                                                                                      0.3s 
 ✔ Container ecamp3-http-cache             Stopped                                                                                      0.2s 
 ✔ Container ecamp3-frontend               Stopped                                                                                      0.2s 
 ✔ Container ecamp3-api                    Stopped                                                                                      0.1s 
 ✔ Container ecamp3-pdf                    Stopped                                                                                      0.1s 
 ✔ Container ecamp3-docker-host-forwarder  Stopped                                                                                      0.1s 
 ✔ Container ecamp3-database               Stopped                                                                                      0.2s
```

The stop is less graceful, but these processes did nothing to shut down gracefully anyways.