### PR TITLE
Add ContentNodeCollectionProvider to all ContentNode-Entities

### DIFF
--- a/api/src/Entity/ContentNode/ChecklistNode.php
+++ b/api/src/Entity/ContentNode/ChecklistNode.php
@@ -13,6 +13,7 @@ use App\Entity\ChecklistItem;
 use App\Entity\ContentNode;
 use App\Repository\ChecklistNodeRepository;
 use App\State\ContentNode\ChecklistNodePersistProcessor;
+use App\State\ContentNodeCollectionProvider;
 use App\Util\EntityMap;
 use App\Validator\ChecklistItem\AssertBelongsToSameCamp;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -36,7 +37,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
             security: '(is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)) and object.parent !== null'
         ),
         new GetCollection(
-            security: 'is_authenticated()'
+            security: 'is_authenticated()',
+            provider: ContentNodeCollectionProvider::class
         ),
         new Post(
             processor: ChecklistNodePersistProcessor::class,

--- a/api/src/Entity/ContentNode/ColumnLayout.php
+++ b/api/src/Entity/ContentNode/ColumnLayout.php
@@ -13,6 +13,7 @@ use App\Entity\ContentNode;
 use App\Entity\SupportsContentNodeChildren;
 use App\Repository\ColumnLayoutRepository;
 use App\State\ContentNode\ContentNodePersistProcessor;
+use App\State\ContentNodeCollectionProvider;
 use App\Validator\AssertJsonSchema;
 use App\Validator\ColumnLayout\AssertColumWidthsSumTo12;
 use App\Validator\ColumnLayout\AssertNoOrphanChildren;
@@ -38,7 +39,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: '(is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)) and object.parent !== null'
         ),
         new GetCollection(
-            security: 'is_authenticated()'
+            security: 'is_authenticated()',
+            provider: ContentNodeCollectionProvider::class
         ),
         new Post(
             processor: ContentNodePersistProcessor::class,

--- a/api/src/Entity/ContentNode/MaterialNode.php
+++ b/api/src/Entity/ContentNode/MaterialNode.php
@@ -13,6 +13,7 @@ use App\Entity\ContentNode;
 use App\Entity\MaterialItem;
 use App\Repository\MaterialNodeRepository;
 use App\State\ContentNode\ContentNodePersistProcessor;
+use App\State\ContentNodeCollectionProvider;
 use App\Util\EntityMap;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -36,7 +37,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: '(is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)) and object.parent !== null'
         ),
         new GetCollection(
-            security: 'is_authenticated()'
+            security: 'is_authenticated()',
+            provider: ContentNodeCollectionProvider::class
         ),
         new Post(
             processor: ContentNodePersistProcessor::class,

--- a/api/src/Entity/ContentNode/MultiSelect.php
+++ b/api/src/Entity/ContentNode/MultiSelect.php
@@ -13,6 +13,7 @@ use App\Entity\ContentNode;
 use App\Repository\MultiSelectRepository;
 use App\State\ContentNode\ContentNodePersistProcessor;
 use App\State\ContentNode\MultiSelectCreateProcessor;
+use App\State\ContentNodeCollectionProvider;
 use App\Validator\AssertJsonSchema;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -34,7 +35,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: '(is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)) and object.parent !== null' // disallow delete when contentNode is a root node
         ),
         new GetCollection(
-            security: 'is_authenticated()'
+            security: 'is_authenticated()',
+            provider: ContentNodeCollectionProvider::class
         ),
         new Post(
             processor: MultiSelectCreateProcessor::class,

--- a/api/src/Entity/ContentNode/ResponsiveLayout.php
+++ b/api/src/Entity/ContentNode/ResponsiveLayout.php
@@ -13,6 +13,7 @@ use App\Entity\ContentNode;
 use App\Entity\SupportsContentNodeChildren;
 use App\Repository\ResponsiveLayoutRepository;
 use App\State\ContentNode\ContentNodePersistProcessor;
+use App\State\ContentNodeCollectionProvider;
 use App\Validator\AssertJsonSchema;
 use App\Validator\ColumnLayout\AssertNoOrphanChildren;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -37,7 +38,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: '(is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)) and object.parent !== null'
         ),
         new GetCollection(
-            security: 'is_authenticated()'
+            security: 'is_authenticated()',
+            provider: ContentNodeCollectionProvider::class
         ),
         new Post(
             processor: ContentNodePersistProcessor::class,

--- a/api/src/Entity/ContentNode/SingleText.php
+++ b/api/src/Entity/ContentNode/SingleText.php
@@ -12,6 +12,7 @@ use ApiPlatform\Metadata\Post;
 use App\Entity\ContentNode;
 use App\Repository\SingleTextRepository;
 use App\State\ContentNode\SingleTextPersistProcessor;
+use App\State\ContentNodeCollectionProvider;
 use App\Validator\AssertJsonSchema;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -33,7 +34,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: '(is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)) and object.parent !== null'
         ),
         new GetCollection(
-            security: 'is_authenticated()'
+            security: 'is_authenticated()',
+            provider: ContentNodeCollectionProvider::class
         ),
         new Post(
             processor: SingleTextPersistProcessor::class,

--- a/api/src/Entity/ContentNode/Storyboard.php
+++ b/api/src/Entity/ContentNode/Storyboard.php
@@ -12,6 +12,7 @@ use ApiPlatform\Metadata\Post;
 use App\Entity\ContentNode;
 use App\Repository\StoryboardRepository;
 use App\State\ContentNode\StoryboardPersistProcessor;
+use App\State\ContentNodeCollectionProvider;
 use App\Validator\AssertJsonSchema;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -33,7 +34,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: '(is_granted("CAMP_MEMBER", object) or is_granted("CAMP_MANAGER", object)) and object.parent !== null'
         ),
         new GetCollection(
-            security: 'is_authenticated()'
+            security: 'is_authenticated()',
+            provider: ContentNodeCollectionProvider::class
         ),
         new Post(
             processor: StoryboardPersistProcessor::class,

--- a/api/src/State/ContentNodeCollectionProvider.php
+++ b/api/src/State/ContentNodeCollectionProvider.php
@@ -19,10 +19,10 @@ class ContentNodeCollectionProvider implements ProviderInterface {
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): array|object|null {
         $request = $this->requestStack->getCurrentRequest();
-        $hasFilter = $request?->query->has('camp') || $request?->query->has('period');
+        $hasFilter = $request?->query->has('camp') || $request?->query->has('period') || $request?->query->has('root');
 
         if (!$hasFilter) {
-            throw new BadRequestHttpException('Filter on camp or period is required');
+            throw new BadRequestHttpException('Filter on camp, period or root is required');
         }
 
         return $this->decorated->provide($operation, $uriVariables, $context);

--- a/api/tests/Api/ContentNodes/ChecklistNode/ListChecklistNodeTest.php
+++ b/api/tests/Api/ContentNodes/ChecklistNode/ListChecklistNodeTest.php
@@ -11,20 +11,23 @@ class ListChecklistNodeTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/checklist_nodes?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpointBase = '/content_node/checklist_nodes';
 
-        $this->contentNodesCamp1and2 = [
-            //            $this->getIriFor('checklistNode1'),
-            //            $this->getIriFor('checklistNode3'),
+        $this->contentNodesCamp1 = [
+            $this->getIriFor('checklistNode1'),
+            $this->getIriFor('checklistNode3'),
         ];
-
+        $this->contentNodesCamp2 = [
+            // none
+        ];
         $this->contentNodesCampUnrelated = [
-            //            $this->getIriFor('checklistNodeCampUnrelated'),
+            $this->getIriFor('checklistNodeCampUnrelated'),
         ];
-
-        $this->contentNodesPublicCamps = [
+        $this->contentNodesCampPrototype = [
             $this->getIriFor('checklistNodeCampPrototype'),
-            //            $this->getIriFor('checklistNodeCampShared'),
+        ];
+        $this->contentNodesCampShared = [
+            $this->getIriFor('checklistNodeCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/ChecklistNode/ListChecklistNodeTest.php
+++ b/api/tests/Api/ContentNodes/ChecklistNode/ListChecklistNodeTest.php
@@ -11,20 +11,20 @@ class ListChecklistNodeTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/checklist_nodes'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpoint = '/content_node/checklist_nodes?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-//            $this->getIriFor('checklistNode1'),
-//            $this->getIriFor('checklistNode3'),
+            //            $this->getIriFor('checklistNode1'),
+            //            $this->getIriFor('checklistNode3'),
         ];
 
         $this->contentNodesCampUnrelated = [
-//            $this->getIriFor('checklistNodeCampUnrelated'),
+            //            $this->getIriFor('checklistNodeCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('checklistNodeCampPrototype'),
-//            $this->getIriFor('checklistNodeCampShared'),
+            //            $this->getIriFor('checklistNodeCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/ChecklistNode/ListChecklistNodeTest.php
+++ b/api/tests/Api/ContentNodes/ChecklistNode/ListChecklistNodeTest.php
@@ -11,20 +11,20 @@ class ListChecklistNodeTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/checklist_nodes';
+        $this->endpoint = '/content_node/checklist_nodes'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-            $this->getIriFor('checklistNode1'),
-            $this->getIriFor('checklistNode3'),
+//            $this->getIriFor('checklistNode1'),
+//            $this->getIriFor('checklistNode3'),
         ];
 
         $this->contentNodesCampUnrelated = [
-            $this->getIriFor('checklistNodeCampUnrelated'),
+//            $this->getIriFor('checklistNodeCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('checklistNodeCampPrototype'),
-            $this->getIriFor('checklistNodeCampShared'),
+//            $this->getIriFor('checklistNodeCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/ColumnLayout/ListColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/ListColumnLayoutTest.php
@@ -11,32 +11,32 @@ class ListColumnLayoutTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/column_layouts';
+        $this->endpoint = '/content_node/column_layouts'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-            $this->getIriFor('columnLayout1'),
-            $this->getIriFor('columnLayout2'),
-            $this->getIriFor('columnLayoutChild1'),
-            $this->getIriFor('columnLayout2Child1'),
-            $this->getIriFor('columnLayout3'),
-            $this->getIriFor('columnLayout4'),
-            $this->getIriFor('columnLayout5'),
-            $this->getIriFor('columnLayout1camp2'),
-            $this->getIriFor('columnLayout2camp2'),
+//            $this->getIriFor('columnLayout1'),
+//            $this->getIriFor('columnLayout2'),
+//            $this->getIriFor('columnLayoutChild1'),
+//            $this->getIriFor('columnLayout2Child1'),
+//            $this->getIriFor('columnLayout3'),
+//            $this->getIriFor('columnLayout4'),
+//            $this->getIriFor('columnLayout5'),
+//            $this->getIriFor('columnLayout1camp2'),
+//            $this->getIriFor('columnLayout2camp2'),
         ];
 
         $this->contentNodesCampUnrelated = [
-            $this->getIriFor('columnLayout1campUnrelated'),
-            $this->getIriFor('columnLayout2campUnrelated'),
+//            $this->getIriFor('columnLayout1campUnrelated'),
+//            $this->getIriFor('columnLayout2campUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('columnLayout1campPrototype'),
-            $this->getIriFor('columnLayout2campPrototype'),
+//            $this->getIriFor('columnLayout2campPrototype'),
             $this->getIriFor('columnLayout3campPrototype'),
-            $this->getIriFor('columnLayout1campShared'),
-            $this->getIriFor('columnLayout2campShared'),
-            $this->getIriFor('columnLayout3campShared'),
+//            $this->getIriFor('columnLayout1campShared'),
+//            $this->getIriFor('columnLayout2campShared'),
+//            $this->getIriFor('columnLayout3campShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/ColumnLayout/ListColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/ListColumnLayoutTest.php
@@ -11,32 +11,28 @@ class ListColumnLayoutTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/column_layouts?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpointBase = '/content_node/column_layouts';
 
-        $this->contentNodesCamp1and2 = [
-            //            $this->getIriFor('columnLayout1'),
-            //            $this->getIriFor('columnLayout2'),
-            //            $this->getIriFor('columnLayoutChild1'),
-            //            $this->getIriFor('columnLayout2Child1'),
-            //            $this->getIriFor('columnLayout3'),
-            //            $this->getIriFor('columnLayout4'),
-            //            $this->getIriFor('columnLayout5'),
-            //            $this->getIriFor('columnLayout1camp2'),
-            //            $this->getIriFor('columnLayout2camp2'),
+        $this->contentNodesCamp1 = [
+            $this->getIriFor('columnLayout1'),
+            $this->getIriFor('columnLayoutChild1'),
+            $this->getIriFor('columnLayout3'),
+        ];
+        $this->contentNodesCamp2 = [
+            $this->getIriFor('columnLayout1camp2'),
         ];
 
         $this->contentNodesCampUnrelated = [
-            //            $this->getIriFor('columnLayout1campUnrelated'),
-            //            $this->getIriFor('columnLayout2campUnrelated'),
+            $this->getIriFor('columnLayout1campUnrelated'),
         ];
 
-        $this->contentNodesPublicCamps = [
+        $this->contentNodesCampPrototype = [
             $this->getIriFor('columnLayout1campPrototype'),
-            //            $this->getIriFor('columnLayout2campPrototype'),
             $this->getIriFor('columnLayout3campPrototype'),
-            //            $this->getIriFor('columnLayout1campShared'),
-            //            $this->getIriFor('columnLayout2campShared'),
-            //            $this->getIriFor('columnLayout3campShared'),
+        ];
+        $this->contentNodesCampShared = [
+            $this->getIriFor('columnLayout1campShared'),
+            $this->getIriFor('columnLayout3campShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/ColumnLayout/ListColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/ListColumnLayoutTest.php
@@ -11,32 +11,32 @@ class ListColumnLayoutTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/column_layouts'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpoint = '/content_node/column_layouts?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-//            $this->getIriFor('columnLayout1'),
-//            $this->getIriFor('columnLayout2'),
-//            $this->getIriFor('columnLayoutChild1'),
-//            $this->getIriFor('columnLayout2Child1'),
-//            $this->getIriFor('columnLayout3'),
-//            $this->getIriFor('columnLayout4'),
-//            $this->getIriFor('columnLayout5'),
-//            $this->getIriFor('columnLayout1camp2'),
-//            $this->getIriFor('columnLayout2camp2'),
+            //            $this->getIriFor('columnLayout1'),
+            //            $this->getIriFor('columnLayout2'),
+            //            $this->getIriFor('columnLayoutChild1'),
+            //            $this->getIriFor('columnLayout2Child1'),
+            //            $this->getIriFor('columnLayout3'),
+            //            $this->getIriFor('columnLayout4'),
+            //            $this->getIriFor('columnLayout5'),
+            //            $this->getIriFor('columnLayout1camp2'),
+            //            $this->getIriFor('columnLayout2camp2'),
         ];
 
         $this->contentNodesCampUnrelated = [
-//            $this->getIriFor('columnLayout1campUnrelated'),
-//            $this->getIriFor('columnLayout2campUnrelated'),
+            //            $this->getIriFor('columnLayout1campUnrelated'),
+            //            $this->getIriFor('columnLayout2campUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('columnLayout1campPrototype'),
-//            $this->getIriFor('columnLayout2campPrototype'),
+            //            $this->getIriFor('columnLayout2campPrototype'),
             $this->getIriFor('columnLayout3campPrototype'),
-//            $this->getIriFor('columnLayout1campShared'),
-//            $this->getIriFor('columnLayout2campShared'),
-//            $this->getIriFor('columnLayout3campShared'),
+            //            $this->getIriFor('columnLayout1campShared'),
+            //            $this->getIriFor('columnLayout2campShared'),
+            //            $this->getIriFor('columnLayout3campShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/ListContentNodeTestCase.php
+++ b/api/tests/Api/ContentNodes/ListContentNodeTestCase.php
@@ -13,20 +13,25 @@ use App\Tests\Api\ECampApiTestCase;
  * @internal
  */
 abstract class ListContentNodeTestCase extends ECampApiTestCase {
+    protected string $endpointBase = '';
+
     // content nodes visible for user 1, 2, 3
-    protected array $contentNodesCamp1and2 = [];
+    protected array $contentNodesCamp1 = [];
+    protected array $contentNodesCamp2 = [];
 
     // content nodes visislb for user 4
     protected array $contentNodesCampUnrelated = [];
 
     // content nodes visible for everyone
-    protected array $contentNodesPublicCamps = [];
+    protected array $contentNodesCampPrototype = [];
+    protected array $contentNodesCampShared = [];
 
     public function setUp(): void {
         parent::setUp();
     }
 
     public function testListForAnonymousUser() {
+        $this->endpoint = $this->endpointBase;
         static::createBasicClient()->request('GET', $this->endpoint);
         $this->assertResponseStatusCodeSame(401);
         $this->assertJsonContains([
@@ -36,38 +41,139 @@ abstract class ListContentNodeTestCase extends ECampApiTestCase {
     }
 
     public function testListForInvitedCollaborator() {
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campPrototype');
         $response = $this->list(user: static::$fixtures['user6invited']);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContainsItems($response, $this->contentNodesPublicCamps);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampPrototype);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campShared');
+        $response = $this->list(user: static::$fixtures['user6invited']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampShared);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campUnrelated');
+        $response = $this->list(user: static::$fixtures['user6invited']);
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains(['status' => 400]);
     }
 
     public function testListForInactiveCollaborator() {
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campPrototype');
         $response = $this->list(user: static::$fixtures['user5inactive']);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContainsItems($response, $this->contentNodesPublicCamps);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampPrototype);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campShared');
+        $response = $this->list(user: static::$fixtures['user5inactive']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampShared);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campUnrelated');
+        $response = $this->list(user: static::$fixtures['user5inactive']);
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains(['status' => 400]);
     }
 
     public function testListForUnrelatedUser() {
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campUnrelated');
         $response = $this->list(user: static::$fixtures['user4unrelated']);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContainsItems($response, array_merge($this->contentNodesCampUnrelated, $this->contentNodesPublicCamps));
+        $this->assertJsonContainsItems($response, $this->contentNodesCampUnrelated);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campPrototype');
+        $response = $this->list(user: static::$fixtures['user4unrelated']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampPrototype);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campShared');
+        $response = $this->list(user: static::$fixtures['user4unrelated']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampShared);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('camp1');
+        $response = $this->list(user: static::$fixtures['user4unrelated']);
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains(['status' => 400]);
     }
 
     public function testListForGuest() {
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('camp1');
         $response = $this->list(user: static::$fixtures['user3guest']);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContainsItems($response, array_merge($this->contentNodesCamp1and2, $this->contentNodesPublicCamps));
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp1);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('camp2');
+        $response = $this->list(user: static::$fixtures['user3guest']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp2);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campPrototype');
+        $response = $this->list(user: static::$fixtures['user3guest']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampPrototype);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campShared');
+        $response = $this->list(user: static::$fixtures['user3guest']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampShared);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campUnrelated');
+        $response = $this->list(user: static::$fixtures['user3guest']);
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains(['status' => 400]);
     }
 
     public function testListForMember() {
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('camp1');
         $response = $this->list(user: static::$fixtures['user2member']);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContainsItems($response, array_merge($this->contentNodesCamp1and2, $this->contentNodesPublicCamps));
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp1);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('camp2');
+        $response = $this->list(user: static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp2);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campPrototype');
+        $response = $this->list(user: static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampPrototype);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campShared');
+        $response = $this->list(user: static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampShared);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campUnrelated');
+        $response = $this->list(user: static::$fixtures['user2member']);
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains(['status' => 400]);
     }
 
     public function testListForManager() {
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('camp1');
         $response = $this->list(user: static::$fixtures['user1manager']);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertJsonContainsItems($response, array_merge($this->contentNodesCamp1and2, $this->contentNodesPublicCamps));
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp1);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('camp2');
+        $response = $this->list(user: static::$fixtures['user1manager']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCamp2);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campPrototype');
+        $response = $this->list(user: static::$fixtures['user1manager']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampPrototype);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campShared');
+        $response = $this->list(user: static::$fixtures['user1manager']);
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContainsItems($response, $this->contentNodesCampShared);
+
+        $this->endpoint = $this->endpointBase.'?camp='.$this->getIriFor('campUnrelated');
+        $response = $this->list(user: static::$fixtures['user1manager']);
+        $this->assertResponseStatusCodeSame(400);
+        $this->assertJsonContains(['status' => 400]);
     }
 }

--- a/api/tests/Api/ContentNodes/MaterialNode/ListMaterialNodeTest.php
+++ b/api/tests/Api/ContentNodes/MaterialNode/ListMaterialNodeTest.php
@@ -11,20 +11,20 @@ class ListMaterialNodeTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/material_nodes';
+        $this->endpoint = '/content_node/material_nodes'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-            $this->getIriFor('materialNode1'),
-            $this->getIriFor('materialNode2'),
+//            $this->getIriFor('materialNode1'),
+//            $this->getIriFor('materialNode2'),
         ];
 
         $this->contentNodesCampUnrelated = [
-            $this->getIriFor('materialNodeCampUnrelated'),
+//            $this->getIriFor('materialNodeCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('materialNodeCampPrototype'),
-            $this->getIriFor('materialNodeCampShared'),
+//            $this->getIriFor('materialNodeCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/MaterialNode/ListMaterialNodeTest.php
+++ b/api/tests/Api/ContentNodes/MaterialNode/ListMaterialNodeTest.php
@@ -11,20 +11,26 @@ class ListMaterialNodeTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/material_nodes?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpointBase = '/content_node/material_nodes';
 
-        $this->contentNodesCamp1and2 = [
-            //            $this->getIriFor('materialNode1'),
-            //            $this->getIriFor('materialNode2'),
+        $this->contentNodesCamp1 = [
+            $this->getIriFor('materialNode1'),
+        ];
+
+        $this->contentNodesCamp2 = [
+            $this->getIriFor('materialNode2'),
         ];
 
         $this->contentNodesCampUnrelated = [
-            //            $this->getIriFor('materialNodeCampUnrelated'),
+            $this->getIriFor('materialNodeCampUnrelated'),
         ];
 
-        $this->contentNodesPublicCamps = [
+        $this->contentNodesCampPrototype = [
             $this->getIriFor('materialNodeCampPrototype'),
-            //            $this->getIriFor('materialNodeCampShared'),
+        ];
+
+        $this->contentNodesCampShared = [
+            $this->getIriFor('materialNodeCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/MaterialNode/ListMaterialNodeTest.php
+++ b/api/tests/Api/ContentNodes/MaterialNode/ListMaterialNodeTest.php
@@ -11,20 +11,20 @@ class ListMaterialNodeTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/material_nodes'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpoint = '/content_node/material_nodes?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-//            $this->getIriFor('materialNode1'),
-//            $this->getIriFor('materialNode2'),
+            //            $this->getIriFor('materialNode1'),
+            //            $this->getIriFor('materialNode2'),
         ];
 
         $this->contentNodesCampUnrelated = [
-//            $this->getIriFor('materialNodeCampUnrelated'),
+            //            $this->getIriFor('materialNodeCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('materialNodeCampPrototype'),
-//            $this->getIriFor('materialNodeCampShared'),
+            //            $this->getIriFor('materialNodeCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/MultiSelect/ListMultiSelectTest.php
+++ b/api/tests/Api/ContentNodes/MultiSelect/ListMultiSelectTest.php
@@ -11,20 +11,20 @@ class ListMultiSelectTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/multi_selects';
+        $this->endpoint = '/content_node/multi_selects'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-            $this->getIriFor('multiSelect1'),
-            $this->getIriFor('multiSelect2'),
+//            $this->getIriFor('multiSelect1'),
+//            $this->getIriFor('multiSelect2'),
         ];
 
         $this->contentNodesCampUnrelated = [
-            $this->getIriFor('multiSelectCampUnrelated'),
+//            $this->getIriFor('multiSelectCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('multiSelectCampPrototype'),
-            $this->getIriFor('multiSelectCampShared'),
+//            $this->getIriFor('multiSelectCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/MultiSelect/ListMultiSelectTest.php
+++ b/api/tests/Api/ContentNodes/MultiSelect/ListMultiSelectTest.php
@@ -11,20 +11,26 @@ class ListMultiSelectTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/multi_selects?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpointBase = '/content_node/multi_selects';
 
-        $this->contentNodesCamp1and2 = [
-            //            $this->getIriFor('multiSelect1'),
-            //            $this->getIriFor('multiSelect2'),
+        $this->contentNodesCamp1 = [
+            $this->getIriFor('multiSelect1'),
+            $this->getIriFor('multiSelect2'),
+        ];
+
+        $this->contentNodesCamp2 = [
         ];
 
         $this->contentNodesCampUnrelated = [
-            //            $this->getIriFor('multiSelectCampUnrelated'),
+            $this->getIriFor('multiSelectCampUnrelated'),
         ];
 
-        $this->contentNodesPublicCamps = [
+        $this->contentNodesCampPrototype = [
             $this->getIriFor('multiSelectCampPrototype'),
-            //            $this->getIriFor('multiSelectCampShared'),
+        ];
+
+        $this->contentNodesCampShared = [
+            $this->getIriFor('multiSelectCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/MultiSelect/ListMultiSelectTest.php
+++ b/api/tests/Api/ContentNodes/MultiSelect/ListMultiSelectTest.php
@@ -11,20 +11,20 @@ class ListMultiSelectTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/multi_selects'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpoint = '/content_node/multi_selects?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-//            $this->getIriFor('multiSelect1'),
-//            $this->getIriFor('multiSelect2'),
+            //            $this->getIriFor('multiSelect1'),
+            //            $this->getIriFor('multiSelect2'),
         ];
 
         $this->contentNodesCampUnrelated = [
-//            $this->getIriFor('multiSelectCampUnrelated'),
+            //            $this->getIriFor('multiSelectCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('multiSelectCampPrototype'),
-//            $this->getIriFor('multiSelectCampShared'),
+            //            $this->getIriFor('multiSelectCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/ResponsiveLayout/ListResponsiveLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ResponsiveLayout/ListResponsiveLayoutTest.php
@@ -11,19 +11,19 @@ class ListResponsiveLayoutTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/responsive_layouts'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpoint = '/content_node/responsive_layouts?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-//            $this->getIriFor('responsiveLayout1'),
+            //            $this->getIriFor('responsiveLayout1'),
         ];
 
         $this->contentNodesCampUnrelated = [
-//            $this->getIriFor('responsiveLayoutCampUnrelated'),
+            //            $this->getIriFor('responsiveLayoutCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('responsiveLayoutCampPrototype'),
-//            $this->getIriFor('responsiveLayoutCampShared'),
+            //            $this->getIriFor('responsiveLayoutCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/ResponsiveLayout/ListResponsiveLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ResponsiveLayout/ListResponsiveLayoutTest.php
@@ -11,19 +11,19 @@ class ListResponsiveLayoutTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/responsive_layouts';
+        $this->endpoint = '/content_node/responsive_layouts'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-            $this->getIriFor('responsiveLayout1'),
+//            $this->getIriFor('responsiveLayout1'),
         ];
 
         $this->contentNodesCampUnrelated = [
-            $this->getIriFor('responsiveLayoutCampUnrelated'),
+//            $this->getIriFor('responsiveLayoutCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('responsiveLayoutCampPrototype'),
-            $this->getIriFor('responsiveLayoutCampShared'),
+//            $this->getIriFor('responsiveLayoutCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/ResponsiveLayout/ListResponsiveLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ResponsiveLayout/ListResponsiveLayoutTest.php
@@ -11,19 +11,26 @@ class ListResponsiveLayoutTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/responsive_layouts?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpointBase = '/content_node/responsive_layouts';
 
-        $this->contentNodesCamp1and2 = [
-            //            $this->getIriFor('responsiveLayout1'),
+        $this->contentNodesCamp1 = [
+            $this->getIriFor('responsiveLayout1'),
+        ];
+
+        $this->contentNodesCamp2 = [
+            // none
         ];
 
         $this->contentNodesCampUnrelated = [
-            //            $this->getIriFor('responsiveLayoutCampUnrelated'),
+            $this->getIriFor('responsiveLayoutCampUnrelated'),
         ];
 
-        $this->contentNodesPublicCamps = [
+        $this->contentNodesCampPrototype = [
             $this->getIriFor('responsiveLayoutCampPrototype'),
-            //            $this->getIriFor('responsiveLayoutCampShared'),
+        ];
+
+        $this->contentNodesCampShared = [
+            $this->getIriFor('responsiveLayoutCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/SingleText/ListSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/ListSingleTextTest.php
@@ -11,21 +11,21 @@ class ListSingleTextTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/single_texts'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpoint = '/content_node/single_texts?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-//            $this->getIriFor('singleText1'),
-//            $this->getIriFor('singleText2'),
-//            $this->getIriFor('safetyConsiderations1'),
+            //            $this->getIriFor('singleText1'),
+            //            $this->getIriFor('singleText2'),
+            //            $this->getIriFor('safetyConsiderations1'),
         ];
 
         $this->contentNodesCampUnrelated = [
-//            $this->getIriFor('singleTextCampUnrelated'),
+            //            $this->getIriFor('singleTextCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('singleTextCampPrototype'),
-//            $this->getIriFor('singleTextCampShared'),
+            //            $this->getIriFor('singleTextCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/SingleText/ListSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/ListSingleTextTest.php
@@ -11,21 +11,28 @@ class ListSingleTextTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/single_texts?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpointBase = '/content_node/single_texts';
 
-        $this->contentNodesCamp1and2 = [
-            //            $this->getIriFor('singleText1'),
-            //            $this->getIriFor('singleText2'),
-            //            $this->getIriFor('safetyConsiderations1'),
+        $this->contentNodesCamp1 = [
+            $this->getIriFor('singleText1'),
+            $this->getIriFor('singleText2'),
+            $this->getIriFor('safetyConsiderations1'),
+        ];
+
+        $this->contentNodesCamp2 = [
+            // none
         ];
 
         $this->contentNodesCampUnrelated = [
-            //            $this->getIriFor('singleTextCampUnrelated'),
+            $this->getIriFor('singleTextCampUnrelated'),
         ];
 
-        $this->contentNodesPublicCamps = [
+        $this->contentNodesCampPrototype = [
             $this->getIriFor('singleTextCampPrototype'),
-            //            $this->getIriFor('singleTextCampShared'),
+        ];
+
+        $this->contentNodesCampShared = [
+            $this->getIriFor('singleTextCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/SingleText/ListSingleTextTest.php
+++ b/api/tests/Api/ContentNodes/SingleText/ListSingleTextTest.php
@@ -11,21 +11,21 @@ class ListSingleTextTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/single_texts';
+        $this->endpoint = '/content_node/single_texts'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-            $this->getIriFor('singleText1'),
-            $this->getIriFor('singleText2'),
-            $this->getIriFor('safetyConsiderations1'),
+//            $this->getIriFor('singleText1'),
+//            $this->getIriFor('singleText2'),
+//            $this->getIriFor('safetyConsiderations1'),
         ];
 
         $this->contentNodesCampUnrelated = [
-            $this->getIriFor('singleTextCampUnrelated'),
+//            $this->getIriFor('singleTextCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('singleTextCampPrototype'),
-            $this->getIriFor('singleTextCampShared'),
+//            $this->getIriFor('singleTextCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/Storyboard/ListStoryboardTest.php
+++ b/api/tests/Api/ContentNodes/Storyboard/ListStoryboardTest.php
@@ -11,20 +11,20 @@ class ListStoryboardTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/storyboards'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpoint = '/content_node/storyboards?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-//            $this->getIriFor('storyboard1'),
-//            $this->getIriFor('storyboard2'),
+            //            $this->getIriFor('storyboard1'),
+            //            $this->getIriFor('storyboard2'),
         ];
 
         $this->contentNodesCampUnrelated = [
-//            $this->getIriFor('storyboardCampUnrelated'),
+            //            $this->getIriFor('storyboardCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('storyboardCampPrototype'),
-//            $this->getIriFor('storyboardCampShared'),
+            //            $this->getIriFor('storyboardCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/Storyboard/ListStoryboardTest.php
+++ b/api/tests/Api/ContentNodes/Storyboard/ListStoryboardTest.php
@@ -11,20 +11,27 @@ class ListStoryboardTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/storyboards?camp=/camps/'.static::$fixtures['campPrototype']->getId();
+        $this->endpointBase = '/content_node/storyboards';
 
-        $this->contentNodesCamp1and2 = [
-            //            $this->getIriFor('storyboard1'),
-            //            $this->getIriFor('storyboard2'),
+        $this->contentNodesCamp1 = [
+            $this->getIriFor('storyboard1'),
+            $this->getIriFor('storyboard2'),
+        ];
+
+        $this->contentNodesCamp2 = [
+            // none
         ];
 
         $this->contentNodesCampUnrelated = [
-            //            $this->getIriFor('storyboardCampUnrelated'),
+            $this->getIriFor('storyboardCampUnrelated'),
         ];
 
-        $this->contentNodesPublicCamps = [
+        $this->contentNodesCampPrototype = [
             $this->getIriFor('storyboardCampPrototype'),
-            //            $this->getIriFor('storyboardCampShared'),
+        ];
+
+        $this->contentNodesCampShared = [
+            $this->getIriFor('storyboardCampShared'),
         ];
     }
 }

--- a/api/tests/Api/ContentNodes/Storyboard/ListStoryboardTest.php
+++ b/api/tests/Api/ContentNodes/Storyboard/ListStoryboardTest.php
@@ -11,20 +11,20 @@ class ListStoryboardTest extends ListContentNodeTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->endpoint = '/content_node/storyboards';
+        $this->endpoint = '/content_node/storyboards'.'?camp=/camps/'.static::$fixtures['campPrototype']->getId();
 
         $this->contentNodesCamp1and2 = [
-            $this->getIriFor('storyboard1'),
-            $this->getIriFor('storyboard2'),
+//            $this->getIriFor('storyboard1'),
+//            $this->getIriFor('storyboard2'),
         ];
 
         $this->contentNodesCampUnrelated = [
-            $this->getIriFor('storyboardCampUnrelated'),
+//            $this->getIriFor('storyboardCampUnrelated'),
         ];
 
         $this->contentNodesPublicCamps = [
             $this->getIriFor('storyboardCampPrototype'),
-            $this->getIriFor('storyboardCampShared'),
+//            $this->getIriFor('storyboardCampShared'),
         ];
     }
 }

--- a/api/tests/Api/SnapshotTests/EndpointPerformanceTest.php
+++ b/api/tests/Api/SnapshotTests/EndpointPerformanceTest.php
@@ -45,7 +45,7 @@ class EndpointPerformanceTest extends ECampApiTestCase {
             }
 
             if (!str_contains($collectionEndpoint, '/content_node')) {
-                $fixtureFor = $this->getFixtureFor($collectionEndpoint);
+                $fixtureFor = self::getFixtureFor($collectionEndpoint);
                 list($statusCode, $queryCount, $executionTimeSeconds) = $this->measurePerformanceFor("{$collectionEndpoint}/{$fixtureFor->getId()}");
                 $responseCodes["{$collectionEndpoint}/item"] = $statusCode;
                 $numberOfQueries["{$collectionEndpoint}/item"] = $queryCount;
@@ -94,7 +94,8 @@ class EndpointPerformanceTest extends ECampApiTestCase {
         if ('test' !== $this->getEnvironment()) {
             self::markTestSkipped(__FUNCTION__.' is only run in test environment, not in '.$this->getEnvironment());
         }
-        list($statusCode, $queryCount, $executionTimeSeconds) = $this->measurePerformanceFor($collectionEndpoint);
+        list($statusCode, $queryCount, $executionTimeSeconds)
+            = $this->measurePerformanceFor($collectionEndpoint.'?camp=/camps/'.self::getFixtureFor('/camps')->getId());
 
         assertThat($statusCode, equalTo(200));
 
@@ -127,7 +128,7 @@ class EndpointPerformanceTest extends ECampApiTestCase {
         if ('/content_nodes' === $collectionEndpoint) {
             self::markTestSkipped("{$collectionEndpoint} does not support get item endpoint");
         }
-        $fixtureFor = $this->getFixtureFor($collectionEndpoint);
+        $fixtureFor = self::getFixtureFor($collectionEndpoint);
         list($statusCode, $queryCount, $executionTimeSeconds) = $this->measurePerformanceFor("{$collectionEndpoint}/{$fixtureFor->getId()}");
 
         assertThat($statusCode, equalTo(200));
@@ -198,19 +199,19 @@ class EndpointPerformanceTest extends ECampApiTestCase {
     private static function getContentNodeEndpointQueryCountRanges(): array {
         return [
             '/content_nodes' => [13, 15],
-            '/content_node/column_layouts' => [6, 6],
+            '/content_node/column_layouts' => [7, 7],
             '/content_node/column_layouts/item' => [9, 9],
             '/content_node/checklist_nodes' => [6, 7],
             '/content_node/checklist_nodes/item' => [9, 9],
             '/content_node/material_nodes' => [6, 7],
             '/content_node/material_nodes/item' => [9, 9],
-            '/content_node/multi_selects' => [6, 7],
+            '/content_node/multi_selects' => [7, 8],
             '/content_node/multi_selects/item' => [9, 9],
-            '/content_node/responsive_layouts' => [6, 6],
+            '/content_node/responsive_layouts' => [7, 7],
             '/content_node/responsive_layouts/item' => [9, 9],
-            '/content_node/single_texts' => [6, 7],
+            '/content_node/single_texts' => [7, 8],
             '/content_node/single_texts/item' => [9, 9],
-            '/content_node/storyboards' => [6, 7],
+            '/content_node/storyboards' => [7, 8],
             '/content_node/storyboards/item' => [9, 9],
         ];
     }
@@ -291,7 +292,7 @@ class EndpointPerformanceTest extends ECampApiTestCase {
         ];
     }
 
-    private function getFixtureFor(string $collectionEndpoint) {
+    private static function getFixtureFor(string $collectionEndpoint) {
         $fixtures = FixtureStore::getFixtures();
 
         return ReadItemFixtureMap::get($collectionEndpoint, $fixtures);

--- a/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
+++ b/api/tests/Api/SnapshotTests/ResponseSnapshotTest.php
@@ -117,6 +117,13 @@ class ResponseSnapshotTest extends ECampApiTestCase {
                 '/auth/reset_password' => false,
                 '/auth/resend_activation' => false,
                 '/content_nodes' => false,
+                '/content_node/checklist_nodes' => false,
+                '/content_node/column_layouts' => false,
+                '/content_node/material_nodes' => false,
+                '/content_node/multi_selects' => false,
+                '/content_node/responsive_layouts' => false,
+                '/content_node/single_texts' => false,
+                '/content_node/storyboards' => false,
                 '/checklist_items' => false,
                 '/invitations' => false,
                 '/material_items' => false,
@@ -153,6 +160,13 @@ class ResponseSnapshotTest extends ECampApiTestCase {
 
         return [
             [$client, '/content_nodes?camp=/camps/'.self::getFixtureFor('/camps')->getId()],
+            [$client, '/content_node/checklist_nodes?camp=/camps/'.self::getFixtureFor('/camps')->getId()],
+            [$client, '/content_node/column_layouts?camp=/camps/'.self::getFixtureFor('/camps')->getId()],
+            [$client, '/content_node/material_nodes?camp=/camps/'.self::getFixtureFor('/camps')->getId()],
+            [$client, '/content_node/multi_selects?camp=/camps/'.self::getFixtureFor('/camps')->getId()],
+            [$client, '/content_node/responsive_layouts?camp=/camps/'.self::getFixtureFor('/camps')->getId()],
+            [$client, '/content_node/single_texts?camp=/camps/'.self::getFixtureFor('/camps')->getId()],
+            [$client, '/content_node/storyboards?camp=/camps/'.self::getFixtureFor('/camps')->getId()],
             [$client, '/checklist_items?checklist=/checklists/'.self::getFixtureFor('/checklists')->getId()],
             [$client, '/material_items?camp=/camps/'.self::getFixtureFor('/camps')->getId()],
         ];

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 3__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 3__1.json
@@ -1,0 +1,69 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_embedded": {
+                    "materialItems": [
+                        {
+                            "_links": {
+                                "camp": {
+                                    "href": "escaped_value"
+                                },
+                                "materialList": {
+                                    "href": "escaped_value"
+                                },
+                                "materialNode": {
+                                    "href": "escaped_value"
+                                },
+                                "period": "escaped_value",
+                                "self": {
+                                    "href": "escaped_value"
+                                }
+                            },
+                            "article": "escaped_value",
+                            "done": "escaped_value",
+                            "id": "escaped_value",
+                            "quantity": "escaped_value",
+                            "unit": "escaped_value"
+                        }
+                    ]
+                },
+                "_links": {
+                    "children": [],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "materialItems": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": "escaped_value",
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 4__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 4__1.json
@@ -3,9 +3,6 @@
         "items": [
             {
                 "_links": {
-                    "checklistItems": {
-                        "href": "escaped_value"
-                    },
                     "children": [],
                     "contentType": {
                         "href": "escaped_value"
@@ -21,7 +18,16 @@
                     }
                 },
                 "contentTypeName": "escaped_value",
-                "data": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        },
+                        "key2": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
                 "id": "escaped_value",
                 "instanceName": "escaped_value",
                 "position": "escaped_value",
@@ -29,9 +35,6 @@
             },
             {
                 "_links": {
-                    "checklistItems": {
-                        "href": "escaped_value"
-                    },
                     "children": [],
                     "contentType": {
                         "href": "escaped_value"
@@ -47,7 +50,13 @@
                     }
                 },
                 "contentTypeName": "escaped_value",
-                "data": "escaped_value",
+                "data": {
+                    "options": {
+                        "key1": {
+                            "checked": "escaped_value"
+                        }
+                    }
+                },
                 "id": "escaped_value",
                 "instanceName": "escaped_value",
                 "position": "escaped_value",

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 5__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 5__1.json
@@ -1,0 +1,71 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        },
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "escaped_value"
+                    },
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "root": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "contentTypeName": "escaped_value",
+                "data": {
+                    "items": [
+                        {
+                            "slot": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value"
+                        },
+                        {
+                            "slot": "escaped_value"
+                        }
+                    ]
+                },
+                "id": "escaped_value",
+                "instanceName": "escaped_value",
+                "position": "escaped_value",
+                "slot": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 6__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 6__1.json
@@ -3,17 +3,7 @@
         "items": [
             {
                 "_links": {
-                    "children": [
-                        {
-                            "href": "escaped_value"
-                        },
-                        {
-                            "href": "escaped_value"
-                        },
-                        {
-                            "href": "escaped_value"
-                        }
-                    ],
+                    "children": [],
                     "contentType": {
                         "href": "escaped_value"
                     },
@@ -29,16 +19,7 @@
                 },
                 "contentTypeName": "escaped_value",
                 "data": {
-                    "columns": [
-                        {
-                            "slot": "escaped_value",
-                            "width": "escaped_value"
-                        },
-                        {
-                            "slot": "escaped_value",
-                            "width": "escaped_value"
-                        }
-                    ]
+                    "html": "escaped_value"
                 },
                 "id": "escaped_value",
                 "instanceName": "escaped_value",
@@ -47,18 +28,13 @@
             },
             {
                 "_links": {
-                    "children": [
-                        {
-                            "href": "escaped_value"
-                        },
-                        {
-                            "href": "escaped_value"
-                        }
-                    ],
+                    "children": [],
                     "contentType": {
                         "href": "escaped_value"
                     },
-                    "parent": "escaped_value",
+                    "parent": {
+                        "href": "escaped_value"
+                    },
                     "root": {
                         "href": "escaped_value"
                     },
@@ -68,12 +44,7 @@
                 },
                 "contentTypeName": "escaped_value",
                 "data": {
-                    "columns": [
-                        {
-                            "slot": "escaped_value",
-                            "width": "escaped_value"
-                        }
-                    ]
+                    "html": "escaped_value"
                 },
                 "id": "escaped_value",
                 "instanceName": "escaped_value",
@@ -82,15 +53,13 @@
             },
             {
                 "_links": {
-                    "children": [
-                        {
-                            "href": "escaped_value"
-                        }
-                    ],
+                    "children": [],
                     "contentType": {
                         "href": "escaped_value"
                     },
-                    "parent": "escaped_value",
+                    "parent": {
+                        "href": "escaped_value"
+                    },
                     "root": {
                         "href": "escaped_value"
                     },
@@ -100,12 +69,7 @@
                 },
                 "contentTypeName": "escaped_value",
                 "data": {
-                    "columns": [
-                        {
-                            "slot": "escaped_value",
-                            "width": "escaped_value"
-                        }
-                    ]
+                    "html": "escaped_value"
                 },
                 "id": "escaped_value",
                 "instanceName": "escaped_value",

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 7__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 7__1.json
@@ -3,9 +3,6 @@
         "items": [
             {
                 "_links": {
-                    "checklistItems": {
-                        "href": "escaped_value"
-                    },
                     "children": [],
                     "contentType": {
                         "href": "escaped_value"
@@ -21,7 +18,22 @@
                     }
                 },
                 "contentTypeName": "escaped_value",
-                "data": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ab9740f6-61a4-4cae-b574-a73aeb7c5ea0": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        },
+                        "cb26d76a-9e3b-43f0-a7c4-0f2ad0ea8029": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
                 "id": "escaped_value",
                 "instanceName": "escaped_value",
                 "position": "escaped_value",
@@ -29,9 +41,6 @@
             },
             {
                 "_links": {
-                    "checklistItems": {
-                        "href": "escaped_value"
-                    },
                     "children": [],
                     "contentType": {
                         "href": "escaped_value"
@@ -47,7 +56,16 @@
                     }
                 },
                 "contentTypeName": "escaped_value",
-                "data": "escaped_value",
+                "data": {
+                    "sections": {
+                        "ea6f1e5d-0ef7-454f-8ae0-1d9b3bfd1177": {
+                            "column1": "escaped_value",
+                            "column2Html": "escaped_value",
+                            "column3": "escaped_value",
+                            "position": "escaped_value"
+                        }
+                    }
+                },
                 "id": "escaped_value",
                 "instanceName": "escaped_value",
                 "position": "escaped_value",

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 8__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 8__1.json
@@ -1,0 +1,106 @@
+{
+    "_embedded": {
+        "items": [
+            {
+                "_links": {
+                    "checklist": {
+                        "href": "escaped_value"
+                    },
+                    "checklistNodes": [],
+                    "children": [],
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "text": "escaped_value"
+            },
+            {
+                "_links": {
+                    "checklist": {
+                        "href": "escaped_value"
+                    },
+                    "checklistNodes": [],
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "parent": "escaped_value",
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "text": "escaped_value"
+            },
+            {
+                "_links": {
+                    "checklist": {
+                        "href": "escaped_value"
+                    },
+                    "checklistNodes": [],
+                    "children": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "parent": {
+                        "href": "escaped_value"
+                    },
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "text": "escaped_value"
+            },
+            {
+                "_links": {
+                    "checklist": {
+                        "href": "escaped_value"
+                    },
+                    "checklistNodes": [
+                        {
+                            "href": "escaped_value"
+                        }
+                    ],
+                    "children": [],
+                    "parent": "escaped_value",
+                    "self": {
+                        "href": "escaped_value"
+                    }
+                },
+                "id": "escaped_value",
+                "position": "escaped_value",
+                "text": "escaped_value"
+            }
+        ]
+    },
+    "_links": {
+        "items": [
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            },
+            {
+                "href": "escaped_value"
+            }
+        ],
+        "self": {
+            "href": "escaped_value"
+        }
+    },
+    "totalItems": "escaped_value"
+}

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 9__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testGetCollectionMatchesStructure with data set 9__1.json
@@ -3,55 +3,47 @@
         "items": [
             {
                 "_links": {
-                    "checklistItems": {
+                    "camp": {
                         "href": "escaped_value"
                     },
-                    "children": [],
-                    "contentType": {
+                    "materialList": {
                         "href": "escaped_value"
                     },
-                    "parent": {
-                        "href": "escaped_value"
-                    },
-                    "root": {
+                    "materialNode": "escaped_value",
+                    "period": {
                         "href": "escaped_value"
                     },
                     "self": {
                         "href": "escaped_value"
                     }
                 },
-                "contentTypeName": "escaped_value",
-                "data": "escaped_value",
+                "article": "escaped_value",
+                "done": "escaped_value",
                 "id": "escaped_value",
-                "instanceName": "escaped_value",
-                "position": "escaped_value",
-                "slot": "escaped_value"
+                "quantity": "escaped_value",
+                "unit": "escaped_value"
             },
             {
                 "_links": {
-                    "checklistItems": {
+                    "camp": {
                         "href": "escaped_value"
                     },
-                    "children": [],
-                    "contentType": {
+                    "materialList": {
                         "href": "escaped_value"
                     },
-                    "parent": {
+                    "materialNode": {
                         "href": "escaped_value"
                     },
-                    "root": {
-                        "href": "escaped_value"
-                    },
+                    "period": "escaped_value",
                     "self": {
                         "href": "escaped_value"
                     }
                 },
-                "contentTypeName": "escaped_value",
-                "data": "escaped_value",
+                "article": "escaped_value",
+                "done": "escaped_value",
                 "id": "escaped_value",
-                "instanceName": "escaped_value",
-                "position": "escaped_value",
-                "slot": "escaped_value"
+                "quantity": "escaped_value",
+                "unit": "escaped_value"
             }
         ]
     },


### PR DESCRIPTION
All endpoints `/content_node/.../` are filtered now. For example, filtered by `camp` or `period`.
Another new feature is that no content nodes belonging to a category would be listed.

I think this makes sense—all ContentNodes from a camp/period are only needed in a few cases. When activity data is displayed, no categories are needed. When category data is displayed, endpoint with all activities should not be used.
