### PR TITLE
chore(api): rector to php80

### DIFF
--- a/api/config/bootstrap.php
+++ b/api/config/bootstrap.php
@@ -19,5 +19,5 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php') && (!isset($env
 
 $_SERVER += $_ENV;
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
-$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
+$_SERVER['APP_DEBUG'] ??= $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/api/rector.php
+++ b/api/rector.php
@@ -13,6 +13,8 @@ use Rector\CodeQuality\Rector\If_\SimplifyIfReturnBoolRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\If_\RemoveDeadInstanceOfRector;
 use Rector\Doctrine\Bundle230\Rector\Class_\AddAnnotationToRepositoryRector;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
@@ -34,6 +36,7 @@ return RectorConfig::configure()
     ->withComposerBased(doctrine: true, phpunit: true, symfony: true)
     ->withPreparedSets(deadCode: true, codeQuality: true, privatization: true, rectorPreset: true, phpunitCodeQuality: true, symfonyCodeQuality: true)
     ->withAttributesSets(all: true)
+    ->withPhpSets(php80: true)
     ->withConfiguredRule(RenameFunctionRector::class, [
         'implode' => 'join',
         'join' => 'join',
@@ -42,6 +45,7 @@ return RectorConfig::configure()
         AddAnnotationToRepositoryRector::class,
         AddInstanceofAssertForNullableInstanceRector::class,
         AssertEmptyNullableObjectToAssertInstanceofRector::class,
+        ClosureToArrowFunctionRector::class,
         CombineIfRector::class,
         ConstraintOptionsToNamedArgumentsRector::class,
         DeclareStrictTypesRector::class,
@@ -56,5 +60,8 @@ return RectorConfig::configure()
         SimplifyIfReturnBoolRector::class,
         ThrowWithPreviousExceptionRector::class,
         UseIdenticalOverEqualWithSameTypeRector::class,
+        ClassPropertyAssignToConstructorPromotionRector::class => [
+            __DIR__.'/src/DTO/*',
+        ],
     ])
 ;

