### PR TITLE
CI: allow configuring deployment name with var in reusable-ecamp3-deployment

### DIFF
--- a/.github/workflows/deployment-stage-prod.yml
+++ b/.github/workflows/deployment-stage-prod.yml
@@ -35,7 +35,7 @@ jobs:
     needs: build-and-push
     uses: ./.github/workflows/reusable-ecamp3-deployment.yml
     with:
-      name: ${{ github.ref_name == 'prod' && 'app' || github.ref_name }}
+      name: ${{ github.ref_name }}
       env: ${{ github.ref_name }}
       action: ${{ github.event.inputs.action || 'deploy' }}
     secrets: inherit

--- a/.github/workflows/reusable-ecamp3-deployment.yml
+++ b/.github/workflows/reusable-ecamp3-deployment.yml
@@ -31,17 +31,16 @@ on:
         required: true
         default: diff
 
-env:
-  NAME: ${{ inputs.name }}
-  IMAGE_TAG: ${{ inputs.sha }}
-  HELM_TIMEOUT: ${{ vars.HELM_TIMEOUT }}
-
 jobs:
   deploy-ecamp3:
     name: Deploy to Kubernetes
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.env }}
+    env:
+      NAME: ${{ vars.NAME || inputs.name }}
+      IMAGE_TAG: ${{ inputs.sha }}
+      HELM_TIMEOUT: ${{ vars.HELM_TIMEOUT }}
     steps:
       - name: Get link to currently running job logs
         if: ${{ inputs.env == 'feature-branch' }}
@@ -132,7 +131,7 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: ${{ (inputs.env == 'staging' || inputs.env == 'prod') && format('https://{0}.{1}', vars.SUBDOMAIN, vars.DOMAIN) || format('https://{0}.{1}', inputs.name, vars.DOMAIN) }}
+          env_url: ${{ format('https://{0}.{1}', (vars.NAME || inputs.name), vars.DOMAIN) }}
           env: ${{ steps.deployment.outputs.env }}
 
       - name: Get current time


### PR DESCRIPTION
That we don't tie it to the branch name prod and the deployment name app.