### PR TITLE
ops-dashboard: hide provider form of oauth2-proxy

### DIFF
--- a/.ops/ops-dashboard/values.yaml.gotmpl
+++ b/.ops/ops-dashboard/values.yaml.gotmpl
@@ -1,3 +1,10 @@
+{{ $configFile := `
+email_domains = [ "*" ]
+upstreams = [ "file:///dev/null" ]
+skip_provider_button = true
+`
+}}
+
 grafana-proxy:
   ingress:
     enabled: true
@@ -14,6 +21,8 @@ grafana-proxy:
     clientID: {{ .Environment.Values | getOrNil "GRAFANA_PROXY_OAUTH_CLIENT_ID" | required "GRAFANA_PROXY_OAUTH_CLIENT_ID is required" | quote }}
     # OAuth client secret
     clientSecret: {{ .Environment.Values | getOrNil "GRAFANA_PROXY_OAUTH_CLIENT_SECRET" | required "GRAFANA_PROXY_OAUTH_CLIENT_SECRET is required" | quote }}
+    configFile: |
+        {{- $configFile | trim | nindent 8 }}
     # Create a new secret with the following command
     # openssl rand -base64 32 | head -c 32 | base64
     cookieSecret: {{ .Environment.Values | getOrNil "COOKIE_SECRET" | required "COOKIE_SECRET is required" | quote }}
@@ -34,6 +43,8 @@ kubernetes-dashboard-proxy:
     clientID: {{ .Environment.Values | getOrNil "KUBERNETES_DASHBOARD_PROXY_OAUTH_CLIENT_ID" | required "KUBERNETES_DASHBOARD_PROXY_OAUTH_CLIENT_ID is required" | quote }}
     # OAuth client secret
     clientSecret: {{ .Environment.Values | getOrNil "KUBERNETES_DASHBOARD_PROXY_OAUTH_CLIENT_SECRET" | required "KUBERNETES_DASHBOARD_PROXY_OAUTH_CLIENT_SECRET is required" | quote }}
+    configFile: |
+        {{- $configFile | trim | nindent 8 }}
     # Create a new secret with the following command
     # openssl rand -base64 32 | head -c 32 | base64
     cookieSecret: {{ .Environment.Values | getOrNil "COOKIE_SECRET" | required "COOKIE_SECRET is required" | quote }}
@@ -53,6 +64,8 @@ logging-proxy:
     clientID: {{ .Environment.Values | getOrNil "LOGGING_PROXY_OAUTH_CLIENT_ID" | required "LOGGING_PROXY_OAUTH_CLIENT_ID is required" | quote }}
     # OAuth client secret
     clientSecret: {{ .Environment.Values | getOrNil "LOGGING_PROXY_OAUTH_CLIENT_SECRET" | required "LOGGING_PROXY_OAUTH_CLIENT_SECRET is required" | quote }}
+    configFile: |
+        {{- $configFile | trim | nindent 8 }}
     # Create a new secret with the following command
     # openssl rand -base64 32 | head -c 32 | base64
     cookieSecret: {{ .Environment.Values | getOrNil "COOKIE_SECRET" | required "COOKIE_SECRET is required" | quote }}


### PR DESCRIPTION
We anyway have only one provider (github).
Like this you can login directly, or are logged in if you already have an open github session. The defaults were taken from:
https://github.com/oauth2-proxy/manifests/blob/c37a414ad8eb31727f9b15f1175e801f7bbe4eca/helm/oauth2-proxy/values.yaml#L48,L50

Already deployed here:
https://dev-grafana.ecamp3.ch