--- a/api/src/Doctrine/Filter/ExpressionDateTimeFilter.php
+++ b/api/src/Doctrine/Filter/ExpressionDateTimeFilter.php
@@ -134,7 +134,7 @@ class ExpressionDateTimeFilter extends AbstractFilter implements DateFilterInter
     ) {
         try {
             $value = new \DateTime($value);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Silently ignore this filter if it can not be transformed to a \DateTime
             $this->logger->notice('Invalid filter ignored', [
                 'exception' => new InvalidArgumentException(sprintf('The field "%s" has a wrong date format. Use one accepted by the \DateTime constructor', $field)),

--- a/api/src/Doctrine/FilterByCurrentUserExtension.php
+++ b/api/src/Doctrine/FilterByCurrentUserExtension.php
@@ -13,13 +13,7 @@ use Doctrine\ORM\QueryBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
 
 final class FilterByCurrentUserExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface {
-    private Security $security;
-    private EntityManagerInterface $entityManager;
-
-    public function __construct(Security $security, EntityManagerInterface $entityManager) {
-        $this->security = $security;
-        $this->entityManager = $entityManager;
-    }
+    public function __construct(private Security $security, private EntityManagerInterface $entityManager) {}
 
     public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, ?string $resourceClass = null, ?Operation $operation = null, array $context = []): void {
         $extraProperties = $operation->getExtraProperties();

--- a/api/src/Doctrine/Orm/Extension/FilterEagerLoadingsExtension.php
+++ b/api/src/Doctrine/Orm/Extension/FilterEagerLoadingsExtension.php
@@ -62,7 +62,7 @@ final class FilterEagerLoadingsExtension implements QueryCollectionExtensionInte
 
         foreach ($joins as $join) {
             // @var Join $join
-            list($fromAlias, $fromProperty) = explode('.', $join->getJoin(), 2);
+            [$fromAlias, $fromProperty] = explode('.', $join->getJoin(), 2);
             $toAlias = $join->getAlias();
 
             $fromClassMetadata = $aliasMap[$fromAlias][0];

--- a/api/src/Entity/Activity.php
+++ b/api/src/Entity/Activity.php
@@ -144,7 +144,7 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
      */
     #[ApiProperty(example: '/activities/1a2b3c4d')]
     #[Groups(['create'])]
-    public ?Activity $copyActivitySource;
+    public ?Activity $copyActivitySource = null;
 
     /**
      * The current assigned ProgressLabel.

--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -246,7 +246,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[ApiProperty(example: 'SoLa 2022')]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]
-    public ?string $shortTitle;
+    public ?string $shortTitle = null;
 
     /**
      * The full title of the camp. Used for identifying the camp in lists of camps, so

--- a/api/src/Entity/Category.php
+++ b/api/src/Entity/Category.php
@@ -140,7 +140,7 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
      */
     #[ApiProperty(example: '/categories/1a2b3c4d')]
     #[Groups(['create'])]
-    public Activity|Category|null $copyCategorySource;
+    public Activity|Category|null $copyCategorySource = null;
 
     /**
      * The id of the category that was used as a template for creating this category. Internal for now, is
@@ -257,25 +257,14 @@ class Category extends BaseEntity implements BelongsToCampInterface, CopyFromPro
     }
 
     public function getStyledNumber(int $num): string {
-        switch ($this->numberingStyle) {
-            case 'a':
-                return strtolower($this->getAlphaNum($num));
-
-            case 'A':
-                return strtoupper($this->getAlphaNum($num));
-
-            case 'i':
-                return strtolower($this->getRomanNum($num));
-
-            case 'I':
-                return strtoupper($this->getRomanNum($num));
-
-            case '-':
-                return '';
-
-            default:
-                return strval($num);
-        }
+        return match ($this->numberingStyle) {
+            'a' => strtolower($this->getAlphaNum($num)),
+            'A' => strtoupper($this->getAlphaNum($num)),
+            'i' => strtolower($this->getRomanNum($num)),
+            'I' => strtoupper($this->getRomanNum($num)),
+            '-' => '',
+            default => strval($num),
+        };
     }
 
     /**

--- a/api/src/Entity/Checklist.php
+++ b/api/src/Entity/Checklist.php
@@ -96,7 +96,7 @@ class Checklist extends BaseEntity implements BelongsToCampInterface, CopyFromPr
      */
     #[ApiProperty(example: '/checklists/1a2b3c4d')]
     #[Groups(['create'])]
-    public ?Checklist $copyChecklistSource;
+    public ?Checklist $copyChecklistSource = null;
 
     /**
      * All ChecklistItems that belong to this Checklist.

--- a/api/src/Entity/Day.php
+++ b/api/src/Entity/Day.php
@@ -157,7 +157,7 @@ class Day extends BaseEntity implements BelongsToCampInterface {
             $start?->add(new \DateInterval('P'.$this->dayOffset.'D'));
 
             return $start;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return null;
         }
     }
@@ -173,7 +173,7 @@ class Day extends BaseEntity implements BelongsToCampInterface {
             $end?->add(new \DateInterval('P'.($this->dayOffset + 1).'D'));
 
             return $end;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return null;
         }
     }

--- a/api/src/InputFilter/CleanHTMLFilter.php
+++ b/api/src/InputFilter/CleanHTMLFilter.php
@@ -3,11 +3,7 @@
 namespace App\InputFilter;
 
 class CleanHTMLFilter extends InputFilter {
-    private \HTMLPurifier $htmlPurifier;
-
-    public function __construct(\HTMLPurifier $htmlPurifier) {
-        $this->htmlPurifier = $htmlPurifier;
-    }
+    public function __construct(private \HTMLPurifier $htmlPurifier) {}
 
     /**
      * {@inheritdoc}

--- a/api/src/InputFilter/FilterAttribute.php
+++ b/api/src/InputFilter/FilterAttribute.php
@@ -12,8 +12,6 @@ namespace App\InputFilter;
  * FilterAttribute instances are immutable and serializable.
  */
 abstract class FilterAttribute {
-    protected int $priority;
-
     /**
      * Initializes the input filter with options.
      *
@@ -25,9 +23,7 @@ abstract class FilterAttribute {
      * @param int   $priority The priority of this input filter. Higher priorities are executed first.
      *                        Priorities are evaluated for the whole entity class at once.
      */
-    public function __construct(array $options = [], int $priority = 0) {
-        $this->priority = $priority;
-
+    public function __construct(array $options = [], protected int $priority = 0) {
         foreach ($options as $name => $value) {
             $this->{$name} = $value;
         }

--- a/api/src/InputFilter/InvalidOptionsException.php
+++ b/api/src/InputFilter/InvalidOptionsException.php
@@ -3,12 +3,8 @@
 namespace App\InputFilter;
 
 class InvalidOptionsException extends \RuntimeException {
-    private array $options;
-
-    public function __construct(string $message, array $options) {
+    public function __construct(string $message, private array $options) {
         parent::__construct($message);
-
-        $this->options = $options;
     }
 
     public function getOptions() {

--- a/api/src/OAuth/JWTStateOAuth2Client.php
+++ b/api/src/OAuth/JWTStateOAuth2Client.php
@@ -72,7 +72,7 @@ class JWTStateOAuth2Client extends OAuth2Client implements OAuth2ClientInterface
 
         try {
             $response->headers->setCookie(
-                Cookie::create($this->getCookieName($this->cookiePrefix))
+                Cookie::create(static::getCookieName($this->cookiePrefix))
                     ->withValue($this->encodeStateJWT(array_merge($options['additionalData'] ?? [], [
                         'state' => $state,
                         'iat' => $now,
@@ -83,7 +83,7 @@ class JWTStateOAuth2Client extends OAuth2Client implements OAuth2ClientInterface
                     ->withSecure('dev' !== $this->appEnv) // in local development, we don't use https
                     ->withExpires($expires)
             );
-        } catch (JWTEncodeFailureException $e) {
+        } catch (JWTEncodeFailureException) {
             throw new \LogicException('Could not create a JWT token for storing the state parameter securely');
         }
 
@@ -108,7 +108,7 @@ class JWTStateOAuth2Client extends OAuth2Client implements OAuth2ClientInterface
      * @throws IdentityProviderException
      */
     public function getAccessToken(array $options = []): AccessTokenInterface {
-        $jwt = $this->getCurrentRequest()->cookies->get($this->getCookieName($this->cookiePrefix));
+        $jwt = $this->getCurrentRequest()->cookies->get(static::getCookieName($this->cookiePrefix));
         if (null === $jwt) {
             throw new InvalidStateException('Expired state');
         }
@@ -122,7 +122,7 @@ class JWTStateOAuth2Client extends OAuth2Client implements OAuth2ClientInterface
 
             $now = new \DateTime('@'.time());
             $persistedState = $this->stateRepository->findOneUnexpiredBy($actualState, $now);
-        } catch (JWTDecodeFailureException|NonUniqueResultException|NoResultException $e) {
+        } catch (JWTDecodeFailureException|NonUniqueResultException|NoResultException) {
             throw new InvalidStateException('Invalid state');
         }
 

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -28,7 +28,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
      */
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void {
         if (!$user instanceof User) {
-            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', $user::class));
         }
 
         $user->password = $newHashedPassword;

--- a/api/src/Serializer/Normalizer/CollectionItemsNormalizer.php
+++ b/api/src/Serializer/Normalizer/CollectionItemsNormalizer.php
@@ -10,11 +10,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * under the relation name `items` instead of `item`.
  */
 class CollectionItemsNormalizer implements NormalizerInterface, NormalizerAwareInterface {
-    private NormalizerInterface $decorated;
-
-    public function __construct(NormalizerInterface $decorated) {
-        $this->decorated = $decorated;
-    }
+    public function __construct(private NormalizerInterface $decorated) {}
 
     public function supportsNormalization($data, $format = null, array $context = []): bool {
         return $this->decorated->supportsNormalization($data, $format, $context);

--- a/api/src/Serializer/Normalizer/Error/TranslationInfoOfConstraintViolation.php
+++ b/api/src/Serializer/Normalizer/Error/TranslationInfoOfConstraintViolation.php
@@ -7,7 +7,7 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
 class TranslationInfoOfConstraintViolation {
     public function extract(ConstraintViolationInterface $constraintViolation): TranslationInfo {
         $constraint = $constraintViolation->getConstraint();
-        $constraintClass = get_class($constraint);
+        $constraintClass = null !== $constraint ? $constraint::class : self::class;
         $key = str_replace('\\', '.', $constraintClass);
         $key = strtolower($key);
         $paramsWithoutCurlyBraces = self::removeCurlyBraces($constraintViolation->getParameters());

--- a/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
+++ b/api/src/Serializer/Normalizer/RelatedCollectionLinkNormalizer.php
@@ -223,7 +223,7 @@ class RelatedCollectionLinkNormalizer implements NormalizerInterface, Serializer
             $attributes = $method->getAttributes(RelatedCollectionLink::class);
 
             return ($attributes[0] ?? null)?->newInstance();
-        } catch (\ReflectionException $e) {
+        } catch (\ReflectionException) {
             return null;
         }
     }

--- a/api/src/Serializer/SerializerContextBuilder.php
+++ b/api/src/Serializer/SerializerContextBuilder.php
@@ -16,11 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
  * building the payload schemas for the API documentation.
  */
 final class SerializerContextBuilder implements SerializerContextBuilderInterface {
-    private SerializerContextBuilderInterface $decorated;
-
-    public function __construct(SerializerContextBuilderInterface $decorated) {
-        $this->decorated = $decorated;
-    }
+    public function __construct(private SerializerContextBuilderInterface $decorated) {}
 
     public function createFromRequest(Request $request, bool $normalization, ?array $extractedAttributes = null): array {
         $context = $this->decorated->createFromRequest($request, $normalization, $extractedAttributes);

--- a/api/src/Service/ClaimInvitationService.php
+++ b/api/src/Service/ClaimInvitationService.php
@@ -46,7 +46,7 @@ class ClaimInvitationService {
                 $invitation->user = $user;
                 $this->em->persist($invitation);
                 $this->em->flush();
-            } catch (UniqueConstraintViolationException $e) {
+            } catch (UniqueConstraintViolationException) {
                 // Even though we already handle this case above, it could still happen due
                 // to race conditions. Just ignore it.
                 $this->em->clear();

--- a/api/src/State/ChecklistCreateProcessor.php
+++ b/api/src/State/ChecklistCreateProcessor.php
@@ -20,7 +20,7 @@ class ChecklistCreateProcessor extends AbstractPersistProcessor {
      * @param Checklist $data
      */
     public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []): Checklist {
-        if (isset($data->copyChecklistSource)) {
+        if (null !== $data->copyChecklistSource) {
             // CopyChecklist Source is set -> copy it's content
             $entityMap = new EntityMap($data->camp);
             $data->copyFromPrototype($data->copyChecklistSource, $entityMap);

--- a/api/src/State/CommentCreateProcessor.php
+++ b/api/src/State/CommentCreateProcessor.php
@@ -13,11 +13,8 @@ use Symfony\Bundle\SecurityBundle\Security;
  * @template-extends AbstractPersistProcessor<Comment>
  */
 class CommentCreateProcessor extends AbstractPersistProcessor {
-    private Security $security;
-
-    public function __construct(ProcessorInterface $decorated, Security $security) {
+    public function __construct(ProcessorInterface $decorated, private Security $security) {
         parent::__construct($decorated);
-        $this->security = $security;
     }
 
     /**

--- a/api/src/Util/CamelPascalNamingStrategy.php
+++ b/api/src/Util/CamelPascalNamingStrategy.php
@@ -55,7 +55,7 @@ class CamelPascalNamingStrategy extends DefaultNamingStrategy {
      * @param string $className
      */
     private function unqualifiedClassName($className): string {
-        if (false !== strpos($className, '\\')) {
+        if (str_contains($className, '\\')) {
             return substr($className, strrpos($className, '\\') + 1);
         }
 

--- a/api/src/Validator/AssertBelongsToSameCamp.php
+++ b/api/src/Validator/AssertBelongsToSameCamp.php
@@ -7,17 +7,15 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class AssertBelongsToSameCamp extends Constraint {
     public string $message = 'Must belong to the same camp.';
-    public bool $compareToPrevious = false;
 
     /**
      * AssertBelongsToSameCamp constructor.
      *
      * @param bool $compareToPrevious in case the camp getter considers the annotated property, use this option (only when updating)
      */
-    public function __construct(?array $options = null, bool $compareToPrevious = false, ?string $message = null, ?array $groups = null, mixed $payload = null) {
+    public function __construct(?array $options = null, public bool $compareToPrevious = false, ?string $message = null, ?array $groups = null, mixed $payload = null) {
         parent::__construct($options ?? [], $groups, $payload);
 
         $this->message = $message ?? $this->message;
-        $this->compareToPrevious = $compareToPrevious;
     }
 }

--- a/api/src/Validator/ColumnLayout/AssertColumWidthsSumTo12Validator.php
+++ b/api/src/Validator/ColumnLayout/AssertColumWidthsSumTo12Validator.php
@@ -17,11 +17,7 @@ class AssertColumWidthsSumTo12Validator extends ConstraintValidator {
         }
 
         $columnWidths = array_sum(array_map(function ($col) {
-            if (isset($col['width'])) {
-                return $col['width'];
-            }
-
-            return 0;
+            return $col['width'] ?? 0;
         }, $value['columns']));
 
         if (12 !== $columnWidths) {

--- a/api/src/Validator/ColumnLayout/AssertNoOrphanChildrenValidator.php
+++ b/api/src/Validator/ColumnLayout/AssertNoOrphanChildrenValidator.php
@@ -36,11 +36,7 @@ class AssertNoOrphanChildrenValidator extends ConstraintValidator {
         }
 
         $slots = array_map(function ($col) {
-            if (isset($col['slot'])) {
-                return $col['slot'];
-            }
-
-            return null;
+            return $col['slot'] ?? null;
         }, $array);
 
         $childSlots = $layout->children->map(function (ContentNode $child) {

--- a/api/tests/Api/ECampApiTestCase.php
+++ b/api/tests/Api/ECampApiTestCase.php
@@ -190,13 +190,13 @@ abstract class ECampApiTestCase extends ApiTestCase {
                     $decoded = json_decode($example, true, 512, JSON_THROW_ON_ERROR);
 
                     return is_array($decoded) || is_null($decoded) ? $decoded : $example;
-                } catch (\JsonException|\TypeError $e) {
+                } catch (\JsonException|\TypeError) {
                     return $example;
                 }
             }, $examples);
 
             return array_diff_key(array_merge(array_diff_key($examples, array_flip($exceptExamples)), $attributes), array_flip($exceptAttributes));
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return [];
         }
     }
@@ -272,13 +272,13 @@ abstract class ECampApiTestCase extends ApiTestCase {
     protected function assertEntityWasRemoved(?BaseEntity $entity = null) {
         $entity ??= $this->defaultEntity;
 
-        $this->assertNull($this->getEntityManager()->getRepository(get_class($entity))->find($entity->getId()));
+        $this->assertNull($this->getEntityManager()->getRepository($entity::class)->find($entity->getId()));
     }
 
     protected function assertEntityStillExists(?BaseEntity $entity = null) {
         $entity ??= $this->defaultEntity;
 
-        $this->assertNotNull($this->getEntityManager()->getRepository(get_class($entity))->find($entity->getId()));
+        $this->assertNotNull($this->getEntityManager()->getRepository($entity::class)->find($entity->getId()));
     }
 
     /**

--- a/api/tests/Api/SnapshotTests/EndpointPerformanceTest.php
+++ b/api/tests/Api/SnapshotTests/EndpointPerformanceTest.php
@@ -38,7 +38,7 @@ class EndpointPerformanceTest extends ECampApiTestCase {
         $collectionEndpoints = self::getCollectionEndpoints();
         foreach ($collectionEndpoints as $collectionEndpoint) {
             if ('/users' !== $collectionEndpoint && !str_contains($collectionEndpoint, '/content_node')) {
-                list($statusCode, $queryCount, $executionTimeSeconds) = $this->measurePerformanceFor($collectionEndpoint);
+                [$statusCode, $queryCount, $executionTimeSeconds] = $this->measurePerformanceFor($collectionEndpoint);
                 $responseCodes[$collectionEndpoint] = $statusCode;
                 $numberOfQueries[$collectionEndpoint] = $queryCount;
                 $queryExecutionTime[$collectionEndpoint] = $executionTimeSeconds;
@@ -46,7 +46,7 @@ class EndpointPerformanceTest extends ECampApiTestCase {
 
             if (!str_contains($collectionEndpoint, '/content_node')) {
                 $fixtureFor = self::getFixtureFor($collectionEndpoint);
-                list($statusCode, $queryCount, $executionTimeSeconds) = $this->measurePerformanceFor("{$collectionEndpoint}/{$fixtureFor->getId()}");
+                [$statusCode, $queryCount, $executionTimeSeconds] = $this->measurePerformanceFor("{$collectionEndpoint}/{$fixtureFor->getId()}");
                 $responseCodes["{$collectionEndpoint}/item"] = $statusCode;
                 $numberOfQueries["{$collectionEndpoint}/item"] = $queryCount;
                 $queryExecutionTime["{$collectionEndpoint}/item"] = $executionTimeSeconds;
@@ -54,14 +54,14 @@ class EndpointPerformanceTest extends ECampApiTestCase {
         }
 
         foreach ($this->getPerformanceCriticalUrls() as $url => $id) {
-            list($statusCode, $queryCount, $executionTimeSeconds) = $this->measurePerformanceFor($url.$id);
+            [$statusCode, $queryCount, $executionTimeSeconds] = $this->measurePerformanceFor($url.$id);
             $responseCodes[$url] = $statusCode;
             $numberOfQueries[$url] = $queryCount;
             $queryExecutionTime[$url] = $executionTimeSeconds;
         }
 
         foreach ($this->getSubresourceUrls() as $url => $id) {
-            list($statusCode, $queryCount, $executionTimeSeconds) = $this->measurePerformanceFor(preg_replace('/\{id}/', $id, $url));
+            [$statusCode, $queryCount, $executionTimeSeconds] = $this->measurePerformanceFor(preg_replace('/\{id}/', $id, $url));
             $responseCodes[$url] = $statusCode;
             $numberOfQueries[$url] = $queryCount;
             $queryExecutionTime[$url] = $executionTimeSeconds;
@@ -94,7 +94,7 @@ class EndpointPerformanceTest extends ECampApiTestCase {
         if ('test' !== $this->getEnvironment()) {
             self::markTestSkipped(__FUNCTION__.' is only run in test environment, not in '.$this->getEnvironment());
         }
-        list($statusCode, $queryCount, $executionTimeSeconds)
+        [$statusCode, $queryCount, $executionTimeSeconds]
             = $this->measurePerformanceFor($collectionEndpoint.'?camp=/camps/'.self::getFixtureFor('/camps')->getId());
 
         assertThat($statusCode, equalTo(200));
@@ -129,7 +129,7 @@ class EndpointPerformanceTest extends ECampApiTestCase {
             self::markTestSkipped("{$collectionEndpoint} does not support get item endpoint");
         }
         $fixtureFor = self::getFixtureFor($collectionEndpoint);
-        list($statusCode, $queryCount, $executionTimeSeconds) = $this->measurePerformanceFor("{$collectionEndpoint}/{$fixtureFor->getId()}");
+        [$statusCode, $queryCount, $executionTimeSeconds] = $this->measurePerformanceFor("{$collectionEndpoint}/{$fixtureFor->getId()}");
 
         assertThat($statusCode, equalTo(200));
 

--- a/api/tests/Constraints/CompatibleHalResponse.php
+++ b/api/tests/Constraints/CompatibleHalResponse.php
@@ -27,7 +27,7 @@ class CompatibleHalResponse extends Constraint {
         sort($otherKeys);
         $otherKeysWithoutEmbedded = array_diff($otherKeys, ['_embedded']);
 
-        if (join($halResponseKeysWithoutEmbedded) !== join($otherKeysWithoutEmbedded)) {
+        if (join('', $halResponseKeysWithoutEmbedded) !== join('', $otherKeysWithoutEmbedded)) {
             return false;
         }
 
@@ -41,7 +41,7 @@ class CompatibleHalResponse extends Constraint {
         $otherRelationKeys = array_unique(array_merge($otherLinksKeys, $otherEmbeddedKeys));
         sort($otherRelationKeys);
 
-        if (join($halResponseRelationKeys) !== join($otherRelationKeys)) {
+        if (join('', $halResponseRelationKeys) !== join('', $otherRelationKeys)) {
             return false;
         }
 

--- a/api/tests/HttpCache/PurgeHttpCacheListenerTest.php
+++ b/api/tests/HttpCache/PurgeHttpCacheListenerTest.php
@@ -75,13 +75,13 @@ class PurgeHttpCacheListenerTest extends TestCase {
         $classMetadataProphecy = $this->prophesize(ClassMetadata::class);
         $classMetadataProphecy->getAssociationMappings()->willReturn([
             'relatedDummy' => [
-                'targetEntity' => 'App\Tests\HttpCache\Entity\RelatedDummy',
+                'targetEntity' => RelatedDummy::class,
                 'isOwningSide' => true,
                 'inversedBy' => 'dummies',
                 'mappedBy' => null,
             ],
             'relatedOwningDummy' => [
-                'targetEntity' => 'App\Tests\HttpCache\Entity\RelatedOwningDummy',
+                'targetEntity' => RelatedOwningDummy::class,
                 'isOwningSide' => true,
                 'inversedBy' => 'ownedDummy',
                 'mappedBy' => null,

--- a/api/tests/Integration/State/ValidationErrorProviderIntegrationTest.php
+++ b/api/tests/Integration/State/ValidationErrorProviderIntegrationTest.php
@@ -32,7 +32,7 @@ class ValidationErrorProviderIntegrationTest extends KernelTestCase {
         parent::setUp();
 
         /** @var ValidationErrorProvider $obj */
-        $obj = self::getContainer()->get('App\State\ValidationErrorProvider');
+        $obj = self::getContainer()->get(ValidationErrorProvider::class);
         $this->validationErrorProvider = $obj;
     }
 

--- a/api/tests/Serializer/Denormalizer/InputFilterDenormalizerTest.php
+++ b/api/tests/Serializer/Denormalizer/InputFilterDenormalizerTest.php
@@ -315,13 +315,6 @@ class AppendBFilter extends InputFilter {
 }
 
 class DummyEntity {
-    #[Dummy]
-    public $foo;
-
-    // other attribute which is not an input filter
-    #[Valid]
-    public $bar;
-
     #[AppendA(priority: 10)]
     #[AppendB(priority: 0)]
     public $ab;
@@ -339,10 +332,12 @@ class DummyEntity {
     #[ORM\Embedded(class: 'EmbeddableEntity')]
     public EmbeddableEntity $embeddableEntity;
 
-    public function __construct($foo, $bar) {
-        $this->foo = $foo;
-        $this->bar = $bar;
-    }
+    public function __construct(
+        #[Dummy]
+        public $foo,
+        #[Valid]
+        public $bar
+    ) {}
 }
 
 class RelatedEntity extends BaseEntity {

--- a/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
@@ -48,7 +48,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
     private MockObject|PropertyAccessorInterface $propertyAccessor;
     private EntityManagerInterface|MockObject $entityManager;
 
-    private DateFilter|SearchFilterInterface|null $filterInstance;
+    private DateFilter|SearchFilterInterface|null $filterInstance = null;
 
     protected function setUp(): void {
         $filterLocatorMock = $this->createMock(ServiceLocator::class);
@@ -534,7 +534,7 @@ class ParentEntity {
     private Collection $children;
 
     #[ORM\OneToOne(targetEntity: Child::class)]
-    private ?Child $firstBorn;
+    private ?Child $firstBorn = null;
 
     #[SerializedName('childrenWithSerializedName')]
     #[ORM\OneToMany(targetEntity: Child::class, mappedBy: 'parent')]
@@ -553,5 +553,5 @@ class ParentEntity {
 #[ApiFilter(SearchFilter::class, properties: ['parent'])]
 class Child {
     #[ORM\ManyToOne(targetEntity: ParentEntity::class, inversedBy: 'children')]
-    private ?ParentEntity $parent;
+    private ?ParentEntity $parent = null;
 }

--- a/api/tests/Serializer/Normalizer/UriTemplateNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/UriTemplateNormalizerTest.php
@@ -29,34 +29,17 @@ class UriTemplateNormalizerTest extends TestCase {
         $englishInflector = new EnglishInflector();
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->method('generate')->willReturnCallback(function (string $arg): string {
-            switch ($arg) {
-                case 'authentication_token':
-                    return '/authentication_token';
-
-                case 'connect_google_start':
-                    return '/auth/google';
-
-                case 'connect_pbsmidata_start':
-                    return '/auth/pbsmidata';
-
-                case 'connect_cevidb_start':
-                    return '/auth/cevidb';
-
-                case 'connect_jubladb_start':
-                    return '/auth/jubladb';
-
-                case 'api_refresh_token':
-                    return '/token/refresh';
-
-                case '_api_/auth/resend_activation{._format}_post':
-                    return '/auth/resend_activation';
-
-                case '_api_/auth/reset_password{._format}_post':
-                    return '/auth/reset_password';
-
-                default:
-                    return null;
-            }
+            return match ($arg) {
+                'authentication_token' => '/authentication_token',
+                'connect_google_start' => '/auth/google',
+                'connect_pbsmidata_start' => '/auth/pbsmidata',
+                'connect_cevidb_start' => '/auth/cevidb',
+                'connect_jubladb_start' => '/auth/jubladb',
+                'api_refresh_token' => '/token/refresh',
+                '_api_/auth/resend_activation{._format}_post' => '/auth/resend_activation',
+                '_api_/auth/reset_password{._format}_post' => '/auth/reset_password',
+                default => null,
+            };
         });
 
         $this->uriTemplateNormalizer = new UriTemplateNormalizer(

--- a/api/tests/Validator/AllowTransitions/AssertAllowTransitionTest.php
+++ b/api/tests/Validator/AllowTransitions/AssertAllowTransitionTest.php
@@ -107,16 +107,14 @@ class AssertAllowTransitionTest extends ConstraintValidatorTestCase {
 }
 
 class TestClass {
-    #[AssertAllowTransitions([
-        ['from' => '1', 'to' => ['2', '3']],
-        ['from' => '2', 'to' => ['3']],
-        ['from' => '3', 'to' => ['1']],
-    ])]
-    public string $a;
-
-    public function __construct($a) {
-        $this->a = $a;
-    }
+    public function __construct(
+        #[AssertAllowTransitions([
+            ['from' => '1', 'to' => ['2', '3']],
+            ['from' => '2', 'to' => ['3']],
+            ['from' => '3', 'to' => ['1']],
+        ])]
+        public string $a
+    ) {}
 
     public function setA(string $a): TestClass {
         $this->a = $a;

--- a/api/tests/Validator/AssertBelongsToSameCampValidatorTest.php
+++ b/api/tests/Validator/AssertBelongsToSameCampValidatorTest.php
@@ -175,7 +175,7 @@ class ChildTestClass implements BelongsToCampInterface {
 
 class ParentTestClass extends BaseEntity implements BelongsToCampInterface {
     #[AssertBelongsToSameCamp]
-    public ?ChildTestClass $child;
+    public ?ChildTestClass $child = null;
 
     public function __construct(public Camp $camp) {}
 

--- a/api/tests/Validator/AssertEitherIsNullValidatorTest.php
+++ b/api/tests/Validator/AssertEitherIsNullValidatorTest.php
@@ -85,13 +85,9 @@ class AssertEitherIsNullValidatorTest extends ConstraintValidatorTestCase {
 }
 
 class AssertEitherIsNullValidatorTestClass {
-    #[AssertEitherIsNull(other: 'b')]
-    public $a;
-
-    public $b;
-
-    public function __construct($a, $b) {
-        $this->a = $a;
-        $this->b = $b;
-    }
+    public function __construct(
+        #[AssertEitherIsNull(other: 'b')]
+        public $a,
+        public $b
+    ) {}
 }

--- a/api/tests/Validator/AssertLastCollectionItemIsNotDeletedValidatorTest.php
+++ b/api/tests/Validator/AssertLastCollectionItemIsNotDeletedValidatorTest.php
@@ -107,10 +107,8 @@ class AssertLastCollectionItemIsNotDeletedValidatorTest extends ConstraintValida
 }
 
 class AssertLastCollectionItemNotDeletedValidatorTestClass {
-    #[AssertLastCollectionItemIsNotDeleted()]
-    public $a;
-
-    public function __construct($a) {
-        $this->a = $a;
-    }
+    public function __construct(
+        #[AssertLastCollectionItemIsNotDeleted()]
+        public $a
+    ) {}
 }


### PR DESCRIPTION
I know we started with php 8 with this version of the backend, but it seems we did not write php8 code.
Disable ClosureToArrowFunctionRector for now because too much would change, and one can argue that it's a choice to use a closure instead of an arrow function.