### PR TITLE
Deploy ops dashboard with helm v4

### DIFF
--- a/.github/actions/setup-helmfile/action.yaml
+++ b/.github/actions/setup-helmfile/action.yaml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: install helmfile
       run: |
-        curl -L https://github.com/helmfile/helmfile/releases/download/v1.1.3/helmfile_1.1.3_linux_amd64.tar.gz -o helmfile.tar.gz
+        curl -L https://github.com/helmfile/helmfile/releases/download/v1.2.2/helmfile_1.2.2_linux_amd64.tar.gz -o helmfile.tar.gz
         tar -xvf /tmp/helmfile.tar.gz
         mv helmfile /usr/local/bin
         chmod +x /usr/local/bin/helmfile

--- a/.github/workflows/deploy-ops-dashboard.yml
+++ b/.github/workflows/deploy-ops-dashboard.yml
@@ -53,6 +53,19 @@ jobs:
           jq '.' env.yaml
         working-directory: .ops/ops-dashboard
 
+      - name: pin helm to correct version
+        run: |
+          helm version
+          
+          curl -o /tmp/helm.tar.gz -sL https://get.helm.sh/helm-v4.0.1-linux-amd64.tar.gz
+          echo "e0365548f01ed52a58a1181ad310b604a3244f59257425bb1739499372bdff60 /tmp/helm.tar.gz" | sha256sum --check
+          
+          tar -xzf /tmp/helm.tar.gz -C /tmp/
+          mv /tmp/linux-amd64/helm /usr/local/bin/helm
+          
+          chmod +x /usr/local/bin/helm
+          helm version
+
       - name: Setup helm
         run: |
           mkdir ~/.kube && echo '${{ secrets.KUBECONFIG }}' > ~/.kube/config && chmod go-r ~/.kube/config


### PR DESCRIPTION
The oauth2-proxy chart had a bug and deployed redis even when disabled.
This is fixed with helm v4.

We also need to update helmfile, the old version of helmfile had a problem with the new helm.

Result can be seen here:
https://github.com/ecamp/ecamp3/actions/runs/19785182325

And with update of oauth2-proxy:
https://github.com/ecamp/ecamp3/actions/runs/19785222001