### PR TITLE
.helm: make AUTHENTICATION_TOKEN_TTL configurable for the api

### DIFF
--- a/.helm/ecamp3/env.example.yaml
+++ b/.helm/ecamp3/env.example.yaml
@@ -1,4 +1,5 @@
 {
+  "API_AUTHENTICATION_TOKEN_TTL": null,
   "API_CACHE_ENABLED": true,
   "API_DATA_MIGRATIONS_DIR": "dev-data",
   "API_NUM_THREADS": null,

--- a/.helm/ecamp3/templates/api_configmap.yaml
+++ b/.helm/ecamp3/templates/api_configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "app.commonLabels" . | nindent 4 }}
 data:
   ADDITIONAL_TRUSTED_HOSTS: {{ .Values.domain | quote }}
-  {{- if not (.Values.api.authenticationTokenTtl | empty) }}
+  {{- if and (.Values.api.authenticationTokenTtl) (ne (.Values.api.authenticationTokenTtl | toString) "<no value>") }}
   AUTHENTICATION_TOKEN_TTL: {{ .Values.api.authenticationTokenTtl | quote }}
   {{- end }}
   COOKIE_PREFIX: {{ include "api.cookiePrefix" . | quote }}

--- a/.helm/ecamp3/values.yaml.gotmpl
+++ b/.helm/ecamp3/values.yaml.gotmpl
@@ -25,6 +25,7 @@ featureToggle:
   checklist: {{ .Environment.Values | getOrNil "FEATURE_CHECKLIST" | default false }}
 
 api:
+  authenticationTokenTtl: {{ .Environment.Values | getOrNil "API_AUTHENTICATION_TOKEN_TTL" }}
   dataMigrationsDir: {{ .Environment.Values | getOrNil "API_DATA_MIGRATIONS_DIR" | default "prod-data" }}
   subpath: "/api"
   image:


### PR DESCRIPTION
Helm has a silly behavior for empty values, see:
- https://github.com/helm/helm/issues/13487

.Values.api.authenticationTokenTtl should catch "", nil.
Sometimes an empty value ends up as string \<no value\> which is explicitly checked here.

I configured it for feature branch deployments to 1 hour.