### PR TITLE
Fix client printing picasso as external person

### DIFF
--- a/pdf/src/campPrint/picasso/PicassoFooter.vue
+++ b/pdf/src/campPrint/picasso/PicassoFooter.vue
@@ -16,7 +16,7 @@
       <Text v-if="dates" class="picasso-footer-field">{{ dates }}</Text>
     </View>
     <View class="picasso-footer-column">
-      <Text class="picasso-footer-field">{{
+      <Text v-if="leaders" class="picasso-footer-field">{{
         $tc('print.picasso.picassoFooter.leaders', { leaders })
       }}</Text>
       <Text v-if="camp.coachName" class="picasso-footer-field">{{
@@ -69,9 +69,15 @@ export default {
           campCollaboration.role === 'manager'
         )
       })
-      const leaderNames = leaders.map((campCollaboration) => {
-        return campCollaborationLegalName(campCollaboration)
-      })
+      const leaderNames = leaders
+        .map((campCollaboration) => {
+          try {
+            return campCollaborationLegalName(campCollaboration)
+          } catch {
+            return ''
+          }
+        })
+        .filter((leaderName) => leaderName.length)
       if ('Intl' in self && 'ListFormat' in Intl) {
         return new Intl.ListFormat(this.locale, { style: 'short' }).format(leaderNames)
       }

--- a/pdf/src/renderer/__tests__/__snapshots__/picasso.spec.json.snap
+++ b/pdf/src/renderer/__tests__/__snapshots__/picasso.spec.json.snap
@@ -8911,6 +8911,7 @@
                   "parent": [Circular],
                   "props": {
                     "class": "picasso-footer-field",
+                    "key": 0,
                   },
                   "style": {
                     "marginBottom": "6pt",


### PR DESCRIPTION
Fixes #8267

External people don't have access to the camp's collaborator profiles, so using campCollaborationLegalName may fail.