### PR TITLE
docker-compose.yaml: restart api container on-failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       timeout: 3s
       retries: 3
       start_period: 30s
+    restart: on-failure
     extra_hosts:
       - 'host.docker.internal:host-gateway'
 


### PR DESCRIPTION
Issue: https://github.com/ecamp/ecamp3/issues/8036