### PR TITLE
Fix deployment PR summary again

### DIFF
--- a/.github/workflows/summarize-changes-on-staging-and-prod-prs.yml
+++ b/.github/workflows/summarize-changes-on-staging-and-prod-prs.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           regex: ".*"
+          regexFlags: s
           content: |
             ### <span aria-hidden="true">🏗️</span> Changes in this deployment
 


### PR DESCRIPTION
Without the regex flag, only the first line of the current PR description is matched and replaced. With the flag, the whole PR description is matched and replaced.
See https://github.com/nefrob/pr-description?tab=readme-ov-file#example-workflows