### PR TITLE
ecamp3-logging: pin fluentd to v1.17.1 again

### DIFF
--- a/.ops/ecamp3-logging/values.yaml.gotmpl
+++ b/.ops/ecamp3-logging/values.yaml.gotmpl
@@ -21,6 +21,9 @@ fluent-operator:
         # enable to debug fluentbit
         enable: false
   fluentd:
+    image:
+      # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluentd
+      tag: v1.17.1
     watchedNamespaces:
       - default
       - ingress-nginx


### PR DESCRIPTION
Elasticsearch plugin 5.4.4 shipping with fluentd 1.19.0 cannot send logs to elasticsearch.

Sorry, i accidentally broke ecamp3-logging by updating.
Fixed it by rolling back on prod, and on dev we fix the helm chart.