### PR TITLE
Really auto update fluent images

### DIFF
--- a/.ops/ecamp3-logging/templates/elasticsearch/elasticsearch_stateful_set.yaml
+++ b/.ops/ecamp3-logging/templates/elasticsearch/elasticsearch_stateful_set.yaml
@@ -57,7 +57,7 @@ spec:
               value: "-Xms{{ $minHeapSpace }}m -Xmx{{ $maxHeapSpace }}m"
         {{- if not (.Values.elasticsearch.removeOldIndexes.maxIndexAge | empty) }}
         - name: remove-old-indexes
-          image: {{ .Values.elasticsearch.removeOldIndexes.image }}
+          image: {{ .Values.elasticsearch.removeOldIndexes.image }}:{{ .Values.elasticsearch.removeOldIndexes.tag }}
           command:
             - node
             - /src/remove-old-indexes.mjs

--- a/.ops/ecamp3-logging/values.yaml.gotmpl
+++ b/.ops/ecamp3-logging/values.yaml.gotmpl
@@ -5,7 +5,7 @@ fluent-operator:
       trigger-recreate: {{ exec "uuidgen" (list) }}
     container:
       # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluent-operator
-      tag: 3.3.0
+      tag: "3.3.0"
   fluentbit:
     enable: true
     input:
@@ -24,7 +24,7 @@ fluent-operator:
   fluentd:
     image:
       # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluentd
-      tag: v1.17.1
+      tag: "v1.17.1"
     watchedNamespaces:
       - default
       - ingress-nginx

--- a/.ops/ecamp3-logging/values.yaml.gotmpl
+++ b/.ops/ecamp3-logging/values.yaml.gotmpl
@@ -60,7 +60,9 @@ elasticsearch:
         storage: {{ .Environment.Values | get "ELASTIC_NODE_STORAGE_SIZE" nil | required "Please define ELASTIC_NODE_STORAGE_SIZE. There is no good default value." }}
   removeOldIndexes:
     maxIndexAge: {{ .Environment.Values | get "ELASTIC_NODE_MAX_INDEX_AGE" "15" }}
-    image: node:24.8.0
+    image: node
+    # renovate: datasource=docker depName=node
+    tag: "24.8.0"
 
 kibana:
   name: kibana


### PR DESCRIPTION
ecamp3-logging: add quotes to image version tags

The regex only matches versions with quotes.

---

ecamp3-logging: auto update node again

Before this was recognized because it was in a values.yaml.

---

Tested it now on my fork how you should do it:
See https://github.com/ecamp/ecamp3/issues/1864 in the "Detected Dependencies" > regex