### PR TITLE
reverse-proxy-nginx: disable dns cache for upstream

### DIFF
--- a/reverse-proxy-nginx.conf
+++ b/reverse-proxy-nginx.conf
@@ -11,7 +11,7 @@ http {
     ''      close;
   }
 
-  resolver 127.0.0.11;
+  resolver 127.0.0.11 valid=0s;
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '


### PR DESCRIPTION
That they are resolved each time.
Helps when you have to recreate upstreams.
Then you don't have to also recreate the reverse-proxy. See https://nginx.org/en/docs/http/ngx_http_core_module.html#resolver

I also tried using variables, but I failed to rewrite the api url when using variables.
https://wisdom.gitbook.io/gyan/nginx/deep-dive-into-nginx-variables