### PR TITLE
Fix client printing activity list

### DIFF
--- a/pdf/src/campPrint/activityList/ActivityList.vue
+++ b/pdf/src/campPrint/activityList/ActivityList.vue
@@ -21,6 +21,11 @@ export default {
   name: 'ActivityList',
   components: { TocSectionStartMarker, ActivityListPeriod },
   extends: PdfComponent,
+  provide() {
+    return {
+      camp: this.camp,
+    }
+  },
   props: {
     content: { type: Object, required: true },
     config: { type: Object, required: true },
@@ -28,6 +33,9 @@ export default {
   computed: {
     periods() {
       return this.content.options.periods.map((periodUri) => this.api.get(periodUri))
+    },
+    camp() {
+      return this.periods[0].camp()
     },
   },
 }

--- a/pdf/src/renderer/__tests__/__snapshots__/activity_list.spec.json.snap
+++ b/pdf/src/renderer/__tests__/__snapshots__/activity_list.spec.json.snap
@@ -1,0 +1,17600 @@
+{
+  "box": {},
+  "children": [
+    {
+      "box": {},
+      "children": [
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "parent": [Circular],
+              "type": "TEXT_INSTANCE",
+              "value": "Activity list: Hauptlager",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "bookmark": {
+              "fit": true,
+              "title": "Activity list: Hauptlager",
+            },
+            "class": "activity-list-period-title",
+            "id": "entry-0-88f1f55a69d7",
+          },
+          "style": {
+            "fontSize": "10pt",
+            "fontWeight": "bold",
+            "textAlign": "center",
+          },
+          "type": "TEXT",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "WP",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#90B7E4",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#90B7E4",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "1.1 Beginn & Anreise",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "WP 1.1 Beginn & Anreise",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-8edd32042a72",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_8edd32042a72",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/13/2026 8:30 AM - 12:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#90B7E4",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#90B7E4",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmittag",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmittag",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-3ff3ca55f540",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_3ff3ca55f540",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/13/2026 12:00 PM - 1:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "LL",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#4DBB52",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#4DBB52",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "1.A LA Lagerbau",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "LL 1.A LA Lagerbau",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-708d5982455b",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_708d5982455b",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/13/2026 1:00 PM - 6:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#4DBB52",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#4DBB52",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die Tn erstellen aus Beobachtungen eine angemessene, förderungsorientierte Rückmeldung.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN wenden die grundlegenden Gesprächstechniken bei einem TN-Gespräch an.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• An konkreten Beispielen förderliche Tätigkeiten für spezifische TN erarbeiten",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Aufgrund von Beobachtungen entscheiden, wo Stärken/Förderpunkte der TN liegen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Beobachtungen zwecks RM selektieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Rückmeldung zu einem TN-Produkt vorbereiten",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Unterschied zwischen Beobachten und Interpretieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-type-name",
+                        "key": 0,
+                      },
+                      "style": {
+                        "color": "grey",
+                        "fontSize": "8pt",
+                        "fontWeight": "normal",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-title",
+                      },
+                      "style": {
+                        "fontWeight": "bold",
+                        "marginBottom": "3pt",
+                        "marginTop": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "2.2",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Methoden zur Planung, Durchführung und Auswertung von Programmen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "2.6",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Planen, Durchführen und Auswerten von J+S Aktivitäten für die Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "4.4",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Vertiefen der Kenntnisse und stufengerechtes Vermitteln der Wolfsstufentechnik",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "checklist",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "marginBottom": "8pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "1.2 Newgames neben Lagerbau",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 1.2 Newgames neben Lagerbau",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-9768e17e461d",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_9768e17e461d",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/13/2026 3:00 PM - 6:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN üben und reflektieren ein förderndes Rückmeldegespräch.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Anspruchsvolles oder förderndes Rückmeldegespräch üben",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Gegebene / erhaltene Rückmeldung analysieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-title",
+                      },
+                      "style": {
+                        "fontWeight": "bold",
+                        "marginBottom": "3pt",
+                        "marginTop": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.1",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Funktion sowie Rechte und Pflichten als Mitglied eines Leitungsteams der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.3",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Umgang mit Wölfen mit herausforderndem Verhalten",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.7",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Regeln für konstruktive Gespräche im Leitungsteam",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "checklist",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "marginBottom": "8pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Znacht",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Znacht",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-544854257650",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_544854257650",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/13/2026 6:00 PM - 8:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "1.3 Sportblock",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 1.3 Sportblock",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-24aaaf914d81",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_24aaaf914d81",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/13/2026 8:00 PM - 9:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN reflektieren Rollen und Aufgaben in einem Kursteam.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN spielen ein lustiges Spiel.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Sammlung von Methoden, um die Bedürfnisse des Teams zu bestimmen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Repetieren, welche Rollen es in einem Team gibt und welche Chancen/Herausforderungen sich daraus ergeben",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Bewusst Aufgaben im Team delegieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Mögliche Aufgaben im Kursteam sammeln",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-title",
+                      },
+                      "style": {
+                        "fontWeight": "bold",
+                        "marginBottom": "3pt",
+                        "marginTop": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Der Kurs bildet die TN zu verantwortungsbewussten Mitgliedern eines Leitungsteams aus.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "4.1",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Pfadimethode „Persönlicher Fortschritt fördern": Inhalte der Etappen und Spezialitäten in Aktivitäten der Wolfsstufe einbauen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "4.2",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Arbeiten mit Gesetz und Versprechen auf der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "4.3",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Gestaltung von Lagerfeuern auf der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "4.4",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Vertiefen der Kenntnisse und stufengerechtes Vermitteln der Wolfsstufentechnik",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "checklist",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "marginBottom": "8pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "2.1 Morgefit",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 2.1 Morgefit",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-ece5fbd25249",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_ece5fbd25249",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Tue 7/14/2026 7:30 AM - 8:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmorge",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmorge",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-7483a97d3811",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_7483a97d3811",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Tue 7/14/2026 8:00 AM - 9:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "2.2 Quidditch",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 2.2 Quidditch",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-d2d292df0d38",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_d2d292df0d38",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Tue 7/14/2026 9:00 AM - 12:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN setzen sich mit dem Modell von Tuckmann auseinander.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN sammeln für jede Phase des Modells von Tuckmann Aufgaben, welche sie als Teamleitung ausführen können oder müssen.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Setzen sich mit dem Leiten und Betreuen eines Teams auseinander (Was sind meine Aufgaben?)",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Kennen ihre Aufgaben und Rechte als Expert*innen / HKL",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Führen Aufgaben von Expert*innen aus (solche, die innerhalb des Lagers Settings umsetzbar sind)",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Tuckmannmodell",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Zwischenfazit der Gruppendynamik ziehen nach Tuckmann",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-title",
+                      },
+                      "style": {
+                        "fontWeight": "bold",
+                        "marginBottom": "3pt",
+                        "marginTop": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "1.4",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Bezug der Pfadigrundlagen zum Pfadialltag",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "1.5",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Stufenmodell und Abgrenzung zw. Biber-, Wolfs- und Pfadistufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "1.6",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Ausgestaltung der sieben Pfadimethoden und fünf Pfadibeziehungen auf der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "2.1",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Einkleidung von Aktivitäten und Quartalsprogrammen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "2.2",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Methoden zur Planung, Durchführung und Auswertung von Programmen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "2.3",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Quartalsprogramm planen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "2.4",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Abenteuer als Alternative zum Quartalsprogramm und als Form der Mitbestimmung auf der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "checklist",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "marginBottom": "8pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmittag",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmittag",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-518cc421e407",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_518cc421e407",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Tue 7/14/2026 12:00 PM - 1:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "LL",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#4DBB52",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#4DBB52",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "2.A Atelier",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "LL 2.A Atelier",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-c4e91fa37beb",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_c4e91fa37beb",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Tue 7/14/2026 1:00 PM - 3:15 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#4DBB52",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#4DBB52",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Gesprächslenkungstechniken ausprobieren und bewusst anwenden",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Spickzettel über zentrale Gesprächslenkungstechniken erstellen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Reflektieren Haltungen an ein Rückmeldegespräch und können begründen, welchen Einfluss eine bestimmte Haltung auf den Gesprächsverlauf hat",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Können bewusst schweigen und zuhören",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Einstieg ins Gefäss",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Theorie / Grundlagen / Richtlinien / Hilfsmittel zur Gesprächsführung vermittelt bekommen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Rückmeldung geben",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Rückmeldung zu TN-Produkt geben",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Gesprächslenkungstechniken anwenden",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-type-name",
+                        "key": 0,
+                      },
+                      "style": {
+                        "color": "grey",
+                        "fontSize": "8pt",
+                        "fontWeight": "normal",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-title",
+                      },
+                      "style": {
+                        "fontWeight": "bold",
+                        "marginBottom": "3pt",
+                        "marginTop": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.8",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Möglichkeiten der Aus- und Weiterbildung",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "checklist",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "marginBottom": "8pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "WP",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#90B7E4",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#90B7E4",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "2.3 Grundlagen Zaubertränke",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "WP 2.3 Grundlagen Zaubertränke",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-00dabfb4abc0",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_00dabfb4abc0",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Tue 7/14/2026 3:15 PM - 6:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#90B7E4",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#90B7E4",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Znacht",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Znacht",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-baa3e084a9fd",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_baa3e084a9fd",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Tue 7/14/2026 6:00 PM - 7:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "WP",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#90B7E4",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#90B7E4",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "2.4 Fähnliabend Pfadis",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "WP 2.4 Fähnliabend Pfadis",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-730e7b52608d",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_730e7b52608d",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Tue 7/14/2026 7:00 PM - 10:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#90B7E4",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#90B7E4",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "2.5 Horkrux",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 2.5 Horkrux",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-68898b96e2f4",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_68898b96e2f4",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Tue 7/14/2026 8:30 PM - 9:45 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "2.6 Silent Disco",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 2.6 Silent Disco",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-31a723c281e9",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_31a723c281e9",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Tue 7/14/2026 10:30 PM - 11:30 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN können weitere Aufgaben nennen, die Coaches ausser Lagerbetreuung machen.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• TN erleben einen Beispiel-Jahresplanungshöck aus Coach-Sicht.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• TN erleben einen Beispiel-Auswertungshöck aus Coach-Sicht.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• TN analysieren eine Krisensituation mit Hilfe der vier Schritte im 3+4-Modell.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Zeitraffer Ganzjahresbetreuung einer Abteilung als Coach",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Übernahme Coachämtli",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Jahresbeginn & Jahresauswertung",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Danke & Anerkennung",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Health Check",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• 3+4-Modell",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Krisen aus Coach-Sicht",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Können Abteilung beraten zu Möglichkeiten & Grenzen Leitungsteam in Krisenfällen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-title",
+                      },
+                      "style": {
+                        "fontWeight": "bold",
+                        "marginBottom": "3pt",
+                        "marginTop": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.1",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Funktion sowie Rechte und Pflichten als Mitglied eines Leitungsteams der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.2",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Leitwölfe betreuen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.3",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Umgang mit Wölfen mit herausforderndem Verhalten",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.4",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Sicherheitskonzepte für sicherheitsrelevante Aktivitäten planen und umsetzen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "checklist",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "marginBottom": "8pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "WP",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#90B7E4",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#90B7E4",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "3.1 Einbruch Verbotene Abteilung",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "WP 3.1 Einbruch Verbotene Abteilung",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-7d7d7c1ec146",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_7d7d7c1ec146",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Wed 7/15/2026 2:00 AM - 4:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#90B7E4",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#90B7E4",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "3.2 Morgefit",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 3.2 Morgefit",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-5f363002c509",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_5f363002c509",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Wed 7/15/2026 7:30 AM - 8:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmorge",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmorge",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-338b1ec643f0",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_338b1ec643f0",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Wed 7/15/2026 8:00 AM - 9:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "LL",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#4DBB52",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#4DBB52",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "3.A SpezEx Erste Hilfe",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "LL 3.A SpezEx Erste Hilfe",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-678b0c9e032b",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_678b0c9e032b",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Wed 7/15/2026 9:00 AM - 12:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#4DBB52",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#4DBB52",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN erstellen aus Beobachtungen eine angemessene, förderungsorientierte Rückmeldung.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN wenden die grundlegenden Gesprächstechniken bei einem TN-Gespräch an.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• An konkreten Beispielen förderliche Tätigkeiten für spezifische TN erarbeiten",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Aufgrund von Beobachtungen entscheiden, wo Stärken/Förderpunkte der TN liegen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Beobachtungen zwecks RM selektieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Rückmeldung zu einem TN-Produkt vorbereiten",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Unterschied zwischen Beobachten und Interpretieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-title",
+                      },
+                      "style": {
+                        "fontWeight": "bold",
+                        "marginBottom": "3pt",
+                        "marginTop": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "1.6",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Ausgestaltung der sieben Pfadimethoden und fünf Pfadibeziehungen auf der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "2.6",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Planen, Durchführen und Auswerten von J+S Aktivitäten für die Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.8",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Möglichkeiten der Aus- und Weiterbildung",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "4.3",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Gestaltung von Lagerfeuern auf der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "checklist",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "marginBottom": "8pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmittag",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmittag",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-5294f9ecab67",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_5294f9ecab67",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Wed 7/15/2026 12:00 PM - 1:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "WP",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#90B7E4",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#90B7E4",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "3.3 Besuch bei Hagrid",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "WP 3.3 Besuch bei Hagrid",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-c8834067a7fb",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_c8834067a7fb",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Wed 7/15/2026 1:30 PM - 3:15 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#90B7E4",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#90B7E4",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN können weitere Aufgaben nennen, die Coaches ausser Lagerbetreuung machen.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• TN erleben einen Beispiel-Jahresplanungshöck aus Coach-Sicht.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• TN erleben einen Beispiel-Auswertungshöck aus Coach-Sicht.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• TN analysieren eine Krisensituation mit Hilfe der vier Schritte im 3+4-Modell.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN erstellen aus Beobachtungen eine angemessene, förderungsorientierte Rückmeldung.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN wenden die grundlegenden Gesprächstechniken bei einem TN-Gespräch an.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• An konkreten Beispielen förderliche Tätigkeiten für spezifische TN erarbeiten.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Diskutieren, inwiefern Siko-Verantwortung - HLL - Coach geteilt wird, Siko als Versicherung?",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Quellen für Sicherheitsfragen- und Vorgaben kennen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Sicherheitsrelevante Aktivitäten beurteilen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Grenzfälle für Coaches (in Bezug auf Beurteilung Sicherheit) bearbeiten + diskutieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Kennen Merkblatt LS/T / refreshen Abgrenzung Sibe und sirel",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Wissen, wo sie Expert*innen für Betreuung Sicherheitsbereich finden",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Lesen ein Lagersiko gegen + Rückmeldung",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Den TN soll vermittelt werden, dass sie gewissermaßen das Sicherheitsnetz/Backup ihrer Leitenden sind - Verantwortung bewusst machen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "3.4 SpoBlo",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 3.4 SpoBlo",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-eebc0f6ef940",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_eebc0f6ef940",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Wed 7/15/2026 3:45 PM - 5:15 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Die TN erleben eine lässige Unternehmung, die ihnen Abwechslung und Pause zum kopflastigen Topkurs-Alltag bietet.",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "p",
+                      },
+                      "style": {
+                        "marginBottom": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Unternehmungen in Gruppen, geplant von Kursteam",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "p",
+                      },
+                      "style": {
+                        "marginBottom": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Znacht",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Znacht",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-866350807e56",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_866350807e56",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Wed 7/15/2026 6:00 PM - 7:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "WP",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#90B7E4",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#90B7E4",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "3.5 Spieleabend im Gemeinschaftsraum",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "WP 3.5 Spieleabend im Gemeinschaftsraum",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-b8ba03731ea2",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_b8ba03731ea2",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Wed 7/15/2026 7:00 PM - 9:15 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#90B7E4",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#90B7E4",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "4.1 Morgefit",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 4.1 Morgefit",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-2b7e20b2c143",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_2b7e20b2c143",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Thu 7/16/2026 7:30 AM - 8:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmorge",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmorge",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-d2b7193ee240",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_d2b7193ee240",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Thu 7/16/2026 8:00 AM - 9:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "4.2 Trolle bekämpfen",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 4.2 Trolle bekämpfen",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-7de79740d21e",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_7de79740d21e",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Thu 7/16/2026 9:00 AM - 12:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• V2 Was ist Ausbildung unterwegs?",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• V2 Umsetzungsmöglichkeiten",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• V2 Chancen / Herausforderungen AU",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• V3 mögliche AS-Themen für spez. Orte",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Ausbildungsstopp erleben",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Ausbildungsstopp analysieren / reflektieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Definition Ausbildungsstopp",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Was für Ausbildungsstopps könnte man an diesem Ort hier machen?",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Herausforderungen Ausbilden unterwegs",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Weitere Formen Ausbilden unterwegs",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Was macht einen gelungenen Ausbildungsstopp aus?",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-title",
+                      },
+                      "style": {
+                        "fontWeight": "bold",
+                        "marginBottom": "3pt",
+                        "marginTop": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.1",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Funktion sowie Rechte und Pflichten als Mitglied eines Leitungsteams der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.3",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Umgang mit Wölfen mit herausforderndem Verhalten",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.5",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Angebote und Anlaufstellen des Kantonalverbands / der Region sowie Krisenkonzept",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.7",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Regeln für konstruktive Gespräche im Leitungsteam",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.9",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Sexuelle Ausbeutung und Grenzverletzungen, mögliche heikle Situationen in Aktivitäten und vorbeugende Massnahmen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "checklist",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "marginBottom": "8pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmittag",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmittag",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-b68b28d54d00",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_b68b28d54d00",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Thu 7/16/2026 12:00 PM - 1:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "4.3 Hajk Flucht vor den Dementoren",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 4.3 Hajk Flucht vor den Dementoren",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-714335f7662b",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_714335f7662b",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Thu 7/16/2026 1:00 PM - Fri 7/17/2026 12:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN wissen, was sie in der KuPla beachten und mitbedenken müssen.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Die TN wissen, was in der KuPla von ihnen erwartet wird.",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Znacht",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Znacht",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-c03308fb793b",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_c03308fb793b",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Thu 7/16/2026 6:00 PM - 7:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "5.1 Morgefit",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 5.1 Morgefit",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-8f88e2766fe4",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_8f88e2766fe4",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Fri 7/17/2026 7:30 AM - 8:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmorge",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmorge",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-1c9849eb3e19",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_1c9849eb3e19",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Fri 7/17/2026 8:00 AM - 9:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmittag",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmittag",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-967ce23da935",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_967ce23da935",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Fri 7/17/2026 12:00 PM - 1:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "5.2 Wasserspiele in Badi",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 5.2 Wasserspiele in Badi",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-340a7c43247f",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_340a7c43247f",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Fri 7/17/2026 1:00 PM - 4:45 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning objectives",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Learning topics",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Was sind produktive Mindestanforderungen?",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Qualifizieren als Mittel zur Förderung diskutieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Trennung Lernmomente & Überprüfungsmomente",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Qualifizieren als Ermessensentscheidung (Bewusstsein entwickeln)",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Häufige Beurteilungsfehler",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Beurteilungsraster als Hilfsmittel - nur anschneiden falls notwendig, vollwertig in einem Wahlblock behandeln",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Wie formuliere ich überprüfbare Mindestanforderungen?",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Mindestanforderungen formulieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Wissen, wie & dass sie die Ethik-Charta als Grundlage für Kurspakt (& nach Hause schicken) verwenden können anstelle von Mindestanforderungen zu "respektvollem / verantwortungsbewussten Verhalten" Umgang mit den Mindestanforderungen während dem Kurs (Flexibilität, wie bindend sind Mindestanforderungen im Kurs?)",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Mindestanforderungen aufs Minimum reduzieren",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "• Zusammenhang Mindestanforderungen mit den Zielen des Kurses",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {
+                                "class": "p",
+                              },
+                              "style": {
+                                "marginBottom": "2pt",
+                              },
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "style": {
+                              "marginLeft": "4pt",
+                            },
+                          },
+                          "style": {
+                            "marginLeft": "4pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {},
+                      "style": {},
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "style": {
+                      "line-height": "0.8",
+                    },
+                  },
+                  "style": {
+                    "lineHeight": "0.8",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Checklists",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "content-node-instance-name",
+                      },
+                      "style": {
+                        "flexGrow": "1",
+                        "fontSize": "11pt",
+                        "fontWeight": "bold",
+                        "paddingBottom": "3pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "content-node-title",
+                  },
+                  "style": {
+                    "alignItems": "baseline",
+                    "borderBottom": "1.5pt solid black",
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "marginBottom": "1pt",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "Ausbildungsziele",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-title",
+                      },
+                      "style": {
+                        "fontWeight": "bold",
+                        "marginBottom": "3pt",
+                        "marginTop": "2pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "1.4",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Bezug der Pfadigrundlagen zum Pfadialltag",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "1.6",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Ausgestaltung der sieben Pfadimethoden und fünf Pfadibeziehungen auf der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "2.3",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Quartalsprogramm planen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "2.6",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Planen, Durchführen und Auswerten von J+S Aktivitäten für die Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.1",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Funktion sowie Rechte und Pflichten als Mitglied eines Leitungsteams der Wolfsstufe",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.2",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Leitwölfe betreuen",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "3.3",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-1",
+                          },
+                          "style": {
+                            "flexBasis": "17pt",
+                            "flexGrow": "0",
+                            "flexShrink": "0",
+                            "fontVariantNumeric": "tabular-nums",
+                            "paddingRight": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                        {
+                          "box": {},
+                          "children": [
+                            {
+                              "box": {},
+                              "children": [
+                                {
+                                  "parent": [Circular],
+                                  "type": "TEXT_INSTANCE",
+                                  "value": "Umgang mit Wölfen mit herausforderndem Verhalten",
+                                },
+                              ],
+                              "parent": [Circular],
+                              "props": {},
+                              "style": {},
+                              "type": "TEXT",
+                            },
+                          ],
+                          "parent": [Circular],
+                          "props": {
+                            "class": "checklist-item-column checklist-item-column-2",
+                          },
+                          "style": {
+                            "flexBasis": "0",
+                            "flexGrow": "1",
+                            "paddingLeft": "2pt",
+                          },
+                          "type": "VIEW",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "checklist-item",
+                      },
+                      "style": {
+                        "display": "flex",
+                        "flexDirection": "row",
+                        "paddingBottom": "5pt",
+                      },
+                      "type": "VIEW",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "checklist",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "marginBottom": "8pt",
+                  },
+                  "type": "VIEW",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "content-node",
+              },
+              "style": {
+                "marginBottom": "6pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Znacht",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Znacht",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-4659f03df5f0",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_4659f03df5f0",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Fri 7/17/2026 6:00 PM - 7:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "WP",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#90B7E4",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#90B7E4",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "5.3 Fühlsch mi Gspürsch mi",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "WP 5.3 Fühlsch mi Gspürsch mi",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-1428d429bcbc",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_1428d429bcbc",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Fri 7/17/2026 7:15 PM - 9:30 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#90B7E4",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#90B7E4",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "6.1 Morgefit",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 6.1 Morgefit",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-b3d8510b3fc0",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_b3d8510b3fc0",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sat 7/18/2026 7:30 AM - 8:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmorge",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmorge",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-76f8de918d33",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_76f8de918d33",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sat 7/18/2026 8:00 AM - 9:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "6.2 Quidditch finale",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 6.2 Quidditch finale",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-d712be44166d",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_d712be44166d",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sat 7/18/2026 9:00 AM - 10:30 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmittag",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmittag",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-6e229cc92bda",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_6e229cc92bda",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sat 7/18/2026 12:00 PM - 1:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "LL",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#4DBB52",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#4DBB52",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "6.A SpezEx Erste Hilfe",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "LL 6.A SpezEx Erste Hilfe",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-5df6703c8c5d",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_5df6703c8c5d",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sat 7/18/2026 1:15 PM - 3:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#4DBB52",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#4DBB52",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "6.3 Spieleturnier",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 6.3 Spieleturnier",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-7c39f20068ce",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_7c39f20068ce",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sat 7/18/2026 1:15 PM - 3:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "LL",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#4DBB52",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#4DBB52",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "6.B SpezEx Erste Hilfe",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "LL 6.B SpezEx Erste Hilfe",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-53d41fb96483",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_53d41fb96483",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sat 7/18/2026 3:45 PM - 5:50 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#4DBB52",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#4DBB52",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "6.4 Spieleturnier",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 6.4 Spieleturnier",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-8bccd22723c0",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_8bccd22723c0",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sat 7/18/2026 3:45 PM - 5:45 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Znacht",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Znacht",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-a8cd28eff86e",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_a8cd28eff86e",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sat 7/18/2026 6:00 PM - 7:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "6.5 Endgame Kampf gegen Voldemort",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 6.5 Endgame Kampf gegen Voldemort",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-d8810b075da1",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_d8810b075da1",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sat 7/18/2026 7:00 PM - 10:15 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "7.1 Morgefit",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 7.1 Morgefit",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-d36256eb597d",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_d36256eb597d",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sun 7/19/2026 7:30 AM - 8:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmorge",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmorge",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-528b12bce91f",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_528b12bce91f",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sun 7/19/2026 8:00 AM - 9:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "WP",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#90B7E4",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#90B7E4",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "7.2 Nachsitzen bei Snape",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "WP 7.2 Nachsitzen bei Snape",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-3c6a421b9598",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_3c6a421b9598",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sun 7/19/2026 9:00 AM - 11:45 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#90B7E4",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#90B7E4",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmittag",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmittag",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-0fde303f5067",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_0fde303f5067",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sun 7/19/2026 12:00 PM - 1:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "LL",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#4DBB52",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#4DBB52",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "7.A Lagerabbau",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "LL 7.A Lagerabbau",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-776938c5a808",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_776938c5a808",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sun 7/19/2026 1:15 PM - 5:30 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#4DBB52",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#4DBB52",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "WP",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#90B7E4",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#90B7E4",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "7.3 Vorbereitung Abschlussabend",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "WP 7.3 Vorbereitung Abschlussabend",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-d281382890e2",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_d281382890e2",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sun 7/19/2026 2:15 PM - 5:45 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#90B7E4",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#90B7E4",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "7.4 Newgames",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 7.4 Newgames",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-327302368fe6",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_327302368fe6",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sun 7/19/2026 3:00 PM - 6:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Znacht",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Znacht",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-72e1569530f1",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_72e1569530f1",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Sun 7/19/2026 6:00 PM - 7:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "A",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#FD7A7A",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#FD7A7A",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "8.1 Morgefit",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "A 8.1 Morgefit",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-0ad209a74fbe",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_0ad209a74fbe",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/20/2026 7:30 AM - 8:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#FD7A7A",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#FD7A7A",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmorge",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmorge",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-7ae50dc8370f",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_7ae50dc8370f",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/20/2026 8:00 AM - 9:00 AM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "LL",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#4DBB52",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#4DBB52",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "8.A Lagerabbau",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "LL 8.A Lagerabbau",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-89239bf4e109",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_89239bf4e109",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/20/2026 9:00 AM - 12:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#4DBB52",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#4DBB52",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "ES",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#BBBBBB",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#BBBBBB",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": " Zmittag",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "ES Zmittag",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-e391db2702a6",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_e391db2702a6",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/20/2026 12:00 PM - 1:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#BBBBBB",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#BBBBBB",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "WP",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "class": "category-label schedule-entry-category-label",
+                        "style": {
+                          "backgroundColor": "#90B7E4",
+                          "color": "#000",
+                        },
+                      },
+                      "style": {
+                        "alignSelf": "center",
+                        "backgroundColor": "#90B7E4",
+                        "borderRadius": "18pt",
+                        "color": "#000",
+                        "fontSize": "12pt",
+                        "margin": "4pt 0",
+                        "padding": "2pt 8pt",
+                      },
+                      "type": "TEXT",
+                    },
+                    {
+                      "box": {},
+                      "children": [
+                        {
+                          "parent": [Circular],
+                          "type": "TEXT_INSTANCE",
+                          "value": "8.2 Totto Lotto",
+                        },
+                      ],
+                      "parent": [Circular],
+                      "props": {
+                        "bookmark": "WP 8.2 Totto Lotto",
+                        "class": "schedule-entry-number-and-title",
+                        "id": "entry-0-b7d1761ab299",
+                      },
+                      "style": {
+                        "margin": "4pt 4pt",
+                        "maxWidth": "345pt",
+                      },
+                      "type": "TEXT",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-title",
+                    "id": "scheduleEntry_b7d1761ab299",
+                  },
+                  "style": {
+                    "display": "flex",
+                    "flexDirection": "row",
+                    "flexGrow": "1",
+                    "fontSize": "14",
+                    "fontWeight": "semibold",
+                  },
+                  "type": "VIEW",
+                },
+                {
+                  "box": {},
+                  "children": [
+                    {
+                      "parent": [Circular],
+                      "type": "TEXT_INSTANCE",
+                      "value": "Mon 7/20/2026 3:00 PM - 5:00 PM",
+                    },
+                  ],
+                  "parent": [Circular],
+                  "props": {
+                    "class": "schedule-entry-date",
+                  },
+                  "style": {
+                    "fontSize": "11pt",
+                  },
+                  "type": "TEXT",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "schedule-entry-header-title",
+                "style": {
+                  "borderBottomColor": "#90B7E4",
+                },
+              },
+              "style": {
+                "alignItems": "baseline",
+                "borderBottom": "2pt solid #aaaaaa",
+                "borderBottomColor": "#90B7E4",
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "paddingBottom": "2pt",
+              },
+              "type": "VIEW",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "minPresenceAhead": 75,
+            "wrap": false,
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "font-size": "10pt",
+              "margin-top": "10pt",
+              "padding-bottom": "20pt",
+            },
+          },
+          "style": {
+            "fontSize": "10pt",
+            "marginTop": "10pt",
+            "paddingBottom": "20pt",
+          },
+          "type": "VIEW",
+        },
+      ],
+      "parent": [Circular],
+      "props": {
+        "class": "page",
+        "id": "entry-0",
+      },
+      "style": {
+        "display": "flex",
+        "flexDirection": "column",
+        "fontFamily": "InterDisplay",
+        "fontSize": "12",
+        "padding": "30",
+      },
+      "type": "PAGE",
+    },
+  ],
+  "parent": null,
+  "props": {
+    "locale": "de",
+    "pdfVersion": "1.7",
+    "store": {
+      "get": [Function],
+      "href": [Function],
+    },
+    "tc": [Function],
+  },
+  "style": {},
+  "type": "DOCUMENT",
+}

--- a/pdf/src/renderer/__tests__/courseActivityListStoreContent.json
+++ b/pdf/src/renderer/__tests__/courseActivityListStoreContent.json
@@ -1,0 +1,24818 @@
+{
+  "": {
+    "invitations": {
+      "href": "/api/invitations{/id}{/action}",
+      "templated": true
+    },
+    "personalInvitations": {
+      "href": "/api/personal_invitations{/id}{/action}",
+      "templated": true
+    },
+    "activities": {
+      "href": "/api/activities{/id}{?camp,camp[]}",
+      "templated": true
+    },
+    "activityProgressLabels": {
+      "href": "/api/activity_progress_labels{/id}{?camp,camp[]}",
+      "templated": true
+    },
+    "activityResponsibles": {
+      "href": "/api/activity_responsibles{/id}{?activity,activity[],activity.camp,activity.camp[]}",
+      "templated": true
+    },
+    "camps": {
+      "href": "/api/camps{/id}{?isPrototype,isPrototype[],campCollaborator}",
+      "templated": true
+    },
+    "campCollaborations": {
+      "href": "/api/camp_collaborations{/id}{/action}{?camp,camp[],activityResponsibles.activity,activityResponsibles.activity[]}",
+      "templated": true
+    },
+    "categories": {
+      "href": "/api/categories{/id}{?camp,camp[]}",
+      "templated": true
+    },
+    "checklists": {
+      "href": "/api/checklists{/id}{?camp,camp[],isPrototype,isPrototype[]}",
+      "templated": true
+    },
+    "checklistItems": {
+      "href": "/api/checklist_items{/id}{?checklist,checklist[],checklist.camp,checklist.camp[],checklistNodes,checklistNodes[]}",
+      "templated": true
+    },
+    "comments": {
+      "href": "/api/comments{/id}{?camp,camp[],activity,activity[]}",
+      "templated": true
+    },
+    "contentNodes": {
+      "href": "/api/content_nodes{?contentType,contentType[],root,root[],camp,period,isRoot}",
+      "templated": true
+    },
+    "checklistNodes": {
+      "href": "/api/content_node/checklist_nodes{/id}{?contentType,contentType[],root,root[],camp,period,isRoot}",
+      "templated": true
+    },
+    "columnLayouts": {
+      "href": "/api/content_node/column_layouts{/id}{?contentType,contentType[],root,root[],camp,period,isRoot}",
+      "templated": true
+    },
+    "materialNodes": {
+      "href": "/api/content_node/material_nodes{/id}{?contentType,contentType[],root,root[],camp,period,isRoot}",
+      "templated": true
+    },
+    "multiSelects": {
+      "href": "/api/content_node/multi_selects{/id}{?contentType,contentType[],root,root[],camp,period,isRoot}",
+      "templated": true
+    },
+    "responsiveLayouts": {
+      "href": "/api/content_node/responsive_layouts{/id}{?contentType,contentType[],root,root[],camp,period,isRoot}",
+      "templated": true
+    },
+    "singleTexts": {
+      "href": "/api/content_node/single_texts{/id}{?contentType,contentType[],root,root[],camp,period,isRoot}",
+      "templated": true
+    },
+    "storyboards": {
+      "href": "/api/content_node/storyboards{/id}{?contentType,contentType[],root,root[],camp,period,isRoot}",
+      "templated": true
+    },
+    "contentTypes": {
+      "href": "/api/content_types{/id}{?name,name[],categories,categories[]}",
+      "templated": true
+    },
+    "days": {
+      "href": "/api/days{/id}{?period,period[],period.camp,period.camp[]}",
+      "templated": true
+    },
+    "dayResponsibles": {
+      "href": "/api/day_responsibles{/id}{?day,day[],day.period,day.period[]}",
+      "templated": true
+    },
+    "materialItems": {
+      "href": "/api/material_items{/id}{?camp,camp[],materialList,materialList[],materialNode,materialNode[],period}",
+      "templated": true
+    },
+    "materialLists": {
+      "href": "/api/material_lists{/id}{?camp,camp[]}",
+      "templated": true
+    },
+    "periods": {
+      "href": "/api/periods{/id}{?camp,camp[],campCollaborator}",
+      "templated": true
+    },
+    "profiles": {
+      "href": "/api/profiles{/id}{?user.collaborations.camp,user.collaborations.camp[],user,user[]}",
+      "templated": true
+    },
+    "scheduleEntries": {
+      "href": "/api/schedule_entries{/id}{?period,period[],activity,activity[],start[before],start[strictly_before],start[after],start[strictly_after],end[before],end[strictly_before],end[after],end[strictly_after]}",
+      "templated": true
+    },
+    "users": {
+      "href": "/api/users{/id}{/action}",
+      "templated": true
+    },
+    "login": {
+      "href": "/authentication_token"
+    },
+    "oauthGoogle": {
+      "href": "/api/auth/google{?callback}",
+      "templated": true
+    },
+    "oauthPbsmidata": {
+      "href": "/api/auth/pbsmidata{?callback}",
+      "templated": true
+    },
+    "oauthCevidb": {
+      "href": "/api/auth/cevidb{?callback}",
+      "templated": true
+    },
+    "oauthJubladb": {
+      "href": "/api/auth/jubladb{?callback}",
+      "templated": true
+    },
+    "refreshToken": {
+      "href": "/token/refresh"
+    },
+    "resetPassword": {
+      "href": "/api/auth/reset_password{/id}",
+      "templated": true
+    },
+    "resendActivation": {
+      "href": "/auth/resend_activation",
+      "templated": false
+    },
+    "_meta": {
+      "self": "",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/profiles?user=%2Fapi%2Fusers%2F9145944210a7": {
+    "totalItems": 1,
+    "items": [
+      {
+        "href": "/profiles/5e387cad273d"
+      }
+    ],
+    "_meta": {
+      "self": "/profiles?user=%2Fapi%2Fusers%2F9145944210a7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camps/5d28f99890bc": {
+    "isShared": false,
+    "sharedSince": null,
+    "isPrototype": false,
+    "shortTitle": "PBS CH 361-25",
+    "title": "Basiskurs Wolfsstufe 2025",
+    "motto": "Auf den Spuren von BiPi",
+    "addressName": "Oskar Hugentobler",
+    "addressStreet": "Rainweg 23",
+    "addressZipcode": "1999",
+    "addressCity": "Les Bois",
+    "organizer": "Pfadi Gryfenberg",
+    "kind": "Sommerlager",
+    "coachName": "Andrea Schneider",
+    "courseNumber": "JS-CH PBS CH 361-25",
+    "courseKind": "Basiskurs",
+    "trainingAdvisorName": "Sandro Bodruzzi",
+    "printYSLogoOnPicasso": true,
+    "id": "5d28f99890bc",
+    "campCollaborations": {
+      "href": "/camp_collaborations?camp=%2Fapi%2Fcamps%2F5d28f99890bc"
+    },
+    "periods": {
+      "href": "/periods?camp=%2Fapi%2Fcamps%2F5d28f99890bc"
+    },
+    "categories": {
+      "href": "/camps/5d28f99890bc/categories"
+    },
+    "progressLabels": {
+      "href": "/camps/5d28f99890bc/activity_progress_labels"
+    },
+    "activities": {
+      "href": "/camps/5d28f99890bc/activities"
+    },
+    "materialLists": {
+      "href": "/material_lists?camp=%2Fapi%2Fcamps%2F5d28f99890bc"
+    },
+    "checklists": {
+      "href": "/camps/5d28f99890bc/checklists"
+    },
+    "sharedBy": null,
+    "creator": {
+      "href": "/users/9145944210a7"
+    },
+    "profiles": {
+      "href": "/profiles?user.collaborations.camp=%2Fapi%2Fcamps%2F5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/camps/5d28f99890bc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/profiles/5e387cad273d": {
+    "email": "test@example.com",
+    "firstname": "Robert",
+    "surname": "Baden-Powell",
+    "nickname": "Bi-Pi",
+    "language": "de-CH-scout",
+    "color": "#6a209b",
+    "abbreviation": "⚜️",
+    "id": "5e387cad273d",
+    "legalName": "Robert Baden-Powell",
+    "user": {
+      "href": "/users/9145944210a7"
+    },
+    "_meta": {
+      "self": "/profiles/5e387cad273d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/users/9145944210a7": {
+    "id": "9145944210a7",
+    "displayName": "Bi-Pi",
+    "color": "#6a209b",
+    "abbreviation": "⚜️",
+    "profile": {
+      "href": "/profiles/5e387cad273d"
+    },
+    "_meta": {
+      "self": "/users/9145944210a7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/periods/88f1f55a69d7": {
+    "description": "Hauptlager",
+    "start": "2026-07-13",
+    "end": "2026-07-20",
+    "id": "88f1f55a69d7",
+    "days": {
+      "href": "/periods/88f1f55a69d7/days"
+    },
+    "scheduleEntries": {
+      "href": "/periods/88f1f55a69d7/schedule_entries"
+    },
+    "materialItems": {
+      "href": "/material_items?period=%2Fapi%2Fperiods%2F88f1f55a69d7"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?period=%2Fapi%2Fperiods%2F88f1f55a69d7"
+    },
+    "dayResponsibles": {
+      "href": "/day_responsibles?day.period=%2Fapi%2Fperiods%2F88f1f55a69d7"
+    },
+    "_meta": {
+      "self": "/periods/88f1f55a69d7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/63163861c828": {
+    "dayOffset": 0,
+    "id": "63163861c828",
+    "number": 1,
+    "start": "2026-07-13T00:00:00+00:00",
+    "end": "2026-07-14T00:00:00+00:00",
+    "dayResponsibles": {
+      "href": "/days/63163861c828/day_responsibles"
+    },
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "scheduleEntries": {
+      "href": "/schedule_entries?end%5Bafter%5D=2026-07-13T00%3A00%3A00%2B00%3A00&period=%2Fapi%2Fperiods%2F88f1f55a69d7&start%5Bstrictly_before%5D=2026-07-14T00%3A00%3A00%2B00%3A00"
+    },
+    "_meta": {
+      "self": "/days/63163861c828",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/1b6e5995c138": {
+    "dayOffset": 1,
+    "id": "1b6e5995c138",
+    "number": 2,
+    "start": "2026-07-14T00:00:00+00:00",
+    "end": "2026-07-15T00:00:00+00:00",
+    "dayResponsibles": {
+      "href": "/days/1b6e5995c138/day_responsibles"
+    },
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "scheduleEntries": {
+      "href": "/schedule_entries?end%5Bafter%5D=2026-07-14T00%3A00%3A00%2B00%3A00&period=%2Fapi%2Fperiods%2F88f1f55a69d7&start%5Bstrictly_before%5D=2026-07-15T00%3A00%3A00%2B00%3A00"
+    },
+    "_meta": {
+      "self": "/days/1b6e5995c138",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/c118aa688d8e": {
+    "dayOffset": 2,
+    "id": "c118aa688d8e",
+    "number": 3,
+    "start": "2026-07-15T00:00:00+00:00",
+    "end": "2026-07-16T00:00:00+00:00",
+    "dayResponsibles": {
+      "href": "/days/c118aa688d8e/day_responsibles"
+    },
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "scheduleEntries": {
+      "href": "/schedule_entries?end%5Bafter%5D=2026-07-15T00%3A00%3A00%2B00%3A00&period=%2Fapi%2Fperiods%2F88f1f55a69d7&start%5Bstrictly_before%5D=2026-07-16T00%3A00%3A00%2B00%3A00"
+    },
+    "_meta": {
+      "self": "/days/c118aa688d8e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/a6a17ccae877": {
+    "dayOffset": 3,
+    "id": "a6a17ccae877",
+    "number": 4,
+    "start": "2026-07-16T00:00:00+00:00",
+    "end": "2026-07-17T00:00:00+00:00",
+    "dayResponsibles": {
+      "href": "/days/a6a17ccae877/day_responsibles"
+    },
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "scheduleEntries": {
+      "href": "/schedule_entries?end%5Bafter%5D=2026-07-16T00%3A00%3A00%2B00%3A00&period=%2Fapi%2Fperiods%2F88f1f55a69d7&start%5Bstrictly_before%5D=2026-07-17T00%3A00%3A00%2B00%3A00"
+    },
+    "_meta": {
+      "self": "/days/a6a17ccae877",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/9411ee803eb4": {
+    "dayOffset": 4,
+    "id": "9411ee803eb4",
+    "number": 5,
+    "start": "2026-07-17T00:00:00+00:00",
+    "end": "2026-07-18T00:00:00+00:00",
+    "dayResponsibles": {
+      "href": "/days/9411ee803eb4/day_responsibles"
+    },
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "scheduleEntries": {
+      "href": "/schedule_entries?end%5Bafter%5D=2026-07-17T00%3A00%3A00%2B00%3A00&period=%2Fapi%2Fperiods%2F88f1f55a69d7&start%5Bstrictly_before%5D=2026-07-18T00%3A00%3A00%2B00%3A00"
+    },
+    "_meta": {
+      "self": "/days/9411ee803eb4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/273358ce9d70": {
+    "dayOffset": 5,
+    "id": "273358ce9d70",
+    "number": 6,
+    "start": "2026-07-18T00:00:00+00:00",
+    "end": "2026-07-19T00:00:00+00:00",
+    "dayResponsibles": {
+      "href": "/days/273358ce9d70/day_responsibles"
+    },
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "scheduleEntries": {
+      "href": "/schedule_entries?end%5Bafter%5D=2026-07-18T00%3A00%3A00%2B00%3A00&period=%2Fapi%2Fperiods%2F88f1f55a69d7&start%5Bstrictly_before%5D=2026-07-19T00%3A00%3A00%2B00%3A00"
+    },
+    "_meta": {
+      "self": "/days/273358ce9d70",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/40e3a286dc08": {
+    "dayOffset": 6,
+    "id": "40e3a286dc08",
+    "number": 7,
+    "start": "2026-07-19T00:00:00+00:00",
+    "end": "2026-07-20T00:00:00+00:00",
+    "dayResponsibles": {
+      "href": "/days/40e3a286dc08/day_responsibles"
+    },
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "scheduleEntries": {
+      "href": "/schedule_entries?end%5Bafter%5D=2026-07-19T00%3A00%3A00%2B00%3A00&period=%2Fapi%2Fperiods%2F88f1f55a69d7&start%5Bstrictly_before%5D=2026-07-20T00%3A00%3A00%2B00%3A00"
+    },
+    "_meta": {
+      "self": "/days/40e3a286dc08",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/485e190f4852": {
+    "dayOffset": 7,
+    "id": "485e190f4852",
+    "number": 8,
+    "start": "2026-07-20T00:00:00+00:00",
+    "end": "2026-07-21T00:00:00+00:00",
+    "dayResponsibles": {
+      "href": "/days/485e190f4852/day_responsibles"
+    },
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "scheduleEntries": {
+      "href": "/schedule_entries?end%5Bafter%5D=2026-07-20T00%3A00%3A00%2B00%3A00&period=%2Fapi%2Fperiods%2F88f1f55a69d7&start%5Bstrictly_before%5D=2026-07-21T00%3A00%3A00%2B00%3A00"
+    },
+    "_meta": {
+      "self": "/days/485e190f4852",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/periods/88f1f55a69d7/days": {
+    "totalItems": 8,
+    "items": [
+      {
+        "href": "/days/63163861c828"
+      },
+      {
+        "href": "/days/1b6e5995c138"
+      },
+      {
+        "href": "/days/c118aa688d8e"
+      },
+      {
+        "href": "/days/a6a17ccae877"
+      },
+      {
+        "href": "/days/9411ee803eb4"
+      },
+      {
+        "href": "/days/273358ce9d70"
+      },
+      {
+        "href": "/days/40e3a286dc08"
+      },
+      {
+        "href": "/days/485e190f4852"
+      }
+    ],
+    "_meta": {
+      "self": "/periods/88f1f55a69d7/days",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camp_collaborations/146c0608237f": {
+    "inviteEmail": null,
+    "status": "established",
+    "role": "manager",
+    "color": null,
+    "abbreviation": null,
+    "id": "146c0608237f",
+    "user": {
+      "href": "/users/9145944210a7"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/camp_collaborations/146c0608237f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camp_collaborations/4b0f654bf743": {
+    "inviteEmail": null,
+    "status": "established",
+    "role": "manager",
+    "color": null,
+    "abbreviation": null,
+    "id": "4b0f654bf743",
+    "user": {
+      "href": "/users/130684395770"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/camp_collaborations/4b0f654bf743",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/users/130684395770": {
+    "id": "130684395770",
+    "displayName": "Snoopy",
+    "color": null,
+    "abbreviation": null,
+    "profile": {
+      "href": "/profiles/22dce794d4e2"
+    },
+    "_meta": {
+      "self": "/users/130684395770",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camp_collaborations/af9f868f0a48": {
+    "inviteEmail": null,
+    "status": "established",
+    "role": "guest",
+    "color": null,
+    "abbreviation": null,
+    "id": "af9f868f0a48",
+    "user": {
+      "href": "/users/48f00685a292"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/camp_collaborations/af9f868f0a48",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/users/48f00685a292": {
+    "id": "48f00685a292",
+    "displayName": "Idefix",
+    "color": null,
+    "abbreviation": null,
+    "profile": {
+      "href": "/profiles/0870635edda6"
+    },
+    "_meta": {
+      "self": "/users/48f00685a292",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camp_collaborations/83cdbbe00f85": {
+    "inviteEmail": null,
+    "status": "established",
+    "role": "member",
+    "color": "#ff0080",
+    "abbreviation": "🐈‍⬛",
+    "id": "83cdbbe00f85",
+    "user": {
+      "href": "/users/bae69a1c9fcc"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/camp_collaborations/83cdbbe00f85",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/users/bae69a1c9fcc": {
+    "id": "bae69a1c9fcc",
+    "displayName": "Baghira",
+    "color": null,
+    "abbreviation": null,
+    "profile": {
+      "href": "/profiles/f9f1a2f9af25"
+    },
+    "_meta": {
+      "self": "/users/bae69a1c9fcc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camp_collaborations/d03003838720": {
+    "inviteEmail": null,
+    "status": "established",
+    "role": "member",
+    "color": null,
+    "abbreviation": "Ca",
+    "id": "d03003838720",
+    "user": {
+      "href": "/users/caeba9f7e728"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/camp_collaborations/d03003838720",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/users/caeba9f7e728": {
+    "id": "caeba9f7e728",
+    "displayName": "Castor",
+    "color": null,
+    "abbreviation": "C",
+    "profile": {
+      "href": "/profiles/7d03c967be7e"
+    },
+    "_meta": {
+      "self": "/users/caeba9f7e728",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camp_collaborations/e64284adf2f2": {
+    "inviteEmail": null,
+    "status": "established",
+    "role": "manager",
+    "color": null,
+    "abbreviation": null,
+    "id": "e64284adf2f2",
+    "user": {
+      "href": "/users/bee7cf5b3871"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/camp_collaborations/e64284adf2f2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/users/bee7cf5b3871": {
+    "id": "bee7cf5b3871",
+    "displayName": "Salamander",
+    "color": null,
+    "abbreviation": null,
+    "profile": {
+      "href": "/profiles/d46337a76a2c"
+    },
+    "_meta": {
+      "self": "/users/bee7cf5b3871",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/periods?camp=%2Fapi%2Fcamps%2F5d28f99890bc": {
+    "totalItems": 1,
+    "items": [
+      {
+        "href": "/periods/88f1f55a69d7"
+      }
+    ],
+    "_meta": {
+      "self": "/periods?camp=%2Fapi%2Fcamps%2F5d28f99890bc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camp_collaborations?camp=%2Fapi%2Fcamps%2F5d28f99890bc": {
+    "items": [
+      {
+        "href": "/camp_collaborations/146c0608237f"
+      },
+      {
+        "href": "/camp_collaborations/4b0f654bf743"
+      },
+      {
+        "href": "/camp_collaborations/af9f868f0a48"
+      },
+      {
+        "href": "/camp_collaborations/83cdbbe00f85"
+      },
+      {
+        "href": "/camp_collaborations/d03003838720"
+      },
+      {
+        "href": "/camp_collaborations/e64284adf2f2"
+      }
+    ],
+    "_meta": {
+      "self": "/camp_collaborations?camp=%2Fapi%2Fcamps%2F5d28f99890bc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camps/5d28f99890bc/checklists": {
+    "totalItems": 1,
+    "items": [
+      {
+        "href": "/checklists/ebbd0c61eb85"
+      }
+    ],
+    "_meta": {
+      "self": "/camps/5d28f99890bc/checklists",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camps/5d28f99890bc/categories": {
+    "totalItems": 4,
+    "items": [
+      {
+        "href": "/categories/fd476c982866"
+      },
+      {
+        "href": "/categories/98f686a32238"
+      },
+      {
+        "href": "/categories/33287493d1c1"
+      },
+      {
+        "href": "/categories/518df7ff2cfb"
+      }
+    ],
+    "_meta": {
+      "self": "/camps/5d28f99890bc/categories",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camps/5d28f99890bc/activity_progress_labels": {
+    "totalItems": 4,
+    "items": [
+      {
+        "href": "/activity_progress_labels/e78a915b0771"
+      },
+      {
+        "href": "/activity_progress_labels/016d7278966a"
+      },
+      {
+        "href": "/activity_progress_labels/de866d6696aa"
+      },
+      {
+        "href": "/activity_progress_labels/da4d05db108e"
+      }
+    ],
+    "_meta": {
+      "self": "/camps/5d28f99890bc/activity_progress_labels",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/personal_invitations": {
+    "totalItems": 1,
+    "items": [
+      {
+        "href": "/personal_invitations/b32db30637c8"
+      }
+    ],
+    "_meta": {
+      "self": "/personal_invitations",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_progress_labels/e78a915b0771": {
+    "position": 1,
+    "title": "In Planung",
+    "id": "e78a915b0771",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/activity_progress_labels/e78a915b0771",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_progress_labels/016d7278966a": {
+    "position": 2,
+    "title": "Geplant",
+    "id": "016d7278966a",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/activity_progress_labels/016d7278966a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_progress_labels/de866d6696aa": {
+    "position": 3,
+    "title": "Kursleitung OK",
+    "id": "de866d6696aa",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/activity_progress_labels/de866d6696aa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_progress_labels/da4d05db108e": {
+    "position": 4,
+    "title": "LKB OK",
+    "id": "da4d05db108e",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "_meta": {
+      "self": "/activity_progress_labels/da4d05db108e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklists/ebbd0c61eb85": {
+    "name": "Ausbildungsziele",
+    "isPrototype": false,
+    "id": "ebbd0c61eb85",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "checklistItems": {
+      "href": "/checklists/ebbd0c61eb85/checklist_items"
+    },
+    "_meta": {
+      "self": "/checklists/ebbd0c61eb85",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_nodes?period=%2Fapi%2Fperiods%2F88f1f55a69d7": {
+    "totalItems": 298,
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/713da7117866"
+      },
+      {
+        "href": "/content_node/single_texts/22a90fa0668a"
+      },
+      {
+        "href": "/content_node/single_texts/bc0c2f20e91e"
+      },
+      {
+        "href": "/content_node/single_texts/2c409794b22b"
+      },
+      {
+        "href": "/content_node/storyboards/ba4d91f6e475"
+      },
+      {
+        "href": "/content_node/material_nodes/48b83082b552"
+      },
+      {
+        "href": "/content_node/column_layouts/09b19f627429"
+      },
+      {
+        "href": "/content_node/responsive_layouts/fb1eb84a9008"
+      },
+      {
+        "href": "/content_node/single_texts/e79958ca067d"
+      },
+      {
+        "href": "/content_node/single_texts/4c2e9ebb70d3"
+      },
+      {
+        "href": "/content_node/single_texts/651e709cb8cf"
+      },
+      {
+        "href": "/content_node/single_texts/9f6c51297b41"
+      },
+      {
+        "href": "/content_node/single_texts/b2291894eb45"
+      },
+      {
+        "href": "/content_node/checklist_nodes/988c216bd9bd"
+      },
+      {
+        "href": "/content_node/storyboards/3cb279d6b1e5"
+      },
+      {
+        "href": "/content_node/material_nodes/943f3caf8ed8"
+      },
+      {
+        "href": "/content_node/column_layouts/09dc148c88c3"
+      },
+      {
+        "href": "/content_node/responsive_layouts/6e3a1a0ed96f"
+      },
+      {
+        "href": "/content_node/single_texts/3db42f235694"
+      },
+      {
+        "href": "/content_node/single_texts/8ef40082bbe6"
+      },
+      {
+        "href": "/content_node/single_texts/cabedaa743f3"
+      },
+      {
+        "href": "/content_node/storyboards/8b7928871e5e"
+      },
+      {
+        "href": "/content_node/material_nodes/a03516f0f654"
+      },
+      {
+        "href": "/content_node/column_layouts/0b1293a027bb"
+      },
+      {
+        "href": "/content_node/responsive_layouts/c1e4546b7d3f"
+      },
+      {
+        "href": "/content_node/single_texts/d9963a9c5e37"
+      },
+      {
+        "href": "/content_node/single_texts/c2c4371d7110"
+      },
+      {
+        "href": "/content_node/single_texts/f07eeac302cf"
+      },
+      {
+        "href": "/content_node/storyboards/8719c59f1289"
+      },
+      {
+        "href": "/content_node/material_nodes/f485d9b05ecf"
+      },
+      {
+        "href": "/content_node/column_layouts/1bee9e7a94a9"
+      },
+      {
+        "href": "/content_node/responsive_layouts/82fc91767762"
+      },
+      {
+        "href": "/content_node/single_texts/7da9fbd50ba5"
+      },
+      {
+        "href": "/content_node/single_texts/df805dfd5817"
+      },
+      {
+        "href": "/content_node/single_texts/d0e9f6ba2bf1"
+      },
+      {
+        "href": "/content_node/multi_selects/64d11bb77f89"
+      },
+      {
+        "href": "/content_node/storyboards/83131fdbef98"
+      },
+      {
+        "href": "/content_node/material_nodes/316b3610bf24"
+      },
+      {
+        "href": "/content_node/column_layouts/1e95f99300b6"
+      },
+      {
+        "href": "/content_node/responsive_layouts/39e8c1ffa1f1"
+      },
+      {
+        "href": "/content_node/single_texts/3c48f2d9fec7"
+      },
+      {
+        "href": "/content_node/single_texts/ae54aad20823"
+      },
+      {
+        "href": "/content_node/single_texts/023ce434a3a1"
+      },
+      {
+        "href": "/content_node/storyboards/0c877b31405c"
+      },
+      {
+        "href": "/content_node/material_nodes/6eb006af2085"
+      },
+      {
+        "href": "/content_node/column_layouts/28b2c881087c"
+      },
+      {
+        "href": "/content_node/responsive_layouts/4f92e986c8a5"
+      },
+      {
+        "href": "/content_node/single_texts/cb52c7d8808f"
+      },
+      {
+        "href": "/content_node/single_texts/5ec5d6ef73e1"
+      },
+      {
+        "href": "/content_node/single_texts/f2fb28b50c98"
+      },
+      {
+        "href": "/content_node/storyboards/a6148f4ff614"
+      },
+      {
+        "href": "/content_node/material_nodes/4c36d884ddcb"
+      },
+      {
+        "href": "/content_node/column_layouts/2c3830024da1"
+      },
+      {
+        "href": "/content_node/responsive_layouts/5ced2417dbbb"
+      },
+      {
+        "href": "/content_node/single_texts/08a319ff9aad"
+      },
+      {
+        "href": "/content_node/single_texts/3329e0cb15d6"
+      },
+      {
+        "href": "/content_node/single_texts/412184bb7fcc"
+      },
+      {
+        "href": "/content_node/single_texts/c1046246e7dd"
+      },
+      {
+        "href": "/content_node/single_texts/d49edd33fb35"
+      },
+      {
+        "href": "/content_node/checklist_nodes/be6972476965"
+      },
+      {
+        "href": "/content_node/storyboards/c52405220ced"
+      },
+      {
+        "href": "/content_node/material_nodes/90285e3c34a5"
+      },
+      {
+        "href": "/content_node/column_layouts/2df77b3f0723"
+      },
+      {
+        "href": "/content_node/responsive_layouts/eab512f9576f"
+      },
+      {
+        "href": "/content_node/single_texts/70bb8cdfa6d8"
+      },
+      {
+        "href": "/content_node/single_texts/248140aa282b"
+      },
+      {
+        "href": "/content_node/single_texts/16b4b12c48a0"
+      },
+      {
+        "href": "/content_node/single_texts/3f8e51330bc2"
+      },
+      {
+        "href": "/content_node/single_texts/c3b9a8b89618"
+      },
+      {
+        "href": "/content_node/checklist_nodes/3157182811bb"
+      },
+      {
+        "href": "/content_node/storyboards/44a06145038a"
+      },
+      {
+        "href": "/content_node/material_nodes/008c2a82f9f4"
+      },
+      {
+        "href": "/content_node/column_layouts/2ebe68599e3f"
+      },
+      {
+        "href": "/content_node/column_layouts/3b061abcbdc8"
+      },
+      {
+        "href": "/content_node/single_texts/8e410cebb44f"
+      },
+      {
+        "href": "/content_node/single_texts/a4775aec3e03"
+      },
+      {
+        "href": "/content_node/single_texts/f5e1a436a1f8"
+      },
+      {
+        "href": "/content_node/single_texts/df5dc810cf3c"
+      },
+      {
+        "href": "/content_node/single_texts/4a0f878a99fc"
+      },
+      {
+        "href": "/content_node/checklist_nodes/1a2905b61cff"
+      },
+      {
+        "href": "/content_node/storyboards/754b7187d819"
+      },
+      {
+        "href": "/content_node/material_nodes/27df0bda503f"
+      },
+      {
+        "href": "/content_node/responsive_layouts/28011dca853c"
+      },
+      {
+        "href": "/content_node/column_layouts/40dd3e9457d6"
+      },
+      {
+        "href": "/content_node/responsive_layouts/5ebcdb64fdb5"
+      },
+      {
+        "href": "/content_node/single_texts/a0eff3e27b5b"
+      },
+      {
+        "href": "/content_node/single_texts/49092518acf4"
+      },
+      {
+        "href": "/content_node/single_texts/199fac4c1b37"
+      },
+      {
+        "href": "/content_node/storyboards/3a833908338d"
+      },
+      {
+        "href": "/content_node/material_nodes/b688b7d91691"
+      },
+      {
+        "href": "/content_node/column_layouts/4488a8669ebf"
+      },
+      {
+        "href": "/content_node/responsive_layouts/af2aeebdc575"
+      },
+      {
+        "href": "/content_node/single_texts/1feebf2b0022"
+      },
+      {
+        "href": "/content_node/single_texts/f0e9b1475213"
+      },
+      {
+        "href": "/content_node/single_texts/92a9bb176ab1"
+      },
+      {
+        "href": "/content_node/single_texts/115001dac1ec"
+      },
+      {
+        "href": "/content_node/single_texts/84f99f42d58a"
+      },
+      {
+        "href": "/content_node/checklist_nodes/9e95b10e3cb0"
+      },
+      {
+        "href": "/content_node/storyboards/16a2d11897eb"
+      },
+      {
+        "href": "/content_node/material_nodes/28e74ee962e9"
+      },
+      {
+        "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+      },
+      {
+        "href": "/content_node/responsive_layouts/f9aa943d2183"
+      },
+      {
+        "href": "/content_node/single_texts/d6727e97c32b"
+      },
+      {
+        "href": "/content_node/single_texts/fc992e3cf8be"
+      },
+      {
+        "href": "/content_node/single_texts/84b8ff722471"
+      },
+      {
+        "href": "/content_node/storyboards/0c94476f8e49"
+      },
+      {
+        "href": "/content_node/material_nodes/e23863466f6a"
+      },
+      {
+        "href": "/content_node/column_layouts/4e70c2f6c206"
+      },
+      {
+        "href": "/content_node/responsive_layouts/c30e6271b10f"
+      },
+      {
+        "href": "/content_node/single_texts/69e2974bd21f"
+      },
+      {
+        "href": "/content_node/single_texts/7d3f7f26e515"
+      },
+      {
+        "href": "/content_node/single_texts/69fac3422851"
+      },
+      {
+        "href": "/content_node/multi_selects/35ca55460da3"
+      },
+      {
+        "href": "/content_node/storyboards/c31e416244ea"
+      },
+      {
+        "href": "/content_node/material_nodes/0c9da6f3a3a9"
+      },
+      {
+        "href": "/content_node/column_layouts/598946669198"
+      },
+      {
+        "href": "/content_node/responsive_layouts/fd30504d4da9"
+      },
+      {
+        "href": "/content_node/single_texts/593512fcabd5"
+      },
+      {
+        "href": "/content_node/single_texts/4e920d5a3186"
+      },
+      {
+        "href": "/content_node/single_texts/c34e7e852229"
+      },
+      {
+        "href": "/content_node/storyboards/aa040c45acde"
+      },
+      {
+        "href": "/content_node/material_nodes/8b9fb26d51d7"
+      },
+      {
+        "href": "/content_node/column_layouts/5a6917af2f55"
+      },
+      {
+        "href": "/content_node/single_texts/ffeadee13be3"
+      },
+      {
+        "href": "/content_node/single_texts/d9aeaa2425ea"
+      },
+      {
+        "href": "/content_node/single_texts/5da0571fac41"
+      },
+      {
+        "href": "/content_node/storyboards/38f008ed3383"
+      },
+      {
+        "href": "/content_node/material_nodes/b99257b01202"
+      },
+      {
+        "href": "/content_node/responsive_layouts/4b914c305170"
+      },
+      {
+        "href": "/content_node/column_layouts/605686add6db"
+      },
+      {
+        "href": "/content_node/responsive_layouts/eb9a3ff7cb89"
+      },
+      {
+        "href": "/content_node/single_texts/58c1550af9f7"
+      },
+      {
+        "href": "/content_node/single_texts/d8ff638bc079"
+      },
+      {
+        "href": "/content_node/single_texts/9c22a72d4666"
+      },
+      {
+        "href": "/content_node/storyboards/14f5cd5cc155"
+      },
+      {
+        "href": "/content_node/material_nodes/884a49a5f928"
+      },
+      {
+        "href": "/content_node/column_layouts/680095ff1e78"
+      },
+      {
+        "href": "/content_node/responsive_layouts/8d21cf90ee34"
+      },
+      {
+        "href": "/content_node/single_texts/d0e95cd6cc79"
+      },
+      {
+        "href": "/content_node/single_texts/5c9c0e7a2379"
+      },
+      {
+        "href": "/content_node/single_texts/1733597b0c44"
+      },
+      {
+        "href": "/content_node/storyboards/ba8c16422297"
+      },
+      {
+        "href": "/content_node/material_nodes/76b43733c8d2"
+      },
+      {
+        "href": "/content_node/column_layouts/6bab443ef52d"
+      },
+      {
+        "href": "/content_node/single_texts/798b70a5034a"
+      },
+      {
+        "href": "/content_node/single_texts/6a277f8c8eb1"
+      },
+      {
+        "href": "/content_node/single_texts/d77eebe66c73"
+      },
+      {
+        "href": "/content_node/storyboards/14f0a0f1749d"
+      },
+      {
+        "href": "/content_node/material_nodes/7e7a75da005b"
+      },
+      {
+        "href": "/content_node/responsive_layouts/1af6ffaca01f"
+      },
+      {
+        "href": "/content_node/column_layouts/801a718813bc"
+      },
+      {
+        "href": "/content_node/responsive_layouts/bcb9dfd0ce33"
+      },
+      {
+        "href": "/content_node/single_texts/2cb25e6c28e8"
+      },
+      {
+        "href": "/content_node/single_texts/6b63b9e34680"
+      },
+      {
+        "href": "/content_node/single_texts/50402861f667"
+      },
+      {
+        "href": "/content_node/storyboards/85e2edf0aa31"
+      },
+      {
+        "href": "/content_node/material_nodes/adcf54c67bc5"
+      },
+      {
+        "href": "/content_node/column_layouts/80f56c759496"
+      },
+      {
+        "href": "/content_node/single_texts/aeb09d91ec3a"
+      },
+      {
+        "href": "/content_node/material_nodes/c66f2f897116"
+      },
+      {
+        "href": "/content_node/column_layouts/82a15d418391"
+      },
+      {
+        "href": "/content_node/single_texts/f814604d5cc4"
+      },
+      {
+        "href": "/content_node/single_texts/5dde5ccdbbbe"
+      },
+      {
+        "href": "/content_node/single_texts/ae876b33f169"
+      },
+      {
+        "href": "/content_node/storyboards/61d6e5fffcd0"
+      },
+      {
+        "href": "/content_node/material_nodes/0f869c953b6b"
+      },
+      {
+        "href": "/content_node/responsive_layouts/1b04e9260129"
+      },
+      {
+        "href": "/content_node/column_layouts/8371c12ee053"
+      },
+      {
+        "href": "/content_node/responsive_layouts/bdef3d4d5adf"
+      },
+      {
+        "href": "/content_node/single_texts/97db2bff4cfc"
+      },
+      {
+        "href": "/content_node/single_texts/e8964f72b1ae"
+      },
+      {
+        "href": "/content_node/single_texts/630cd9f27359"
+      },
+      {
+        "href": "/content_node/storyboards/f737b29609a6"
+      },
+      {
+        "href": "/content_node/material_nodes/7a2508304e3d"
+      },
+      {
+        "href": "/content_node/column_layouts/873190b3bc7d"
+      },
+      {
+        "href": "/content_node/responsive_layouts/d227f0b77c0d"
+      },
+      {
+        "href": "/content_node/single_texts/24a9075ef9ad"
+      },
+      {
+        "href": "/content_node/single_texts/041c1ced3537"
+      },
+      {
+        "href": "/content_node/single_texts/f9039b90d830"
+      },
+      {
+        "href": "/content_node/storyboards/2536db88eaf3"
+      },
+      {
+        "href": "/content_node/material_nodes/1e9d4c52a16e"
+      },
+      {
+        "href": "/content_node/column_layouts/87c416512162"
+      },
+      {
+        "href": "/content_node/single_texts/8a7e84bc01a0"
+      },
+      {
+        "href": "/content_node/single_texts/1c80bc6e37f0"
+      },
+      {
+        "href": "/content_node/single_texts/64282928c1c1"
+      },
+      {
+        "href": "/content_node/single_texts/f7ad89a7ad94"
+      },
+      {
+        "href": "/content_node/single_texts/a052888033a0"
+      },
+      {
+        "href": "/content_node/checklist_nodes/d8e5da1e3d52"
+      },
+      {
+        "href": "/content_node/storyboards/42db3e3a34d2"
+      },
+      {
+        "href": "/content_node/material_nodes/b013653d4e8e"
+      },
+      {
+        "href": "/content_node/responsive_layouts/7199bc9a9992"
+      },
+      {
+        "href": "/content_node/column_layouts/894fb1deeae4"
+      },
+      {
+        "href": "/content_node/single_texts/d1aef4f6acc0"
+      },
+      {
+        "href": "/content_node/single_texts/ff1facaeb2e1"
+      },
+      {
+        "href": "/content_node/single_texts/d7fd95658683"
+      },
+      {
+        "href": "/content_node/single_texts/af89d7109360"
+      },
+      {
+        "href": "/content_node/checklist_nodes/42a32ff460d3"
+      },
+      {
+        "href": "/content_node/material_nodes/aa051d56b5ea"
+      },
+      {
+        "href": "/content_node/single_texts/964d86225857"
+      },
+      {
+        "href": "/content_node/column_layouts/187d8fb812a0"
+      },
+      {
+        "href": "/content_node/storyboards/ea6d00a9b637"
+      },
+      {
+        "href": "/content_node/column_layouts/4bf902d85c36"
+      },
+      {
+        "href": "/content_node/column_layouts/9e6da5607ba0"
+      },
+      {
+        "href": "/content_node/single_texts/5ee10f41ccef"
+      },
+      {
+        "href": "/content_node/single_texts/4f1b284cf530"
+      },
+      {
+        "href": "/content_node/single_texts/e697afffa4ab"
+      },
+      {
+        "href": "/content_node/storyboards/2a48d96e9d31"
+      },
+      {
+        "href": "/content_node/material_nodes/245f2480960f"
+      },
+      {
+        "href": "/content_node/responsive_layouts/40d85c3885aa"
+      },
+      {
+        "href": "/content_node/column_layouts/aa1fbba3f877"
+      },
+      {
+        "href": "/content_node/single_texts/7eb94a710e3c"
+      },
+      {
+        "href": "/content_node/single_texts/f1584e2a0e4c"
+      },
+      {
+        "href": "/content_node/single_texts/a291cdda200f"
+      },
+      {
+        "href": "/content_node/storyboards/71503dce4007"
+      },
+      {
+        "href": "/content_node/material_nodes/049e308e2c5b"
+      },
+      {
+        "href": "/content_node/responsive_layouts/411d9321d09a"
+      },
+      {
+        "href": "/content_node/column_layouts/ad0d42c70368"
+      },
+      {
+        "href": "/content_node/single_texts/6380d907cc0f"
+      },
+      {
+        "href": "/content_node/single_texts/2242da9aafe6"
+      },
+      {
+        "href": "/content_node/single_texts/b0d5b4a57199"
+      },
+      {
+        "href": "/content_node/single_texts/6441aeccb22f"
+      },
+      {
+        "href": "/content_node/single_texts/4b8bcd43de1d"
+      },
+      {
+        "href": "/content_node/checklist_nodes/81f4e528f1fc"
+      },
+      {
+        "href": "/content_node/storyboards/93049f7f3088"
+      },
+      {
+        "href": "/content_node/material_nodes/192c488ea1a3"
+      },
+      {
+        "href": "/content_node/responsive_layouts/828b3db50fcd"
+      },
+      {
+        "href": "/content_node/column_layouts/b2140367dd1c"
+      },
+      {
+        "href": "/content_node/single_texts/8cd3ef049436"
+      },
+      {
+        "href": "/content_node/single_texts/a78514380bc2"
+      },
+      {
+        "href": "/content_node/single_texts/43de3cf4dce8"
+      },
+      {
+        "href": "/content_node/multi_selects/1c00be30b8f0"
+      },
+      {
+        "href": "/content_node/single_texts/14349285da7d"
+      },
+      {
+        "href": "/content_node/single_texts/6b08091371a4"
+      },
+      {
+        "href": "/content_node/checklist_nodes/3f48816bccae"
+      },
+      {
+        "href": "/content_node/storyboards/9217300a2e42"
+      },
+      {
+        "href": "/content_node/material_nodes/7378fdc1b281"
+      },
+      {
+        "href": "/content_node/responsive_layouts/4e2489db9ac0"
+      },
+      {
+        "href": "/content_node/column_layouts/b87ef76bcb88"
+      },
+      {
+        "href": "/content_node/responsive_layouts/df73c81205c4"
+      },
+      {
+        "href": "/content_node/single_texts/f5030fa1fd76"
+      },
+      {
+        "href": "/content_node/single_texts/ef076b227ad2"
+      },
+      {
+        "href": "/content_node/single_texts/c89a5a617bcb"
+      },
+      {
+        "href": "/content_node/single_texts/6177394117a5"
+      },
+      {
+        "href": "/content_node/single_texts/2c6a78222e28"
+      },
+      {
+        "href": "/content_node/checklist_nodes/946afc306e3b"
+      },
+      {
+        "href": "/content_node/storyboards/8facbb6bf77f"
+      },
+      {
+        "href": "/content_node/material_nodes/9bb32189efb5"
+      },
+      {
+        "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+      },
+      {
+        "href": "/content_node/single_texts/4aa1846e670b"
+      },
+      {
+        "href": "/content_node/single_texts/5b60b27e3a46"
+      },
+      {
+        "href": "/content_node/single_texts/0e28f76880ac"
+      },
+      {
+        "href": "/content_node/checklist_nodes/bf4fc1e44a0b"
+      },
+      {
+        "href": "/content_node/single_texts/de7f7a8282e3"
+      },
+      {
+        "href": "/content_node/single_texts/7207e69fa2de"
+      },
+      {
+        "href": "/content_node/storyboards/b45a8d24dca0"
+      },
+      {
+        "href": "/content_node/material_nodes/c210b29eb641"
+      },
+      {
+        "href": "/content_node/responsive_layouts/2f6f68d62636"
+      },
+      {
+        "href": "/content_node/column_layouts/c7a7558a5120"
+      },
+      {
+        "href": "/content_node/single_texts/7331923798fe"
+      },
+      {
+        "href": "/content_node/single_texts/d95a38cdcc42"
+      },
+      {
+        "href": "/content_node/single_texts/48d1d2015058"
+      },
+      {
+        "href": "/content_node/storyboards/4509fb5ca22b"
+      },
+      {
+        "href": "/content_node/material_nodes/08236b944919"
+      },
+      {
+        "href": "/content_node/responsive_layouts/21f466229a77"
+      },
+      {
+        "href": "/content_node/column_layouts/d19401fcb194"
+      },
+      {
+        "href": "/content_node/single_texts/96975939e170"
+      },
+      {
+        "href": "/content_node/single_texts/38109ff0777c"
+      },
+      {
+        "href": "/content_node/single_texts/60e9b1b0a2b4"
+      },
+      {
+        "href": "/content_node/multi_selects/dc3f25ff5d2a"
+      },
+      {
+        "href": "/content_node/storyboards/eea245f1073a"
+      },
+      {
+        "href": "/content_node/material_nodes/d3e71bb6b49d"
+      },
+      {
+        "href": "/content_node/responsive_layouts/d1c26b9a788b"
+      },
+      {
+        "href": "/content_node/column_layouts/d84535201db8"
+      },
+      {
+        "href": "/content_node/single_texts/d4d501d04b31"
+      },
+      {
+        "href": "/content_node/single_texts/b50ba356f76b"
+      },
+      {
+        "href": "/content_node/single_texts/4726e6c0fee2"
+      },
+      {
+        "href": "/content_node/storyboards/2366430e91ad"
+      },
+      {
+        "href": "/content_node/material_nodes/c87507c3f2b6"
+      },
+      {
+        "href": "/content_node/responsive_layouts/7d95cf35c936"
+      },
+      {
+        "href": "/content_node/column_layouts/e09a8713b583"
+      },
+      {
+        "href": "/content_node/single_texts/e076af6ebb70"
+      },
+      {
+        "href": "/content_node/single_texts/2ee68d4dc61f"
+      },
+      {
+        "href": "/content_node/single_texts/7bbf67615903"
+      },
+      {
+        "href": "/content_node/single_texts/fc302facf468"
+      },
+      {
+        "href": "/content_node/single_texts/fb257d2a09c9"
+      },
+      {
+        "href": "/content_node/checklist_nodes/503cf893fa56"
+      },
+      {
+        "href": "/content_node/storyboards/e9a23adaadaa"
+      },
+      {
+        "href": "/content_node/material_nodes/18b67e3c98b3"
+      },
+      {
+        "href": "/content_node/responsive_layouts/32d931d9309f"
+      },
+      {
+        "href": "/content_node/column_layouts/e5c1d6082dfb"
+      },
+      {
+        "href": "/content_node/column_layouts/f8752e69a851"
+      },
+      {
+        "href": "/content_node/single_texts/afb7af7fc173"
+      },
+      {
+        "href": "/content_node/single_texts/c19c659470fa"
+      },
+      {
+        "href": "/content_node/single_texts/74b4dd9d188f"
+      },
+      {
+        "href": "/content_node/storyboards/508870d0da97"
+      },
+      {
+        "href": "/content_node/material_nodes/fba7bde6b6a5"
+      },
+      {
+        "href": "/content_node/responsive_layouts/f763c4c69ff4"
+      },
+      {
+        "href": "/content_node/column_layouts/fcb048b79244"
+      }
+    ],
+    "_meta": {
+      "self": "/content_nodes?period=%2Fapi%2Fperiods%2F88f1f55a69d7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/camps/5d28f99890bc/activities": {
+    "totalItems": 39,
+    "items": [
+      {
+        "href": "/activities/100dc5175796"
+      },
+      {
+        "href": "/activities/1c0ba134ee6b"
+      },
+      {
+        "href": "/activities/1d1fd1b415b5"
+      },
+      {
+        "href": "/activities/2e9c7bdba0e9"
+      },
+      {
+        "href": "/activities/38d1a410480e"
+      },
+      {
+        "href": "/activities/3da0fef3326e"
+      },
+      {
+        "href": "/activities/5331a674042e"
+      },
+      {
+        "href": "/activities/5b592f4f4da8"
+      },
+      {
+        "href": "/activities/633f1d93c6f7"
+      },
+      {
+        "href": "/activities/66243b51db3b"
+      },
+      {
+        "href": "/activities/70cf53233d11"
+      },
+      {
+        "href": "/activities/75b400aec63c"
+      },
+      {
+        "href": "/activities/7814aa132fce"
+      },
+      {
+        "href": "/activities/7ba5ae8ddf20"
+      },
+      {
+        "href": "/activities/7c8bbb9a5946"
+      },
+      {
+        "href": "/activities/81b993600c3f"
+      },
+      {
+        "href": "/activities/820cf7c77c1f"
+      },
+      {
+        "href": "/activities/85bb1677e32f"
+      },
+      {
+        "href": "/activities/8b18d2d4d436"
+      },
+      {
+        "href": "/activities/8bd29263d33a"
+      },
+      {
+        "href": "/activities/8c1c703d901d"
+      },
+      {
+        "href": "/activities/8f90766d94d1"
+      },
+      {
+        "href": "/activities/96285541cd32"
+      },
+      {
+        "href": "/activities/9c2464d15868"
+      },
+      {
+        "href": "/activities/a540bbed36ab"
+      },
+      {
+        "href": "/activities/ad2ec31ae7a5"
+      },
+      {
+        "href": "/activities/ad4da17161d9"
+      },
+      {
+        "href": "/activities/b16f518b9c59"
+      },
+      {
+        "href": "/activities/c173b29dad32"
+      },
+      {
+        "href": "/activities/c7d2923bfefb"
+      },
+      {
+        "href": "/activities/d0532df1021e"
+      },
+      {
+        "href": "/activities/d74b28de5f70"
+      },
+      {
+        "href": "/activities/d7c4dc4e8245"
+      },
+      {
+        "href": "/activities/decbda3ce0fa"
+      },
+      {
+        "href": "/activities/df771fa5f4aa"
+      },
+      {
+        "href": "/activities/dfb91a4d9b18"
+      },
+      {
+        "href": "/activities/e781c2558f5f"
+      },
+      {
+        "href": "/activities/e918bb1287b1"
+      },
+      {
+        "href": "/activities/fe6c1a3c12a1"
+      }
+    ],
+    "_meta": {
+      "self": "/camps/5d28f99890bc/activities",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/categories/fd476c982866": {
+    "short": "A",
+    "name": "Ausbildung",
+    "color": "#FD7A7A",
+    "numberingStyle": "1",
+    "id": "fd476c982866",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "preferredContentTypes": {
+      "href": "/content_types?categories=%2Fapi%2Fcategories%2Ffd476c982866"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/5c4b6fb14fe4"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F5c4b6fb14fe4"
+    },
+    "_meta": {
+      "self": "/categories/fd476c982866",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/f17470519474": {
+    "name": "ColumnLayout",
+    "active": true,
+    "id": "f17470519474",
+    "contentNodes": {
+      "href": "/content_node/column_layouts?contentType=%2Fapi%2Fcontent_types%2Ff17470519474"
+    },
+    "_meta": {
+      "self": "/content_types/f17470519474",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/3ef17bd1df72": {
+    "name": "Material",
+    "active": true,
+    "id": "3ef17bd1df72",
+    "contentNodes": {
+      "href": "/content_node/material_nodes?contentType=%2Fapi%2Fcontent_types%2F3ef17bd1df72"
+    },
+    "_meta": {
+      "self": "/content_types/3ef17bd1df72",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/4f0c657fecef": {
+    "name": "Notes",
+    "active": true,
+    "id": "4f0c657fecef",
+    "contentNodes": {
+      "href": "/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F4f0c657fecef"
+    },
+    "_meta": {
+      "self": "/content_types/4f0c657fecef",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/a4211c112939": {
+    "name": "ResponsiveLayout",
+    "active": true,
+    "id": "a4211c112939",
+    "contentNodes": {
+      "href": "/content_node/responsive_layouts?contentType=%2Fapi%2Fcontent_types%2Fa4211c112939"
+    },
+    "_meta": {
+      "self": "/content_types/a4211c112939",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/44dcc7493c65": {
+    "name": "SafetyConsiderations",
+    "active": true,
+    "id": "44dcc7493c65",
+    "contentNodes": {
+      "href": "/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F44dcc7493c65"
+    },
+    "_meta": {
+      "self": "/content_types/44dcc7493c65",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/cfccaecd4bad": {
+    "name": "Storyboard",
+    "active": true,
+    "id": "cfccaecd4bad",
+    "contentNodes": {
+      "href": "/content_node/storyboards?contentType=%2Fapi%2Fcontent_types%2Fcfccaecd4bad"
+    },
+    "_meta": {
+      "self": "/content_types/cfccaecd4bad",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/318e064ea0c9": {
+    "name": "Storycontext",
+    "active": true,
+    "id": "318e064ea0c9",
+    "contentNodes": {
+      "href": "/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F318e064ea0c9"
+    },
+    "_meta": {
+      "self": "/content_types/318e064ea0c9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types?categories=%2Fapi%2Fcategories%2Ffd476c982866": {
+    "items": [
+      {
+        "href": "/content_types/f17470519474"
+      },
+      {
+        "href": "/content_types/3ef17bd1df72"
+      },
+      {
+        "href": "/content_types/4f0c657fecef"
+      },
+      {
+        "href": "/content_types/a4211c112939"
+      },
+      {
+        "href": "/content_types/44dcc7493c65"
+      },
+      {
+        "href": "/content_types/cfccaecd4bad"
+      },
+      {
+        "href": "/content_types/318e064ea0c9"
+      }
+    ],
+    "_meta": {
+      "self": "/content_types?categories=%2Fapi%2Fcategories%2Ffd476c982866",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/categories/98f686a32238": {
+    "short": "ES",
+    "name": "Essen",
+    "color": "#BBBBBB",
+    "numberingStyle": "-",
+    "id": "98f686a32238",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "preferredContentTypes": {
+      "href": "/content_types?categories=%2Fapi%2Fcategories%2F98f686a32238"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/56f97d3a00d6"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F56f97d3a00d6"
+    },
+    "_meta": {
+      "self": "/categories/98f686a32238",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types?categories=%2Fapi%2Fcategories%2F98f686a32238": {
+    "items": [],
+    "_meta": {
+      "self": "/content_types?categories=%2Fapi%2Fcategories%2F98f686a32238",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/categories/33287493d1c1": {
+    "short": "LL",
+    "name": "Lernen und lehren",
+    "color": "#4DBB52",
+    "numberingStyle": "A",
+    "id": "33287493d1c1",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "preferredContentTypes": {
+      "href": "/content_types?categories=%2Fapi%2Fcategories%2F33287493d1c1"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/dd8432af2d6d"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fdd8432af2d6d"
+    },
+    "_meta": {
+      "self": "/categories/33287493d1c1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/1a0f84e322c8": {
+    "name": "LAThematicArea",
+    "active": true,
+    "id": "1a0f84e322c8",
+    "contentNodes": {
+      "href": "/content_node/multi_selects?contentType=%2Fapi%2Fcontent_types%2F1a0f84e322c8"
+    },
+    "_meta": {
+      "self": "/content_types/1a0f84e322c8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types?categories=%2Fapi%2Fcategories%2F33287493d1c1": {
+    "items": [
+      {
+        "href": "/content_types/f17470519474"
+      },
+      {
+        "href": "/content_types/1a0f84e322c8"
+      },
+      {
+        "href": "/content_types/3ef17bd1df72"
+      },
+      {
+        "href": "/content_types/4f0c657fecef"
+      },
+      {
+        "href": "/content_types/a4211c112939"
+      },
+      {
+        "href": "/content_types/44dcc7493c65"
+      },
+      {
+        "href": "/content_types/cfccaecd4bad"
+      },
+      {
+        "href": "/content_types/318e064ea0c9"
+      }
+    ],
+    "_meta": {
+      "self": "/content_types?categories=%2Fapi%2Fcategories%2F33287493d1c1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/categories/518df7ff2cfb": {
+    "short": "WP",
+    "name": "Wahlprogramm",
+    "color": "#90B7E4",
+    "numberingStyle": "1",
+    "id": "518df7ff2cfb",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "preferredContentTypes": {
+      "href": "/content_types?categories=%2Fapi%2Fcategories%2F518df7ff2cfb"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/a0447c5659cd"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fa0447c5659cd"
+    },
+    "_meta": {
+      "self": "/categories/518df7ff2cfb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types?categories=%2Fapi%2Fcategories%2F518df7ff2cfb": {
+    "items": [
+      {
+        "href": "/content_types/f17470519474"
+      },
+      {
+        "href": "/content_types/3ef17bd1df72"
+      },
+      {
+        "href": "/content_types/4f0c657fecef"
+      },
+      {
+        "href": "/content_types/a4211c112939"
+      },
+      {
+        "href": "/content_types/44dcc7493c65"
+      },
+      {
+        "href": "/content_types/cfccaecd4bad"
+      },
+      {
+        "href": "/content_types/318e064ea0c9"
+      }
+    ],
+    "_meta": {
+      "self": "/content_types?categories=%2Fapi%2Fcategories%2F518df7ff2cfb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/personal_invitations/b32db30637c8": {
+    "id": "b32db30637c8",
+    "campId": "9c2447aefe38",
+    "campTitle": "Lorem ipsum dolor sit amet",
+    "_meta": {
+      "self": "/personal_invitations/b32db30637c8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/day_responsibles/068c64c8a494": {
+    "id": "068c64c8a494",
+    "day": {
+      "href": "/days/63163861c828"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/146c0608237f"
+    },
+    "_meta": {
+      "self": "/day_responsibles/068c64c8a494",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/63163861c828/day_responsibles": {
+    "items": [
+      {
+        "href": "/day_responsibles/068c64c8a494"
+      }
+    ],
+    "_meta": {
+      "self": "/days/63163861c828/day_responsibles",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/day_responsibles/c60d37e48966": {
+    "id": "c60d37e48966",
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/4b0f654bf743"
+    },
+    "_meta": {
+      "self": "/day_responsibles/c60d37e48966",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/1b6e5995c138/day_responsibles": {
+    "items": [
+      {
+        "href": "/day_responsibles/c60d37e48966"
+      }
+    ],
+    "_meta": {
+      "self": "/days/1b6e5995c138/day_responsibles",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/day_responsibles/a1b2a402ed98": {
+    "id": "a1b2a402ed98",
+    "day": {
+      "href": "/days/c118aa688d8e"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/af9f868f0a48"
+    },
+    "_meta": {
+      "self": "/day_responsibles/a1b2a402ed98",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/c118aa688d8e/day_responsibles": {
+    "items": [
+      {
+        "href": "/day_responsibles/a1b2a402ed98"
+      }
+    ],
+    "_meta": {
+      "self": "/days/c118aa688d8e/day_responsibles",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/day_responsibles/d42c79cf45d1": {
+    "id": "d42c79cf45d1",
+    "day": {
+      "href": "/days/a6a17ccae877"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/83cdbbe00f85"
+    },
+    "_meta": {
+      "self": "/day_responsibles/d42c79cf45d1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/a6a17ccae877/day_responsibles": {
+    "items": [
+      {
+        "href": "/day_responsibles/d42c79cf45d1"
+      }
+    ],
+    "_meta": {
+      "self": "/days/a6a17ccae877/day_responsibles",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/day_responsibles/207ea1926f27": {
+    "id": "207ea1926f27",
+    "day": {
+      "href": "/days/9411ee803eb4"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/83cdbbe00f85"
+    },
+    "_meta": {
+      "self": "/day_responsibles/207ea1926f27",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/9411ee803eb4/day_responsibles": {
+    "items": [
+      {
+        "href": "/day_responsibles/207ea1926f27"
+      }
+    ],
+    "_meta": {
+      "self": "/days/9411ee803eb4/day_responsibles",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/day_responsibles/cb5726304025": {
+    "id": "cb5726304025",
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/af9f868f0a48"
+    },
+    "_meta": {
+      "self": "/day_responsibles/cb5726304025",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/273358ce9d70/day_responsibles": {
+    "items": [
+      {
+        "href": "/day_responsibles/cb5726304025"
+      }
+    ],
+    "_meta": {
+      "self": "/days/273358ce9d70/day_responsibles",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/day_responsibles/5b8a43dced14": {
+    "id": "5b8a43dced14",
+    "day": {
+      "href": "/days/40e3a286dc08"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/d03003838720"
+    },
+    "_meta": {
+      "self": "/day_responsibles/5b8a43dced14",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/40e3a286dc08/day_responsibles": {
+    "items": [
+      {
+        "href": "/day_responsibles/5b8a43dced14"
+      }
+    ],
+    "_meta": {
+      "self": "/days/40e3a286dc08/day_responsibles",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/day_responsibles/a6462d35b185": {
+    "id": "a6462d35b185",
+    "day": {
+      "href": "/days/485e190f4852"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/146c0608237f"
+    },
+    "_meta": {
+      "self": "/day_responsibles/a6462d35b185",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/days/485e190f4852/day_responsibles": {
+    "items": [
+      {
+        "href": "/day_responsibles/a6462d35b185"
+      }
+    ],
+    "_meta": {
+      "self": "/days/485e190f4852/day_responsibles",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/100dc5175796": {
+    "title": "Morgefit",
+    "location": "",
+    "id": "100dc5175796",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F100dc5175796"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/de866d6696aa"
+    },
+    "comments": {
+      "href": "/activities/100dc5175796/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F100dc5175796"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/4e70c2f6c206"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F4e70c2f6c206"
+    },
+    "_meta": {
+      "self": "/activities/100dc5175796",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/5f363002c509": {
+    "left": 0,
+    "width": 1,
+    "id": "5f363002c509",
+    "start": "2026-07-15T07:30:00+00:00",
+    "end": "2026-07-15T08:00:00+00:00",
+    "dayNumber": 3,
+    "scheduleEntryNumber": 2,
+    "number": "3.2",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/100dc5175796"
+    },
+    "day": {
+      "href": "/days/c118aa688d8e"
+    },
+    "_meta": {
+      "self": "/schedule_entries/5f363002c509",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/f4dcab509e05": {
+    "id": "f4dcab509e05",
+    "activity": {
+      "href": "/activities/100dc5175796"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/e64284adf2f2"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/f4dcab509e05",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F100dc5175796": {
+    "items": [
+      {
+        "href": "/schedule_entries/5f363002c509"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F100dc5175796",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F100dc5175796": {
+    "items": [
+      {
+        "href": "/activity_responsibles/f4dcab509e05"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F100dc5175796",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/1c0ba134ee6b": {
+    "title": "Zmorge",
+    "location": "",
+    "id": "1c0ba134ee6b",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F1c0ba134ee6b"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/98f686a32238"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/1c0ba134ee6b/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F1c0ba134ee6b"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/82a15d418391"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F82a15d418391"
+    },
+    "_meta": {
+      "self": "/activities/1c0ba134ee6b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/7483a97d3811": {
+    "left": 0,
+    "width": 1,
+    "id": "7483a97d3811",
+    "start": "2026-07-14T08:00:00+00:00",
+    "end": "2026-07-14T09:00:00+00:00",
+    "dayNumber": 2,
+    "scheduleEntryNumber": 1,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/1c0ba134ee6b"
+    },
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "_meta": {
+      "self": "/schedule_entries/7483a97d3811",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/338b1ec643f0": {
+    "left": 0,
+    "width": 1,
+    "id": "338b1ec643f0",
+    "start": "2026-07-15T08:00:00+00:00",
+    "end": "2026-07-15T09:00:00+00:00",
+    "dayNumber": 3,
+    "scheduleEntryNumber": 1,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/1c0ba134ee6b"
+    },
+    "day": {
+      "href": "/days/c118aa688d8e"
+    },
+    "_meta": {
+      "self": "/schedule_entries/338b1ec643f0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/d2b7193ee240": {
+    "left": 0,
+    "width": 1,
+    "id": "d2b7193ee240",
+    "start": "2026-07-16T08:00:00+00:00",
+    "end": "2026-07-16T09:00:00+00:00",
+    "dayNumber": 4,
+    "scheduleEntryNumber": 1,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/1c0ba134ee6b"
+    },
+    "day": {
+      "href": "/days/a6a17ccae877"
+    },
+    "_meta": {
+      "self": "/schedule_entries/d2b7193ee240",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/1c9849eb3e19": {
+    "left": 0,
+    "width": 1,
+    "id": "1c9849eb3e19",
+    "start": "2026-07-17T08:00:00+00:00",
+    "end": "2026-07-17T09:00:00+00:00",
+    "dayNumber": 5,
+    "scheduleEntryNumber": 1,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/1c0ba134ee6b"
+    },
+    "day": {
+      "href": "/days/9411ee803eb4"
+    },
+    "_meta": {
+      "self": "/schedule_entries/1c9849eb3e19",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/76f8de918d33": {
+    "left": 0,
+    "width": 1,
+    "id": "76f8de918d33",
+    "start": "2026-07-18T08:00:00+00:00",
+    "end": "2026-07-18T09:00:00+00:00",
+    "dayNumber": 6,
+    "scheduleEntryNumber": 1,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/1c0ba134ee6b"
+    },
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "_meta": {
+      "self": "/schedule_entries/76f8de918d33",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/528b12bce91f": {
+    "left": 0,
+    "width": 1,
+    "id": "528b12bce91f",
+    "start": "2026-07-19T08:00:00+00:00",
+    "end": "2026-07-19T09:00:00+00:00",
+    "dayNumber": 7,
+    "scheduleEntryNumber": 1,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/1c0ba134ee6b"
+    },
+    "day": {
+      "href": "/days/40e3a286dc08"
+    },
+    "_meta": {
+      "self": "/schedule_entries/528b12bce91f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/7ae50dc8370f": {
+    "left": 0,
+    "width": 1,
+    "id": "7ae50dc8370f",
+    "start": "2026-07-20T08:00:00+00:00",
+    "end": "2026-07-20T09:00:00+00:00",
+    "dayNumber": 8,
+    "scheduleEntryNumber": 1,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/1c0ba134ee6b"
+    },
+    "day": {
+      "href": "/days/485e190f4852"
+    },
+    "_meta": {
+      "self": "/schedule_entries/7ae50dc8370f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F1c0ba134ee6b": {
+    "items": [
+      {
+        "href": "/schedule_entries/7483a97d3811"
+      },
+      {
+        "href": "/schedule_entries/338b1ec643f0"
+      },
+      {
+        "href": "/schedule_entries/d2b7193ee240"
+      },
+      {
+        "href": "/schedule_entries/1c9849eb3e19"
+      },
+      {
+        "href": "/schedule_entries/76f8de918d33"
+      },
+      {
+        "href": "/schedule_entries/528b12bce91f"
+      },
+      {
+        "href": "/schedule_entries/7ae50dc8370f"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F1c0ba134ee6b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F1c0ba134ee6b": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F1c0ba134ee6b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/1d1fd1b415b5": {
+    "title": "Wasserspiele in Badi",
+    "location": "",
+    "id": "1d1fd1b415b5",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F1d1fd1b415b5"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/da4d05db108e"
+    },
+    "comments": {
+      "href": "/activities/1d1fd1b415b5/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F1d1fd1b415b5"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F2ebe68599e3f"
+    },
+    "_meta": {
+      "self": "/activities/1d1fd1b415b5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/340a7c43247f": {
+    "left": 0,
+    "width": 1,
+    "id": "340a7c43247f",
+    "start": "2026-07-17T13:00:00+00:00",
+    "end": "2026-07-17T16:45:00+00:00",
+    "dayNumber": 5,
+    "scheduleEntryNumber": 2,
+    "number": "5.2",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/1d1fd1b415b5"
+    },
+    "day": {
+      "href": "/days/9411ee803eb4"
+    },
+    "_meta": {
+      "self": "/schedule_entries/340a7c43247f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/1d826261ee4b": {
+    "id": "1d826261ee4b",
+    "activity": {
+      "href": "/activities/1d1fd1b415b5"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/4b0f654bf743"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/1d826261ee4b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F1d1fd1b415b5": {
+    "items": [
+      {
+        "href": "/schedule_entries/340a7c43247f"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F1d1fd1b415b5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F1d1fd1b415b5": {
+    "items": [
+      {
+        "href": "/activity_responsibles/1d826261ee4b"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F1d1fd1b415b5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/2e9c7bdba0e9": {
+    "title": "Morgefit",
+    "location": "",
+    "id": "2e9c7bdba0e9",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F2e9c7bdba0e9"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/2e9c7bdba0e9/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F2e9c7bdba0e9"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/d19401fcb194"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fd19401fcb194"
+    },
+    "_meta": {
+      "self": "/activities/2e9c7bdba0e9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/d36256eb597d": {
+    "left": 0,
+    "width": 1,
+    "id": "d36256eb597d",
+    "start": "2026-07-19T07:30:00+00:00",
+    "end": "2026-07-19T08:00:00+00:00",
+    "dayNumber": 7,
+    "scheduleEntryNumber": 1,
+    "number": "7.1",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/2e9c7bdba0e9"
+    },
+    "day": {
+      "href": "/days/40e3a286dc08"
+    },
+    "_meta": {
+      "self": "/schedule_entries/d36256eb597d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F2e9c7bdba0e9": {
+    "items": [
+      {
+        "href": "/schedule_entries/d36256eb597d"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F2e9c7bdba0e9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F2e9c7bdba0e9": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F2e9c7bdba0e9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/38d1a410480e": {
+    "title": "Newgames neben Lagerbau",
+    "location": "Spielwiese",
+    "id": "38d1a410480e",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F38d1a410480e"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/da4d05db108e"
+    },
+    "comments": {
+      "href": "/activities/38d1a410480e/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F38d1a410480e"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fe5c1d6082dfb"
+    },
+    "_meta": {
+      "self": "/activities/38d1a410480e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/9768e17e461d": {
+    "left": 0,
+    "width": 1,
+    "id": "9768e17e461d",
+    "start": "2026-07-13T15:00:00+00:00",
+    "end": "2026-07-13T18:00:00+00:00",
+    "dayNumber": 1,
+    "scheduleEntryNumber": 2,
+    "number": "1.2",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/38d1a410480e"
+    },
+    "day": {
+      "href": "/days/63163861c828"
+    },
+    "_meta": {
+      "self": "/schedule_entries/9768e17e461d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/6ad22dfe6d0b": {
+    "id": "6ad22dfe6d0b",
+    "activity": {
+      "href": "/activities/38d1a410480e"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/af9f868f0a48"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/6ad22dfe6d0b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F38d1a410480e": {
+    "items": [
+      {
+        "href": "/schedule_entries/9768e17e461d"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F38d1a410480e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F38d1a410480e": {
+    "items": [
+      {
+        "href": "/activity_responsibles/6ad22dfe6d0b"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F38d1a410480e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/3da0fef3326e": {
+    "title": "Quidditch finale",
+    "location": "",
+    "id": "3da0fef3326e",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F3da0fef3326e"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/3da0fef3326e/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F3da0fef3326e"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/2c3830024da1"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F2c3830024da1"
+    },
+    "_meta": {
+      "self": "/activities/3da0fef3326e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/d712be44166d": {
+    "left": 0,
+    "width": 1,
+    "id": "d712be44166d",
+    "start": "2026-07-18T09:00:00+00:00",
+    "end": "2026-07-18T10:30:00+00:00",
+    "dayNumber": 6,
+    "scheduleEntryNumber": 2,
+    "number": "6.2",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/3da0fef3326e"
+    },
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "_meta": {
+      "self": "/schedule_entries/d712be44166d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/009114d5f5e9": {
+    "id": "009114d5f5e9",
+    "activity": {
+      "href": "/activities/3da0fef3326e"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/e64284adf2f2"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/009114d5f5e9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F3da0fef3326e": {
+    "items": [
+      {
+        "href": "/schedule_entries/d712be44166d"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F3da0fef3326e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F3da0fef3326e": {
+    "items": [
+      {
+        "href": "/activity_responsibles/009114d5f5e9"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F3da0fef3326e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/5331a674042e": {
+    "title": "Morgefit",
+    "location": "",
+    "id": "5331a674042e",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F5331a674042e"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/016d7278966a"
+    },
+    "comments": {
+      "href": "/activities/5331a674042e/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F5331a674042e"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/09b19f627429"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F09b19f627429"
+    },
+    "_meta": {
+      "self": "/activities/5331a674042e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/2b7e20b2c143": {
+    "left": 0,
+    "width": 1,
+    "id": "2b7e20b2c143",
+    "start": "2026-07-16T07:30:00+00:00",
+    "end": "2026-07-16T08:00:00+00:00",
+    "dayNumber": 4,
+    "scheduleEntryNumber": 1,
+    "number": "4.1",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/5331a674042e"
+    },
+    "day": {
+      "href": "/days/a6a17ccae877"
+    },
+    "_meta": {
+      "self": "/schedule_entries/2b7e20b2c143",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/c7dceb3e550d": {
+    "id": "c7dceb3e550d",
+    "activity": {
+      "href": "/activities/5331a674042e"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/146c0608237f"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/c7dceb3e550d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F5331a674042e": {
+    "items": [
+      {
+        "href": "/schedule_entries/2b7e20b2c143"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F5331a674042e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F5331a674042e": {
+    "items": [
+      {
+        "href": "/activity_responsibles/c7dceb3e550d"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F5331a674042e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/5b592f4f4da8": {
+    "title": "Nachsitzen bei Snape",
+    "location": "",
+    "id": "5b592f4f4da8",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F5b592f4f4da8"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/518df7ff2cfb"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/5b592f4f4da8/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F5b592f4f4da8"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/4488a8669ebf"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F4488a8669ebf"
+    },
+    "_meta": {
+      "self": "/activities/5b592f4f4da8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/3c6a421b9598": {
+    "left": 0,
+    "width": 1,
+    "id": "3c6a421b9598",
+    "start": "2026-07-19T09:00:00+00:00",
+    "end": "2026-07-19T11:45:00+00:00",
+    "dayNumber": 7,
+    "scheduleEntryNumber": 2,
+    "number": "7.2",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/5b592f4f4da8"
+    },
+    "day": {
+      "href": "/days/40e3a286dc08"
+    },
+    "_meta": {
+      "self": "/schedule_entries/3c6a421b9598",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F5b592f4f4da8": {
+    "items": [
+      {
+        "href": "/schedule_entries/3c6a421b9598"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F5b592f4f4da8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F5b592f4f4da8": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F5b592f4f4da8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/633f1d93c6f7": {
+    "title": "Beginn & Anreise",
+    "location": "",
+    "id": "633f1d93c6f7",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F633f1d93c6f7"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/518df7ff2cfb"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/e78a915b0771"
+    },
+    "comments": {
+      "href": "/activities/633f1d93c6f7/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F633f1d93c6f7"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/801a718813bc"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F801a718813bc"
+    },
+    "_meta": {
+      "self": "/activities/633f1d93c6f7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/8edd32042a72": {
+    "left": 0,
+    "width": 1,
+    "id": "8edd32042a72",
+    "start": "2026-07-13T08:30:00+00:00",
+    "end": "2026-07-13T12:00:00+00:00",
+    "dayNumber": 1,
+    "scheduleEntryNumber": 1,
+    "number": "1.1",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/633f1d93c6f7"
+    },
+    "day": {
+      "href": "/days/63163861c828"
+    },
+    "_meta": {
+      "self": "/schedule_entries/8edd32042a72",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/0086e7bc6978": {
+    "id": "0086e7bc6978",
+    "activity": {
+      "href": "/activities/633f1d93c6f7"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/146c0608237f"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/0086e7bc6978",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F633f1d93c6f7": {
+    "items": [
+      {
+        "href": "/schedule_entries/8edd32042a72"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F633f1d93c6f7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F633f1d93c6f7": {
+    "items": [
+      {
+        "href": "/activity_responsibles/0086e7bc6978"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F633f1d93c6f7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/66243b51db3b": {
+    "title": "Vorbereitung Abschlussabend",
+    "location": "",
+    "id": "66243b51db3b",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F66243b51db3b"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/518df7ff2cfb"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/66243b51db3b/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F66243b51db3b"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/fcb048b79244"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Ffcb048b79244"
+    },
+    "_meta": {
+      "self": "/activities/66243b51db3b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/d281382890e2": {
+    "left": 0,
+    "width": 1,
+    "id": "d281382890e2",
+    "start": "2026-07-19T14:15:00+00:00",
+    "end": "2026-07-19T17:45:00+00:00",
+    "dayNumber": 7,
+    "scheduleEntryNumber": 3,
+    "number": "7.3",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/66243b51db3b"
+    },
+    "day": {
+      "href": "/days/40e3a286dc08"
+    },
+    "_meta": {
+      "self": "/schedule_entries/d281382890e2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F66243b51db3b": {
+    "items": [
+      {
+        "href": "/schedule_entries/d281382890e2"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F66243b51db3b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F66243b51db3b": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F66243b51db3b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/70cf53233d11": {
+    "title": "Spieleturnier",
+    "location": "",
+    "id": "70cf53233d11",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F70cf53233d11"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/70cf53233d11/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F70cf53233d11"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/5a6917af2f55"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F5a6917af2f55"
+    },
+    "_meta": {
+      "self": "/activities/70cf53233d11",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/7c39f20068ce": {
+    "left": 0,
+    "width": 1,
+    "id": "7c39f20068ce",
+    "start": "2026-07-18T13:15:00+00:00",
+    "end": "2026-07-18T15:00:00+00:00",
+    "dayNumber": 6,
+    "scheduleEntryNumber": 3,
+    "number": "6.3",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/70cf53233d11"
+    },
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "_meta": {
+      "self": "/schedule_entries/7c39f20068ce",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/8bccd22723c0": {
+    "left": 0,
+    "width": 1,
+    "id": "8bccd22723c0",
+    "start": "2026-07-18T15:45:00+00:00",
+    "end": "2026-07-18T17:45:00+00:00",
+    "dayNumber": 6,
+    "scheduleEntryNumber": 4,
+    "number": "6.4",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/70cf53233d11"
+    },
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "_meta": {
+      "self": "/schedule_entries/8bccd22723c0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/48347f331db2": {
+    "id": "48347f331db2",
+    "activity": {
+      "href": "/activities/70cf53233d11"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/83cdbbe00f85"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/48347f331db2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F70cf53233d11": {
+    "items": [
+      {
+        "href": "/schedule_entries/7c39f20068ce"
+      },
+      {
+        "href": "/schedule_entries/8bccd22723c0"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F70cf53233d11",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F70cf53233d11": {
+    "items": [
+      {
+        "href": "/activity_responsibles/48347f331db2"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F70cf53233d11",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/75b400aec63c": {
+    "title": "Atelier",
+    "location": "",
+    "id": "75b400aec63c",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F75b400aec63c"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/33287493d1c1"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/75b400aec63c/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F75b400aec63c"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F4bd0b0f3f3a6"
+    },
+    "_meta": {
+      "self": "/activities/75b400aec63c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/c4e91fa37beb": {
+    "left": 0,
+    "width": 1,
+    "id": "c4e91fa37beb",
+    "start": "2026-07-14T13:00:00+00:00",
+    "end": "2026-07-14T15:15:00+00:00",
+    "dayNumber": 2,
+    "scheduleEntryNumber": 1,
+    "number": "2.A",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/75b400aec63c"
+    },
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "_meta": {
+      "self": "/schedule_entries/c4e91fa37beb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F75b400aec63c": {
+    "items": [
+      {
+        "href": "/schedule_entries/c4e91fa37beb"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F75b400aec63c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F75b400aec63c": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F75b400aec63c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/7814aa132fce": {
+    "title": "SpezEx Erste Hilfe",
+    "location": "",
+    "id": "7814aa132fce",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F7814aa132fce"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/33287493d1c1"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/016d7278966a"
+    },
+    "comments": {
+      "href": "/activities/7814aa132fce/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F7814aa132fce"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fb87ef76bcb88"
+    },
+    "_meta": {
+      "self": "/activities/7814aa132fce",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/678b0c9e032b": {
+    "left": 0,
+    "width": 1,
+    "id": "678b0c9e032b",
+    "start": "2026-07-15T09:00:00+00:00",
+    "end": "2026-07-15T12:00:00+00:00",
+    "dayNumber": 3,
+    "scheduleEntryNumber": 1,
+    "number": "3.A",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/7814aa132fce"
+    },
+    "day": {
+      "href": "/days/c118aa688d8e"
+    },
+    "_meta": {
+      "self": "/schedule_entries/678b0c9e032b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/9c9b30245328": {
+    "id": "9c9b30245328",
+    "activity": {
+      "href": "/activities/7814aa132fce"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/d03003838720"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/9c9b30245328",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F7814aa132fce": {
+    "items": [
+      {
+        "href": "/schedule_entries/678b0c9e032b"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F7814aa132fce",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F7814aa132fce": {
+    "items": [
+      {
+        "href": "/activity_responsibles/9c9b30245328"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F7814aa132fce",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/7ba5ae8ddf20": {
+    "title": "Grundlagen Zaubertränke",
+    "location": "",
+    "id": "7ba5ae8ddf20",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F7ba5ae8ddf20"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/518df7ff2cfb"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/da4d05db108e"
+    },
+    "comments": {
+      "href": "/activities/7ba5ae8ddf20/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F7ba5ae8ddf20"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/6bab443ef52d"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F6bab443ef52d"
+    },
+    "_meta": {
+      "self": "/activities/7ba5ae8ddf20",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/00dabfb4abc0": {
+    "left": 0,
+    "width": 1,
+    "id": "00dabfb4abc0",
+    "start": "2026-07-14T15:15:00+00:00",
+    "end": "2026-07-14T18:00:00+00:00",
+    "dayNumber": 2,
+    "scheduleEntryNumber": 3,
+    "number": "2.3",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/7ba5ae8ddf20"
+    },
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "_meta": {
+      "self": "/schedule_entries/00dabfb4abc0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/a35b7eb5de52": {
+    "id": "a35b7eb5de52",
+    "activity": {
+      "href": "/activities/7ba5ae8ddf20"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/83cdbbe00f85"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/a35b7eb5de52",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F7ba5ae8ddf20": {
+    "items": [
+      {
+        "href": "/schedule_entries/00dabfb4abc0"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F7ba5ae8ddf20",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F7ba5ae8ddf20": {
+    "items": [
+      {
+        "href": "/activity_responsibles/a35b7eb5de52"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F7ba5ae8ddf20",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/7c8bbb9a5946": {
+    "title": "Lagerabbau",
+    "location": "",
+    "id": "7c8bbb9a5946",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F7c8bbb9a5946"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/33287493d1c1"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/7c8bbb9a5946/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F7c8bbb9a5946"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/1e95f99300b6"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F1e95f99300b6"
+    },
+    "_meta": {
+      "self": "/activities/7c8bbb9a5946",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/89239bf4e109": {
+    "left": 0,
+    "width": 1,
+    "id": "89239bf4e109",
+    "start": "2026-07-20T09:00:00+00:00",
+    "end": "2026-07-20T12:00:00+00:00",
+    "dayNumber": 8,
+    "scheduleEntryNumber": 1,
+    "number": "8.A",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/7c8bbb9a5946"
+    },
+    "day": {
+      "href": "/days/485e190f4852"
+    },
+    "_meta": {
+      "self": "/schedule_entries/89239bf4e109",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F7c8bbb9a5946": {
+    "items": [
+      {
+        "href": "/schedule_entries/89239bf4e109"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F7c8bbb9a5946",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F7c8bbb9a5946": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F7c8bbb9a5946",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/81b993600c3f": {
+    "title": "Totto Lotto",
+    "location": "",
+    "id": "81b993600c3f",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F81b993600c3f"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/518df7ff2cfb"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/81b993600c3f/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F81b993600c3f"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/1bee9e7a94a9"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F1bee9e7a94a9"
+    },
+    "_meta": {
+      "self": "/activities/81b993600c3f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/b7d1761ab299": {
+    "left": 0,
+    "width": 1,
+    "id": "b7d1761ab299",
+    "start": "2026-07-20T15:00:00+00:00",
+    "end": "2026-07-20T17:00:00+00:00",
+    "dayNumber": 8,
+    "scheduleEntryNumber": 2,
+    "number": "8.2",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/81b993600c3f"
+    },
+    "day": {
+      "href": "/days/485e190f4852"
+    },
+    "_meta": {
+      "self": "/schedule_entries/b7d1761ab299",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F81b993600c3f": {
+    "items": [
+      {
+        "href": "/schedule_entries/b7d1761ab299"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F81b993600c3f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F81b993600c3f": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F81b993600c3f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/820cf7c77c1f": {
+    "title": "Fühlsch mi Gspürsch mi",
+    "location": "",
+    "id": "820cf7c77c1f",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F820cf7c77c1f"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/518df7ff2cfb"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/e78a915b0771"
+    },
+    "comments": {
+      "href": "/activities/820cf7c77c1f/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F820cf7c77c1f"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/605686add6db"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F605686add6db"
+    },
+    "_meta": {
+      "self": "/activities/820cf7c77c1f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/1428d429bcbc": {
+    "left": 0,
+    "width": 1,
+    "id": "1428d429bcbc",
+    "start": "2026-07-17T19:15:00+00:00",
+    "end": "2026-07-17T21:30:00+00:00",
+    "dayNumber": 5,
+    "scheduleEntryNumber": 3,
+    "number": "5.3",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/820cf7c77c1f"
+    },
+    "day": {
+      "href": "/days/9411ee803eb4"
+    },
+    "_meta": {
+      "self": "/schedule_entries/1428d429bcbc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/e1ff09d531cc": {
+    "id": "e1ff09d531cc",
+    "activity": {
+      "href": "/activities/820cf7c77c1f"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/4b0f654bf743"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/e1ff09d531cc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F820cf7c77c1f": {
+    "items": [
+      {
+        "href": "/schedule_entries/1428d429bcbc"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F820cf7c77c1f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F820cf7c77c1f": {
+    "items": [
+      {
+        "href": "/activity_responsibles/e1ff09d531cc"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F820cf7c77c1f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/85bb1677e32f": {
+    "title": "Morgefit",
+    "location": "",
+    "id": "85bb1677e32f",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F85bb1677e32f"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/de866d6696aa"
+    },
+    "comments": {
+      "href": "/activities/85bb1677e32f/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F85bb1677e32f"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/8371c12ee053"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F8371c12ee053"
+    },
+    "_meta": {
+      "self": "/activities/85bb1677e32f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/ece5fbd25249": {
+    "left": 0,
+    "width": 1,
+    "id": "ece5fbd25249",
+    "start": "2026-07-14T07:30:00+00:00",
+    "end": "2026-07-14T08:00:00+00:00",
+    "dayNumber": 2,
+    "scheduleEntryNumber": 1,
+    "number": "2.1",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/85bb1677e32f"
+    },
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "_meta": {
+      "self": "/schedule_entries/ece5fbd25249",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/8b1a1b9422ec": {
+    "id": "8b1a1b9422ec",
+    "activity": {
+      "href": "/activities/85bb1677e32f"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/e64284adf2f2"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/8b1a1b9422ec",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F85bb1677e32f": {
+    "items": [
+      {
+        "href": "/schedule_entries/ece5fbd25249"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F85bb1677e32f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F85bb1677e32f": {
+    "items": [
+      {
+        "href": "/activity_responsibles/8b1a1b9422ec"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F85bb1677e32f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/8b18d2d4d436": {
+    "title": "Endgame Kampf gegen Voldemort",
+    "location": "",
+    "id": "8b18d2d4d436",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F8b18d2d4d436"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/8b18d2d4d436/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F8b18d2d4d436"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/ad0d42c70368"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fad0d42c70368"
+    },
+    "_meta": {
+      "self": "/activities/8b18d2d4d436",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/d8810b075da1": {
+    "left": 0,
+    "width": 1,
+    "id": "d8810b075da1",
+    "start": "2026-07-18T19:00:00+00:00",
+    "end": "2026-07-18T22:15:00+00:00",
+    "dayNumber": 6,
+    "scheduleEntryNumber": 5,
+    "number": "6.5",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/8b18d2d4d436"
+    },
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "_meta": {
+      "self": "/schedule_entries/d8810b075da1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/767eacd392e7": {
+    "id": "767eacd392e7",
+    "activity": {
+      "href": "/activities/8b18d2d4d436"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/d03003838720"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/767eacd392e7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F8b18d2d4d436": {
+    "items": [
+      {
+        "href": "/schedule_entries/d8810b075da1"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F8b18d2d4d436",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F8b18d2d4d436": {
+    "items": [
+      {
+        "href": "/activity_responsibles/767eacd392e7"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F8b18d2d4d436",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/8bd29263d33a": {
+    "title": "LA Lagerbau",
+    "location": "Lagerplatz",
+    "id": "8bd29263d33a",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F8bd29263d33a"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/33287493d1c1"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/de866d6696aa"
+    },
+    "comments": {
+      "href": "/activities/8bd29263d33a/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F8bd29263d33a"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fc7a7558a5120"
+    },
+    "_meta": {
+      "self": "/activities/8bd29263d33a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/708d5982455b": {
+    "left": 0,
+    "width": 1,
+    "id": "708d5982455b",
+    "start": "2026-07-13T13:00:00+00:00",
+    "end": "2026-07-13T18:00:00+00:00",
+    "dayNumber": 1,
+    "scheduleEntryNumber": 1,
+    "number": "1.A",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/8bd29263d33a"
+    },
+    "day": {
+      "href": "/days/63163861c828"
+    },
+    "_meta": {
+      "self": "/schedule_entries/708d5982455b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/d2f4f04bcd29": {
+    "id": "d2f4f04bcd29",
+    "activity": {
+      "href": "/activities/8bd29263d33a"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/4b0f654bf743"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/d2f4f04bcd29",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F8bd29263d33a": {
+    "items": [
+      {
+        "href": "/schedule_entries/708d5982455b"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F8bd29263d33a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F8bd29263d33a": {
+    "items": [
+      {
+        "href": "/activity_responsibles/d2f4f04bcd29"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F8bd29263d33a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/8c1c703d901d": {
+    "title": "Einbruch Verbotene Abteilung",
+    "location": "",
+    "id": "8c1c703d901d",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F8c1c703d901d"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/518df7ff2cfb"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/8c1c703d901d/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F8c1c703d901d"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/e09a8713b583"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fe09a8713b583"
+    },
+    "_meta": {
+      "self": "/activities/8c1c703d901d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/7d7d7c1ec146": {
+    "left": 0,
+    "width": 1,
+    "id": "7d7d7c1ec146",
+    "start": "2026-07-15T02:00:00+00:00",
+    "end": "2026-07-15T04:00:00+00:00",
+    "dayNumber": 3,
+    "scheduleEntryNumber": 1,
+    "number": "3.1",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/8c1c703d901d"
+    },
+    "day": {
+      "href": "/days/c118aa688d8e"
+    },
+    "_meta": {
+      "self": "/schedule_entries/7d7d7c1ec146",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/77db0aafd3f2": {
+    "id": "77db0aafd3f2",
+    "activity": {
+      "href": "/activities/8c1c703d901d"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/83cdbbe00f85"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/77db0aafd3f2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F8c1c703d901d": {
+    "items": [
+      {
+        "href": "/schedule_entries/7d7d7c1ec146"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F8c1c703d901d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F8c1c703d901d": {
+    "items": [
+      {
+        "href": "/activity_responsibles/77db0aafd3f2"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F8c1c703d901d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/8f90766d94d1": {
+    "title": "SpezEx Erste Hilfe",
+    "location": "",
+    "id": "8f90766d94d1",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F8f90766d94d1"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/33287493d1c1"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/e78a915b0771"
+    },
+    "comments": {
+      "href": "/activities/8f90766d94d1/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F8f90766d94d1"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/598946669198"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F598946669198"
+    },
+    "_meta": {
+      "self": "/activities/8f90766d94d1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/5df6703c8c5d": {
+    "left": 0,
+    "width": 1,
+    "id": "5df6703c8c5d",
+    "start": "2026-07-18T13:15:00+00:00",
+    "end": "2026-07-18T15:00:00+00:00",
+    "dayNumber": 6,
+    "scheduleEntryNumber": 1,
+    "number": "6.A",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/8f90766d94d1"
+    },
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "_meta": {
+      "self": "/schedule_entries/5df6703c8c5d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/53d41fb96483": {
+    "left": 0,
+    "width": 1,
+    "id": "53d41fb96483",
+    "start": "2026-07-18T15:45:00+00:00",
+    "end": "2026-07-18T17:50:00+00:00",
+    "dayNumber": 6,
+    "scheduleEntryNumber": 2,
+    "number": "6.B",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/8f90766d94d1"
+    },
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "_meta": {
+      "self": "/schedule_entries/53d41fb96483",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/d2d258cb4793": {
+    "id": "d2d258cb4793",
+    "activity": {
+      "href": "/activities/8f90766d94d1"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/4b0f654bf743"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/d2d258cb4793",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F8f90766d94d1": {
+    "items": [
+      {
+        "href": "/schedule_entries/5df6703c8c5d"
+      },
+      {
+        "href": "/schedule_entries/53d41fb96483"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F8f90766d94d1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F8f90766d94d1": {
+    "items": [
+      {
+        "href": "/activity_responsibles/d2d258cb4793"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F8f90766d94d1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/96285541cd32": {
+    "title": "Zmittag",
+    "location": "",
+    "id": "96285541cd32",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F96285541cd32"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/98f686a32238"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/96285541cd32/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F96285541cd32"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/3b061abcbdc8"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F3b061abcbdc8"
+    },
+    "_meta": {
+      "self": "/activities/96285541cd32",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/3ff3ca55f540": {
+    "left": 0,
+    "width": 1,
+    "id": "3ff3ca55f540",
+    "start": "2026-07-13T12:00:00+00:00",
+    "end": "2026-07-13T13:00:00+00:00",
+    "dayNumber": 1,
+    "scheduleEntryNumber": 1,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/96285541cd32"
+    },
+    "day": {
+      "href": "/days/63163861c828"
+    },
+    "_meta": {
+      "self": "/schedule_entries/3ff3ca55f540",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/518cc421e407": {
+    "left": 0,
+    "width": 1,
+    "id": "518cc421e407",
+    "start": "2026-07-14T12:00:00+00:00",
+    "end": "2026-07-14T13:00:00+00:00",
+    "dayNumber": 2,
+    "scheduleEntryNumber": 2,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/96285541cd32"
+    },
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "_meta": {
+      "self": "/schedule_entries/518cc421e407",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/5294f9ecab67": {
+    "left": 0,
+    "width": 1,
+    "id": "5294f9ecab67",
+    "start": "2026-07-15T12:00:00+00:00",
+    "end": "2026-07-15T13:00:00+00:00",
+    "dayNumber": 3,
+    "scheduleEntryNumber": 2,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/96285541cd32"
+    },
+    "day": {
+      "href": "/days/c118aa688d8e"
+    },
+    "_meta": {
+      "self": "/schedule_entries/5294f9ecab67",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/b68b28d54d00": {
+    "left": 0,
+    "width": 1,
+    "id": "b68b28d54d00",
+    "start": "2026-07-16T12:00:00+00:00",
+    "end": "2026-07-16T13:00:00+00:00",
+    "dayNumber": 4,
+    "scheduleEntryNumber": 2,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/96285541cd32"
+    },
+    "day": {
+      "href": "/days/a6a17ccae877"
+    },
+    "_meta": {
+      "self": "/schedule_entries/b68b28d54d00",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/967ce23da935": {
+    "left": 0,
+    "width": 1,
+    "id": "967ce23da935",
+    "start": "2026-07-17T12:00:00+00:00",
+    "end": "2026-07-17T13:00:00+00:00",
+    "dayNumber": 5,
+    "scheduleEntryNumber": 2,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/96285541cd32"
+    },
+    "day": {
+      "href": "/days/9411ee803eb4"
+    },
+    "_meta": {
+      "self": "/schedule_entries/967ce23da935",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/6e229cc92bda": {
+    "left": 0,
+    "width": 1,
+    "id": "6e229cc92bda",
+    "start": "2026-07-18T12:00:00+00:00",
+    "end": "2026-07-18T13:00:00+00:00",
+    "dayNumber": 6,
+    "scheduleEntryNumber": 2,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/96285541cd32"
+    },
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "_meta": {
+      "self": "/schedule_entries/6e229cc92bda",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/0fde303f5067": {
+    "left": 0,
+    "width": 1,
+    "id": "0fde303f5067",
+    "start": "2026-07-19T12:00:00+00:00",
+    "end": "2026-07-19T13:00:00+00:00",
+    "dayNumber": 7,
+    "scheduleEntryNumber": 2,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/96285541cd32"
+    },
+    "day": {
+      "href": "/days/40e3a286dc08"
+    },
+    "_meta": {
+      "self": "/schedule_entries/0fde303f5067",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/e391db2702a6": {
+    "left": 0,
+    "width": 1,
+    "id": "e391db2702a6",
+    "start": "2026-07-20T12:00:00+00:00",
+    "end": "2026-07-20T13:00:00+00:00",
+    "dayNumber": 8,
+    "scheduleEntryNumber": 2,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/96285541cd32"
+    },
+    "day": {
+      "href": "/days/485e190f4852"
+    },
+    "_meta": {
+      "self": "/schedule_entries/e391db2702a6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F96285541cd32": {
+    "items": [
+      {
+        "href": "/schedule_entries/3ff3ca55f540"
+      },
+      {
+        "href": "/schedule_entries/518cc421e407"
+      },
+      {
+        "href": "/schedule_entries/5294f9ecab67"
+      },
+      {
+        "href": "/schedule_entries/b68b28d54d00"
+      },
+      {
+        "href": "/schedule_entries/967ce23da935"
+      },
+      {
+        "href": "/schedule_entries/6e229cc92bda"
+      },
+      {
+        "href": "/schedule_entries/0fde303f5067"
+      },
+      {
+        "href": "/schedule_entries/e391db2702a6"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F96285541cd32",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F96285541cd32": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F96285541cd32",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/9c2464d15868": {
+    "title": "Besuch bei Hagrid",
+    "location": "",
+    "id": "9c2464d15868",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2F9c2464d15868"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/518df7ff2cfb"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/da4d05db108e"
+    },
+    "comments": {
+      "href": "/activities/9c2464d15868/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2F9c2464d15868"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fb2140367dd1c"
+    },
+    "_meta": {
+      "self": "/activities/9c2464d15868",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/c8834067a7fb": {
+    "left": 0,
+    "width": 1,
+    "id": "c8834067a7fb",
+    "start": "2026-07-15T13:30:00+00:00",
+    "end": "2026-07-15T15:15:00+00:00",
+    "dayNumber": 3,
+    "scheduleEntryNumber": 3,
+    "number": "3.3",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/9c2464d15868"
+    },
+    "day": {
+      "href": "/days/c118aa688d8e"
+    },
+    "_meta": {
+      "self": "/schedule_entries/c8834067a7fb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/794cf800ee67": {
+    "id": "794cf800ee67",
+    "activity": {
+      "href": "/activities/9c2464d15868"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/af9f868f0a48"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/794cf800ee67",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2F9c2464d15868": {
+    "items": [
+      {
+        "href": "/schedule_entries/c8834067a7fb"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2F9c2464d15868",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2F9c2464d15868": {
+    "items": [
+      {
+        "href": "/activity_responsibles/794cf800ee67"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2F9c2464d15868",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/a540bbed36ab": {
+    "title": "Trolle bekämpfen",
+    "location": "",
+    "id": "a540bbed36ab",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fa540bbed36ab"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/a540bbed36ab/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fa540bbed36ab"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F40dd3e9457d6"
+    },
+    "_meta": {
+      "self": "/activities/a540bbed36ab",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/7de79740d21e": {
+    "left": 0,
+    "width": 1,
+    "id": "7de79740d21e",
+    "start": "2026-07-16T09:00:00+00:00",
+    "end": "2026-07-16T12:00:00+00:00",
+    "dayNumber": 4,
+    "scheduleEntryNumber": 2,
+    "number": "4.2",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/a540bbed36ab"
+    },
+    "day": {
+      "href": "/days/a6a17ccae877"
+    },
+    "_meta": {
+      "self": "/schedule_entries/7de79740d21e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/3d194905101b": {
+    "id": "3d194905101b",
+    "activity": {
+      "href": "/activities/a540bbed36ab"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/4b0f654bf743"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/3d194905101b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fa540bbed36ab": {
+    "items": [
+      {
+        "href": "/schedule_entries/7de79740d21e"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fa540bbed36ab",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fa540bbed36ab": {
+    "items": [
+      {
+        "href": "/activity_responsibles/3d194905101b"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fa540bbed36ab",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/ad2ec31ae7a5": {
+    "title": "Fähnliabend Pfadis",
+    "location": "",
+    "id": "ad2ec31ae7a5",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fad2ec31ae7a5"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/518df7ff2cfb"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/ad2ec31ae7a5/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fad2ec31ae7a5"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/80f56c759496"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F80f56c759496"
+    },
+    "_meta": {
+      "self": "/activities/ad2ec31ae7a5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/730e7b52608d": {
+    "left": 0,
+    "width": 1,
+    "id": "730e7b52608d",
+    "start": "2026-07-14T19:00:00+00:00",
+    "end": "2026-07-14T22:00:00+00:00",
+    "dayNumber": 2,
+    "scheduleEntryNumber": 4,
+    "number": "2.4",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/ad2ec31ae7a5"
+    },
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "_meta": {
+      "self": "/schedule_entries/730e7b52608d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fad2ec31ae7a5": {
+    "items": [
+      {
+        "href": "/schedule_entries/730e7b52608d"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fad2ec31ae7a5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fad2ec31ae7a5": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fad2ec31ae7a5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/ad4da17161d9": {
+    "title": "Quidditch",
+    "location": "",
+    "id": "ad4da17161d9",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fad4da17161d9"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/e78a915b0771"
+    },
+    "comments": {
+      "href": "/activities/ad4da17161d9/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fad4da17161d9"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F894fb1deeae4"
+    },
+    "_meta": {
+      "self": "/activities/ad4da17161d9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/d2d292df0d38": {
+    "left": 0,
+    "width": 1,
+    "id": "d2d292df0d38",
+    "start": "2026-07-14T09:00:00+00:00",
+    "end": "2026-07-14T12:00:00+00:00",
+    "dayNumber": 2,
+    "scheduleEntryNumber": 2,
+    "number": "2.2",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/ad4da17161d9"
+    },
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "_meta": {
+      "self": "/schedule_entries/d2d292df0d38",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/f3fe61e30205": {
+    "id": "f3fe61e30205",
+    "activity": {
+      "href": "/activities/ad4da17161d9"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/146c0608237f"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/f3fe61e30205",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fad4da17161d9": {
+    "items": [
+      {
+        "href": "/schedule_entries/d2d292df0d38"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fad4da17161d9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fad4da17161d9": {
+    "items": [
+      {
+        "href": "/activity_responsibles/f3fe61e30205"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fad4da17161d9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/b16f518b9c59": {
+    "title": "Morgefit",
+    "location": "",
+    "id": "b16f518b9c59",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fb16f518b9c59"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/b16f518b9c59/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fb16f518b9c59"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/873190b3bc7d"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F873190b3bc7d"
+    },
+    "_meta": {
+      "self": "/activities/b16f518b9c59",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/8f88e2766fe4": {
+    "left": 0,
+    "width": 1,
+    "id": "8f88e2766fe4",
+    "start": "2026-07-17T07:30:00+00:00",
+    "end": "2026-07-17T08:00:00+00:00",
+    "dayNumber": 5,
+    "scheduleEntryNumber": 1,
+    "number": "5.1",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/b16f518b9c59"
+    },
+    "day": {
+      "href": "/days/9411ee803eb4"
+    },
+    "_meta": {
+      "self": "/schedule_entries/8f88e2766fe4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fb16f518b9c59": {
+    "items": [
+      {
+        "href": "/schedule_entries/8f88e2766fe4"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fb16f518b9c59",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fb16f518b9c59": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fb16f518b9c59",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/c173b29dad32": {
+    "title": "SpoBlo",
+    "location": "",
+    "id": "c173b29dad32",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fc173b29dad32"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/c173b29dad32/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fc173b29dad32"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F09dc148c88c3"
+    },
+    "_meta": {
+      "self": "/activities/c173b29dad32",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/eebc0f6ef940": {
+    "left": 0,
+    "width": 1,
+    "id": "eebc0f6ef940",
+    "start": "2026-07-15T15:45:00+00:00",
+    "end": "2026-07-15T17:15:00+00:00",
+    "dayNumber": 3,
+    "scheduleEntryNumber": 4,
+    "number": "3.4",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/c173b29dad32"
+    },
+    "day": {
+      "href": "/days/c118aa688d8e"
+    },
+    "_meta": {
+      "self": "/schedule_entries/eebc0f6ef940",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/126b45b2c272": {
+    "id": "126b45b2c272",
+    "activity": {
+      "href": "/activities/c173b29dad32"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/e64284adf2f2"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/126b45b2c272",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fc173b29dad32": {
+    "items": [
+      {
+        "href": "/schedule_entries/eebc0f6ef940"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fc173b29dad32",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fc173b29dad32": {
+    "items": [
+      {
+        "href": "/activity_responsibles/126b45b2c272"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fc173b29dad32",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/c7d2923bfefb": {
+    "title": "Znacht",
+    "location": "",
+    "id": "c7d2923bfefb",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fc7d2923bfefb"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/98f686a32238"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/c7d2923bfefb/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fc7d2923bfefb"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/f8752e69a851"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Ff8752e69a851"
+    },
+    "_meta": {
+      "self": "/activities/c7d2923bfefb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/544854257650": {
+    "left": 0,
+    "width": 1,
+    "id": "544854257650",
+    "start": "2026-07-13T18:00:00+00:00",
+    "end": "2026-07-13T20:00:00+00:00",
+    "dayNumber": 1,
+    "scheduleEntryNumber": 2,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/c7d2923bfefb"
+    },
+    "day": {
+      "href": "/days/63163861c828"
+    },
+    "_meta": {
+      "self": "/schedule_entries/544854257650",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/baa3e084a9fd": {
+    "left": 0,
+    "width": 1,
+    "id": "baa3e084a9fd",
+    "start": "2026-07-14T18:00:00+00:00",
+    "end": "2026-07-14T19:00:00+00:00",
+    "dayNumber": 2,
+    "scheduleEntryNumber": 3,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/c7d2923bfefb"
+    },
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "_meta": {
+      "self": "/schedule_entries/baa3e084a9fd",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/866350807e56": {
+    "left": 0,
+    "width": 1,
+    "id": "866350807e56",
+    "start": "2026-07-15T18:00:00+00:00",
+    "end": "2026-07-15T19:00:00+00:00",
+    "dayNumber": 3,
+    "scheduleEntryNumber": 3,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/c7d2923bfefb"
+    },
+    "day": {
+      "href": "/days/c118aa688d8e"
+    },
+    "_meta": {
+      "self": "/schedule_entries/866350807e56",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/c03308fb793b": {
+    "left": 0,
+    "width": 1,
+    "id": "c03308fb793b",
+    "start": "2026-07-16T18:00:00+00:00",
+    "end": "2026-07-16T19:00:00+00:00",
+    "dayNumber": 4,
+    "scheduleEntryNumber": 3,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/c7d2923bfefb"
+    },
+    "day": {
+      "href": "/days/a6a17ccae877"
+    },
+    "_meta": {
+      "self": "/schedule_entries/c03308fb793b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/4659f03df5f0": {
+    "left": 0,
+    "width": 1,
+    "id": "4659f03df5f0",
+    "start": "2026-07-17T18:00:00+00:00",
+    "end": "2026-07-17T19:00:00+00:00",
+    "dayNumber": 5,
+    "scheduleEntryNumber": 3,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/c7d2923bfefb"
+    },
+    "day": {
+      "href": "/days/9411ee803eb4"
+    },
+    "_meta": {
+      "self": "/schedule_entries/4659f03df5f0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/a8cd28eff86e": {
+    "left": 0,
+    "width": 1,
+    "id": "a8cd28eff86e",
+    "start": "2026-07-18T18:00:00+00:00",
+    "end": "2026-07-18T19:00:00+00:00",
+    "dayNumber": 6,
+    "scheduleEntryNumber": 3,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/c7d2923bfefb"
+    },
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "_meta": {
+      "self": "/schedule_entries/a8cd28eff86e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/72e1569530f1": {
+    "left": 0,
+    "width": 1,
+    "id": "72e1569530f1",
+    "start": "2026-07-19T18:00:00+00:00",
+    "end": "2026-07-19T19:00:00+00:00",
+    "dayNumber": 7,
+    "scheduleEntryNumber": 3,
+    "number": "",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/c7d2923bfefb"
+    },
+    "day": {
+      "href": "/days/40e3a286dc08"
+    },
+    "_meta": {
+      "self": "/schedule_entries/72e1569530f1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fc7d2923bfefb": {
+    "items": [
+      {
+        "href": "/schedule_entries/544854257650"
+      },
+      {
+        "href": "/schedule_entries/baa3e084a9fd"
+      },
+      {
+        "href": "/schedule_entries/866350807e56"
+      },
+      {
+        "href": "/schedule_entries/c03308fb793b"
+      },
+      {
+        "href": "/schedule_entries/4659f03df5f0"
+      },
+      {
+        "href": "/schedule_entries/a8cd28eff86e"
+      },
+      {
+        "href": "/schedule_entries/72e1569530f1"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fc7d2923bfefb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fc7d2923bfefb": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fc7d2923bfefb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/d0532df1021e": {
+    "title": "Morgefit",
+    "location": "",
+    "id": "d0532df1021e",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fd0532df1021e"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/d0532df1021e/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fd0532df1021e"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/0b1293a027bb"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F0b1293a027bb"
+    },
+    "_meta": {
+      "self": "/activities/d0532df1021e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/b3d8510b3fc0": {
+    "left": 0,
+    "width": 1,
+    "id": "b3d8510b3fc0",
+    "start": "2026-07-18T07:30:00+00:00",
+    "end": "2026-07-18T08:00:00+00:00",
+    "dayNumber": 6,
+    "scheduleEntryNumber": 1,
+    "number": "6.1",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/d0532df1021e"
+    },
+    "day": {
+      "href": "/days/273358ce9d70"
+    },
+    "_meta": {
+      "self": "/schedule_entries/b3d8510b3fc0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/3c32beade044": {
+    "id": "3c32beade044",
+    "activity": {
+      "href": "/activities/d0532df1021e"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/83cdbbe00f85"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/3c32beade044",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fd0532df1021e": {
+    "items": [
+      {
+        "href": "/schedule_entries/b3d8510b3fc0"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fd0532df1021e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fd0532df1021e": {
+    "items": [
+      {
+        "href": "/activity_responsibles/3c32beade044"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fd0532df1021e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/d74b28de5f70": {
+    "title": "Silent Disco",
+    "location": "",
+    "id": "d74b28de5f70",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fd74b28de5f70"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/e78a915b0771"
+    },
+    "comments": {
+      "href": "/activities/d74b28de5f70/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fd74b28de5f70"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F9e6da5607ba0"
+    },
+    "_meta": {
+      "self": "/activities/d74b28de5f70",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/31a723c281e9": {
+    "left": 0,
+    "width": 1,
+    "id": "31a723c281e9",
+    "start": "2026-07-14T22:30:00+00:00",
+    "end": "2026-07-14T23:30:00+00:00",
+    "dayNumber": 2,
+    "scheduleEntryNumber": 6,
+    "number": "2.6",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/d74b28de5f70"
+    },
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "_meta": {
+      "self": "/schedule_entries/31a723c281e9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/fbf0cbcc987f": {
+    "id": "fbf0cbcc987f",
+    "activity": {
+      "href": "/activities/d74b28de5f70"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/146c0608237f"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/fbf0cbcc987f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fd74b28de5f70": {
+    "items": [
+      {
+        "href": "/schedule_entries/31a723c281e9"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fd74b28de5f70",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fd74b28de5f70": {
+    "items": [
+      {
+        "href": "/activity_responsibles/fbf0cbcc987f"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fd74b28de5f70",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/d7c4dc4e8245": {
+    "title": "Horkrux",
+    "location": "",
+    "id": "d7c4dc4e8245",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fd7c4dc4e8245"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/d7c4dc4e8245/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fd7c4dc4e8245"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/28b2c881087c"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F28b2c881087c"
+    },
+    "_meta": {
+      "self": "/activities/d7c4dc4e8245",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/68898b96e2f4": {
+    "left": 0,
+    "width": 1,
+    "id": "68898b96e2f4",
+    "start": "2026-07-14T20:30:00+00:00",
+    "end": "2026-07-14T21:45:00+00:00",
+    "dayNumber": 2,
+    "scheduleEntryNumber": 5,
+    "number": "2.5",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/d7c4dc4e8245"
+    },
+    "day": {
+      "href": "/days/1b6e5995c138"
+    },
+    "_meta": {
+      "self": "/schedule_entries/68898b96e2f4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fd7c4dc4e8245": {
+    "items": [
+      {
+        "href": "/schedule_entries/68898b96e2f4"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fd7c4dc4e8245",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fd7c4dc4e8245": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fd7c4dc4e8245",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/decbda3ce0fa": {
+    "title": "Spieleabend im Gemeinschaftsraum",
+    "location": "",
+    "id": "decbda3ce0fa",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fdecbda3ce0fa"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/518df7ff2cfb"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/da4d05db108e"
+    },
+    "comments": {
+      "href": "/activities/decbda3ce0fa/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fdecbda3ce0fa"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/680095ff1e78"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F680095ff1e78"
+    },
+    "_meta": {
+      "self": "/activities/decbda3ce0fa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/b8ba03731ea2": {
+    "left": 0,
+    "width": 1,
+    "id": "b8ba03731ea2",
+    "start": "2026-07-15T19:00:00+00:00",
+    "end": "2026-07-15T21:15:00+00:00",
+    "dayNumber": 3,
+    "scheduleEntryNumber": 5,
+    "number": "3.5",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/decbda3ce0fa"
+    },
+    "day": {
+      "href": "/days/c118aa688d8e"
+    },
+    "_meta": {
+      "self": "/schedule_entries/b8ba03731ea2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/88a8b6956096": {
+    "id": "88a8b6956096",
+    "activity": {
+      "href": "/activities/decbda3ce0fa"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/e64284adf2f2"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/88a8b6956096",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fdecbda3ce0fa": {
+    "items": [
+      {
+        "href": "/schedule_entries/b8ba03731ea2"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fdecbda3ce0fa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fdecbda3ce0fa": {
+    "items": [
+      {
+        "href": "/activity_responsibles/88a8b6956096"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fdecbda3ce0fa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/df771fa5f4aa": {
+    "title": "Sportblock",
+    "location": "",
+    "id": "df771fa5f4aa",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fdf771fa5f4aa"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/de866d6696aa"
+    },
+    "comments": {
+      "href": "/activities/df771fa5f4aa/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fdf771fa5f4aa"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fc0a6d4cf0ebc"
+    },
+    "_meta": {
+      "self": "/activities/df771fa5f4aa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/24aaaf914d81": {
+    "left": 0,
+    "width": 1,
+    "id": "24aaaf914d81",
+    "start": "2026-07-13T20:00:00+00:00",
+    "end": "2026-07-13T21:00:00+00:00",
+    "dayNumber": 1,
+    "scheduleEntryNumber": 3,
+    "number": "1.3",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/df771fa5f4aa"
+    },
+    "day": {
+      "href": "/days/63163861c828"
+    },
+    "_meta": {
+      "self": "/schedule_entries/24aaaf914d81",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/42b1b6841def": {
+    "id": "42b1b6841def",
+    "activity": {
+      "href": "/activities/df771fa5f4aa"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/d03003838720"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/42b1b6841def",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fdf771fa5f4aa": {
+    "items": [
+      {
+        "href": "/schedule_entries/24aaaf914d81"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fdf771fa5f4aa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fdf771fa5f4aa": {
+    "items": [
+      {
+        "href": "/activity_responsibles/42b1b6841def"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fdf771fa5f4aa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/dfb91a4d9b18": {
+    "title": "Newgames",
+    "location": "",
+    "id": "dfb91a4d9b18",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fdfb91a4d9b18"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/dfb91a4d9b18/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fdfb91a4d9b18"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/aa1fbba3f877"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Faa1fbba3f877"
+    },
+    "_meta": {
+      "self": "/activities/dfb91a4d9b18",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/327302368fe6": {
+    "left": 0,
+    "width": 1,
+    "id": "327302368fe6",
+    "start": "2026-07-19T15:00:00+00:00",
+    "end": "2026-07-19T18:00:00+00:00",
+    "dayNumber": 7,
+    "scheduleEntryNumber": 4,
+    "number": "7.4",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/dfb91a4d9b18"
+    },
+    "day": {
+      "href": "/days/40e3a286dc08"
+    },
+    "_meta": {
+      "self": "/schedule_entries/327302368fe6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fdfb91a4d9b18": {
+    "items": [
+      {
+        "href": "/schedule_entries/327302368fe6"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fdfb91a4d9b18",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fdfb91a4d9b18": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fdfb91a4d9b18",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/e781c2558f5f": {
+    "title": "Hajk Flucht vor den Dementoren",
+    "location": "",
+    "id": "e781c2558f5f",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fe781c2558f5f"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": {
+      "href": "/activity_progress_labels/de866d6696aa"
+    },
+    "comments": {
+      "href": "/activities/e781c2558f5f/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fe781c2558f5f"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F2df77b3f0723"
+    },
+    "_meta": {
+      "self": "/activities/e781c2558f5f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/714335f7662b": {
+    "left": 0,
+    "width": 1,
+    "id": "714335f7662b",
+    "start": "2026-07-16T13:00:00+00:00",
+    "end": "2026-07-17T12:00:00+00:00",
+    "dayNumber": 4,
+    "scheduleEntryNumber": 3,
+    "number": "4.3",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/e781c2558f5f"
+    },
+    "day": {
+      "href": "/days/a6a17ccae877"
+    },
+    "_meta": {
+      "self": "/schedule_entries/714335f7662b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles/5f73cc13b3f6": {
+    "id": "5f73cc13b3f6",
+    "activity": {
+      "href": "/activities/e781c2558f5f"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/83cdbbe00f85"
+    },
+    "_meta": {
+      "self": "/activity_responsibles/5f73cc13b3f6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fe781c2558f5f": {
+    "items": [
+      {
+        "href": "/schedule_entries/714335f7662b"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fe781c2558f5f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fe781c2558f5f": {
+    "items": [
+      {
+        "href": "/activity_responsibles/5f73cc13b3f6"
+      }
+    ],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fe781c2558f5f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/e918bb1287b1": {
+    "title": "Morgefit",
+    "location": "",
+    "id": "e918bb1287b1",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Fe918bb1287b1"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/fd476c982866"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/e918bb1287b1/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fe918bb1287b1"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/87c416512162"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F87c416512162"
+    },
+    "_meta": {
+      "self": "/activities/e918bb1287b1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/0ad209a74fbe": {
+    "left": 0,
+    "width": 1,
+    "id": "0ad209a74fbe",
+    "start": "2026-07-20T07:30:00+00:00",
+    "end": "2026-07-20T08:00:00+00:00",
+    "dayNumber": 8,
+    "scheduleEntryNumber": 1,
+    "number": "8.1",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/e918bb1287b1"
+    },
+    "day": {
+      "href": "/days/485e190f4852"
+    },
+    "_meta": {
+      "self": "/schedule_entries/0ad209a74fbe",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Fe918bb1287b1": {
+    "items": [
+      {
+        "href": "/schedule_entries/0ad209a74fbe"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Fe918bb1287b1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Fe918bb1287b1": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Fe918bb1287b1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activities/fe6c1a3c12a1": {
+    "title": "Lagerabbau",
+    "location": "",
+    "id": "fe6c1a3c12a1",
+    "scheduleEntries": {
+      "href": "/schedule_entries?activity=%2Fapi%2Factivities%2Ffe6c1a3c12a1"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "category": {
+      "href": "/categories/33287493d1c1"
+    },
+    "progressLabel": null,
+    "comments": {
+      "href": "/activities/fe6c1a3c12a1/comments"
+    },
+    "activityResponsibles": {
+      "href": "/activity_responsibles?activity=%2Fapi%2Factivities%2Ffe6c1a3c12a1"
+    },
+    "rootContentNode": {
+      "href": "/content_node/column_layouts/d84535201db8"
+    },
+    "contentNodes": {
+      "href": "/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2Fd84535201db8"
+    },
+    "_meta": {
+      "self": "/activities/fe6c1a3c12a1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries/776938c5a808": {
+    "left": 0,
+    "width": 1,
+    "id": "776938c5a808",
+    "start": "2026-07-19T13:15:00+00:00",
+    "end": "2026-07-19T17:30:00+00:00",
+    "dayNumber": 7,
+    "scheduleEntryNumber": 1,
+    "number": "7.A",
+    "period": {
+      "href": "/periods/88f1f55a69d7"
+    },
+    "activity": {
+      "href": "/activities/fe6c1a3c12a1"
+    },
+    "day": {
+      "href": "/days/40e3a286dc08"
+    },
+    "_meta": {
+      "self": "/schedule_entries/776938c5a808",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/schedule_entries?activity=%2Fapi%2Factivities%2Ffe6c1a3c12a1": {
+    "items": [
+      {
+        "href": "/schedule_entries/776938c5a808"
+      }
+    ],
+    "_meta": {
+      "self": "/schedule_entries?activity=%2Fapi%2Factivities%2Ffe6c1a3c12a1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/activity_responsibles?activity=%2Fapi%2Factivities%2Ffe6c1a3c12a1": {
+    "items": [],
+    "_meta": {
+      "self": "/activity_responsibles?activity=%2Fapi%2Factivities%2Ffe6c1a3c12a1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/713da7117866": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "713da7117866",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/09b19f627429"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/09b19f627429"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/713da7117866#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/713da7117866",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/713da7117866#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/22a90fa0668a"
+      },
+      {
+        "href": "/content_node/single_texts/2c409794b22b"
+      },
+      {
+        "href": "/content_node/single_texts/bc0c2f20e91e"
+      },
+      {
+        "href": "/content_node/storyboards/ba4d91f6e475"
+      },
+      {
+        "href": "/content_node/material_nodes/48b83082b552"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/713da7117866#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/713da7117866",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/22a90fa0668a": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "22a90fa0668a",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/09b19f627429"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/713da7117866"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/22a90fa0668a#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/22a90fa0668a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/22a90fa0668a#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/22a90fa0668a#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/22a90fa0668a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/bc0c2f20e91e": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "bc0c2f20e91e",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/09b19f627429"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/713da7117866"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/bc0c2f20e91e#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/bc0c2f20e91e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/bc0c2f20e91e#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/bc0c2f20e91e#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/bc0c2f20e91e",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/2c409794b22b": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "2c409794b22b",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/09b19f627429"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/713da7117866"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/2c409794b22b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/2c409794b22b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/2c409794b22b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/2c409794b22b#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/2c409794b22b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/ba4d91f6e475": {
+    "data": {
+      "sections": {
+        "5a61fcd6-0285-4b2e-826b-6410caf096c5": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "9504b43d-20c9-4de1-8403-bb9cf083878c": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "ba4d91f6e475",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/09b19f627429"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/713da7117866"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/ba4d91f6e475#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/ba4d91f6e475",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/ba4d91f6e475#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/ba4d91f6e475#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/ba4d91f6e475",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/48b83082b552": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "48b83082b552",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F48b83082b552"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/09b19f627429"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/713da7117866"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/48b83082b552#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/48b83082b552",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F48b83082b552": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F48b83082b552",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/48b83082b552#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/48b83082b552#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/48b83082b552",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/09b19f627429": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "09b19f627429",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/09b19f627429"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/09b19f627429#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/09b19f627429",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/09b19f627429#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/713da7117866"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/09b19f627429#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/09b19f627429",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/fb1eb84a9008": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "fb1eb84a9008",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/fb1eb84a9008#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/fb1eb84a9008",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/fb1eb84a9008#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/e79958ca067d"
+      },
+      {
+        "href": "/content_node/storyboards/3cb279d6b1e5"
+      },
+      {
+        "href": "/content_node/single_texts/651e709cb8cf"
+      },
+      {
+        "href": "/content_node/single_texts/9f6c51297b41"
+      },
+      {
+        "href": "/content_node/single_texts/b2291894eb45"
+      },
+      {
+        "href": "/content_node/checklist_nodes/988c216bd9bd"
+      },
+      {
+        "href": "/content_node/single_texts/4c2e9ebb70d3"
+      },
+      {
+        "href": "/content_node/material_nodes/943f3caf8ed8"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/fb1eb84a9008#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/fb1eb84a9008",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/e79958ca067d": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "e79958ca067d",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fb1eb84a9008"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/e79958ca067d#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/e79958ca067d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/e79958ca067d#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/e79958ca067d#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/e79958ca067d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4c2e9ebb70d3": {
+    "data": {
+      "html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "4c2e9ebb70d3",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fb1eb84a9008"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/4c2e9ebb70d3#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/4c2e9ebb70d3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4c2e9ebb70d3#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/4c2e9ebb70d3#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/4c2e9ebb70d3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/651e709cb8cf": {
+    "data": {
+      "html": "<p>Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "651e709cb8cf",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fb1eb84a9008"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/651e709cb8cf#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/651e709cb8cf",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/651e709cb8cf#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/651e709cb8cf#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/651e709cb8cf",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/9f6c51297b41": {
+    "data": {
+      "html": "<p>Die TN erleben eine lässige Unternehmung, die ihnen Abwechslung und Pause zum kopflastigen Topkurs-Alltag bietet.</p>"
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "9f6c51297b41",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fb1eb84a9008"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/9f6c51297b41#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/9f6c51297b41",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/9f6c51297b41#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/9f6c51297b41#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/9f6c51297b41",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/b2291894eb45": {
+    "data": {
+      "html": "<p>Unternehmungen in Gruppen, geplant von Kursteam</p>"
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "b2291894eb45",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fb1eb84a9008"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/b2291894eb45#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/b2291894eb45",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/b2291894eb45#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/b2291894eb45#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/b2291894eb45",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/988c216bd9bd": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": null,
+    "id": "988c216bd9bd",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2F988c216bd9bd"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fb1eb84a9008"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/988c216bd9bd#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/988c216bd9bd",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/988c216bd9bd#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/988c216bd9bd#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/988c216bd9bd",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/3cb279d6b1e5": {
+    "data": {
+      "sections": {
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p><br />In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p><p>Zu den positiven Aspekten gehören:</p><ol><li><p><strong>Kommunikation</strong>: Technologische Fortschritte haben die Kommunikation revolutioniert. Menschen können weltweit in Echtzeit miteinander in Verbindung treten, sei es über soziale Medien, Videoanrufe oder Nachrichten-Apps.</p></li><li><p><strong>Effizienzsteigerung</strong>: Technologie hat Arbeitsabläufe in vielen Branchen optimiert. Automatisierung, künstliche Intelligenz und maschinelles Lernen tragen dazu bei, Aufgaben schneller und präziser zu erledigen.</p></li><li><p><strong>Zugang zu Informationen</strong>: Das Internet bietet einen beispiellosen Zugang zu Wissen und Informationen. Bildung, Forschung und Lernen sind global zugänglich und erschwinglich geworden.</p></li></ol><p>Allerdings gibt es auch einige Herausforderungen:</p><ol><li><p><strong>Datenschutz</strong>: Die digitale Vernetzung führt zu Bedenken hinsichtlich Datenschutz und Privatsphäre. Persönliche Daten können leicht in die falschen Hände geraten.</p></li><li><p><strong>Abhängigkeit</strong>: Die zunehmende Abhängigkeit von Technologie kann negative Auswirkungen auf soziale Interaktionen und die physische Gesundheit haben.</p></li><li><p><strong>Ungleichheit</strong>: Technologische Fortschritte können zu einer Kluft zwischen Technologie-Nutzern und -Nichtnutzern führen, was soziale Ungleichheit verstärken kann.</p></li></ol><p>Es ist wichtig, die Vorteile der Technologie zu nutzen, während gleichzeitig bewusst mit ihren Herausforderungen umgegangen wird, um eine ausgewogene und nachhaltige Zukunft zu gestalten.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "3cb279d6b1e5",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fb1eb84a9008"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/3cb279d6b1e5#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/3cb279d6b1e5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/3cb279d6b1e5#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/3cb279d6b1e5#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/3cb279d6b1e5",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/943f3caf8ed8": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "943f3caf8ed8",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F943f3caf8ed8"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fb1eb84a9008"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/943f3caf8ed8#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/943f3caf8ed8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/0c12244f45e7": {
+    "article": "Pizza",
+    "quantity": 5,
+    "unit": "Stück",
+    "done": false,
+    "id": "0c12244f45e7",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/308765cf5631"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/943f3caf8ed8"
+    },
+    "_meta": {
+      "self": "/material_items/0c12244f45e7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/f7aba9c40166": {
+    "article": "Luftballone",
+    "quantity": 3,
+    "unit": null,
+    "done": false,
+    "id": "f7aba9c40166",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/fc33f57a7198"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/943f3caf8ed8"
+    },
+    "_meta": {
+      "self": "/material_items/f7aba9c40166",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/cbb2378f17cf": {
+    "article": "Hüpfsäcke",
+    "quantity": 3,
+    "unit": null,
+    "done": false,
+    "id": "cbb2378f17cf",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/2a66659e9aa5"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/943f3caf8ed8"
+    },
+    "_meta": {
+      "self": "/material_items/cbb2378f17cf",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/7c1a3a8f939f": {
+    "article": "Spitzhacken",
+    "quantity": 8,
+    "unit": null,
+    "done": false,
+    "id": "7c1a3a8f939f",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/049b1890fb94"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/943f3caf8ed8"
+    },
+    "_meta": {
+      "self": "/material_items/7c1a3a8f939f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/2ec64be0833b": {
+    "article": "Blacken",
+    "quantity": 5,
+    "unit": null,
+    "done": false,
+    "id": "2ec64be0833b",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/049b1890fb94"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/943f3caf8ed8"
+    },
+    "_meta": {
+      "self": "/material_items/2ec64be0833b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/098340b85b09": {
+    "article": "Sugus",
+    "quantity": 20,
+    "unit": null,
+    "done": false,
+    "id": "098340b85b09",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/308765cf5631"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/943f3caf8ed8"
+    },
+    "_meta": {
+      "self": "/material_items/098340b85b09",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/ccb5a88bdc70": {
+    "article": "Verkleidung Harry Potter",
+    "quantity": 1,
+    "unit": null,
+    "done": false,
+    "id": "ccb5a88bdc70",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/e06677070032"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/943f3caf8ed8"
+    },
+    "_meta": {
+      "self": "/material_items/ccb5a88bdc70",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/a859f7a44767": {
+    "article": "Äpfel",
+    "quantity": 10,
+    "unit": "Stück",
+    "done": false,
+    "id": "a859f7a44767",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/6e3d8bf92360"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/943f3caf8ed8"
+    },
+    "_meta": {
+      "self": "/material_items/a859f7a44767",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/84d41dc61c69": {
+    "article": "Knoblauch",
+    "quantity": 4,
+    "unit": null,
+    "done": false,
+    "id": "84d41dc61c69",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/6e3d8bf92360"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/943f3caf8ed8"
+    },
+    "_meta": {
+      "self": "/material_items/84d41dc61c69",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/7655793a3287": {
+    "article": "Zucker",
+    "quantity": 800,
+    "unit": "g",
+    "done": false,
+    "id": "7655793a3287",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/6e3d8bf92360"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/943f3caf8ed8"
+    },
+    "_meta": {
+      "self": "/material_items/7655793a3287",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F943f3caf8ed8": {
+    "items": [
+      {
+        "href": "/material_items/0c12244f45e7"
+      },
+      {
+        "href": "/material_items/f7aba9c40166"
+      },
+      {
+        "href": "/material_items/cbb2378f17cf"
+      },
+      {
+        "href": "/material_items/7c1a3a8f939f"
+      },
+      {
+        "href": "/material_items/2ec64be0833b"
+      },
+      {
+        "href": "/material_items/098340b85b09"
+      },
+      {
+        "href": "/material_items/ccb5a88bdc70"
+      },
+      {
+        "href": "/material_items/a859f7a44767"
+      },
+      {
+        "href": "/material_items/84d41dc61c69"
+      },
+      {
+        "href": "/material_items/7655793a3287"
+      }
+    ],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F943f3caf8ed8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/943f3caf8ed8#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/943f3caf8ed8#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/943f3caf8ed8",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/09dc148c88c3": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "09dc148c88c3",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/09dc148c88c3"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/09dc148c88c3#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/09dc148c88c3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/09dc148c88c3#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/fb1eb84a9008"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/09dc148c88c3#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/09dc148c88c3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/6e3a1a0ed96f": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "6e3a1a0ed96f",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/0b1293a027bb"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/0b1293a027bb"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/6e3a1a0ed96f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/6e3a1a0ed96f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/6e3a1a0ed96f#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/3db42f235694"
+      },
+      {
+        "href": "/content_node/storyboards/8b7928871e5e"
+      },
+      {
+        "href": "/content_node/single_texts/cabedaa743f3"
+      },
+      {
+        "href": "/content_node/single_texts/8ef40082bbe6"
+      },
+      {
+        "href": "/content_node/material_nodes/a03516f0f654"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/6e3a1a0ed96f#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/6e3a1a0ed96f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/3db42f235694": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "3db42f235694",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/0b1293a027bb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/6e3a1a0ed96f"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/3db42f235694#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/3db42f235694",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/3db42f235694#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/3db42f235694#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/3db42f235694",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/8ef40082bbe6": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "8ef40082bbe6",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/0b1293a027bb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/6e3a1a0ed96f"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/8ef40082bbe6#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/8ef40082bbe6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/8ef40082bbe6#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/8ef40082bbe6#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/8ef40082bbe6",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/cabedaa743f3": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "cabedaa743f3",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/0b1293a027bb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/6e3a1a0ed96f"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/cabedaa743f3#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/cabedaa743f3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/cabedaa743f3#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/cabedaa743f3#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/cabedaa743f3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/8b7928871e5e": {
+    "data": {
+      "sections": {
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "c8bd5470-764e-4e73-a586-bdef8a6df9ac": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "e7e88f7a-3368-419c-b3a9-126e9f4511fe": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "8b7928871e5e",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/0b1293a027bb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/6e3a1a0ed96f"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/8b7928871e5e#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/8b7928871e5e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/8b7928871e5e#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/8b7928871e5e#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/8b7928871e5e",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/a03516f0f654": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "a03516f0f654",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fa03516f0f654"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/0b1293a027bb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/6e3a1a0ed96f"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/a03516f0f654#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/a03516f0f654",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fa03516f0f654": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fa03516f0f654",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/a03516f0f654#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/a03516f0f654#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/a03516f0f654",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/0b1293a027bb": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "0b1293a027bb",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/0b1293a027bb"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/0b1293a027bb#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/0b1293a027bb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/0b1293a027bb#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/6e3a1a0ed96f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/0b1293a027bb#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/0b1293a027bb",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/c1e4546b7d3f": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "c1e4546b7d3f",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/1bee9e7a94a9"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/1bee9e7a94a9"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/c1e4546b7d3f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/c1e4546b7d3f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/c1e4546b7d3f#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/d9963a9c5e37"
+      },
+      {
+        "href": "/content_node/material_nodes/f485d9b05ecf"
+      },
+      {
+        "href": "/content_node/storyboards/8719c59f1289"
+      },
+      {
+        "href": "/content_node/single_texts/f07eeac302cf"
+      },
+      {
+        "href": "/content_node/single_texts/c2c4371d7110"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/c1e4546b7d3f#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/c1e4546b7d3f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d9963a9c5e37": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "d9963a9c5e37",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/1bee9e7a94a9"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c1e4546b7d3f"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d9963a9c5e37#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d9963a9c5e37",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d9963a9c5e37#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d9963a9c5e37#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d9963a9c5e37",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c2c4371d7110": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "c2c4371d7110",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/1bee9e7a94a9"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c1e4546b7d3f"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/c2c4371d7110#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/c2c4371d7110",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c2c4371d7110#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/c2c4371d7110#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/c2c4371d7110",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f07eeac302cf": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "f07eeac302cf",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/1bee9e7a94a9"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c1e4546b7d3f"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/f07eeac302cf#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/f07eeac302cf",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f07eeac302cf#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/f07eeac302cf#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/f07eeac302cf",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/8719c59f1289": {
+    "data": {
+      "sections": {
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "8719c59f1289",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/1bee9e7a94a9"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c1e4546b7d3f"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/8719c59f1289#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/8719c59f1289",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/8719c59f1289#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/8719c59f1289#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/8719c59f1289",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/f485d9b05ecf": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "f485d9b05ecf",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Ff485d9b05ecf"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/1bee9e7a94a9"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c1e4546b7d3f"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/f485d9b05ecf#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/f485d9b05ecf",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Ff485d9b05ecf": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Ff485d9b05ecf",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/f485d9b05ecf#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/f485d9b05ecf#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/f485d9b05ecf",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/1bee9e7a94a9": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "1bee9e7a94a9",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/1bee9e7a94a9"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/1bee9e7a94a9#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/1bee9e7a94a9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/1bee9e7a94a9#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/c1e4546b7d3f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/1bee9e7a94a9#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/1bee9e7a94a9",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/82fc91767762": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "82fc91767762",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/1e95f99300b6"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/1e95f99300b6"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/82fc91767762#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/82fc91767762",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/82fc91767762#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/df805dfd5817"
+      },
+      {
+        "href": "/content_node/storyboards/83131fdbef98"
+      },
+      {
+        "href": "/content_node/single_texts/d0e9f6ba2bf1"
+      },
+      {
+        "href": "/content_node/single_texts/7da9fbd50ba5"
+      },
+      {
+        "href": "/content_node/material_nodes/316b3610bf24"
+      },
+      {
+        "href": "/content_node/multi_selects/64d11bb77f89"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/82fc91767762#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/82fc91767762",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7da9fbd50ba5": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "7da9fbd50ba5",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/1e95f99300b6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/82fc91767762"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/7da9fbd50ba5#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/7da9fbd50ba5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7da9fbd50ba5#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/7da9fbd50ba5#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/7da9fbd50ba5",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/df805dfd5817": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "df805dfd5817",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/1e95f99300b6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/82fc91767762"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/df805dfd5817#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/df805dfd5817",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/df805dfd5817#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/df805dfd5817#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/df805dfd5817",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d0e9f6ba2bf1": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "d0e9f6ba2bf1",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/1e95f99300b6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/82fc91767762"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d0e9f6ba2bf1#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d0e9f6ba2bf1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d0e9f6ba2bf1#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d0e9f6ba2bf1#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d0e9f6ba2bf1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/multi_selects/64d11bb77f89": {
+    "data": {
+      "options": {
+        "security": {
+          "checked": false
+        },
+        "outdoorTechnique": {
+          "checked": false
+        },
+        "pioneeringTechnique": {
+          "checked": false
+        },
+        "natureAndEnvironment": {
+          "checked": false
+        },
+        "campsiteAndSurroundings": {
+          "checked": false
+        },
+        "preventionAndIntegration": {
+          "checked": false
+        }
+      }
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "64d11bb77f89",
+    "contentTypeName": "LAThematicArea",
+    "root": {
+      "href": "/content_node/column_layouts/1e95f99300b6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/82fc91767762"
+    },
+    "contentType": {
+      "href": "/content_types/1a0f84e322c8"
+    },
+    "children": {
+      "href": "/content_node/multi_selects/64d11bb77f89#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/multi_selects/64d11bb77f89",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/multi_selects/64d11bb77f89#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/multi_selects/64d11bb77f89#children",
+      "virtual": true,
+      "owningResource": "/content_node/multi_selects/64d11bb77f89",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/83131fdbef98": {
+    "data": {
+      "sections": {
+        "4c126a50-f729-46a7-8326-811586922995": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "83131fdbef98",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/1e95f99300b6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/82fc91767762"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/83131fdbef98#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/83131fdbef98",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/83131fdbef98#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/83131fdbef98#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/83131fdbef98",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/316b3610bf24": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "316b3610bf24",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F316b3610bf24"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/1e95f99300b6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/82fc91767762"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/316b3610bf24#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/316b3610bf24",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F316b3610bf24": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F316b3610bf24",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/316b3610bf24#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/316b3610bf24#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/316b3610bf24",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/1e95f99300b6": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "1e95f99300b6",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/1e95f99300b6"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/1e95f99300b6#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/1e95f99300b6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/1e95f99300b6#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/82fc91767762"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/1e95f99300b6#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/1e95f99300b6",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/39e8c1ffa1f1": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "39e8c1ffa1f1",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/28b2c881087c"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/28b2c881087c"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/39e8c1ffa1f1#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/39e8c1ffa1f1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/39e8c1ffa1f1#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/ae54aad20823"
+      },
+      {
+        "href": "/content_node/single_texts/3c48f2d9fec7"
+      },
+      {
+        "href": "/content_node/material_nodes/6eb006af2085"
+      },
+      {
+        "href": "/content_node/single_texts/023ce434a3a1"
+      },
+      {
+        "href": "/content_node/storyboards/0c877b31405c"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/39e8c1ffa1f1#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/39e8c1ffa1f1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/3c48f2d9fec7": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "3c48f2d9fec7",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/28b2c881087c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/39e8c1ffa1f1"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/3c48f2d9fec7#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/3c48f2d9fec7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/3c48f2d9fec7#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/3c48f2d9fec7#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/3c48f2d9fec7",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/ae54aad20823": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "ae54aad20823",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/28b2c881087c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/39e8c1ffa1f1"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/ae54aad20823#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/ae54aad20823",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/ae54aad20823#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/ae54aad20823#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/ae54aad20823",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/023ce434a3a1": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "023ce434a3a1",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/28b2c881087c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/39e8c1ffa1f1"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/023ce434a3a1#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/023ce434a3a1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/023ce434a3a1#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/023ce434a3a1#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/023ce434a3a1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/0c877b31405c": {
+    "data": {
+      "sections": {
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "0c877b31405c",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/28b2c881087c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/39e8c1ffa1f1"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/0c877b31405c#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/0c877b31405c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/0c877b31405c#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/0c877b31405c#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/0c877b31405c",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/6eb006af2085": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "6eb006af2085",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F6eb006af2085"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/28b2c881087c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/39e8c1ffa1f1"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/6eb006af2085#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/6eb006af2085",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F6eb006af2085": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F6eb006af2085",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/6eb006af2085#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/6eb006af2085#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/6eb006af2085",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/28b2c881087c": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "28b2c881087c",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/28b2c881087c"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/28b2c881087c#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/28b2c881087c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/28b2c881087c#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/39e8c1ffa1f1"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/28b2c881087c#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/28b2c881087c",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/4f92e986c8a5": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "4f92e986c8a5",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/2c3830024da1"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/2c3830024da1"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/4f92e986c8a5#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/4f92e986c8a5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/4f92e986c8a5#children": {
+    "items": [
+      {
+        "href": "/content_node/storyboards/a6148f4ff614"
+      },
+      {
+        "href": "/content_node/single_texts/5ec5d6ef73e1"
+      },
+      {
+        "href": "/content_node/single_texts/f2fb28b50c98"
+      },
+      {
+        "href": "/content_node/material_nodes/4c36d884ddcb"
+      },
+      {
+        "href": "/content_node/single_texts/cb52c7d8808f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/4f92e986c8a5#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/4f92e986c8a5",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/cb52c7d8808f": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "cb52c7d8808f",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/2c3830024da1"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4f92e986c8a5"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/cb52c7d8808f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/cb52c7d8808f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/cb52c7d8808f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/cb52c7d8808f#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/cb52c7d8808f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5ec5d6ef73e1": {
+    "data": {
+      "html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "5ec5d6ef73e1",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/2c3830024da1"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4f92e986c8a5"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/5ec5d6ef73e1#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/5ec5d6ef73e1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5ec5d6ef73e1#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/5ec5d6ef73e1#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/5ec5d6ef73e1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f2fb28b50c98": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "f2fb28b50c98",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/2c3830024da1"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4f92e986c8a5"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/f2fb28b50c98#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/f2fb28b50c98",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f2fb28b50c98#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/f2fb28b50c98#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/f2fb28b50c98",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/a6148f4ff614": {
+    "data": {
+      "sections": {
+        "101a9918-312b-49b3-a5e5-0a5f886014a6": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "59c0d77f-7c65-4996-8de1-d44b9665e946": {
+          "column1": "",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "cce00fc2-3ce5-4845-ac8a-c4e434059aef": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "a6148f4ff614",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/2c3830024da1"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4f92e986c8a5"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/a6148f4ff614#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/a6148f4ff614",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/a6148f4ff614#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/a6148f4ff614#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/a6148f4ff614",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/4c36d884ddcb": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "4c36d884ddcb",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F4c36d884ddcb"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/2c3830024da1"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4f92e986c8a5"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/4c36d884ddcb#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/4c36d884ddcb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F4c36d884ddcb": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F4c36d884ddcb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/4c36d884ddcb#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/4c36d884ddcb#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/4c36d884ddcb",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/2c3830024da1": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "2c3830024da1",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/2c3830024da1"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/2c3830024da1#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/2c3830024da1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/2c3830024da1#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/4f92e986c8a5"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/2c3830024da1#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/2c3830024da1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/5ced2417dbbb": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "5ced2417dbbb",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/5ced2417dbbb#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/5ced2417dbbb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/5ced2417dbbb#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/d49edd33fb35"
+      },
+      {
+        "href": "/content_node/single_texts/412184bb7fcc"
+      },
+      {
+        "href": "/content_node/storyboards/c52405220ced"
+      },
+      {
+        "href": "/content_node/single_texts/3329e0cb15d6"
+      },
+      {
+        "href": "/content_node/single_texts/08a319ff9aad"
+      },
+      {
+        "href": "/content_node/material_nodes/90285e3c34a5"
+      },
+      {
+        "href": "/content_node/single_texts/c1046246e7dd"
+      },
+      {
+        "href": "/content_node/checklist_nodes/be6972476965"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/5ced2417dbbb#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/5ced2417dbbb",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/08a319ff9aad": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "08a319ff9aad",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ced2417dbbb"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/08a319ff9aad#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/08a319ff9aad",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/08a319ff9aad#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/08a319ff9aad#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/08a319ff9aad",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/3329e0cb15d6": {
+    "data": {
+      "html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "3329e0cb15d6",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ced2417dbbb"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/3329e0cb15d6#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/3329e0cb15d6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/3329e0cb15d6#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/3329e0cb15d6#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/3329e0cb15d6",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/412184bb7fcc": {
+    "data": {
+      "html": "<ol><li><p><strong>Kommunikation</strong>: Technologische Fortschritte haben die Kommunikation revolutioniert. Menschen können weltweit in Echtzeit miteinander in Verbindung treten, sei es über soziale Medien, Videoanrufe oder Nachrichten-Apps.</p></li><li><p><strong>Effizienzsteigerung</strong>: Technologie hat Arbeitsabläufe in vielen Branchen optimiert. Automatisierung, künstliche Intelligenz und maschinelles Lernen tragen dazu bei, Aufgaben schneller und präziser zu erledigen.</p></li><li><p><strong>Zugang zu Informationen</strong>: Das Internet bietet einen beispiellosen Zugang zu Wissen und Informationen. Bildung, Forschung und Lernen sind global zugänglich und erschwinglich geworden.</p></li></ol><p>Allerdings gibt es auch einige Herausforderungen:</p><ol><li><p><strong>Datenschutz</strong>: Die digitale Vernetzung führt zu Bedenken hinsichtlich Datenschutz und Privatsphäre. Persönliche Daten können leicht in die falschen Hände geraten.</p></li><li><p><strong>Abhängigkeit</strong>: Die zunehmende Abhängigkeit von Technologie kann negative Auswirkungen auf soziale Interaktionen und die physische Gesundheit haben.</p></li><li><p><strong>Ungleichheit</strong>: Technologische Fortschritte können zu einer Kluft zwischen Technologie-Nutzern und -Nichtnutzern führen, was soziale Ungleichheit verstärken kann.</p></li></ol>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "412184bb7fcc",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ced2417dbbb"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/412184bb7fcc#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/412184bb7fcc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/412184bb7fcc#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/412184bb7fcc#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/412184bb7fcc",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c1046246e7dd": {
+    "data": {
+      "html": "<ul><li><p>Die TN wissen, was sie in der KuPla beachten und mitbedenken müssen.</p></li><li><p>Die TN wissen, was in der KuPla von ihnen erwartet wird.</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "c1046246e7dd",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ced2417dbbb"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/c1046246e7dd#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/c1046246e7dd",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c1046246e7dd#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/c1046246e7dd#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/c1046246e7dd",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d49edd33fb35": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "d49edd33fb35",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ced2417dbbb"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d49edd33fb35#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d49edd33fb35",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d49edd33fb35#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d49edd33fb35#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d49edd33fb35",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/be6972476965": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": null,
+    "id": "be6972476965",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2Fbe6972476965"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ced2417dbbb"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/be6972476965#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/be6972476965",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/be6972476965#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/be6972476965#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/be6972476965",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/c52405220ced": {
+    "data": {
+      "sections": {
+        "70e81723-60c9-41c9-9181-9bd788b6dbb6": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p><p>Zu den positiven Aspekten gehören:</p><ol><li><p><strong>Kommunikation</strong>: Technologische Fortschritte haben die Kommunikation revolutioniert. Menschen können weltweit in Echtzeit miteinander in Verbindung treten, sei es über soziale Medien, Videoanrufe oder Nachrichten-Apps.</p></li><li><p><strong>Effizienzsteigerung</strong>: Technologie hat Arbeitsabläufe in vielen Branchen optimiert. Automatisierung, künstliche Intelligenz und maschinelles Lernen tragen dazu bei, Aufgaben schneller und präziser zu erledigen.</p></li><li><p><strong>Zugang zu Informationen</strong>: Das Internet bietet einen beispiellosen Zugang zu Wissen und Informationen. Bildung, Forschung und Lernen sind global zugänglich und erschwinglich geworden.</p></li></ol><p>Allerdings gibt es auch einige Herausforderungen:</p><ol><li><p><strong>Datenschutz</strong>: Die digitale Vernetzung führt zu Bedenken hinsichtlich Datenschutz und Privatsphäre. Persönliche Daten können leicht in die falschen Hände geraten.</p></li><li><p><strong>Abhängigkeit</strong>: Die zunehmende Abhängigkeit von Technologie kann negative Auswirkungen auf soziale Interaktionen und die physische Gesundheit haben.</p></li><li><p><strong>Ungleichheit</strong>: Technologische Fortschritte können zu einer Kluft zwischen Technologie-Nutzern und -Nichtnutzern führen, was soziale Ungleichheit verstärken kann.</p></li></ol><p>Es ist wichtig, die Vorteile der Technologie zu nutzen, während gleichzeitig bewusst mit ihren Herausforderungen umgegangen wird, um eine ausgewogene und nachhaltige Zukunft zu gestalten.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p><p>Zu den positiven Aspekten gehören:</p><ol><li><p><strong>Kommunikation</strong>: Technologische Fortschritte haben die Kommunikation revolutioniert. Menschen können weltweit in Echtzeit miteinander in Verbindung treten, sei es über soziale Medien, Videoanrufe oder Nachrichten-Apps.</p></li><li><p><strong>Effizienzsteigerung</strong>: Technologie hat Arbeitsabläufe in vielen Branchen optimiert. Automatisierung, künstliche Intelligenz und maschinelles Lernen tragen dazu bei, Aufgaben schneller und präziser zu erledigen.</p></li><li><p><strong>Zugang zu Informationen</strong>: Das Internet bietet einen beispiellosen Zugang zu Wissen und Informationen. Bildung, Forschung und Lernen sind global zugänglich und erschwinglich geworden.</p></li></ol><p>Allerdings gibt es auch einige Herausforderungen:</p><ol><li><p><strong>Datenschutz</strong>: Die digitale Vernetzung führt zu Bedenken hinsichtlich Datenschutz und Privatsphäre. Persönliche Daten können leicht in die falschen Hände geraten.</p></li><li><p><strong>Abhängigkeit</strong>: Die zunehmende Abhängigkeit von Technologie kann negative Auswirkungen auf soziale Interaktionen und die physische Gesundheit haben.</p></li><li><p><strong>Ungleichheit</strong>: Technologische Fortschritte können zu einer Kluft zwischen Technologie-Nutzern und -Nichtnutzern führen, was soziale Ungleichheit verstärken kann.</p></li></ol><p>Es ist wichtig, die Vorteile der Technologie zu nutzen, während gleichzeitig bewusst mit ihren Herausforderungen umgegangen wird, um eine ausgewogene und nachhaltige Zukunft zu gestalten.</p>"
+        },
+        "c1cd8ed3-3b98-4dcc-a9f6-c9069bb179e2": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p><p>Zu den positiven Aspekten gehören:</p><ol><li><p><strong>Kommunikation</strong>: Technologische Fortschritte haben die Kommunikation revolutioniert. Menschen können weltweit in Echtzeit miteinander in Verbindung treten, sei es über soziale Medien, Videoanrufe oder Nachrichten-Apps.</p></li><li><p><strong>Effizienzsteigerung</strong>: Technologie hat Arbeitsabläufe in vielen Branchen optimiert. Automatisierung, künstliche Intelligenz und maschinelles Lernen tragen dazu bei, Aufgaben schneller und präziser zu erledigen.</p></li><li><p><strong>Zugang zu Informationen</strong>: Das Internet bietet einen beispiellosen Zugang zu Wissen und Informationen. Bildung, Forschung und Lernen sind global zugänglich und erschwinglich geworden.</p></li></ol><p>Allerdings gibt es auch einige Herausforderungen:</p><ol><li><p><strong>Datenschutz</strong>: Die digitale Vernetzung führt zu Bedenken hinsichtlich Datenschutz und Privatsphäre. Persönliche Daten können leicht in die falschen Hände geraten.</p></li><li><p><strong>Abhängigkeit</strong>: Die zunehmende Abhängigkeit von Technologie kann negative Auswirkungen auf soziale Interaktionen und die physische Gesundheit haben.</p></li><li><p><strong>Ungleichheit</strong>: Technologische Fortschritte können zu einer Kluft zwischen Technologie-Nutzern und -Nichtnutzern führen, was soziale Ungleichheit verstärken kann.</p></li></ol><p>Es ist wichtig, die Vorteile der Technologie zu nutzen, während gleichzeitig bewusst mit ihren Herausforderungen umgegangen wird, um eine ausgewogene und nachhaltige Zukunft zu gestalten.</p>"
+        },
+        "d3ea45e2-8838-4887-aaf7-2902fca12baf": {
+          "column1": "",
+          "column3": "",
+          "position": 4,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "c52405220ced",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ced2417dbbb"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/c52405220ced#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/c52405220ced",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/c52405220ced#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/c52405220ced#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/c52405220ced",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/90285e3c34a5": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "90285e3c34a5",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F90285e3c34a5"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ced2417dbbb"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/90285e3c34a5#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/90285e3c34a5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F90285e3c34a5": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F90285e3c34a5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/90285e3c34a5#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/90285e3c34a5#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/90285e3c34a5",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/2df77b3f0723": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "2df77b3f0723",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/2df77b3f0723"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/2df77b3f0723#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/2df77b3f0723",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/2df77b3f0723#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/5ced2417dbbb"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/2df77b3f0723#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/2df77b3f0723",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/eab512f9576f": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "eab512f9576f",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/eab512f9576f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/eab512f9576f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/eab512f9576f#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/70bb8cdfa6d8"
+      },
+      {
+        "href": "/content_node/single_texts/248140aa282b"
+      },
+      {
+        "href": "/content_node/single_texts/16b4b12c48a0"
+      },
+      {
+        "href": "/content_node/material_nodes/008c2a82f9f4"
+      },
+      {
+        "href": "/content_node/storyboards/44a06145038a"
+      },
+      {
+        "href": "/content_node/single_texts/3f8e51330bc2"
+      },
+      {
+        "href": "/content_node/checklist_nodes/3157182811bb"
+      },
+      {
+        "href": "/content_node/single_texts/c3b9a8b89618"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/eab512f9576f#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/eab512f9576f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/70bb8cdfa6d8": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "70bb8cdfa6d8",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eab512f9576f"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/70bb8cdfa6d8#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/70bb8cdfa6d8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/70bb8cdfa6d8#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/70bb8cdfa6d8#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/70bb8cdfa6d8",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/248140aa282b": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "248140aa282b",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eab512f9576f"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/248140aa282b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/248140aa282b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/248140aa282b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/248140aa282b#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/248140aa282b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/16b4b12c48a0": {
+    "data": {
+      "html": "<ol><li><p><strong>Kommunikation</strong>: Technologische Fortschritte haben die Kommunikation revolutioniert. Menschen können weltweit in Echtzeit miteinander in Verbindung treten, sei es über soziale Medien, Videoanrufe oder Nachrichten-Apps.</p></li><li><p><strong>Effizienzsteigerung</strong>: Technologie hat Arbeitsabläufe in vielen Branchen optimiert. Automatisierung, künstliche Intelligenz und maschinelles Lernen tragen dazu bei, Aufgaben schneller und präziser zu erledigen.</p></li><li><p><strong>Zugang zu Informationen</strong>: Das Internet bietet einen beispiellosen Zugang zu Wissen und Informationen. Bildung, Forschung und Lernen sind global zugänglich und erschwinglich geworden.</p></li></ol>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "16b4b12c48a0",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eab512f9576f"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/16b4b12c48a0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/16b4b12c48a0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/16b4b12c48a0#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/16b4b12c48a0#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/16b4b12c48a0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/3f8e51330bc2": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "3f8e51330bc2",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eab512f9576f"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/3f8e51330bc2#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/3f8e51330bc2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/3f8e51330bc2#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/3f8e51330bc2#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/3f8e51330bc2",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c3b9a8b89618": {
+    "data": {
+      "html": "<ul><li><p>Was sind produktive Mindestanforderungen?</p></li><li><p>Qualifizieren als Mittel zur Förderung diskutieren</p></li><li><p>Trennung Lernmomente &amp; Überprüfungsmomente</p></li><li><p>Qualifizieren als Ermessensentscheidung (Bewusstsein entwickeln)</p></li><li><p>Häufige Beurteilungsfehler</p></li><li><p>Beurteilungsraster als Hilfsmittel - nur anschneiden falls notwendig, vollwertig in einem Wahlblock behandeln</p></li><li><p>Wie formuliere ich überprüfbare Mindestanforderungen?</p></li><li><p>Mindestanforderungen formulieren</p></li><li><p>Wissen, wie &amp; dass sie die Ethik-Charta als Grundlage für Kurspakt (&amp; nach Hause schicken) verwenden können anstelle von Mindestanforderungen zu \"respektvollem / verantwortungsbewussten Verhalten\" Umgang mit den Mindestanforderungen während dem Kurs (Flexibilität, wie bindend sind Mindestanforderungen im Kurs?)</p></li><li><p>Mindestanforderungen aufs Minimum reduzieren</p></li><li><p>Zusammenhang Mindestanforderungen mit den Zielen des Kurses</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "c3b9a8b89618",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eab512f9576f"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/c3b9a8b89618#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/c3b9a8b89618",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c3b9a8b89618#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/c3b9a8b89618#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/c3b9a8b89618",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/3157182811bb": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": null,
+    "id": "3157182811bb",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2F3157182811bb"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eab512f9576f"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/3157182811bb#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/3157182811bb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/3157182811bb#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/3157182811bb#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/3157182811bb",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/44a06145038a": {
+    "data": {
+      "sections": {
+        "0f1792d0-1b1f-43f5-af15-77a9cb8e5432": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        },
+        "6cc41aa5-2fd1-4ad6-ab25-260d737062d2": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "44a06145038a",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eab512f9576f"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/44a06145038a#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/44a06145038a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/44a06145038a#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/44a06145038a#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/44a06145038a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/008c2a82f9f4": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "008c2a82f9f4",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F008c2a82f9f4"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eab512f9576f"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/008c2a82f9f4#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/008c2a82f9f4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F008c2a82f9f4": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F008c2a82f9f4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/008c2a82f9f4#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/008c2a82f9f4#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/008c2a82f9f4",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/2ebe68599e3f": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "2ebe68599e3f",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/2ebe68599e3f"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/2ebe68599e3f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/2ebe68599e3f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/2ebe68599e3f#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/eab512f9576f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/2ebe68599e3f#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/2ebe68599e3f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/3b061abcbdc8": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "3b061abcbdc8",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/3b061abcbdc8"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/3b061abcbdc8#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/3b061abcbdc8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/3b061abcbdc8#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/column_layouts/3b061abcbdc8#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/3b061abcbdc8",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/8e410cebb44f": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "8e410cebb44f",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/28011dca853c"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/8e410cebb44f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/8e410cebb44f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/8e410cebb44f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/8e410cebb44f#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/8e410cebb44f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/a4775aec3e03": {
+    "data": {
+      "html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "a4775aec3e03",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/28011dca853c"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/a4775aec3e03#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/a4775aec3e03",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/a4775aec3e03#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/a4775aec3e03#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/a4775aec3e03",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f5e1a436a1f8": {
+    "data": {
+      "html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "f5e1a436a1f8",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/28011dca853c"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/f5e1a436a1f8#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/f5e1a436a1f8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f5e1a436a1f8#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/f5e1a436a1f8#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/f5e1a436a1f8",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/df5dc810cf3c": {
+    "data": {
+      "html": "<ul><li><p>V2 Was ist Ausbildung unterwegs?</p></li><li><p>V2 Umsetzungsmöglichkeiten</p></li><li><p>V2 Chancen / Herausforderungen AU</p></li><li><p>V3 mögliche AS-Themen für spez. Orte</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "df5dc810cf3c",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/28011dca853c"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/df5dc810cf3c#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/df5dc810cf3c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/df5dc810cf3c#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/df5dc810cf3c#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/df5dc810cf3c",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4a0f878a99fc": {
+    "data": {
+      "html": "<ul><li><p>Ausbildungsstopp erleben</p></li><li><p>Ausbildungsstopp analysieren / reflektieren</p></li><li><p>Definition Ausbildungsstopp</p></li><li><p>Was für Ausbildungsstopps könnte man an diesem Ort hier machen?</p></li><li><p>Herausforderungen Ausbilden unterwegs</p></li><li><p>Weitere Formen Ausbilden unterwegs</p></li><li><p>Was macht einen gelungenen Ausbildungsstopp aus?</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "4a0f878a99fc",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/28011dca853c"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/4a0f878a99fc#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/4a0f878a99fc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4a0f878a99fc#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/4a0f878a99fc#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/4a0f878a99fc",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/1a2905b61cff": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": null,
+    "id": "1a2905b61cff",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2F1a2905b61cff"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/28011dca853c"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/1a2905b61cff#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/1a2905b61cff",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/1a2905b61cff#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/1a2905b61cff#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/1a2905b61cff",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/754b7187d819": {
+    "data": {
+      "sections": {
+        "26a120c8-7391-44aa-bf7a-3fdfc2c39f26": {
+          "column1": "",
+          "column3": "",
+          "position": 6,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "74bee006-5513-4a2d-80fa-d253abcbbfe3": {
+          "column1": "",
+          "column3": "",
+          "position": 5,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "ca756169-d097-4619-bd6d-b13060bea190": {
+          "column1": "",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "d50c32e8-3bb0-4d52-8d9e-8c26756a14b9": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "de1fe977-b2d4-4c71-85c8-b8916a4e7881": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "754b7187d819",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/28011dca853c"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/754b7187d819#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/754b7187d819",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/754b7187d819#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/754b7187d819#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/754b7187d819",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/27df0bda503f": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "27df0bda503f",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F27df0bda503f"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/28011dca853c"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/27df0bda503f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/27df0bda503f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F27df0bda503f": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F27df0bda503f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/27df0bda503f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/27df0bda503f#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/27df0bda503f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/28011dca853c": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "28011dca853c",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/28011dca853c#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/28011dca853c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/28011dca853c#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/4a0f878a99fc"
+      },
+      {
+        "href": "/content_node/storyboards/754b7187d819"
+      },
+      {
+        "href": "/content_node/single_texts/df5dc810cf3c"
+      },
+      {
+        "href": "/content_node/checklist_nodes/1a2905b61cff"
+      },
+      {
+        "href": "/content_node/single_texts/a4775aec3e03"
+      },
+      {
+        "href": "/content_node/material_nodes/27df0bda503f"
+      },
+      {
+        "href": "/content_node/single_texts/f5e1a436a1f8"
+      },
+      {
+        "href": "/content_node/single_texts/8e410cebb44f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/28011dca853c#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/28011dca853c",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/40dd3e9457d6": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "40dd3e9457d6",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/40dd3e9457d6"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/40dd3e9457d6#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/40dd3e9457d6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/40dd3e9457d6#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/28011dca853c"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/40dd3e9457d6#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/40dd3e9457d6",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/5ebcdb64fdb5": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "5ebcdb64fdb5",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/4488a8669ebf"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/4488a8669ebf"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/5ebcdb64fdb5#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/5ebcdb64fdb5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/5ebcdb64fdb5#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/49092518acf4"
+      },
+      {
+        "href": "/content_node/single_texts/199fac4c1b37"
+      },
+      {
+        "href": "/content_node/single_texts/a0eff3e27b5b"
+      },
+      {
+        "href": "/content_node/material_nodes/b688b7d91691"
+      },
+      {
+        "href": "/content_node/storyboards/3a833908338d"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/5ebcdb64fdb5#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/5ebcdb64fdb5",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/a0eff3e27b5b": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "a0eff3e27b5b",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/4488a8669ebf"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ebcdb64fdb5"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/a0eff3e27b5b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/a0eff3e27b5b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/a0eff3e27b5b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/a0eff3e27b5b#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/a0eff3e27b5b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/49092518acf4": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "49092518acf4",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/4488a8669ebf"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ebcdb64fdb5"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/49092518acf4#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/49092518acf4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/49092518acf4#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/49092518acf4#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/49092518acf4",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/199fac4c1b37": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "199fac4c1b37",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/4488a8669ebf"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ebcdb64fdb5"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/199fac4c1b37#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/199fac4c1b37",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/199fac4c1b37#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/199fac4c1b37#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/199fac4c1b37",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/3a833908338d": {
+    "data": {
+      "sections": {
+        "effa3fa5-cd07-4e82-a8aa-198ed9a7c1d4": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "3a833908338d",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/4488a8669ebf"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ebcdb64fdb5"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/3a833908338d#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/3a833908338d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/3a833908338d#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/3a833908338d#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/3a833908338d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/b688b7d91691": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "b688b7d91691",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fb688b7d91691"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/4488a8669ebf"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/5ebcdb64fdb5"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/b688b7d91691#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/b688b7d91691",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fb688b7d91691": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fb688b7d91691",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/b688b7d91691#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/b688b7d91691#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/b688b7d91691",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/4488a8669ebf": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "4488a8669ebf",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/4488a8669ebf"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/4488a8669ebf#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/4488a8669ebf",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/4488a8669ebf#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/5ebcdb64fdb5"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/4488a8669ebf#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/4488a8669ebf",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/af2aeebdc575": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "af2aeebdc575",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/af2aeebdc575#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/af2aeebdc575",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/af2aeebdc575#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/115001dac1ec"
+      },
+      {
+        "href": "/content_node/storyboards/16a2d11897eb"
+      },
+      {
+        "href": "/content_node/material_nodes/28e74ee962e9"
+      },
+      {
+        "href": "/content_node/single_texts/84f99f42d58a"
+      },
+      {
+        "href": "/content_node/checklist_nodes/9e95b10e3cb0"
+      },
+      {
+        "href": "/content_node/single_texts/f0e9b1475213"
+      },
+      {
+        "href": "/content_node/single_texts/1feebf2b0022"
+      },
+      {
+        "href": "/content_node/single_texts/92a9bb176ab1"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/af2aeebdc575#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/af2aeebdc575",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/1feebf2b0022": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "1feebf2b0022",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/af2aeebdc575"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/1feebf2b0022#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/1feebf2b0022",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/1feebf2b0022#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/1feebf2b0022#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/1feebf2b0022",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f0e9b1475213": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "f0e9b1475213",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/af2aeebdc575"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/f0e9b1475213#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/f0e9b1475213",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f0e9b1475213#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/f0e9b1475213#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/f0e9b1475213",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/92a9bb176ab1": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "92a9bb176ab1",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/af2aeebdc575"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/92a9bb176ab1#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/92a9bb176ab1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/92a9bb176ab1#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/92a9bb176ab1#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/92a9bb176ab1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/115001dac1ec": {
+    "data": {
+      "html": "<ul><li><p>Gesprächslenkungstechniken ausprobieren und bewusst anwenden</p></li><li><p>Spickzettel über zentrale Gesprächslenkungstechniken erstellen</p></li><li><p>Reflektieren Haltungen an ein Rückmeldegespräch und können begründen, welchen Einfluss eine bestimmte Haltung auf den Gesprächsverlauf hat</p></li><li><p>Können bewusst schweigen und zuhören</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "115001dac1ec",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/af2aeebdc575"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/115001dac1ec#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/115001dac1ec",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/115001dac1ec#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/115001dac1ec#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/115001dac1ec",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/84f99f42d58a": {
+    "data": {
+      "html": "<ul><li><p>Einstieg ins Gefäss</p></li><li><p>Theorie / Grundlagen / Richtlinien / Hilfsmittel zur Gesprächsführung vermittelt bekommen</p></li><li><p>Rückmeldung geben</p></li><li><p>Rückmeldung zu TN-Produkt geben</p></li><li><p>Gesprächslenkungstechniken anwenden</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "84f99f42d58a",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/af2aeebdc575"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/84f99f42d58a#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/84f99f42d58a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/84f99f42d58a#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/84f99f42d58a#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/84f99f42d58a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/9e95b10e3cb0": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": "Ausbildungsziele",
+    "id": "9e95b10e3cb0",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2F9e95b10e3cb0"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/af2aeebdc575"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/9e95b10e3cb0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/9e95b10e3cb0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/9e95b10e3cb0#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/9e95b10e3cb0#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/9e95b10e3cb0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/16a2d11897eb": {
+    "data": {
+      "sections": {
+        "02707c76-12e7-439a-a002-9c5dcbdd8801": {
+          "column1": "00:45",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Deprehensus omnem poenam contemnet. De vacuitate doloris eadem sententia erit. Contineo me ab exemplis. Duo Reges: constructio interrete. Omnes enim iucundum motum, quo sensus hilaretur. Bonum incolumis acies: misera caecitas. Ergo ita: non posse honeste vivi, nisi honeste vivatur? </p>"
+        },
+        "22cd7841-a225-47df-b7da-698b17e870ee": {
+          "column1": "01:30",
+          "column3": "",
+          "position": 6,
+          "column2Html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Deprehensus omnem poenam contemnet. De vacuitate doloris eadem sententia erit. Contineo me ab exemplis. Duo Reges: constructio interrete. Omnes enim iucundum motum, quo sensus hilaretur. Bonum incolumis acies: misera caecitas. Ergo ita: non posse honeste vivi, nisi honeste vivatur? </p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "00:00",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Deprehensus omnem poenam contemnet. De vacuitate doloris eadem sententia erit. Contineo me ab exemplis. Duo Reges: constructio interrete. Omnes enim iucundum motum, quo sensus hilaretur. Bonum incolumis acies: misera caecitas. Ergo ita: non posse honeste vivi, nisi honeste vivatur? </p>"
+        },
+        "b3824ecf-8ed9-457a-9f7d-8d2ea2866c26": {
+          "column1": "01:15",
+          "column3": "",
+          "position": 5,
+          "column2Html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Deprehensus omnem poenam contemnet. De vacuitate doloris eadem sententia erit. Contineo me ab exemplis. Duo Reges: constructio interrete. Omnes enim iucundum motum, quo sensus hilaretur. Bonum incolumis acies: misera caecitas. Ergo ita: non posse honeste vivi, nisi honeste vivatur? </p>"
+        },
+        "c085166f-d469-458d-821e-781c17475c18": {
+          "column1": "00:30",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Deprehensus omnem poenam contemnet. De vacuitate doloris eadem sententia erit. Contineo me ab exemplis. Duo Reges: constructio interrete. Omnes enim iucundum motum, quo sensus hilaretur. Bonum incolumis acies: misera caecitas. Ergo ita: non posse honeste vivi, nisi honeste vivatur? </p>"
+        },
+        "ed292871-8374-41ae-8124-c4271cb21492": {
+          "column1": "00:15",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Deprehensus omnem poenam contemnet. De vacuitate doloris eadem sententia erit. Contineo me ab exemplis. Duo Reges: constructio interrete. Omnes enim iucundum motum, quo sensus hilaretur. Bonum incolumis acies: misera caecitas. Ergo ita: non posse honeste vivi, nisi honeste vivatur? </p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "16a2d11897eb",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/af2aeebdc575"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/16a2d11897eb#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/16a2d11897eb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/16a2d11897eb#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/16a2d11897eb#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/16a2d11897eb",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/28e74ee962e9": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "28e74ee962e9",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F28e74ee962e9"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/af2aeebdc575"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/28e74ee962e9#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/28e74ee962e9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/575940e0d36a": {
+    "article": "Äpfel",
+    "quantity": 5,
+    "unit": "kg",
+    "done": false,
+    "id": "575940e0d36a",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/235d4e49db04"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/28e74ee962e9"
+    },
+    "_meta": {
+      "self": "/material_items/575940e0d36a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/ccefca359227": {
+    "article": "Seil",
+    "quantity": 8,
+    "unit": "m",
+    "done": false,
+    "id": "ccefca359227",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/6e3d8bf92360"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/28e74ee962e9"
+    },
+    "_meta": {
+      "self": "/material_items/ccefca359227",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/52fd6a30e2df": {
+    "article": "Verkleidung Dolor",
+    "quantity": 1,
+    "unit": null,
+    "done": false,
+    "id": "52fd6a30e2df",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/cc18aaa03b18"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/28e74ee962e9"
+    },
+    "_meta": {
+      "self": "/material_items/52fd6a30e2df",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F28e74ee962e9": {
+    "items": [
+      {
+        "href": "/material_items/575940e0d36a"
+      },
+      {
+        "href": "/material_items/ccefca359227"
+      },
+      {
+        "href": "/material_items/52fd6a30e2df"
+      }
+    ],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F28e74ee962e9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/28e74ee962e9#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/28e74ee962e9#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/28e74ee962e9",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/4bd0b0f3f3a6": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "4bd0b0f3f3a6",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/4bd0b0f3f3a6#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/4bd0b0f3f3a6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/4bd0b0f3f3a6#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/af2aeebdc575"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/4bd0b0f3f3a6#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/4bd0b0f3f3a6",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/f9aa943d2183": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "f9aa943d2183",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/4e70c2f6c206"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/4e70c2f6c206"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/f9aa943d2183#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/f9aa943d2183",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/f9aa943d2183#children": {
+    "items": [
+      {
+        "href": "/content_node/material_nodes/e23863466f6a"
+      },
+      {
+        "href": "/content_node/single_texts/84b8ff722471"
+      },
+      {
+        "href": "/content_node/single_texts/fc992e3cf8be"
+      },
+      {
+        "href": "/content_node/storyboards/0c94476f8e49"
+      },
+      {
+        "href": "/content_node/single_texts/d6727e97c32b"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/f9aa943d2183#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/f9aa943d2183",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d6727e97c32b": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "d6727e97c32b",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/4e70c2f6c206"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/f9aa943d2183"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d6727e97c32b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d6727e97c32b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d6727e97c32b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d6727e97c32b#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d6727e97c32b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/fc992e3cf8be": {
+    "data": {
+      "html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "fc992e3cf8be",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/4e70c2f6c206"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/f9aa943d2183"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/fc992e3cf8be#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/fc992e3cf8be",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/fc992e3cf8be#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/fc992e3cf8be#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/fc992e3cf8be",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/84b8ff722471": {
+    "data": {
+      "html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "84b8ff722471",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/4e70c2f6c206"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/f9aa943d2183"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/84b8ff722471#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/84b8ff722471",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/84b8ff722471#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/84b8ff722471#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/84b8ff722471",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/0c94476f8e49": {
+    "data": {
+      "sections": {
+        "1fba4185-8be3-48e3-ac1b-8f82d0d77e47": {
+          "column1": "",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "4d164baf-0934-4b95-9eda-af75fad7c588": {
+          "column1": "",
+          "column3": "",
+          "position": 5,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "5da0b2f1-aad0-4ebd-9f59-aef454cd41b7": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "b67d458b-58a8-4c91-b2cb-de6642746683": {
+          "column1": "",
+          "column3": "",
+          "position": 6,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "c81f489b-92d0-4d80-a130-8d0fa3a1fc78": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "0c94476f8e49",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/4e70c2f6c206"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/f9aa943d2183"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/0c94476f8e49#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/0c94476f8e49",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/0c94476f8e49#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/0c94476f8e49#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/0c94476f8e49",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/e23863466f6a": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "e23863466f6a",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fe23863466f6a"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/4e70c2f6c206"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/f9aa943d2183"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/e23863466f6a#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/e23863466f6a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fe23863466f6a": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fe23863466f6a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/e23863466f6a#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/e23863466f6a#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/e23863466f6a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/4e70c2f6c206": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "4e70c2f6c206",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/4e70c2f6c206"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/4e70c2f6c206#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/4e70c2f6c206",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/4e70c2f6c206#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/f9aa943d2183"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/4e70c2f6c206#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/4e70c2f6c206",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/c30e6271b10f": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "c30e6271b10f",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/598946669198"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/598946669198"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/c30e6271b10f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/c30e6271b10f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/c30e6271b10f#children": {
+    "items": [
+      {
+        "href": "/content_node/multi_selects/35ca55460da3"
+      },
+      {
+        "href": "/content_node/storyboards/c31e416244ea"
+      },
+      {
+        "href": "/content_node/single_texts/7d3f7f26e515"
+      },
+      {
+        "href": "/content_node/single_texts/69e2974bd21f"
+      },
+      {
+        "href": "/content_node/material_nodes/0c9da6f3a3a9"
+      },
+      {
+        "href": "/content_node/single_texts/69fac3422851"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/c30e6271b10f#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/c30e6271b10f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/69e2974bd21f": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "69e2974bd21f",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/598946669198"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c30e6271b10f"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/69e2974bd21f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/69e2974bd21f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/69e2974bd21f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/69e2974bd21f#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/69e2974bd21f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7d3f7f26e515": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "7d3f7f26e515",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/598946669198"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c30e6271b10f"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/7d3f7f26e515#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/7d3f7f26e515",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7d3f7f26e515#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/7d3f7f26e515#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/7d3f7f26e515",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/69fac3422851": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "69fac3422851",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/598946669198"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c30e6271b10f"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/69fac3422851#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/69fac3422851",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/69fac3422851#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/69fac3422851#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/69fac3422851",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/multi_selects/35ca55460da3": {
+    "data": {
+      "options": {
+        "security": {
+          "checked": false
+        },
+        "outdoorTechnique": {
+          "checked": false
+        },
+        "pioneeringTechnique": {
+          "checked": false
+        },
+        "natureAndEnvironment": {
+          "checked": false
+        },
+        "campsiteAndSurroundings": {
+          "checked": true
+        },
+        "preventionAndIntegration": {
+          "checked": true
+        }
+      }
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "35ca55460da3",
+    "contentTypeName": "LAThematicArea",
+    "root": {
+      "href": "/content_node/column_layouts/598946669198"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c30e6271b10f"
+    },
+    "contentType": {
+      "href": "/content_types/1a0f84e322c8"
+    },
+    "children": {
+      "href": "/content_node/multi_selects/35ca55460da3#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/multi_selects/35ca55460da3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/multi_selects/35ca55460da3#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/multi_selects/35ca55460da3#children",
+      "virtual": true,
+      "owningResource": "/content_node/multi_selects/35ca55460da3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/c31e416244ea": {
+    "data": {
+      "sections": {
+        "215fda4f-d90d-4ff0-abaf-f71ce5188f8d": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p><br />Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+        },
+        "4c126a50-f729-46a7-8326-811586922995": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p><br />Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+        },
+        "886988cf-d419-4ac6-be21-286e2de7fe5c": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p><br />Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "c31e416244ea",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/598946669198"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c30e6271b10f"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/c31e416244ea#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/c31e416244ea",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/c31e416244ea#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/c31e416244ea#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/c31e416244ea",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/0c9da6f3a3a9": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "0c9da6f3a3a9",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F0c9da6f3a3a9"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/598946669198"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/c30e6271b10f"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/0c9da6f3a3a9#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/0c9da6f3a3a9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F0c9da6f3a3a9": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F0c9da6f3a3a9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/0c9da6f3a3a9#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/0c9da6f3a3a9#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/0c9da6f3a3a9",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/598946669198": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "598946669198",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/598946669198"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/598946669198#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/598946669198",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/598946669198#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/c30e6271b10f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/598946669198#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/598946669198",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/fd30504d4da9": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "fd30504d4da9",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/5a6917af2f55"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/5a6917af2f55"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/fd30504d4da9#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/fd30504d4da9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/fd30504d4da9#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/593512fcabd5"
+      },
+      {
+        "href": "/content_node/storyboards/aa040c45acde"
+      },
+      {
+        "href": "/content_node/single_texts/4e920d5a3186"
+      },
+      {
+        "href": "/content_node/single_texts/c34e7e852229"
+      },
+      {
+        "href": "/content_node/material_nodes/8b9fb26d51d7"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/fd30504d4da9#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/fd30504d4da9",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/593512fcabd5": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "593512fcabd5",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/5a6917af2f55"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fd30504d4da9"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/593512fcabd5#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/593512fcabd5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/593512fcabd5#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/593512fcabd5#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/593512fcabd5",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4e920d5a3186": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "4e920d5a3186",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/5a6917af2f55"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fd30504d4da9"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/4e920d5a3186#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/4e920d5a3186",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4e920d5a3186#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/4e920d5a3186#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/4e920d5a3186",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c34e7e852229": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "c34e7e852229",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/5a6917af2f55"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fd30504d4da9"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/c34e7e852229#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/c34e7e852229",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c34e7e852229#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/c34e7e852229#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/c34e7e852229",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/aa040c45acde": {
+    "data": {
+      "sections": {
+        "834806f6-9cd3-4102-acd8-fd4a5c88590e": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p><br />Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+        },
+        "effa3fa5-cd07-4e82-a8aa-198ed9a7c1d4": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "aa040c45acde",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/5a6917af2f55"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fd30504d4da9"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/aa040c45acde#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/aa040c45acde",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/aa040c45acde#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/aa040c45acde#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/aa040c45acde",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/8b9fb26d51d7": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "8b9fb26d51d7",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F8b9fb26d51d7"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/5a6917af2f55"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/fd30504d4da9"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/8b9fb26d51d7#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/8b9fb26d51d7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F8b9fb26d51d7": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F8b9fb26d51d7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/8b9fb26d51d7#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/8b9fb26d51d7#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/8b9fb26d51d7",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/5a6917af2f55": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "5a6917af2f55",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/5a6917af2f55"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/5a6917af2f55#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/5a6917af2f55",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/5a6917af2f55#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/fd30504d4da9"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/5a6917af2f55#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/5a6917af2f55",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/ffeadee13be3": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "ffeadee13be3",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/605686add6db"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4b914c305170"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/ffeadee13be3#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/ffeadee13be3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/ffeadee13be3#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/ffeadee13be3#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/ffeadee13be3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d9aeaa2425ea": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "d9aeaa2425ea",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/605686add6db"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4b914c305170"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d9aeaa2425ea#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d9aeaa2425ea",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d9aeaa2425ea#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d9aeaa2425ea#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d9aeaa2425ea",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5da0571fac41": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "5da0571fac41",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/605686add6db"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4b914c305170"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/5da0571fac41#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/5da0571fac41",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5da0571fac41#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/5da0571fac41#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/5da0571fac41",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/38f008ed3383": {
+    "data": {
+      "sections": {
+        "558bd532-989e-4032-8199-606d6de488ec": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        },
+        "92ff4f49-555e-4189-a524-9e85c0bb785f": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        },
+        "effa3fa5-cd07-4e82-a8aa-198ed9a7c1d4": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "38f008ed3383",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/605686add6db"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4b914c305170"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/38f008ed3383#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/38f008ed3383",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/38f008ed3383#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/38f008ed3383#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/38f008ed3383",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/b99257b01202": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "b99257b01202",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fb99257b01202"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/605686add6db"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4b914c305170"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/b99257b01202#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/b99257b01202",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fb99257b01202": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fb99257b01202",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/b99257b01202#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/b99257b01202#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/b99257b01202",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/4b914c305170": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "4b914c305170",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/605686add6db"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/605686add6db"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/4b914c305170#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/4b914c305170",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/4b914c305170#children": {
+    "items": [
+      {
+        "href": "/content_node/material_nodes/b99257b01202"
+      },
+      {
+        "href": "/content_node/single_texts/ffeadee13be3"
+      },
+      {
+        "href": "/content_node/storyboards/38f008ed3383"
+      },
+      {
+        "href": "/content_node/single_texts/d9aeaa2425ea"
+      },
+      {
+        "href": "/content_node/single_texts/5da0571fac41"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/4b914c305170#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/4b914c305170",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/605686add6db": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "605686add6db",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/605686add6db"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/605686add6db#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/605686add6db",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/605686add6db#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/4b914c305170"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/605686add6db#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/605686add6db",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/eb9a3ff7cb89": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "eb9a3ff7cb89",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/680095ff1e78"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/680095ff1e78"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/eb9a3ff7cb89#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/eb9a3ff7cb89",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/eb9a3ff7cb89#children": {
+    "items": [
+      {
+        "href": "/content_node/material_nodes/884a49a5f928"
+      },
+      {
+        "href": "/content_node/storyboards/14f5cd5cc155"
+      },
+      {
+        "href": "/content_node/single_texts/d8ff638bc079"
+      },
+      {
+        "href": "/content_node/single_texts/58c1550af9f7"
+      },
+      {
+        "href": "/content_node/single_texts/9c22a72d4666"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/eb9a3ff7cb89#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/eb9a3ff7cb89",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/58c1550af9f7": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "58c1550af9f7",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/680095ff1e78"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eb9a3ff7cb89"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/58c1550af9f7#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/58c1550af9f7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/58c1550af9f7#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/58c1550af9f7#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/58c1550af9f7",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d8ff638bc079": {
+    "data": {
+      "html": "<p>Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "d8ff638bc079",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/680095ff1e78"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eb9a3ff7cb89"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d8ff638bc079#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d8ff638bc079",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d8ff638bc079#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d8ff638bc079#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d8ff638bc079",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/9c22a72d4666": {
+    "data": {
+      "html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "9c22a72d4666",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/680095ff1e78"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eb9a3ff7cb89"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/9c22a72d4666#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/9c22a72d4666",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/9c22a72d4666#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/9c22a72d4666#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/9c22a72d4666",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/14f5cd5cc155": {
+    "data": {
+      "sections": {
+        "247b29f1-59e5-4d59-8111-83fb3305adaa": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p><br />In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        },
+        "2cec518f-fc6a-4820-a195-3b78414a4b9a": {
+          "column1": "",
+          "column3": "",
+          "position": 5,
+          "column2Html": "<p><br />In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        },
+        "6326c0d6-5d69-4308-b80a-3689ea970871": {
+          "column1": "",
+          "column3": "",
+          "position": 6,
+          "column2Html": "<p><br />In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        },
+        "69307fe7-c1ad-4291-86c7-60f8ac8758d0": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p><br />In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        },
+        "d3513bdb-061b-4190-86ef-ff03191b4191": {
+          "column1": "",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p><br />In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        },
+        "db646a6d-880c-4f56-9238-184d01189a3b": {
+          "column1": "",
+          "column3": "",
+          "position": 7,
+          "column2Html": "<p><br />In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        },
+        "effa3fa5-cd07-4e82-a8aa-198ed9a7c1d4": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p><br />In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "14f5cd5cc155",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/680095ff1e78"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eb9a3ff7cb89"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/14f5cd5cc155#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/14f5cd5cc155",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/14f5cd5cc155#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/14f5cd5cc155#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/14f5cd5cc155",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/884a49a5f928": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "884a49a5f928",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F884a49a5f928"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/680095ff1e78"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/eb9a3ff7cb89"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/884a49a5f928#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/884a49a5f928",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F884a49a5f928": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F884a49a5f928",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/884a49a5f928#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/884a49a5f928#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/884a49a5f928",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/680095ff1e78": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "680095ff1e78",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/680095ff1e78"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/680095ff1e78#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/680095ff1e78",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/680095ff1e78#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/eb9a3ff7cb89"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/680095ff1e78#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/680095ff1e78",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/8d21cf90ee34": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "8d21cf90ee34",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/6bab443ef52d"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/6bab443ef52d"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/8d21cf90ee34#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/8d21cf90ee34",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/8d21cf90ee34#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/5c9c0e7a2379"
+      },
+      {
+        "href": "/content_node/storyboards/ba8c16422297"
+      },
+      {
+        "href": "/content_node/single_texts/1733597b0c44"
+      },
+      {
+        "href": "/content_node/material_nodes/76b43733c8d2"
+      },
+      {
+        "href": "/content_node/single_texts/d0e95cd6cc79"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/8d21cf90ee34#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/8d21cf90ee34",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d0e95cd6cc79": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "d0e95cd6cc79",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/6bab443ef52d"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/8d21cf90ee34"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d0e95cd6cc79#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d0e95cd6cc79",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d0e95cd6cc79#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d0e95cd6cc79#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d0e95cd6cc79",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5c9c0e7a2379": {
+    "data": {
+      "html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Theophrasti igitur, inquit, tibi liber ille placet de beata vita? Quamquam ab iis philosophiam et omnes ingenuas disciplinas habemus; Quod autem satis est, eo quicquid accessit, nimium est; Nec hoc ille non vidit, sed verborum magnificentia est et gloria delectatus. Duo Reges: constructio interrete. Multa sunt dicta ab antiquis de contemnendis ac despiciendis rebus humanis; Mihi enim satis est, ipsis non satis. Nam aliquando posse recte fieri dicunt nulla expectata nec quaesita voluptate. Eaedem enim utilitates poterunt eas labefactare atque pervertere. Utrum igitur tibi litteram videor an totas paginas commovere? </p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "5c9c0e7a2379",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/6bab443ef52d"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/8d21cf90ee34"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/5c9c0e7a2379#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/5c9c0e7a2379",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5c9c0e7a2379#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/5c9c0e7a2379#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/5c9c0e7a2379",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/1733597b0c44": {
+    "data": {
+      "html": "<p>Natürliche Ökosysteme spielen eine entscheidende Rolle im Erhalt der globalen Biodiversität und der Stabilität des Planeten. Diese vielfältigen Lebensräume bieten Lebensraum für eine breite Palette von Pflanzen und Tieren, von mikroskopisch kleinen Organismen bis hin zu majestätischen Raubtieren. Der reibungslose Ablauf dieser Ökosysteme hängt von komplexen Wechselwirkungen zwischen den verschiedenen Arten und den Umweltbedingungen ab. Von Regenwäldern bis hin zu Wüsten, von Ozeanen bis hin zu Flussufern - jedes Ökosystem trägt auf seine eigene Weise zur Aufrechterhaltung des ökologischen Gleichgewichts bei. Es ist von größter Bedeutung, diese Ökosysteme zu schützen und nachhaltige Praktiken zu fördern, um die langfristige Gesundheit unseres Planeten zu gewährleisten.</p>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "1733597b0c44",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/6bab443ef52d"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/8d21cf90ee34"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/1733597b0c44#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/1733597b0c44",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/1733597b0c44#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/1733597b0c44#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/1733597b0c44",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/ba8c16422297": {
+    "data": {
+      "sections": {
+        "5ae40118-e423-4972-bb27-caee2065dbdf": {
+          "column1": "20",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Natürliche Ökosysteme spielen eine entscheidende Rolle im Erhalt der globalen Biodiversität und der Stabilität des Planeten. Diese vielfältigen Lebensräume bieten Lebensraum für eine breite Palette von Pflanzen und Tieren, von mikroskopisch kleinen Organismen bis hin zu majestätischen Raubtieren. Der reibungslose Ablauf dieser Ökosysteme hängt von komplexen Wechselwirkungen zwischen den verschiedenen Arten und den Umweltbedingungen ab. Von Regenwäldern bis hin zu Wüsten, von Ozeanen bis hin zu Flussufern - jedes Ökosystem trägt auf seine eigene Weise zur Aufrechterhaltung des ökologischen Gleichgewichts bei. Es ist von größter Bedeutung, diese Ökosysteme zu schützen und nachhaltige Praktiken zu fördern, um die langfristige Gesundheit unseres Planeten zu gewährleisten.</p>"
+        },
+        "d8504cbc-993c-465b-a494-94968093ff6d": {
+          "column1": "50",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Natürliche Ökosysteme spielen eine entscheidende Rolle im Erhalt der globalen Biodiversität und der Stabilität des Planeten. Diese vielfältigen Lebensräume bieten Lebensraum für eine breite Palette von Pflanzen und Tieren, von mikroskopisch kleinen Organismen bis hin zu majestätischen Raubtieren. Der reibungslose Ablauf dieser Ökosysteme hängt von komplexen Wechselwirkungen zwischen den verschiedenen Arten und den Umweltbedingungen ab. Von Regenwäldern bis hin zu Wüsten, von Ozeanen bis hin zu Flussufern - jedes Ökosystem trägt auf seine eigene Weise zur Aufrechterhaltung des ökologischen Gleichgewichts bei. Es ist von größter Bedeutung, diese Ökosysteme zu schützen und nachhaltige Praktiken zu fördern, um die langfristige Gesundheit unseres Planeten zu gewährleisten.</p>"
+        },
+        "effa3fa5-cd07-4e82-a8aa-198ed9a7c1d4": {
+          "column1": "0",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Natürliche Ökosysteme spielen eine entscheidende Rolle im Erhalt der globalen Biodiversität und der Stabilität des Planeten. Diese vielfältigen Lebensräume bieten Lebensraum für eine breite Palette von Pflanzen und Tieren, von mikroskopisch kleinen Organismen bis hin zu majestätischen Raubtieren. Der reibungslose Ablauf dieser Ökosysteme hängt von komplexen Wechselwirkungen zwischen den verschiedenen Arten und den Umweltbedingungen ab. Von Regenwäldern bis hin zu Wüsten, von Ozeanen bis hin zu Flussufern - jedes Ökosystem trägt auf seine eigene Weise zur Aufrechterhaltung des ökologischen Gleichgewichts bei. Es ist von größter Bedeutung, diese Ökosysteme zu schützen und nachhaltige Praktiken zu fördern, um die langfristige Gesundheit unseres Planeten zu gewährleisten.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "ba8c16422297",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/6bab443ef52d"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/8d21cf90ee34"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/ba8c16422297#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/ba8c16422297",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/ba8c16422297#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/ba8c16422297#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/ba8c16422297",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/76b43733c8d2": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "76b43733c8d2",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F76b43733c8d2"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/6bab443ef52d"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/8d21cf90ee34"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/76b43733c8d2#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/76b43733c8d2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/a1d02ad7609b": {
+    "article": "Chips",
+    "quantity": 8,
+    "unit": "Pack",
+    "done": false,
+    "id": "a1d02ad7609b",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/308765cf5631"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/76b43733c8d2"
+    },
+    "_meta": {
+      "self": "/material_items/a1d02ad7609b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/537d3d5fc24d": {
+    "article": "MIlch",
+    "quantity": 10,
+    "unit": "Liter",
+    "done": false,
+    "id": "537d3d5fc24d",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/308765cf5631"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/76b43733c8d2"
+    },
+    "_meta": {
+      "self": "/material_items/537d3d5fc24d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/dd658171b877": {
+    "article": "Bändeli",
+    "quantity": 5,
+    "unit": "Farben",
+    "done": false,
+    "id": "dd658171b877",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/f4268fba5b4b"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/76b43733c8d2"
+    },
+    "_meta": {
+      "self": "/material_items/dd658171b877",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/12a721a69bc6": {
+    "article": "Spaten",
+    "quantity": 6,
+    "unit": null,
+    "done": false,
+    "id": "12a721a69bc6",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/049b1890fb94"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/76b43733c8d2"
+    },
+    "_meta": {
+      "self": "/material_items/12a721a69bc6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F76b43733c8d2": {
+    "items": [
+      {
+        "href": "/material_items/a1d02ad7609b"
+      },
+      {
+        "href": "/material_items/537d3d5fc24d"
+      },
+      {
+        "href": "/material_items/dd658171b877"
+      },
+      {
+        "href": "/material_items/12a721a69bc6"
+      }
+    ],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F76b43733c8d2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/76b43733c8d2#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/76b43733c8d2#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/76b43733c8d2",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/6bab443ef52d": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "6bab443ef52d",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/6bab443ef52d"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/6bab443ef52d#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/6bab443ef52d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/6bab443ef52d#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/8d21cf90ee34"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/6bab443ef52d#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/6bab443ef52d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/798b70a5034a": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "798b70a5034a",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/801a718813bc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/1af6ffaca01f"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/798b70a5034a#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/798b70a5034a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/798b70a5034a#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/798b70a5034a#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/798b70a5034a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6a277f8c8eb1": {
+    "data": {
+      "html": "<p>Wir haben ja alle den Brief von Hogwarts bekommen, und sind jetzt in Kings Kross.</p><p>Hier sehen wir all die Leute, die zwischen Bahngleis 9 und 10 durch die Wand aufs Gleis 9 3/4 gehen.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "6a277f8c8eb1",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/801a718813bc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/1af6ffaca01f"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/6a277f8c8eb1#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/6a277f8c8eb1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6a277f8c8eb1#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/6a277f8c8eb1#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/6a277f8c8eb1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d77eebe66c73": {
+    "data": {
+      "html": "<p>Apotheke ist Dabei</p>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "d77eebe66c73",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/801a718813bc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/1af6ffaca01f"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d77eebe66c73#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d77eebe66c73",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d77eebe66c73#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d77eebe66c73#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d77eebe66c73",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/14f0a0f1749d": {
+    "data": {
+      "sections": {
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Bahnhof/Haltestelle Zeit Reise mit Informationen</p><p> Zürich Oerlikon, Bahnhof</p><p>       </p><p>Fussweg</p><p>4' Fussweg 49 m</p><p>Zürich Oerlikon</p><p> ab 15:43 Gl. 1 S 14 19458 S-Bahn 14<br />Richtung: Affoltern am Albis <br /></p><ul><li></li></ul><p>Zürich Altstetten</p><p> an 15:54 Gl. 2</p><p>       </p><p>Umsteigen</p><p>Umsteigen</p><p>Zürich Altstetten</p><p> ab 15:59 Gl. 7 IR 35 2374 InterRegio 35<br />Richtung: Bern <br /></p><ul><li><p></p></li></ul><p>Aare Linth<br /> Olten</p><p> an 16:28 Gl. 9</p><p>       </p><p>Umsteigen</p><p>Umsteigen</p><p>Olten</p><p> ab 16:35 Gl. 1B-D S 20 7678 S-Bahn 20<br />Richtung: Biel/Bienne <br /></p><ul><li><p></p></li></ul><p>Wangen an der Aare</p><p> an 17:00 Gl. 3</p><p>       </p><p>Fussweg</p><p>10' Fussweg 580 m</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "14f0a0f1749d",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/801a718813bc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/1af6ffaca01f"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/14f0a0f1749d#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/14f0a0f1749d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/14f0a0f1749d#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/14f0a0f1749d#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/14f0a0f1749d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/7e7a75da005b": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "7e7a75da005b",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F7e7a75da005b"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/801a718813bc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/1af6ffaca01f"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/7e7a75da005b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/7e7a75da005b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/3f212014b34a": {
+    "article": "Gruppenbillet",
+    "quantity": 1,
+    "unit": null,
+    "done": false,
+    "id": "3f212014b34a",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/e06677070032"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/7e7a75da005b"
+    },
+    "_meta": {
+      "self": "/material_items/3f212014b34a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/5bd3969c000e": {
+    "article": "Apotheke",
+    "quantity": 1,
+    "unit": null,
+    "done": false,
+    "id": "5bd3969c000e",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/e06677070032"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/7e7a75da005b"
+    },
+    "_meta": {
+      "self": "/material_items/5bd3969c000e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/b4e5902fdf39": {
+    "article": "Teilnehmerliste",
+    "quantity": 1,
+    "unit": null,
+    "done": false,
+    "id": "b4e5902fdf39",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/e06677070032"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/7e7a75da005b"
+    },
+    "_meta": {
+      "self": "/material_items/b4e5902fdf39",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/2d864ccf23cf": {
+    "article": "Ordner für Notfallblätter",
+    "quantity": 1,
+    "unit": null,
+    "done": false,
+    "id": "2d864ccf23cf",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/e06677070032"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/7e7a75da005b"
+    },
+    "_meta": {
+      "self": "/material_items/2d864ccf23cf",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F7e7a75da005b": {
+    "items": [
+      {
+        "href": "/material_items/3f212014b34a"
+      },
+      {
+        "href": "/material_items/5bd3969c000e"
+      },
+      {
+        "href": "/material_items/b4e5902fdf39"
+      },
+      {
+        "href": "/material_items/2d864ccf23cf"
+      }
+    ],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F7e7a75da005b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/7e7a75da005b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/7e7a75da005b#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/7e7a75da005b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/1af6ffaca01f": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "1af6ffaca01f",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/801a718813bc"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/801a718813bc"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/1af6ffaca01f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/1af6ffaca01f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/1af6ffaca01f#children": {
+    "items": [
+      {
+        "href": "/content_node/material_nodes/7e7a75da005b"
+      },
+      {
+        "href": "/content_node/single_texts/d77eebe66c73"
+      },
+      {
+        "href": "/content_node/single_texts/6a277f8c8eb1"
+      },
+      {
+        "href": "/content_node/storyboards/14f0a0f1749d"
+      },
+      {
+        "href": "/content_node/single_texts/798b70a5034a"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/1af6ffaca01f#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/1af6ffaca01f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/801a718813bc": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "801a718813bc",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/801a718813bc"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/801a718813bc#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/801a718813bc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/801a718813bc#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/1af6ffaca01f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/801a718813bc#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/801a718813bc",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/bcb9dfd0ce33": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "bcb9dfd0ce33",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/80f56c759496"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/80f56c759496"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/bcb9dfd0ce33#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/bcb9dfd0ce33",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/bcb9dfd0ce33#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/2cb25e6c28e8"
+      },
+      {
+        "href": "/content_node/single_texts/6b63b9e34680"
+      },
+      {
+        "href": "/content_node/material_nodes/adcf54c67bc5"
+      },
+      {
+        "href": "/content_node/storyboards/85e2edf0aa31"
+      },
+      {
+        "href": "/content_node/single_texts/50402861f667"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/bcb9dfd0ce33#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/bcb9dfd0ce33",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/2cb25e6c28e8": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "2cb25e6c28e8",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/80f56c759496"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/bcb9dfd0ce33"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/2cb25e6c28e8#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/2cb25e6c28e8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/2cb25e6c28e8#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/2cb25e6c28e8#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/2cb25e6c28e8",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6b63b9e34680": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "6b63b9e34680",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/80f56c759496"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/bcb9dfd0ce33"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/6b63b9e34680#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/6b63b9e34680",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6b63b9e34680#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/6b63b9e34680#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/6b63b9e34680",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/50402861f667": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "50402861f667",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/80f56c759496"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/bcb9dfd0ce33"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/50402861f667#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/50402861f667",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/50402861f667#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/50402861f667#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/50402861f667",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/85e2edf0aa31": {
+    "data": {
+      "sections": {
+        "effa3fa5-cd07-4e82-a8aa-198ed9a7c1d4": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Fähnliabend für die Fähnli</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "85e2edf0aa31",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/80f56c759496"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/bcb9dfd0ce33"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/85e2edf0aa31#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/85e2edf0aa31",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/85e2edf0aa31#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/85e2edf0aa31#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/85e2edf0aa31",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/adcf54c67bc5": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "adcf54c67bc5",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fadcf54c67bc5"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/80f56c759496"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/bcb9dfd0ce33"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/adcf54c67bc5#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/adcf54c67bc5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fadcf54c67bc5": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fadcf54c67bc5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/adcf54c67bc5#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/adcf54c67bc5#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/adcf54c67bc5",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/80f56c759496": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "80f56c759496",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/80f56c759496"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/80f56c759496#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/80f56c759496",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/80f56c759496#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/bcb9dfd0ce33"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/80f56c759496#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/80f56c759496",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/aeb09d91ec3a": {
+    "data": {
+      "html": "<p>Wir essen in Hogwarts.</p>"
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "aeb09d91ec3a",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/82a15d418391"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/82a15d418391"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/aeb09d91ec3a#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/aeb09d91ec3a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/aeb09d91ec3a#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/aeb09d91ec3a#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/aeb09d91ec3a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/c66f2f897116": {
+    "data": null,
+    "slot": "1",
+    "position": 1,
+    "instanceName": null,
+    "id": "c66f2f897116",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fc66f2f897116"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/82a15d418391"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/82a15d418391"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/c66f2f897116#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/c66f2f897116",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/076f418a0608": {
+    "article": "Zauberhüte",
+    "quantity": null,
+    "unit": null,
+    "done": false,
+    "id": "076f418a0608",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/f4268fba5b4b"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/c66f2f897116"
+    },
+    "_meta": {
+      "self": "/material_items/076f418a0608",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fc66f2f897116": {
+    "items": [
+      {
+        "href": "/material_items/076f418a0608"
+      }
+    ],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fc66f2f897116",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/c66f2f897116#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/c66f2f897116#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/c66f2f897116",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/82a15d418391": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "82a15d418391",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/82a15d418391"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/82a15d418391#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/82a15d418391",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/82a15d418391#children": {
+    "items": [
+      {
+        "href": "/content_node/material_nodes/c66f2f897116"
+      },
+      {
+        "href": "/content_node/single_texts/aeb09d91ec3a"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/82a15d418391#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/82a15d418391",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f814604d5cc4": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "f814604d5cc4",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/8371c12ee053"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/1b04e9260129"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/f814604d5cc4#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/f814604d5cc4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f814604d5cc4#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/f814604d5cc4#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/f814604d5cc4",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5dde5ccdbbbe": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "5dde5ccdbbbe",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/8371c12ee053"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/1b04e9260129"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/5dde5ccdbbbe#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/5dde5ccdbbbe",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5dde5ccdbbbe#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/5dde5ccdbbbe#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/5dde5ccdbbbe",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/ae876b33f169": {
+    "data": {
+      "html": "<p>Apotheke dabei</p>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "ae876b33f169",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/8371c12ee053"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/1b04e9260129"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/ae876b33f169#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/ae876b33f169",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/ae876b33f169#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/ae876b33f169#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/ae876b33f169",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/61d6e5fffcd0": {
+    "data": {
+      "sections": {
+        "23309bc0-7518-42c9-99a1-9cc35a7d429f": {
+          "column1": "00:30",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die Schatzkarten werden verteilt. Jedes Team erhält eine Karte mit markierten Wegpunkten im Wald, die sie zu verschiedenen Stationen führen. Die Teams müssen den Kompass verwenden, um die Richtung und die Entfernung zu den jeweiligen Stationen zu bestimmen.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "00:00",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Teilnehmer versammeln sich am Treffpunkt im Lager. Die Leiter erklären, dass heute eine aufregende Schatzsuche im Wald stattfinden wird. Die Kinder werden in Teams von 4-5 Personen eingeteilt und erhalten jeweils eine Karte des Waldgebiets.</p>"
+        },
+        "f280f4f8-db1d-4a98-b84a-d9abe7d52e10": {
+          "column1": "00:15",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Leiter erklären den Teilnehmern, wie man einen Kompass benutzt, um die Himmelsrichtungen zu bestimmen. Jedes Team bekommt einen Kompass und lernt die Grundlagen der Orientierung.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "61d6e5fffcd0",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/8371c12ee053"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/1b04e9260129"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/61d6e5fffcd0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/61d6e5fffcd0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/61d6e5fffcd0#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/61d6e5fffcd0#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/61d6e5fffcd0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/0f869c953b6b": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "0f869c953b6b",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F0f869c953b6b"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/8371c12ee053"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/1b04e9260129"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/0f869c953b6b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/0f869c953b6b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/ad4a17b7a9be": {
+    "article": "Schnur",
+    "quantity": 4,
+    "unit": "m",
+    "done": false,
+    "id": "ad4a17b7a9be",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/2a66659e9aa5"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/0f869c953b6b"
+    },
+    "_meta": {
+      "self": "/material_items/ad4a17b7a9be",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F0f869c953b6b": {
+    "items": [
+      {
+        "href": "/material_items/ad4a17b7a9be"
+      }
+    ],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F0f869c953b6b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/0f869c953b6b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/0f869c953b6b#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/0f869c953b6b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/1b04e9260129": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "1b04e9260129",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/8371c12ee053"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/8371c12ee053"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/1b04e9260129#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/1b04e9260129",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/1b04e9260129#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/5dde5ccdbbbe"
+      },
+      {
+        "href": "/content_node/material_nodes/0f869c953b6b"
+      },
+      {
+        "href": "/content_node/single_texts/ae876b33f169"
+      },
+      {
+        "href": "/content_node/storyboards/61d6e5fffcd0"
+      },
+      {
+        "href": "/content_node/single_texts/f814604d5cc4"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/1b04e9260129#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/1b04e9260129",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/8371c12ee053": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "8371c12ee053",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/8371c12ee053"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/8371c12ee053#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/8371c12ee053",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/8371c12ee053#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/1b04e9260129"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/8371c12ee053#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/8371c12ee053",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/bdef3d4d5adf": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "bdef3d4d5adf",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/873190b3bc7d"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/873190b3bc7d"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/bdef3d4d5adf#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/bdef3d4d5adf",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/bdef3d4d5adf#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/e8964f72b1ae"
+      },
+      {
+        "href": "/content_node/single_texts/630cd9f27359"
+      },
+      {
+        "href": "/content_node/single_texts/97db2bff4cfc"
+      },
+      {
+        "href": "/content_node/material_nodes/7a2508304e3d"
+      },
+      {
+        "href": "/content_node/storyboards/f737b29609a6"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/bdef3d4d5adf#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/bdef3d4d5adf",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/97db2bff4cfc": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "97db2bff4cfc",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/873190b3bc7d"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/bdef3d4d5adf"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/97db2bff4cfc#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/97db2bff4cfc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/97db2bff4cfc#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/97db2bff4cfc#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/97db2bff4cfc",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/e8964f72b1ae": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "e8964f72b1ae",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/873190b3bc7d"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/bdef3d4d5adf"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/e8964f72b1ae#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/e8964f72b1ae",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/e8964f72b1ae#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/e8964f72b1ae#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/e8964f72b1ae",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/630cd9f27359": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "630cd9f27359",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/873190b3bc7d"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/bdef3d4d5adf"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/630cd9f27359#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/630cd9f27359",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/630cd9f27359#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/630cd9f27359#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/630cd9f27359",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/f737b29609a6": {
+    "data": {
+      "sections": {
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "f737b29609a6",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/873190b3bc7d"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/bdef3d4d5adf"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/f737b29609a6#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/f737b29609a6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/f737b29609a6#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/f737b29609a6#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/f737b29609a6",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/7a2508304e3d": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "7a2508304e3d",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F7a2508304e3d"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/873190b3bc7d"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/bdef3d4d5adf"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/7a2508304e3d#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/7a2508304e3d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F7a2508304e3d": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F7a2508304e3d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/7a2508304e3d#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/7a2508304e3d#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/7a2508304e3d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/873190b3bc7d": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "873190b3bc7d",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/873190b3bc7d"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/873190b3bc7d#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/873190b3bc7d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/873190b3bc7d#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/bdef3d4d5adf"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/873190b3bc7d#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/873190b3bc7d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/d227f0b77c0d": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "d227f0b77c0d",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/87c416512162"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/87c416512162"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/d227f0b77c0d#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/d227f0b77c0d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/d227f0b77c0d#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/041c1ced3537"
+      },
+      {
+        "href": "/content_node/material_nodes/1e9d4c52a16e"
+      },
+      {
+        "href": "/content_node/single_texts/24a9075ef9ad"
+      },
+      {
+        "href": "/content_node/single_texts/f9039b90d830"
+      },
+      {
+        "href": "/content_node/storyboards/2536db88eaf3"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/d227f0b77c0d#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/d227f0b77c0d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/24a9075ef9ad": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "24a9075ef9ad",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/87c416512162"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d227f0b77c0d"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/24a9075ef9ad#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/24a9075ef9ad",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/24a9075ef9ad#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/24a9075ef9ad#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/24a9075ef9ad",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/041c1ced3537": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "041c1ced3537",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/87c416512162"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d227f0b77c0d"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/041c1ced3537#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/041c1ced3537",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/041c1ced3537#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/041c1ced3537#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/041c1ced3537",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f9039b90d830": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "f9039b90d830",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/87c416512162"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d227f0b77c0d"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/f9039b90d830#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/f9039b90d830",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f9039b90d830#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/f9039b90d830#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/f9039b90d830",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/2536db88eaf3": {
+    "data": {
+      "sections": {
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "2536db88eaf3",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/87c416512162"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d227f0b77c0d"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/2536db88eaf3#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/2536db88eaf3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/2536db88eaf3#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/2536db88eaf3#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/2536db88eaf3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/1e9d4c52a16e": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "1e9d4c52a16e",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F1e9d4c52a16e"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/87c416512162"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d227f0b77c0d"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/1e9d4c52a16e#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/1e9d4c52a16e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F1e9d4c52a16e": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F1e9d4c52a16e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/1e9d4c52a16e#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/1e9d4c52a16e#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/1e9d4c52a16e",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/87c416512162": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "87c416512162",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/87c416512162"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/87c416512162#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/87c416512162",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/87c416512162#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/d227f0b77c0d"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/87c416512162#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/87c416512162",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/8a7e84bc01a0": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "8a7e84bc01a0",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7199bc9a9992"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/8a7e84bc01a0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/8a7e84bc01a0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/8a7e84bc01a0#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/8a7e84bc01a0#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/8a7e84bc01a0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/1c80bc6e37f0": {
+    "data": {
+      "html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duo enim genera quae erant, fecit tria. Si longus, levis. Licet hic rursus ea commemores, quae optimis verbis ab Epicuro de laude amicitiae dicta sunt. Mihi quidem Antiochum, quem audis, satis belle videris attendere. Magni enim aestimabat pecuniam non modo non contra leges, sed etiam legibus partam. Quod autem ratione actum est, id officium appellamus. Nondum autem explanatum satis, erat, quid maxime natura vellet. </p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "1c80bc6e37f0",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7199bc9a9992"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/1c80bc6e37f0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/1c80bc6e37f0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/1c80bc6e37f0#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/1c80bc6e37f0#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/1c80bc6e37f0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/64282928c1c1": {
+    "data": {
+      "html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Bonum patria: miserum exilium. Ita enim vivunt quidam, ut eorum vita refellatur oratio. At, illa, ut vobis placet, partem quandam tuetur, reliquam deserit. Haec et tu ita posuisti, et verba vestra sunt. Tu quidem reddes; </p>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "64282928c1c1",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7199bc9a9992"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/64282928c1c1#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/64282928c1c1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/64282928c1c1#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/64282928c1c1#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/64282928c1c1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f7ad89a7ad94": {
+    "data": {
+      "html": "<ul><li><p>Die TN setzen sich mit dem Modell von Tuckmann auseinander.</p></li><li><p>Die TN sammeln für jede Phase des Modells von Tuckmann Aufgaben, welche sie als Teamleitung ausführen können oder müssen.</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "f7ad89a7ad94",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7199bc9a9992"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/f7ad89a7ad94#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/f7ad89a7ad94",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f7ad89a7ad94#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/f7ad89a7ad94#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/f7ad89a7ad94",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/a052888033a0": {
+    "data": {
+      "html": "<ul><li><p>Setzen sich mit dem Leiten und Betreuen eines Teams auseinander (Was sind meine Aufgaben?)</p></li><li><p>Kennen ihre Aufgaben und Rechte als Expert*innen / HKL</p></li><li><p>Führen Aufgaben von Expert*innen aus (solche, die innerhalb des Lagers Settings umsetzbar sind)</p></li><li><p>Tuckmannmodell</p></li><li><p>Zwischenfazit der Gruppendynamik ziehen nach Tuckmann</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "a052888033a0",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7199bc9a9992"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/a052888033a0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/a052888033a0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/a052888033a0#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/a052888033a0#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/a052888033a0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/d8e5da1e3d52": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": null,
+    "id": "d8e5da1e3d52",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2Fd8e5da1e3d52"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7199bc9a9992"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/d8e5da1e3d52#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/d8e5da1e3d52",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/d8e5da1e3d52#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/d8e5da1e3d52#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/d8e5da1e3d52",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/42db3e3a34d2": {
+    "data": {
+      "sections": {
+        "1c42c9a8-e968-4a77-add7-ed616824b38b": {
+          "column1": "00:10",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quid autem habent admirationis, cum prope accesseris? Aliter autem vobis placet. </p><p>Ne in odium veniam, si amicum destitero tueri. Nondum autem explanatum satis, erat, quid maxime natura vellet. In schola desinis. </p><p>Tu quidem reddes; Sed ad bona praeterita redeamus. Duo Reges: constructio interrete. Tecum optime, deinde etiam cum mediocri amico. </p><p>\tHaeret in salebra.</p><p>\tErgo et avarus erit, sed finite, et adulter, verum habebit modum, et luxuriosus eodem modo.</p><p>\tFacete M.</p><p>\tCerte, nisi voluptatem tanti aestimaretis.</p><p>\tStoicos roga.</p><p>\tItaque his sapiens semper vacabit.</p><p>\tBork</p><p>\tCum autem negant ea quicquam ad beatam vitam pertinere, rursus naturam relinquunt.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "00:00",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. At ille pellit, qui permulcet sensum voluptate. Non est igitur voluptas bonum. Quae duo sunt, unum facit. Proclivi currit oratio. Egone quaeris, inquit, quid sentiam? </p><p>\tImmo videri fortasse.</p><p>\tEam si varietatem diceres, intellegerem, ut etiam non dicente te intellego;</p><p>\tProclivi currit oratio.</p><p>\tTu vero, inquam, ducas licet, si sequetur;</p><p>\tCerte non potest.</p><p>\tA primo, ut opinor, animantium ortu petitur origo summi boni.</p><p>\tBork</p><p>\tEst igitur officium eius generis, quod nec in bonis ponatur nec in contrariis.</p><p>Equidem e Cn. Velut ego nunc moveor. Tuo vero id quidem, inquam, arbitratu. Cur deinde Metrodori liberos commendas? Istic sum, inquit. Nemo igitur esse beatus potest. </p><p>Quod cum dixissent, ille contra. Confecta res esset. Sullae consulatum? Inde igitur, inquit, ordiendum est. Huius ego nunc auctoritatem sequens idem faciam. At multis malis affectus. </p><p>Tu vero, inquam, ducas licet, si sequetur; Philosophi autem in suis lectulis plerumque moriuntur. Hoc loco tenere se Triarius non potuit. Eam stabilem appellas. Bestiarum vero nullum iudicium puto. Vide, quantum, inquam, fallare, Torquate. Paria sunt igitur. Videsne quam sit magna dissensio? </p><p>Duo Reges: constructio interrete. De hominibus dici non necesse est. Sed ad bona praeterita redeamus. Eadem nunc mea adversum te oratio est. </p>"
+        },
+        "a9f5a2cd-bb70-4189-88d2-ee81407e7d13": {
+          "column1": "",
+          "column3": "",
+          "position": 4,
+          "column2Html": ""
+        },
+        "f6ea31be-f007-4a13-a821-b4e628d32542": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Bork Sint ista Graecorum; Duo Reges: constructio interrete. Eam tum adesse, cum dolor omnis absit; </p><p>\tBork</p><p>\tQuod autem ratione actum est, id officium appellamus.</p><p>\tQuae sequuntur igitur?</p><p>\tNon igitur de improbo, sed de callido improbo quaerimus, qualis Q.</p><p>\tStoici scilicet.</p><p>\tFortitudinis quaedam praecepta sunt ac paene leges, quae effeminari virum vetant in dolore.</p><p>\tQui convenit?</p><p>\tQuam illa ardentis amores excitaret sui! Cur tandem?</p><p>\tBork</p><p>\tQuid ei reliquisti, nisi te, quoquo modo loqueretur, intellegere, quid diceret?</p><p>Quod totum contra est. Idem iste, inquam, de voluptate quid sentit? Bork Murenam te accusante defenderem. Duo enim genera quae erant, fecit tria. </p><p>Age, inquies, ista parva sunt. Bonum valitudo: miser morbus. Sumenda potius quam expetenda. Audeo dicere, inquit. Id enim natura desiderat. Non est ista, inquam, Piso, magna dissensio. Quid autem habent admirationis, cum prope accesseris? </p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "42db3e3a34d2",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7199bc9a9992"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/42db3e3a34d2#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/42db3e3a34d2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/42db3e3a34d2#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/42db3e3a34d2#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/42db3e3a34d2",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/b013653d4e8e": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "b013653d4e8e",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fb013653d4e8e"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7199bc9a9992"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/b013653d4e8e#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/b013653d4e8e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fb013653d4e8e": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fb013653d4e8e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/b013653d4e8e#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/b013653d4e8e#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/b013653d4e8e",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/7199bc9a9992": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "7199bc9a9992",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/7199bc9a9992#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/7199bc9a9992",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/7199bc9a9992#children": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/d8e5da1e3d52"
+      },
+      {
+        "href": "/content_node/material_nodes/b013653d4e8e"
+      },
+      {
+        "href": "/content_node/single_texts/8a7e84bc01a0"
+      },
+      {
+        "href": "/content_node/single_texts/1c80bc6e37f0"
+      },
+      {
+        "href": "/content_node/single_texts/64282928c1c1"
+      },
+      {
+        "href": "/content_node/single_texts/f7ad89a7ad94"
+      },
+      {
+        "href": "/content_node/storyboards/42db3e3a34d2"
+      },
+      {
+        "href": "/content_node/single_texts/a052888033a0"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/7199bc9a9992#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/7199bc9a9992",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/894fb1deeae4": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "894fb1deeae4",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/894fb1deeae4"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/894fb1deeae4#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/894fb1deeae4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/894fb1deeae4#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/7199bc9a9992"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/894fb1deeae4#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/894fb1deeae4",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d1aef4f6acc0": {
+    "data": {
+      "html": "<p>Die rasante Entwicklung von künstlicher Intelligenz (KI) hat tiefgreifende Auswirkungen auf verschiedene Bereiche unseres Lebens. Von automatisierten </p>"
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "d1aef4f6acc0",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/187d8fb812a0"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d1aef4f6acc0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d1aef4f6acc0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d1aef4f6acc0#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d1aef4f6acc0#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d1aef4f6acc0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/ff1facaeb2e1": {
+    "data": {
+      "html": "<ul><li><p>Die TN können weitere Aufgaben nennen, die Coaches ausser Lagerbetreuung machen.</p></li><li><p>TN erleben einen Beispiel-Jahresplanungshöck aus Coach-Sicht.</p></li><li><p>TN erleben einen Beispiel-Auswertungshöck aus Coach-Sicht.</p></li><li><p>TN analysieren eine Krisensituation mit Hilfe der vier Schritte im 3+4-Modell.</p></li></ul>"
+    },
+    "slot": "1",
+    "position": 1,
+    "instanceName": null,
+    "id": "ff1facaeb2e1",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/187d8fb812a0"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/ff1facaeb2e1#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/ff1facaeb2e1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/ff1facaeb2e1#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/ff1facaeb2e1#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/ff1facaeb2e1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d7fd95658683": {
+    "data": {
+      "html": "<ul><li><p>Zeitraffer Ganzjahresbetreuung einer Abteilung als Coach</p></li><li><p>Übernahme Coachämtli</p></li><li><p>Jahresbeginn &amp; Jahresauswertung</p></li><li><p>Danke &amp; Anerkennung</p></li><li><p>Health Check</p></li><li><p>3+4-Modell</p></li><li><p>Krisen aus Coach-Sicht</p></li><li><p>Können Abteilung beraten zu Möglichkeiten &amp; Grenzen Leitungsteam in Krisenfällen</p></li></ul>"
+    },
+    "slot": "1",
+    "position": 2,
+    "instanceName": null,
+    "id": "d7fd95658683",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/187d8fb812a0"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d7fd95658683#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d7fd95658683",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d7fd95658683#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d7fd95658683#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d7fd95658683",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/af89d7109360": {
+    "data": {
+      "html": "<p>Die rasante Entwicklung von künstlicher Intelligenz (KI) hat tiefgreifende Auswirkungen auf verschiedene Bereiche unseres Lebens. Von automatisierten Kundenbetreuungssystemen bis hin zu fortschrittlichen medizinischen Diagnosewerkzeugen verändert KI die Art und Weise, wie wir arbeiten, kommunizieren und Entscheidungen treffen.</p>"
+    },
+    "slot": "2",
+    "position": 0,
+    "instanceName": null,
+    "id": "af89d7109360",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/187d8fb812a0"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/af89d7109360#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/af89d7109360",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/af89d7109360#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/af89d7109360#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/af89d7109360",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/42a32ff460d3": {
+    "data": null,
+    "slot": "2",
+    "position": 1,
+    "instanceName": null,
+    "id": "42a32ff460d3",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2F42a32ff460d3"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/187d8fb812a0"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/42a32ff460d3#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/42a32ff460d3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/42a32ff460d3#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/42a32ff460d3#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/42a32ff460d3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/aa051d56b5ea": {
+    "data": null,
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "aa051d56b5ea",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Faa051d56b5ea"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/4bf902d85c36"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/aa051d56b5ea#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/aa051d56b5ea",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Faa051d56b5ea": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Faa051d56b5ea",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/aa051d56b5ea#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/aa051d56b5ea#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/aa051d56b5ea",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/964d86225857": {
+    "data": {
+      "html": ""
+    },
+    "slot": "2",
+    "position": 0,
+    "instanceName": null,
+    "id": "964d86225857",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/4bf902d85c36"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/964d86225857#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/964d86225857",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/964d86225857#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/964d86225857#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/964d86225857",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/187d8fb812a0": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 5
+        },
+        {
+          "slot": "2",
+          "width": 7
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "187d8fb812a0",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/187d8fb812a0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/187d8fb812a0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/187d8fb812a0#children": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/42a32ff460d3"
+      },
+      {
+        "href": "/content_node/single_texts/d7fd95658683"
+      },
+      {
+        "href": "/content_node/single_texts/af89d7109360"
+      },
+      {
+        "href": "/content_node/single_texts/d1aef4f6acc0"
+      },
+      {
+        "href": "/content_node/single_texts/ff1facaeb2e1"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/187d8fb812a0#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/187d8fb812a0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/ea6d00a9b637": {
+    "data": {
+      "sections": {
+        "2ad67a5c-6de1-43a2-a8e4-c633794725c9": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die rasante Entwicklung von künstlicher Intelligenz (KI) hat tiefgreifende Auswirkungen auf verschiedene Bereiche unseres Lebens. Von automatisierten Kundenbetreuungssystemen bis hin zu fortschrittlichen medizinischen Diagnosewerkzeugen verändert KI die Art und Weise, wie wir arbeiten, kommunizieren und Entscheidungen treffen.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die rasante Entwicklung von künstlicher Intelligenz (KI) hat tiefgreifende Auswirkungen auf verschiedene Bereiche unseres Lebens. Von automatisierten Kundenbetreuungssystemen bis hin zu fortschrittlichen medizinischen Diagnosewerkzeugen verändert KI die Art und Weise, wie wir arbeiten, kommunizieren und Entscheidungen treffen.</p>"
+        },
+        "790469e9-b890-4624-8afa-7d87f56d822d": {
+          "column1": "",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p>Die rasante Entwicklung von künstlicher Intelligenz (KI) hat tiefgreifende Auswirkungen auf verschiedene Bereiche unseres Lebens. Von automatisierten Kundenbetreuungssystemen bis hin zu fortschrittlichen medizinischen Diagnosewerkzeugen verändert KI die Art und Weise, wie wir arbeiten, kommunizieren und Entscheidungen treffen.</p>"
+        },
+        "874cbafd-8fe4-49ed-9fb1-0bd8e519b994": {
+          "column1": "",
+          "column3": "",
+          "position": 5,
+          "column2Html": "<p>Die rasante Entwicklung von künstlicher Intelligenz (KI) hat tiefgreifende Auswirkungen auf verschiedene Bereiche unseres Lebens. Von automatisierten Kundenbetreuungssystemen bis hin zu fortschrittlichen medizinischen Diagnosewerkzeugen verändert KI die Art und Weise, wie wir arbeiten, kommunizieren und Entscheidungen treffen.</p>"
+        },
+        "ce0889d8-2609-4e41-aa89-23caf43a0407": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die rasante Entwicklung von künstlicher Intelligenz (KI) hat tiefgreifende Auswirkungen auf verschiedene Bereiche unseres Lebens. Von automatisierten Kundenbetreuungssystemen bis hin zu fortschrittlichen medizinischen Diagnosewerkzeugen verändert KI die Art und Weise, wie wir arbeiten, kommunizieren und Entscheidungen treffen.</p>"
+        }
+      }
+    },
+    "slot": "1",
+    "position": 1,
+    "instanceName": null,
+    "id": "ea6d00a9b637",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/ea6d00a9b637#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/ea6d00a9b637",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/ea6d00a9b637#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/ea6d00a9b637#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/ea6d00a9b637",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/4bf902d85c36": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 9
+        },
+        {
+          "slot": "2",
+          "width": 3
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 2,
+    "instanceName": null,
+    "id": "4bf902d85c36",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/4bf902d85c36#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/4bf902d85c36",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/4bf902d85c36#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/964d86225857"
+      },
+      {
+        "href": "/content_node/material_nodes/aa051d56b5ea"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/4bf902d85c36#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/4bf902d85c36",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/9e6da5607ba0": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "9e6da5607ba0",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/9e6da5607ba0"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/9e6da5607ba0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/9e6da5607ba0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/9e6da5607ba0#children": {
+    "items": [
+      {
+        "href": "/content_node/storyboards/ea6d00a9b637"
+      },
+      {
+        "href": "/content_node/column_layouts/4bf902d85c36"
+      },
+      {
+        "href": "/content_node/column_layouts/187d8fb812a0"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/9e6da5607ba0#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/9e6da5607ba0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5ee10f41ccef": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "5ee10f41ccef",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/aa1fbba3f877"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/40d85c3885aa"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/5ee10f41ccef#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/5ee10f41ccef",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5ee10f41ccef#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/5ee10f41ccef#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/5ee10f41ccef",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4f1b284cf530": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "4f1b284cf530",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/aa1fbba3f877"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/40d85c3885aa"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/4f1b284cf530#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/4f1b284cf530",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4f1b284cf530#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/4f1b284cf530#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/4f1b284cf530",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/e697afffa4ab": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "e697afffa4ab",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/aa1fbba3f877"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/40d85c3885aa"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/e697afffa4ab#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/e697afffa4ab",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/e697afffa4ab#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/e697afffa4ab#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/e697afffa4ab",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/2a48d96e9d31": {
+    "data": {
+      "sections": {
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "2a48d96e9d31",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/aa1fbba3f877"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/40d85c3885aa"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/2a48d96e9d31#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/2a48d96e9d31",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/2a48d96e9d31#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/2a48d96e9d31#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/2a48d96e9d31",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/245f2480960f": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "245f2480960f",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F245f2480960f"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/aa1fbba3f877"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/40d85c3885aa"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/245f2480960f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/245f2480960f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F245f2480960f": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F245f2480960f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/245f2480960f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/245f2480960f#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/245f2480960f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/40d85c3885aa": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "40d85c3885aa",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/aa1fbba3f877"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/aa1fbba3f877"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/40d85c3885aa#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/40d85c3885aa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/40d85c3885aa#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/5ee10f41ccef"
+      },
+      {
+        "href": "/content_node/material_nodes/245f2480960f"
+      },
+      {
+        "href": "/content_node/storyboards/2a48d96e9d31"
+      },
+      {
+        "href": "/content_node/single_texts/e697afffa4ab"
+      },
+      {
+        "href": "/content_node/single_texts/4f1b284cf530"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/40d85c3885aa#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/40d85c3885aa",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/aa1fbba3f877": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "aa1fbba3f877",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/aa1fbba3f877"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/aa1fbba3f877#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/aa1fbba3f877",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/aa1fbba3f877#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/40d85c3885aa"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/aa1fbba3f877#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/aa1fbba3f877",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7eb94a710e3c": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "7eb94a710e3c",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/ad0d42c70368"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/411d9321d09a"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/7eb94a710e3c#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/7eb94a710e3c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7eb94a710e3c#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/7eb94a710e3c#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/7eb94a710e3c",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f1584e2a0e4c": {
+    "data": {
+      "html": "<p><br />Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "f1584e2a0e4c",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/ad0d42c70368"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/411d9321d09a"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/f1584e2a0e4c#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/f1584e2a0e4c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f1584e2a0e4c#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/f1584e2a0e4c#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/f1584e2a0e4c",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/a291cdda200f": {
+    "data": {
+      "html": "<p><br />Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "a291cdda200f",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/ad0d42c70368"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/411d9321d09a"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/a291cdda200f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/a291cdda200f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/a291cdda200f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/a291cdda200f#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/a291cdda200f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/71503dce4007": {
+    "data": {
+      "sections": {
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p><br />Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+        },
+        "7e0d92a7-bf83-4f14-8253-0d7515d0b4ba": {
+          "column1": "",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p><br />Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+        },
+        "a33a2d2d-cfae-4cfa-9f23-57d390304bd2": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p><br />Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+        },
+        "a5838e3c-a926-48a3-b060-e3d9756abf98": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p><br />Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "71503dce4007",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/ad0d42c70368"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/411d9321d09a"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/71503dce4007#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/71503dce4007",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/71503dce4007#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/71503dce4007#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/71503dce4007",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/049e308e2c5b": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "049e308e2c5b",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F049e308e2c5b"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/ad0d42c70368"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/411d9321d09a"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/049e308e2c5b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/049e308e2c5b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F049e308e2c5b": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F049e308e2c5b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/049e308e2c5b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/049e308e2c5b#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/049e308e2c5b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/411d9321d09a": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "411d9321d09a",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/ad0d42c70368"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/ad0d42c70368"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/411d9321d09a#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/411d9321d09a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/411d9321d09a#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/f1584e2a0e4c"
+      },
+      {
+        "href": "/content_node/material_nodes/049e308e2c5b"
+      },
+      {
+        "href": "/content_node/single_texts/7eb94a710e3c"
+      },
+      {
+        "href": "/content_node/storyboards/71503dce4007"
+      },
+      {
+        "href": "/content_node/single_texts/a291cdda200f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/411d9321d09a#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/411d9321d09a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/ad0d42c70368": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "ad0d42c70368",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/ad0d42c70368"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/ad0d42c70368#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/ad0d42c70368",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/ad0d42c70368#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/411d9321d09a"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/ad0d42c70368#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/ad0d42c70368",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6380d907cc0f": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "6380d907cc0f",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/828b3db50fcd"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/6380d907cc0f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/6380d907cc0f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6380d907cc0f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/6380d907cc0f#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/6380d907cc0f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/2242da9aafe6": {
+    "data": {
+      "html": "<p>Smartphones haben sich zu unverzichtbaren Alltagsbegleitern entwickelt. Sie dienen nicht nur der Kommunikation, sondern bieten Zugang zu einer Fülle von Informationen, Unterhaltung und Dienstleistungen. Von sozialen Medien über mobile Apps bis hin zur Navigation erleichtern Smartphones unser Leben erheblich. Dennoch ist es wichtig, ein gesundes Maß im Umgang mit diesen Geräten zu finden, um eine ausgewogene Nutzung zu gewährleisten und potenzielle Auswirkungen auf unsere physische und psychische Gesundheit zu minimieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "2242da9aafe6",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/828b3db50fcd"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/2242da9aafe6#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/2242da9aafe6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/2242da9aafe6#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/2242da9aafe6#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/2242da9aafe6",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/b0d5b4a57199": {
+    "data": {
+      "html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "b0d5b4a57199",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/828b3db50fcd"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/b0d5b4a57199#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/b0d5b4a57199",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/b0d5b4a57199#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/b0d5b4a57199#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/b0d5b4a57199",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6441aeccb22f": {
+    "data": {
+      "html": "<ul><li><p>Die TN können weitere Aufgaben nennen, die Coaches ausser Lagerbetreuung machen.</p></li><li><p>TN erleben einen Beispiel-Jahresplanungshöck aus Coach-Sicht.</p></li><li><p>TN erleben einen Beispiel-Auswertungshöck aus Coach-Sicht.</p></li><li><p>TN analysieren eine Krisensituation mit Hilfe der vier Schritte im 3+4-Modell.</p></li><li><p>Die TN erstellen aus Beobachtungen eine angemessene, förderungsorientierte Rückmeldung.</p></li><li><p>Die TN wenden die grundlegenden Gesprächstechniken bei einem TN-Gespräch an.</p></li><li><p>An konkreten Beispielen förderliche Tätigkeiten für spezifische TN erarbeiten.</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "6441aeccb22f",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/828b3db50fcd"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/6441aeccb22f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/6441aeccb22f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6441aeccb22f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/6441aeccb22f#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/6441aeccb22f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4b8bcd43de1d": {
+    "data": {
+      "html": "<ul><li><p>Diskutieren, inwiefern Siko-Verantwortung - HLL - Coach geteilt wird, Siko als Versicherung?</p></li><li><p>Quellen für Sicherheitsfragen- und Vorgaben kennen</p></li><li><p>Sicherheitsrelevante Aktivitäten beurteilen</p></li><li><p>Grenzfälle für Coaches (in Bezug auf Beurteilung Sicherheit) bearbeiten + diskutieren</p></li><li><p>Kennen Merkblatt LS/T / refreshen Abgrenzung Sibe und sirel</p></li><li><p>Wissen, wo sie Expert*innen für Betreuung Sicherheitsbereich finden</p></li><li><p>Lesen ein Lagersiko gegen + Rückmeldung</p></li><li><p>Den TN soll vermittelt werden, dass sie gewissermaßen das Sicherheitsnetz/Backup ihrer Leitenden sind - Verantwortung bewusst machen</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "4b8bcd43de1d",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/828b3db50fcd"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/4b8bcd43de1d#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/4b8bcd43de1d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4b8bcd43de1d#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/4b8bcd43de1d#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/4b8bcd43de1d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/81f4e528f1fc": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": null,
+    "id": "81f4e528f1fc",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2F81f4e528f1fc"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/828b3db50fcd"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/81f4e528f1fc#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/81f4e528f1fc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/81f4e528f1fc#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/81f4e528f1fc#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/81f4e528f1fc",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/93049f7f3088": {
+    "data": {
+      "sections": {
+        "3c47dcdf-ed7c-42bc-a12a-9d1a223a6d45": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "52181da4-8dad-4c39-9584-7bef9a368da1": {
+          "column1": "",
+          "column3": "",
+          "position": 6,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "7504fbf1-d126-44f1-bfab-9cbdb420938a": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "9c7e117b-cfa2-4d13-84f0-d1ca5bb9f639": {
+          "column1": "",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "edf482ed-9f67-4ab7-ab96-4ed337debb00": {
+          "column1": "",
+          "column3": "",
+          "position": 5,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "effa3fa5-cd07-4e82-a8aa-198ed9a7c1d4": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "93049f7f3088",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/828b3db50fcd"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/93049f7f3088#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/93049f7f3088",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/93049f7f3088#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/93049f7f3088#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/93049f7f3088",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/192c488ea1a3": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "192c488ea1a3",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F192c488ea1a3"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/828b3db50fcd"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/192c488ea1a3#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/192c488ea1a3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F192c488ea1a3": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F192c488ea1a3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/192c488ea1a3#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/192c488ea1a3#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/192c488ea1a3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/828b3db50fcd": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "828b3db50fcd",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/828b3db50fcd#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/828b3db50fcd",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/828b3db50fcd#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/2242da9aafe6"
+      },
+      {
+        "href": "/content_node/single_texts/6441aeccb22f"
+      },
+      {
+        "href": "/content_node/single_texts/4b8bcd43de1d"
+      },
+      {
+        "href": "/content_node/storyboards/93049f7f3088"
+      },
+      {
+        "href": "/content_node/checklist_nodes/81f4e528f1fc"
+      },
+      {
+        "href": "/content_node/single_texts/b0d5b4a57199"
+      },
+      {
+        "href": "/content_node/material_nodes/192c488ea1a3"
+      },
+      {
+        "href": "/content_node/single_texts/6380d907cc0f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/828b3db50fcd#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/828b3db50fcd",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/b2140367dd1c": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "b2140367dd1c",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/b2140367dd1c"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/b2140367dd1c#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/b2140367dd1c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/b2140367dd1c#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/828b3db50fcd"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/b2140367dd1c#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/b2140367dd1c",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/8cd3ef049436": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "8cd3ef049436",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4e2489db9ac0"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/8cd3ef049436#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/8cd3ef049436",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/8cd3ef049436#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/8cd3ef049436#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/8cd3ef049436",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/a78514380bc2": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "a78514380bc2",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4e2489db9ac0"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/a78514380bc2#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/a78514380bc2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/a78514380bc2#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/a78514380bc2#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/a78514380bc2",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/43de3cf4dce8": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "43de3cf4dce8",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4e2489db9ac0"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/43de3cf4dce8#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/43de3cf4dce8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/43de3cf4dce8#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/43de3cf4dce8#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/43de3cf4dce8",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/multi_selects/1c00be30b8f0": {
+    "data": {
+      "options": {
+        "security": {
+          "checked": false
+        },
+        "outdoorTechnique": {
+          "checked": true
+        },
+        "pioneeringTechnique": {
+          "checked": false
+        },
+        "natureAndEnvironment": {
+          "checked": true
+        },
+        "campsiteAndSurroundings": {
+          "checked": false
+        },
+        "preventionAndIntegration": {
+          "checked": false
+        }
+      }
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "1c00be30b8f0",
+    "contentTypeName": "LAThematicArea",
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4e2489db9ac0"
+    },
+    "contentType": {
+      "href": "/content_types/1a0f84e322c8"
+    },
+    "children": {
+      "href": "/content_node/multi_selects/1c00be30b8f0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/multi_selects/1c00be30b8f0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/multi_selects/1c00be30b8f0#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/multi_selects/1c00be30b8f0#children",
+      "virtual": true,
+      "owningResource": "/content_node/multi_selects/1c00be30b8f0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/14349285da7d": {
+    "data": {
+      "html": "<ul><li><p>Die TN erstellen aus Beobachtungen eine angemessene, förderungsorientierte Rückmeldung.</p></li><li><p>Die TN wenden die grundlegenden Gesprächstechniken bei einem TN-Gespräch an.</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "14349285da7d",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4e2489db9ac0"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/14349285da7d#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/14349285da7d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/14349285da7d#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/14349285da7d#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/14349285da7d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6b08091371a4": {
+    "data": {
+      "html": "<ul><li><p>An konkreten Beispielen förderliche Tätigkeiten für spezifische TN erarbeiten</p></li><li><p>Aufgrund von Beobachtungen entscheiden, wo Stärken/Förderpunkte der TN liegen</p></li><li><p>Beobachtungen zwecks RM selektieren</p></li><li><p>Rückmeldung zu einem TN-Produkt vorbereiten</p></li><li><p>Unterschied zwischen Beobachten und Interpretieren</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": null,
+    "id": "6b08091371a4",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4e2489db9ac0"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/6b08091371a4#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/6b08091371a4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6b08091371a4#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/6b08091371a4#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/6b08091371a4",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/3f48816bccae": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 5,
+    "instanceName": null,
+    "id": "3f48816bccae",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2F3f48816bccae"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4e2489db9ac0"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/3f48816bccae#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/3f48816bccae",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/3f48816bccae#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/3f48816bccae#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/3f48816bccae",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/9217300a2e42": {
+    "data": {
+      "sections": {
+        "1650b848-66ce-4481-a89a-6fc3b43da9f2": {
+          "column1": "",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "45ae22cc-8458-4495-b7ce-58f67d5ba6d6": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "4c126a50-f729-46a7-8326-811586922995": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "65360004-c48b-4e78-87da-fe7f0b921014": {
+          "column1": "",
+          "column3": "",
+          "position": 7,
+          "column2Html": ""
+        },
+        "6aecc2fc-b14d-4650-99a0-26020c8d049f": {
+          "column1": "",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "bc975626-3e34-4db7-8f1f-f243106ef19a": {
+          "column1": "",
+          "column3": "",
+          "position": 6,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "eb5555ce-254f-4c65-8d0b-d29349ae1776": {
+          "column1": "",
+          "column3": "",
+          "position": 5,
+          "column2Html": "<p>In den letzten Jahrzehnten hat sich die Technologie in rasantem Tempo entwickelt und hat nahezu alle Aspekte unseres Lebens beeinflusst. Diese Entwicklung hat zahlreiche positive Auswirkungen, darunter verbesserte Kommunikation, effizientere Arbeitsprozesse und eine Fülle von Informationsquellen. Dennoch bringt sie auch Herausforderungen mit sich, die es zu bewältigen gilt.</p><p>Zu den positiven Aspekten gehören:</p><ol><li><p><strong>Kommunikation</strong>: Technologische Fortschritte haben die Kommunikation revolutioniert. Menschen können weltweit in Echtzeit miteinander in Verbindung treten, sei es über soziale Medien, Videoanrufe oder Nachrichten-Apps.</p></li><li><p><strong>Effizienzsteigerung</strong>: Technologie hat Arbeitsabläufe in vielen Branchen optimiert. Automatisierung, künstliche Intelligenz und maschinelles Lernen tragen dazu bei, Aufgaben schneller und präziser zu erledigen.</p></li><li><p><strong>Zugang zu Informationen</strong>: Das Internet bietet einen beispiellosen Zugang zu Wissen und Informationen. Bildung, Forschung und Lernen sind global zugänglich und erschwinglich geworden.</p></li></ol><p>Allerdings gibt es auch einige Herausforderungen:</p><ol><li><p><strong>Datenschutz</strong>: Die digitale Vernetzung führt zu Bedenken hinsichtlich Datenschutz und Privatsphäre. Persönliche Daten können leicht in die falschen Hände geraten.</p></li><li><p><strong>Abhängigkeit</strong>: Die zunehmende Abhängigkeit von Technologie kann negative Auswirkungen auf soziale Interaktionen und die physische Gesundheit haben.</p></li><li><p><strong>Ungleichheit</strong>: Technologische Fortschritte können zu einer Kluft zwischen Technologie-Nutzern und -Nichtnutzern führen, was soziale Ungleichheit verstärken kann.</p></li></ol><p>Es ist wichtig, die Vorteile der Technologie zu nutzen, während gleichzeitig bewusst mit ihren Herausforderungen umgegangen wird, um eine ausgewogene und nachhaltige Zukunft zu gestalten.</p>"
+        },
+        "f940e27b-695c-4e5a-ae52-1b45bac4a520": {
+          "column1": "",
+          "column3": "",
+          "position": 8,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "9217300a2e42",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4e2489db9ac0"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/9217300a2e42#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/9217300a2e42",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/9217300a2e42#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/9217300a2e42#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/9217300a2e42",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/7378fdc1b281": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "7378fdc1b281",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F7378fdc1b281"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/4e2489db9ac0"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/7378fdc1b281#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/7378fdc1b281",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F7378fdc1b281": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F7378fdc1b281",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/7378fdc1b281#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/7378fdc1b281#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/7378fdc1b281",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/4e2489db9ac0": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "4e2489db9ac0",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/4e2489db9ac0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/4e2489db9ac0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/4e2489db9ac0#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/43de3cf4dce8"
+      },
+      {
+        "href": "/content_node/single_texts/14349285da7d"
+      },
+      {
+        "href": "/content_node/checklist_nodes/3f48816bccae"
+      },
+      {
+        "href": "/content_node/storyboards/9217300a2e42"
+      },
+      {
+        "href": "/content_node/single_texts/6b08091371a4"
+      },
+      {
+        "href": "/content_node/multi_selects/1c00be30b8f0"
+      },
+      {
+        "href": "/content_node/single_texts/a78514380bc2"
+      },
+      {
+        "href": "/content_node/material_nodes/7378fdc1b281"
+      },
+      {
+        "href": "/content_node/single_texts/8cd3ef049436"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/4e2489db9ac0#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/4e2489db9ac0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/b87ef76bcb88": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "b87ef76bcb88",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/b87ef76bcb88"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/b87ef76bcb88#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/b87ef76bcb88",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/b87ef76bcb88#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/4e2489db9ac0"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/b87ef76bcb88#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/b87ef76bcb88",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/df73c81205c4": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "df73c81205c4",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/df73c81205c4#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/df73c81205c4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/df73c81205c4#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/f5030fa1fd76"
+      },
+      {
+        "href": "/content_node/single_texts/ef076b227ad2"
+      },
+      {
+        "href": "/content_node/checklist_nodes/946afc306e3b"
+      },
+      {
+        "href": "/content_node/single_texts/2c6a78222e28"
+      },
+      {
+        "href": "/content_node/single_texts/6177394117a5"
+      },
+      {
+        "href": "/content_node/storyboards/8facbb6bf77f"
+      },
+      {
+        "href": "/content_node/material_nodes/9bb32189efb5"
+      },
+      {
+        "href": "/content_node/single_texts/c89a5a617bcb"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/df73c81205c4#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/df73c81205c4",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f5030fa1fd76": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "f5030fa1fd76",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/df73c81205c4"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/f5030fa1fd76#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/f5030fa1fd76",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/f5030fa1fd76#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/f5030fa1fd76#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/f5030fa1fd76",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/ef076b227ad2": {
+    "data": {
+      "html": "<p>Die Teilnehmer versammeln sich am Treffpunkt im Lager. Die Leiter erklären, dass heute eine aufregende Schatzsuche im Wald stattfinden wird. Die Kinder werden in Teams von 4-5 Personen eingeteilt und erhalten jeweils eine Karte des Waldgebiets.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "ef076b227ad2",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/df73c81205c4"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/ef076b227ad2#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/ef076b227ad2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/ef076b227ad2#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/ef076b227ad2#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/ef076b227ad2",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c89a5a617bcb": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "c89a5a617bcb",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/df73c81205c4"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/c89a5a617bcb#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/c89a5a617bcb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c89a5a617bcb#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/c89a5a617bcb#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/c89a5a617bcb",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6177394117a5": {
+    "data": {
+      "html": "<ul><li><p>Die TN reflektieren Rollen und Aufgaben in einem Kursteam.</p></li><li><p>Die TN spielen ein lustiges Spiel.</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "6177394117a5",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/df73c81205c4"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/6177394117a5#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/6177394117a5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/6177394117a5#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/6177394117a5#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/6177394117a5",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/2c6a78222e28": {
+    "data": {
+      "html": "<ul><li><p>Sammlung von Methoden, um die Bedürfnisse des Teams zu bestimmen</p></li><li><p>Repetieren, welche Rollen es in einem Team gibt und welche Chancen/Herausforderungen sich daraus ergeben</p></li><li><p>Bewusst Aufgaben im Team delegieren</p></li><li><p>Mögliche Aufgaben im Kursteam sammeln</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "2c6a78222e28",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/df73c81205c4"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/2c6a78222e28#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/2c6a78222e28",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/2c6a78222e28#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/2c6a78222e28#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/2c6a78222e28",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/946afc306e3b": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": null,
+    "id": "946afc306e3b",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2F946afc306e3b"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/df73c81205c4"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/946afc306e3b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/946afc306e3b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/946afc306e3b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/946afc306e3b#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/946afc306e3b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/8facbb6bf77f": {
+    "data": {
+      "sections": {
+        "125510c4-3fb2-4836-ab84-fecd34662f9c": {
+          "column1": "00:45",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p>Die Teams starten ihre Schatzsuche. An den markierten Stationen finden sie Rätsel oder Aufgaben, die gelöst werden müssen, um Hinweise auf den nächsten Wegpunkt zu erhalten. Die Rätsel sind altersgerecht und fördern die Teamarbeit sowie das logische Denken.</p>"
+        },
+        "431f3995-4da8-4902-ada4-8acecce0c4ed": {
+          "column1": "00:30",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die Schatzkarten werden verteilt. Jedes Team erhält eine Karte mit markierten Wegpunkten im Wald, die sie zu verschiedenen Stationen führen. Die Teams müssen den Kompass verwenden, um die Richtung und die Entfernung zu den jeweiligen Stationen zu bestimmen.</p>"
+        },
+        "60be378a-d494-48e9-ad8e-4c42563e8a86": {
+          "column1": "00:15",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Leiter erklären den Teilnehmern, wie man einen Kompass benutzt, um die Himmelsrichtungen zu bestimmen. Jedes Team bekommt einen Kompass und lernt die Grundlagen der Orientierung.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "00:00",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Teilnehmer versammeln sich am Treffpunkt im Lager. Die Leiter erklären, dass heute eine aufregende Schatzsuche im Wald stattfinden wird. Die Kinder werden in Teams von 4-5 Personen eingeteilt und erhalten jeweils eine Karte des Waldgebiets.</p>"
+        },
+        "d4f57a2a-9bf2-438e-8984-64a5354dabd0": {
+          "column1": "01:30",
+          "column3": "",
+          "position": 6,
+          "column2Html": "<p>Die Teams erreichen das finale Schatzversteck. Dort entdecken sie eine Schatztruhe, die mit kleinen Belohnungen gefüllt ist, wie zum Beispiel Süßigkeiten, Abzeichen oder kleine Spielzeuge. Die Kinder freuen sich über ihre Errungenschaften und feiern ihren Erfolg.</p>"
+        },
+        "f321a314-f4c1-4027-8894-3b758745c90a": {
+          "column1": "01:15",
+          "column3": "",
+          "position": 5,
+          "column2Html": "<p>Die Teams haben nun mehrere Stationen durchlaufen und Hinweise gesammelt. Diese Hinweise ergeben zusammen die Koordinaten des finalen Schatzverstecks. Die Kinder sind aufgeregt und motiviert, den Schatz zu finden.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "8facbb6bf77f",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/df73c81205c4"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/8facbb6bf77f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/8facbb6bf77f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/8facbb6bf77f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/8facbb6bf77f#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/8facbb6bf77f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/9bb32189efb5": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "9bb32189efb5",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F9bb32189efb5"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/df73c81205c4"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/9bb32189efb5#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/9bb32189efb5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F9bb32189efb5": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F9bb32189efb5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/9bb32189efb5#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/9bb32189efb5#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/9bb32189efb5",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/c0a6d4cf0ebc": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "c0a6d4cf0ebc",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/c0a6d4cf0ebc#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/c0a6d4cf0ebc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/c0a6d4cf0ebc#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/df73c81205c4"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/c0a6d4cf0ebc#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/c0a6d4cf0ebc",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4aa1846e670b": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "4aa1846e670b",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/2f6f68d62636"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/4aa1846e670b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/4aa1846e670b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4aa1846e670b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/4aa1846e670b#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/4aa1846e670b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5b60b27e3a46": {
+    "data": {
+      "html": "<p>Die Teilnehmer versammeln sich am Treffpunkt im Lager. Die Leiter erklären, dass heute eine aufregende Schatzsuche im Wald stattfinden wird. Die Kinder werden in Teams von 4-5 Personen eingeteilt und erhalten jeweils eine Karte des Waldgebiets.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "5b60b27e3a46",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/2f6f68d62636"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/5b60b27e3a46#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/5b60b27e3a46",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/5b60b27e3a46#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/5b60b27e3a46#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/5b60b27e3a46",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/0e28f76880ac": {
+    "data": {
+      "html": "<p>Die Leiter erklären den Teilnehmern, wie man einen Kompass benutzt, um die Himmelsrichtungen zu bestimmen. Jedes Team bekommt einen Kompass und lernt die Grundlagen der Orientierung.</p><ul><li><p>Apotheke</p></li><li><p>Handy</p></li><li><p>Siko</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "0e28f76880ac",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/2f6f68d62636"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/0e28f76880ac#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/0e28f76880ac",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/0e28f76880ac#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/0e28f76880ac#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/0e28f76880ac",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/bf4fc1e44a0b": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": "Ausbildungsziele",
+    "id": "bf4fc1e44a0b",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2Fbf4fc1e44a0b"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/2f6f68d62636"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/bf4fc1e44a0b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/bf4fc1e44a0b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/bf4fc1e44a0b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/bf4fc1e44a0b#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/bf4fc1e44a0b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/de7f7a8282e3": {
+    "data": {
+      "html": "<ul><li><p>Die Tn erstellen aus Beobachtungen eine angemessene, förderungsorientierte Rückmeldung.</p></li><li><p>Die TN wenden die grundlegenden Gesprächstechniken bei einem TN-Gespräch an.</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "de7f7a8282e3",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/2f6f68d62636"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/de7f7a8282e3#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/de7f7a8282e3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/de7f7a8282e3#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/de7f7a8282e3#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/de7f7a8282e3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7207e69fa2de": {
+    "data": {
+      "html": "<ul><li><p>An konkreten Beispielen förderliche Tätigkeiten für spezifische TN erarbeiten</p></li><li><p>Aufgrund von Beobachtungen entscheiden, wo Stärken/Förderpunkte der TN liegen</p></li><li><p>Beobachtungen zwecks RM selektieren</p></li><li><p>Rückmeldung zu einem TN-Produkt vorbereiten</p></li><li><p>Unterschied zwischen Beobachten und Interpretieren</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": null,
+    "id": "7207e69fa2de",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/2f6f68d62636"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/7207e69fa2de#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/7207e69fa2de",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7207e69fa2de#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/7207e69fa2de#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/7207e69fa2de",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/b45a8d24dca0": {
+    "data": {
+      "sections": {
+        "067523c1-001c-4792-8fa5-e1156d6b177b": {
+          "column1": "00:30",
+          "column3": "Salamander, Castor",
+          "position": 3,
+          "column2Html": "<p>Die Schatzkarten werden verteilt. Jedes Team erhält eine Karte mit markierten Wegpunkten im Wald, die sie zu verschiedenen Stationen führen. Die Teams müssen den Kompass verwenden, um die Richtung und die Entfernung zu den jeweiligen Stationen zu bestimmen.</p>"
+        },
+        "0f1cea2e-280e-47f1-a793-9f219aeda0ba": {
+          "column1": "02:00",
+          "column3": "Snoopy",
+          "position": 8,
+          "column2Html": "<p>Ende der Pfadiübung. Die Teilnehmer sind stolz auf ihre Leistungen und haben eine unterhaltsame und lehrreiche Zeit im Wald verbracht.</p>"
+        },
+        "638e045a-a50c-45c0-aad8-c60357eba601": {
+          "column1": "00:15",
+          "column3": "Salamander, Castor",
+          "position": 2,
+          "column2Html": "<p>Die Leiter erklären den Teilnehmern, wie man einen Kompass benutzt, um die Himmelsrichtungen zu bestimmen. Jedes Team bekommt einen Kompass und lernt die Grundlagen der Orientierung.</p>"
+        },
+        "7123787d-5a75-4b97-a3fb-d035a57c28f1": {
+          "column1": "01:45",
+          "column3": "Salamander, Castor",
+          "position": 7,
+          "column2Html": "<p>Die Gruppen kehren zum Lager zurück. Gemeinsam besprechen sie die Herausforderungen der Schatzsuche, was sie gelernt haben und wie sie als Team zusammengearbeitet haben.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "00:00",
+          "column3": "Salamander, Castor",
+          "position": 1,
+          "column2Html": "<p>Die Teilnehmer versammeln sich am Treffpunkt im Lager. Die Leiter erklären, dass heute eine aufregende Schatzsuche im Wald stattfinden wird. Die Kinder werden in Teams von 4-5 Personen eingeteilt und erhalten jeweils eine Karte des Waldgebiets.</p>"
+        },
+        "a449795a-8dbb-45a6-a755-ba408dcad03e": {
+          "column1": "01:30",
+          "column3": "Salamander, Castor",
+          "position": 6,
+          "column2Html": "<p>Die Teams erreichen das finale Schatzversteck. Dort entdecken sie eine Schatztruhe, die mit kleinen Belohnungen gefüllt ist, wie zum Beispiel Süßigkeiten, Abzeichen oder kleine Spielzeuge. Die Kinder freuen sich über ihre Errungenschaften und feiern ihren Erfolg.</p>"
+        },
+        "b2e9ec8b-e7cf-41da-b174-350357bfcb85": {
+          "column1": "01:15",
+          "column3": "Snoopy",
+          "position": 5,
+          "column2Html": "<p>Die Teams haben nun mehrere Stationen durchlaufen und Hinweise gesammelt. Diese Hinweise ergeben zusammen die Koordinaten des finalen Schatzverstecks. Die Kinder sind aufgeregt und motiviert, den Schatz zu finden.</p>"
+        },
+        "cb243c88-9c08-4bfb-8b9b-9b4afd057699": {
+          "column1": "00:45",
+          "column3": "Salamnder",
+          "position": 4,
+          "column2Html": "<p>Die Teams starten ihre Schatzsuche. An den markierten Stationen finden sie Rätsel oder Aufgaben, die gelöst werden müssen, um Hinweise auf den nächsten Wegpunkt zu erhalten. Die Rätsel sind altersgerecht und fördern die Teamarbeit sowie das logische Denken.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "b45a8d24dca0",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/2f6f68d62636"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/b45a8d24dca0#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/b45a8d24dca0",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/b45a8d24dca0#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/b45a8d24dca0#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/b45a8d24dca0",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/c210b29eb641": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "c210b29eb641",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fc210b29eb641"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/2f6f68d62636"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/c210b29eb641#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/c210b29eb641",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/e05d86703b48": {
+    "article": "Schatzkarten",
+    "quantity": 5,
+    "unit": null,
+    "done": false,
+    "id": "e05d86703b48",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/2a66659e9aa5"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/c210b29eb641"
+    },
+    "_meta": {
+      "self": "/material_items/e05d86703b48",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/46ea62c11d60": {
+    "article": "Süssigkeiten",
+    "quantity": 1,
+    "unit": "kg",
+    "done": false,
+    "id": "46ea62c11d60",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/308765cf5631"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/c210b29eb641"
+    },
+    "_meta": {
+      "self": "/material_items/46ea62c11d60",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/77d134191f74": {
+    "article": "Blachen",
+    "quantity": 6,
+    "unit": null,
+    "done": false,
+    "id": "77d134191f74",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/f4268fba5b4b"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/c210b29eb641"
+    },
+    "_meta": {
+      "self": "/material_items/77d134191f74",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/395c2b67dcf8": {
+    "article": "Schatztruhe",
+    "quantity": 1,
+    "unit": null,
+    "done": false,
+    "id": "395c2b67dcf8",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/f4268fba5b4b"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/c210b29eb641"
+    },
+    "_meta": {
+      "self": "/material_items/395c2b67dcf8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fc210b29eb641": {
+    "items": [
+      {
+        "href": "/material_items/e05d86703b48"
+      },
+      {
+        "href": "/material_items/46ea62c11d60"
+      },
+      {
+        "href": "/material_items/77d134191f74"
+      },
+      {
+        "href": "/material_items/395c2b67dcf8"
+      }
+    ],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fc210b29eb641",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/c210b29eb641#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/c210b29eb641#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/c210b29eb641",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/2f6f68d62636": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "2f6f68d62636",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/2f6f68d62636#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/2f6f68d62636",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/2f6f68d62636#children": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/bf4fc1e44a0b"
+      },
+      {
+        "href": "/content_node/single_texts/7207e69fa2de"
+      },
+      {
+        "href": "/content_node/single_texts/de7f7a8282e3"
+      },
+      {
+        "href": "/content_node/storyboards/b45a8d24dca0"
+      },
+      {
+        "href": "/content_node/material_nodes/c210b29eb641"
+      },
+      {
+        "href": "/content_node/single_texts/0e28f76880ac"
+      },
+      {
+        "href": "/content_node/single_texts/4aa1846e670b"
+      },
+      {
+        "href": "/content_node/single_texts/5b60b27e3a46"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/2f6f68d62636#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/2f6f68d62636",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/c7a7558a5120": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "c7a7558a5120",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/c7a7558a5120"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/c7a7558a5120#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/c7a7558a5120",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/c7a7558a5120#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/2f6f68d62636"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/c7a7558a5120#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/c7a7558a5120",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7331923798fe": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "7331923798fe",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/d19401fcb194"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/21f466229a77"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/7331923798fe#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/7331923798fe",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7331923798fe#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/7331923798fe#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/7331923798fe",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d95a38cdcc42": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "d95a38cdcc42",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/d19401fcb194"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/21f466229a77"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d95a38cdcc42#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d95a38cdcc42",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d95a38cdcc42#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d95a38cdcc42#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d95a38cdcc42",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/48d1d2015058": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "48d1d2015058",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/d19401fcb194"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/21f466229a77"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/48d1d2015058#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/48d1d2015058",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/48d1d2015058#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/48d1d2015058#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/48d1d2015058",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/4509fb5ca22b": {
+    "data": {
+      "sections": {
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "4509fb5ca22b",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/d19401fcb194"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/21f466229a77"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/4509fb5ca22b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/4509fb5ca22b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/4509fb5ca22b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/4509fb5ca22b#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/4509fb5ca22b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/08236b944919": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "08236b944919",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F08236b944919"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/d19401fcb194"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/21f466229a77"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/08236b944919#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/08236b944919",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F08236b944919": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F08236b944919",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/08236b944919#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/08236b944919#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/08236b944919",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/21f466229a77": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "21f466229a77",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/d19401fcb194"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/d19401fcb194"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/21f466229a77#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/21f466229a77",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/21f466229a77#children": {
+    "items": [
+      {
+        "href": "/content_node/storyboards/4509fb5ca22b"
+      },
+      {
+        "href": "/content_node/material_nodes/08236b944919"
+      },
+      {
+        "href": "/content_node/single_texts/7331923798fe"
+      },
+      {
+        "href": "/content_node/single_texts/d95a38cdcc42"
+      },
+      {
+        "href": "/content_node/single_texts/48d1d2015058"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/21f466229a77#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/21f466229a77",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/d19401fcb194": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "d19401fcb194",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/d19401fcb194"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/d19401fcb194#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/d19401fcb194",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/d19401fcb194#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/21f466229a77"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/d19401fcb194#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/d19401fcb194",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/96975939e170": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "96975939e170",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/d84535201db8"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d1c26b9a788b"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/96975939e170#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/96975939e170",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/96975939e170#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/96975939e170#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/96975939e170",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/38109ff0777c": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "38109ff0777c",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/d84535201db8"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d1c26b9a788b"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/38109ff0777c#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/38109ff0777c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/38109ff0777c#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/38109ff0777c#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/38109ff0777c",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/60e9b1b0a2b4": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "60e9b1b0a2b4",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/d84535201db8"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d1c26b9a788b"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/60e9b1b0a2b4#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/60e9b1b0a2b4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/60e9b1b0a2b4#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/60e9b1b0a2b4#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/60e9b1b0a2b4",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/multi_selects/dc3f25ff5d2a": {
+    "data": {
+      "options": {
+        "security": {
+          "checked": false
+        },
+        "outdoorTechnique": {
+          "checked": false
+        },
+        "pioneeringTechnique": {
+          "checked": false
+        },
+        "natureAndEnvironment": {
+          "checked": false
+        },
+        "campsiteAndSurroundings": {
+          "checked": false
+        },
+        "preventionAndIntegration": {
+          "checked": false
+        }
+      }
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "dc3f25ff5d2a",
+    "contentTypeName": "LAThematicArea",
+    "root": {
+      "href": "/content_node/column_layouts/d84535201db8"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d1c26b9a788b"
+    },
+    "contentType": {
+      "href": "/content_types/1a0f84e322c8"
+    },
+    "children": {
+      "href": "/content_node/multi_selects/dc3f25ff5d2a#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/multi_selects/dc3f25ff5d2a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/multi_selects/dc3f25ff5d2a#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/multi_selects/dc3f25ff5d2a#children",
+      "virtual": true,
+      "owningResource": "/content_node/multi_selects/dc3f25ff5d2a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/eea245f1073a": {
+    "data": {
+      "sections": {
+        "4c126a50-f729-46a7-8326-811586922995": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "eea245f1073a",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/d84535201db8"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d1c26b9a788b"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/eea245f1073a#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/eea245f1073a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/eea245f1073a#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/eea245f1073a#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/eea245f1073a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/d3e71bb6b49d": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "d3e71bb6b49d",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fd3e71bb6b49d"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/d84535201db8"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/d1c26b9a788b"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/d3e71bb6b49d#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/d3e71bb6b49d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fd3e71bb6b49d": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fd3e71bb6b49d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/d3e71bb6b49d#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/d3e71bb6b49d#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/d3e71bb6b49d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/d1c26b9a788b": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "d1c26b9a788b",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/d84535201db8"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/d84535201db8"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/d1c26b9a788b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/d1c26b9a788b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/d1c26b9a788b#children": {
+    "items": [
+      {
+        "href": "/content_node/storyboards/eea245f1073a"
+      },
+      {
+        "href": "/content_node/material_nodes/d3e71bb6b49d"
+      },
+      {
+        "href": "/content_node/single_texts/96975939e170"
+      },
+      {
+        "href": "/content_node/single_texts/38109ff0777c"
+      },
+      {
+        "href": "/content_node/single_texts/60e9b1b0a2b4"
+      },
+      {
+        "href": "/content_node/multi_selects/dc3f25ff5d2a"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/d1c26b9a788b#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/d1c26b9a788b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/d84535201db8": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "d84535201db8",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/d84535201db8"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/d84535201db8#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/d84535201db8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/d84535201db8#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/d1c26b9a788b"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/d84535201db8#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/d84535201db8",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d4d501d04b31": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "d4d501d04b31",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/e09a8713b583"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7d95cf35c936"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/d4d501d04b31#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/d4d501d04b31",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/d4d501d04b31#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/d4d501d04b31#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/d4d501d04b31",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/b50ba356f76b": {
+    "data": {
+      "html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "b50ba356f76b",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/e09a8713b583"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7d95cf35c936"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/b50ba356f76b#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/b50ba356f76b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/b50ba356f76b#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/b50ba356f76b#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/b50ba356f76b",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4726e6c0fee2": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "4726e6c0fee2",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/e09a8713b583"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7d95cf35c936"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/4726e6c0fee2#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/4726e6c0fee2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/4726e6c0fee2#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/4726e6c0fee2#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/4726e6c0fee2",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/2366430e91ad": {
+    "data": {
+      "sections": {
+        "56c67b3a-7d90-4f8f-bcff-a67233ce24be": {
+          "column1": "",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        },
+        "effa3fa5-cd07-4e82-a8aa-198ed9a7c1d4": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Erde ist der einzige bekannte Planet, auf dem Leben existiert. Ihr komplexes Ökosystem umfasst vielfältige Lebensformen, die eng miteinander und mit ihrer Umwelt interagieren.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "2366430e91ad",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/e09a8713b583"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7d95cf35c936"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/2366430e91ad#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/2366430e91ad",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/2366430e91ad#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/2366430e91ad#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/2366430e91ad",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/c87507c3f2b6": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "c87507c3f2b6",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fc87507c3f2b6"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/e09a8713b583"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/7d95cf35c936"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/c87507c3f2b6#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/c87507c3f2b6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fc87507c3f2b6": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Fc87507c3f2b6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/c87507c3f2b6#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/c87507c3f2b6#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/c87507c3f2b6",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/7d95cf35c936": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "7d95cf35c936",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/e09a8713b583"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/e09a8713b583"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/7d95cf35c936#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/7d95cf35c936",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/7d95cf35c936#children": {
+    "items": [
+      {
+        "href": "/content_node/storyboards/2366430e91ad"
+      },
+      {
+        "href": "/content_node/single_texts/d4d501d04b31"
+      },
+      {
+        "href": "/content_node/single_texts/4726e6c0fee2"
+      },
+      {
+        "href": "/content_node/material_nodes/c87507c3f2b6"
+      },
+      {
+        "href": "/content_node/single_texts/b50ba356f76b"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/7d95cf35c936#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/7d95cf35c936",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/e09a8713b583": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "e09a8713b583",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/e09a8713b583"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/e09a8713b583#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/e09a8713b583",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/e09a8713b583#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/7d95cf35c936"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/e09a8713b583#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/e09a8713b583",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/e076af6ebb70": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "e076af6ebb70",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/32d931d9309f"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/e076af6ebb70#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/e076af6ebb70",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/e076af6ebb70#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/e076af6ebb70#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/e076af6ebb70",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/2ee68d4dc61f": {
+    "data": {
+      "html": "<p>Die Teilnehmer versammeln sich am Treffpunkt im Lager. Die Leiter erklären, dass heute eine aufregende Schatzsuche im Wald stattfinden wird. Die Kinder werden in Teams von 4-5 Personen eingeteilt und erhalten jeweils eine Karte des Waldgebiets.</p>"
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "2ee68d4dc61f",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/32d931d9309f"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/2ee68d4dc61f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/2ee68d4dc61f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/2ee68d4dc61f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/2ee68d4dc61f#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/2ee68d4dc61f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7bbf67615903": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "7bbf67615903",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/32d931d9309f"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/7bbf67615903#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/7bbf67615903",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/7bbf67615903#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/7bbf67615903#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/7bbf67615903",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/fc302facf468": {
+    "data": {
+      "html": "<ul><li><p>Die TN üben und reflektieren ein förderndes Rückmeldegespräch.</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 2,
+    "instanceName": null,
+    "id": "fc302facf468",
+    "contentTypeName": "LearningObjectives",
+    "root": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/32d931d9309f"
+    },
+    "contentType": {
+      "href": "/content_types/c462edd869f3"
+    },
+    "children": {
+      "href": "/content_node/single_texts/fc302facf468#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/fc302facf468",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/fc302facf468#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/fc302facf468#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/fc302facf468",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/fb257d2a09c9": {
+    "data": {
+      "html": "<ul><li><p>Anspruchsvolles oder förderndes Rückmeldegespräch üben</p></li><li><p>Gegebene / erhaltene Rückmeldung analysieren</p></li></ul>"
+    },
+    "slot": "aside-top",
+    "position": 3,
+    "instanceName": null,
+    "id": "fb257d2a09c9",
+    "contentTypeName": "LearningTopics",
+    "root": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/32d931d9309f"
+    },
+    "contentType": {
+      "href": "/content_types/5e2028c55ee4"
+    },
+    "children": {
+      "href": "/content_node/single_texts/fb257d2a09c9#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/fb257d2a09c9",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/fb257d2a09c9#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/fb257d2a09c9#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/fb257d2a09c9",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/503cf893fa56": {
+    "data": null,
+    "slot": "aside-top",
+    "position": 4,
+    "instanceName": null,
+    "id": "503cf893fa56",
+    "contentTypeName": "Checklist",
+    "checklistItems": {
+      "href": "/checklist_items?checklistNodes=%2Fapi%2Fcontent_node%2Fchecklist_nodes%2F503cf893fa56"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/32d931d9309f"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c11211c"
+    },
+    "children": {
+      "href": "/content_node/checklist_nodes/503cf893fa56#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/checklist_nodes/503cf893fa56",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/checklist_nodes/503cf893fa56#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/checklist_nodes/503cf893fa56#children",
+      "virtual": true,
+      "owningResource": "/content_node/checklist_nodes/503cf893fa56",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/e9a23adaadaa": {
+    "data": {
+      "sections": {
+        "56336f59-8b73-45a7-a807-d0235b0501db": {
+          "column1": "00:45",
+          "column3": "",
+          "position": 4,
+          "column2Html": "<p>Die Teams starten ihre Schatzsuche. An den markierten Stationen finden sie Rätsel oder Aufgaben, die gelöst werden müssen, um Hinweise auf den nächsten Wegpunkt zu erhalten. Die Rätsel sind altersgerecht und fördern die Teamarbeit sowie das logische Denken.</p>"
+        },
+        "7412b417-389b-4458-b3dc-af3626a34b30": {
+          "column1": "00:00",
+          "column3": "",
+          "position": 1,
+          "column2Html": "<p>Die Teilnehmer versammeln sich am Treffpunkt im Lager. Die Leiter erklären, dass heute eine aufregende Schatzsuche im Wald stattfinden wird. Die Kinder werden in Teams von 4-5 Personen eingeteilt und erhalten jeweils eine Karte des Waldgebiets.</p>"
+        },
+        "9c752a02-6c2e-403f-a06a-71309299e983": {
+          "column1": "00:15",
+          "column3": "",
+          "position": 2,
+          "column2Html": "<p>Die Leiter erklären den Teilnehmern, wie man einen Kompass benutzt, um die Himmelsrichtungen zu bestimmen. Jedes Team bekommt einen Kompass und lernt die Grundlagen der Orientierung.</p>"
+        },
+        "b3cd34bc-92b6-49de-9dc4-dcb2f23c3e01": {
+          "column1": "01:30",
+          "column3": "",
+          "position": 6,
+          "column2Html": "<p>Die Teams erreichen das finale Schatzversteck. Dort entdecken sie eine Schatztruhe, die mit kleinen Belohnungen gefüllt ist, wie zum Beispiel Süßigkeiten, Abzeichen oder kleine Spielzeuge. Die Kinder freuen sich über ihre Errungenschaften und feiern ihren Erfolg.</p>"
+        },
+        "c5df80a0-0f6c-4e3c-9fea-bbbc30593226": {
+          "column1": "01:15",
+          "column3": "",
+          "position": 5,
+          "column2Html": "<p>Die Teams haben nun mehrere Stationen durchlaufen und Hinweise gesammelt. Diese Hinweise ergeben zusammen die Koordinaten des finalen Schatzverstecks. Die Kinder sind aufgeregt und motiviert, den Schatz zu finden.</p>"
+        },
+        "c65c5d44-1878-4fb3-844a-4939ffc1ca73": {
+          "column1": "00:30",
+          "column3": "",
+          "position": 3,
+          "column2Html": "<p>Die Schatzkarten werden verteilt. Jedes Team erhält eine Karte mit markierten Wegpunkten im Wald, die sie zu verschiedenen Stationen führen. Die Teams müssen den Kompass verwenden, um die Richtung und die Entfernung zu den jeweiligen Stationen zu bestimmen.</p>"
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "e9a23adaadaa",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/32d931d9309f"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/e9a23adaadaa#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/e9a23adaadaa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/e9a23adaadaa#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/e9a23adaadaa#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/e9a23adaadaa",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/18b67e3c98b3": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "18b67e3c98b3",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F18b67e3c98b3"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/32d931d9309f"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/18b67e3c98b3#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/18b67e3c98b3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/b93e13fb5e32": {
+    "article": "Schatzversteck",
+    "quantity": 1,
+    "unit": null,
+    "done": false,
+    "id": "b93e13fb5e32",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/b6f53a71078f"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/18b67e3c98b3"
+    },
+    "_meta": {
+      "self": "/material_items/b93e13fb5e32",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items/fff5792b9b32": {
+    "article": "Tee",
+    "quantity": 10,
+    "unit": "Liter",
+    "done": false,
+    "id": "fff5792b9b32",
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "materialList": {
+      "href": "/material_lists/308765cf5631"
+    },
+    "period": null,
+    "materialNode": {
+      "href": "/content_node/material_nodes/18b67e3c98b3"
+    },
+    "_meta": {
+      "self": "/material_items/fff5792b9b32",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F18b67e3c98b3": {
+    "items": [
+      {
+        "href": "/material_items/b93e13fb5e32"
+      },
+      {
+        "href": "/material_items/fff5792b9b32"
+      }
+    ],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2F18b67e3c98b3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/18b67e3c98b3#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/18b67e3c98b3#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/18b67e3c98b3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/32d931d9309f": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "32d931d9309f",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/32d931d9309f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/32d931d9309f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/32d931d9309f#children": {
+    "items": [
+      {
+        "href": "/content_node/storyboards/e9a23adaadaa"
+      },
+      {
+        "href": "/content_node/material_nodes/18b67e3c98b3"
+      },
+      {
+        "href": "/content_node/single_texts/fc302facf468"
+      },
+      {
+        "href": "/content_node/single_texts/fb257d2a09c9"
+      },
+      {
+        "href": "/content_node/checklist_nodes/503cf893fa56"
+      },
+      {
+        "href": "/content_node/single_texts/2ee68d4dc61f"
+      },
+      {
+        "href": "/content_node/single_texts/e076af6ebb70"
+      },
+      {
+        "href": "/content_node/single_texts/7bbf67615903"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/32d931d9309f#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/32d931d9309f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/e5c1d6082dfb": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": "est",
+    "id": "e5c1d6082dfb",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/e5c1d6082dfb#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/e5c1d6082dfb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/e5c1d6082dfb#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/32d931d9309f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/e5c1d6082dfb#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/e5c1d6082dfb",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/f8752e69a851": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "f8752e69a851",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/f8752e69a851"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/f8752e69a851#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/f8752e69a851",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/f8752e69a851#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/column_layouts/f8752e69a851#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/f8752e69a851",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/afb7af7fc173": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-bottom",
+    "position": 0,
+    "instanceName": null,
+    "id": "afb7af7fc173",
+    "contentTypeName": "Notes",
+    "root": {
+      "href": "/content_node/column_layouts/fcb048b79244"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/f763c4c69ff4"
+    },
+    "contentType": {
+      "href": "/content_types/4f0c657fecef"
+    },
+    "children": {
+      "href": "/content_node/single_texts/afb7af7fc173#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/afb7af7fc173",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/afb7af7fc173#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/afb7af7fc173#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/afb7af7fc173",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c19c659470fa": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 0,
+    "instanceName": null,
+    "id": "c19c659470fa",
+    "contentTypeName": "Storycontext",
+    "root": {
+      "href": "/content_node/column_layouts/fcb048b79244"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/f763c4c69ff4"
+    },
+    "contentType": {
+      "href": "/content_types/318e064ea0c9"
+    },
+    "children": {
+      "href": "/content_node/single_texts/c19c659470fa#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/c19c659470fa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/c19c659470fa#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/c19c659470fa#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/c19c659470fa",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/74b4dd9d188f": {
+    "data": {
+      "html": ""
+    },
+    "slot": "aside-top",
+    "position": 1,
+    "instanceName": null,
+    "id": "74b4dd9d188f",
+    "contentTypeName": "SafetyConsiderations",
+    "root": {
+      "href": "/content_node/column_layouts/fcb048b79244"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/f763c4c69ff4"
+    },
+    "contentType": {
+      "href": "/content_types/44dcc7493c65"
+    },
+    "children": {
+      "href": "/content_node/single_texts/74b4dd9d188f#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/single_texts/74b4dd9d188f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/single_texts/74b4dd9d188f#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/single_texts/74b4dd9d188f#children",
+      "virtual": true,
+      "owningResource": "/content_node/single_texts/74b4dd9d188f",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/508870d0da97": {
+    "data": {
+      "sections": {
+        "effa3fa5-cd07-4e82-a8aa-198ed9a7c1d4": {
+          "column1": "",
+          "column3": "",
+          "position": 1,
+          "column2Html": ""
+        }
+      }
+    },
+    "slot": "main",
+    "position": 0,
+    "instanceName": null,
+    "id": "508870d0da97",
+    "contentTypeName": "Storyboard",
+    "root": {
+      "href": "/content_node/column_layouts/fcb048b79244"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/f763c4c69ff4"
+    },
+    "contentType": {
+      "href": "/content_types/cfccaecd4bad"
+    },
+    "children": {
+      "href": "/content_node/storyboards/508870d0da97#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/storyboards/508870d0da97",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/storyboards/508870d0da97#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/storyboards/508870d0da97#children",
+      "virtual": true,
+      "owningResource": "/content_node/storyboards/508870d0da97",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/fba7bde6b6a5": {
+    "data": null,
+    "slot": "main",
+    "position": 1,
+    "instanceName": null,
+    "id": "fba7bde6b6a5",
+    "contentTypeName": "Material",
+    "materialItems": {
+      "href": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Ffba7bde6b6a5"
+    },
+    "root": {
+      "href": "/content_node/column_layouts/fcb048b79244"
+    },
+    "parent": {
+      "href": "/content_node/responsive_layouts/f763c4c69ff4"
+    },
+    "contentType": {
+      "href": "/content_types/3ef17bd1df72"
+    },
+    "children": {
+      "href": "/content_node/material_nodes/fba7bde6b6a5#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/material_nodes/fba7bde6b6a5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Ffba7bde6b6a5": {
+    "items": [],
+    "_meta": {
+      "self": "/material_items?materialNode=%2Fapi%2Fcontent_node%2Fmaterial_nodes%2Ffba7bde6b6a5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/material_nodes/fba7bde6b6a5#children": {
+    "items": [],
+    "_meta": {
+      "self": "/content_node/material_nodes/fba7bde6b6a5#children",
+      "virtual": true,
+      "owningResource": "/content_node/material_nodes/fba7bde6b6a5",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/f763c4c69ff4": {
+    "data": {
+      "items": [
+        {
+          "slot": "main"
+        },
+        {
+          "slot": "aside-top"
+        },
+        {
+          "slot": "aside-bottom"
+        }
+      ]
+    },
+    "slot": "1",
+    "position": 0,
+    "instanceName": null,
+    "id": "f763c4c69ff4",
+    "contentTypeName": "ResponsiveLayout",
+    "root": {
+      "href": "/content_node/column_layouts/fcb048b79244"
+    },
+    "parent": {
+      "href": "/content_node/column_layouts/fcb048b79244"
+    },
+    "contentType": {
+      "href": "/content_types/a4211c112939"
+    },
+    "children": {
+      "href": "/content_node/responsive_layouts/f763c4c69ff4#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/responsive_layouts/f763c4c69ff4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/responsive_layouts/f763c4c69ff4#children": {
+    "items": [
+      {
+        "href": "/content_node/single_texts/c19c659470fa"
+      },
+      {
+        "href": "/content_node/single_texts/afb7af7fc173"
+      },
+      {
+        "href": "/content_node/material_nodes/fba7bde6b6a5"
+      },
+      {
+        "href": "/content_node/storyboards/508870d0da97"
+      },
+      {
+        "href": "/content_node/single_texts/74b4dd9d188f"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/responsive_layouts/f763c4c69ff4#children",
+      "virtual": true,
+      "owningResource": "/content_node/responsive_layouts/f763c4c69ff4",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/fcb048b79244": {
+    "data": {
+      "columns": [
+        {
+          "slot": "1",
+          "width": 12
+        }
+      ]
+    },
+    "slot": null,
+    "position": 0,
+    "instanceName": null,
+    "id": "fcb048b79244",
+    "contentTypeName": "ColumnLayout",
+    "root": {
+      "href": "/content_node/column_layouts/fcb048b79244"
+    },
+    "parent": null,
+    "contentType": {
+      "href": "/content_types/f17470519474"
+    },
+    "children": {
+      "href": "/content_node/column_layouts/fcb048b79244#children",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/content_node/column_layouts/fcb048b79244",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_node/column_layouts/fcb048b79244#children": {
+    "items": [
+      {
+        "href": "/content_node/responsive_layouts/f763c4c69ff4"
+      }
+    ],
+    "_meta": {
+      "self": "/content_node/column_layouts/fcb048b79244#children",
+      "virtual": true,
+      "owningResource": "/content_node/column_layouts/fcb048b79244",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/periods/88f1f55a69d7/schedule_entries": {
+    "totalItems": 60,
+    "items": [
+      {
+        "href": "/schedule_entries/8edd32042a72"
+      },
+      {
+        "href": "/schedule_entries/3ff3ca55f540"
+      },
+      {
+        "href": "/schedule_entries/708d5982455b"
+      },
+      {
+        "href": "/schedule_entries/9768e17e461d"
+      },
+      {
+        "href": "/schedule_entries/544854257650"
+      },
+      {
+        "href": "/schedule_entries/24aaaf914d81"
+      },
+      {
+        "href": "/schedule_entries/ece5fbd25249"
+      },
+      {
+        "href": "/schedule_entries/7483a97d3811"
+      },
+      {
+        "href": "/schedule_entries/d2d292df0d38"
+      },
+      {
+        "href": "/schedule_entries/518cc421e407"
+      },
+      {
+        "href": "/schedule_entries/c4e91fa37beb"
+      },
+      {
+        "href": "/schedule_entries/00dabfb4abc0"
+      },
+      {
+        "href": "/schedule_entries/baa3e084a9fd"
+      },
+      {
+        "href": "/schedule_entries/730e7b52608d"
+      },
+      {
+        "href": "/schedule_entries/68898b96e2f4"
+      },
+      {
+        "href": "/schedule_entries/31a723c281e9"
+      },
+      {
+        "href": "/schedule_entries/7d7d7c1ec146"
+      },
+      {
+        "href": "/schedule_entries/5f363002c509"
+      },
+      {
+        "href": "/schedule_entries/338b1ec643f0"
+      },
+      {
+        "href": "/schedule_entries/678b0c9e032b"
+      },
+      {
+        "href": "/schedule_entries/5294f9ecab67"
+      },
+      {
+        "href": "/schedule_entries/c8834067a7fb"
+      },
+      {
+        "href": "/schedule_entries/eebc0f6ef940"
+      },
+      {
+        "href": "/schedule_entries/866350807e56"
+      },
+      {
+        "href": "/schedule_entries/b8ba03731ea2"
+      },
+      {
+        "href": "/schedule_entries/2b7e20b2c143"
+      },
+      {
+        "href": "/schedule_entries/d2b7193ee240"
+      },
+      {
+        "href": "/schedule_entries/7de79740d21e"
+      },
+      {
+        "href": "/schedule_entries/b68b28d54d00"
+      },
+      {
+        "href": "/schedule_entries/714335f7662b"
+      },
+      {
+        "href": "/schedule_entries/c03308fb793b"
+      },
+      {
+        "href": "/schedule_entries/8f88e2766fe4"
+      },
+      {
+        "href": "/schedule_entries/1c9849eb3e19"
+      },
+      {
+        "href": "/schedule_entries/967ce23da935"
+      },
+      {
+        "href": "/schedule_entries/340a7c43247f"
+      },
+      {
+        "href": "/schedule_entries/4659f03df5f0"
+      },
+      {
+        "href": "/schedule_entries/1428d429bcbc"
+      },
+      {
+        "href": "/schedule_entries/b3d8510b3fc0"
+      },
+      {
+        "href": "/schedule_entries/76f8de918d33"
+      },
+      {
+        "href": "/schedule_entries/d712be44166d"
+      },
+      {
+        "href": "/schedule_entries/6e229cc92bda"
+      },
+      {
+        "href": "/schedule_entries/5df6703c8c5d"
+      },
+      {
+        "href": "/schedule_entries/7c39f20068ce"
+      },
+      {
+        "href": "/schedule_entries/53d41fb96483"
+      },
+      {
+        "href": "/schedule_entries/8bccd22723c0"
+      },
+      {
+        "href": "/schedule_entries/a8cd28eff86e"
+      },
+      {
+        "href": "/schedule_entries/d8810b075da1"
+      },
+      {
+        "href": "/schedule_entries/d36256eb597d"
+      },
+      {
+        "href": "/schedule_entries/528b12bce91f"
+      },
+      {
+        "href": "/schedule_entries/3c6a421b9598"
+      },
+      {
+        "href": "/schedule_entries/0fde303f5067"
+      },
+      {
+        "href": "/schedule_entries/776938c5a808"
+      },
+      {
+        "href": "/schedule_entries/d281382890e2"
+      },
+      {
+        "href": "/schedule_entries/327302368fe6"
+      },
+      {
+        "href": "/schedule_entries/72e1569530f1"
+      },
+      {
+        "href": "/schedule_entries/0ad209a74fbe"
+      },
+      {
+        "href": "/schedule_entries/7ae50dc8370f"
+      },
+      {
+        "href": "/schedule_entries/89239bf4e109"
+      },
+      {
+        "href": "/schedule_entries/e391db2702a6"
+      },
+      {
+        "href": "/schedule_entries/b7d1761ab299"
+      }
+    ],
+    "_meta": {
+      "self": "/periods/88f1f55a69d7/schedule_entries",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/profiles?user.collaborations.camp=%2Fapi%2Fcamps%2F5d28f99890bc": {
+    "totalItems": 6,
+    "items": [
+      {
+        "href": "/profiles/0870635edda6"
+      },
+      {
+        "href": "/profiles/22dce794d4e2"
+      },
+      {
+        "href": "/profiles/5e387cad273d"
+      },
+      {
+        "href": "/profiles/7d03c967be7e"
+      },
+      {
+        "href": "/profiles/d46337a76a2c"
+      },
+      {
+        "href": "/profiles/f9f1a2f9af25"
+      }
+    ],
+    "_meta": {
+      "self": "/profiles?user.collaborations.camp=%2Fapi%2Fcamps%2F5d28f99890bc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists?camp=%2Fapi%2Fcamps%2F5d28f99890bc": {
+    "totalItems": 11,
+    "items": [
+      {
+        "href": "/material_lists/186994977e47"
+      },
+      {
+        "href": "/material_lists/308765cf5631"
+      },
+      {
+        "href": "/material_lists/049b1890fb94"
+      },
+      {
+        "href": "/material_lists/b6f53a71078f"
+      },
+      {
+        "href": "/material_lists/f4268fba5b4b"
+      },
+      {
+        "href": "/material_lists/e06677070032"
+      },
+      {
+        "href": "/material_lists/2a66659e9aa5"
+      },
+      {
+        "href": "/material_lists/235d4e49db04"
+      },
+      {
+        "href": "/material_lists/6e3d8bf92360"
+      },
+      {
+        "href": "/material_lists/fc33f57a7198"
+      },
+      {
+        "href": "/material_lists/cc18aaa03b18"
+      }
+    ],
+    "_meta": {
+      "self": "/material_lists?camp=%2Fapi%2Fcamps%2F5d28f99890bc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types": {
+    "totalItems": 11,
+    "items": [
+      {
+        "href": "/content_types/a4211c11211c"
+      },
+      {
+        "href": "/content_types/f17470519474"
+      },
+      {
+        "href": "/content_types/1a0f84e322c8"
+      },
+      {
+        "href": "/content_types/c462edd869f3"
+      },
+      {
+        "href": "/content_types/5e2028c55ee4"
+      },
+      {
+        "href": "/content_types/3ef17bd1df72"
+      },
+      {
+        "href": "/content_types/4f0c657fecef"
+      },
+      {
+        "href": "/content_types/a4211c112939"
+      },
+      {
+        "href": "/content_types/44dcc7493c65"
+      },
+      {
+        "href": "/content_types/cfccaecd4bad"
+      },
+      {
+        "href": "/content_types/318e064ea0c9"
+      }
+    ],
+    "_meta": {
+      "self": "/content_types",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items?checklist.camp=%2Fcamps%2F5d28f99890bc": {
+    "totalItems": 31,
+    "items": [
+      {
+        "href": "/checklist_items/0c52c9e3d76e"
+      },
+      {
+        "href": "/checklist_items/103e45908cf8"
+      },
+      {
+        "href": "/checklist_items/18db4adbe9b1"
+      },
+      {
+        "href": "/checklist_items/220e86221558"
+      },
+      {
+        "href": "/checklist_items/2466b1775468"
+      },
+      {
+        "href": "/checklist_items/2526365b41bd"
+      },
+      {
+        "href": "/checklist_items/2d852f508228"
+      },
+      {
+        "href": "/checklist_items/4f5f857dd79c"
+      },
+      {
+        "href": "/checklist_items/5a636c05a4ea"
+      },
+      {
+        "href": "/checklist_items/69b897a3a88a"
+      },
+      {
+        "href": "/checklist_items/7adeeaf021e1"
+      },
+      {
+        "href": "/checklist_items/892d52359de7"
+      },
+      {
+        "href": "/checklist_items/8df77c33eb17"
+      },
+      {
+        "href": "/checklist_items/9603344533d2"
+      },
+      {
+        "href": "/checklist_items/9c7f2bef2b46"
+      },
+      {
+        "href": "/checklist_items/9c9f75e6354a"
+      },
+      {
+        "href": "/checklist_items/a343d952c7b3"
+      },
+      {
+        "href": "/checklist_items/a7a0b22553eb"
+      },
+      {
+        "href": "/checklist_items/b451128bb144"
+      },
+      {
+        "href": "/checklist_items/b4e7fb5a8ccb"
+      },
+      {
+        "href": "/checklist_items/b603b7455075"
+      },
+      {
+        "href": "/checklist_items/b64e29d134ab"
+      },
+      {
+        "href": "/checklist_items/bc505beba987"
+      },
+      {
+        "href": "/checklist_items/c1ae205f695c"
+      },
+      {
+        "href": "/checklist_items/c3821307f292"
+      },
+      {
+        "href": "/checklist_items/d89bc5e145fc"
+      },
+      {
+        "href": "/checklist_items/d8becc2dbd1d"
+      },
+      {
+        "href": "/checklist_items/e04ccc274611"
+      },
+      {
+        "href": "/checklist_items/e36bf8ea1eaa"
+      },
+      {
+        "href": "/checklist_items/e6fcf0036360"
+      },
+      {
+        "href": "/checklist_items/facdd937ab38"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items?checklist.camp=%2Fcamps%2F5d28f99890bc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/day_responsibles?day.period=%2Fapi%2Fperiods%2F88f1f55a69d7": {
+    "totalItems": 8,
+    "items": [
+      {
+        "href": "/day_responsibles/068c64c8a494"
+      },
+      {
+        "href": "/day_responsibles/207ea1926f27"
+      },
+      {
+        "href": "/day_responsibles/5b8a43dced14"
+      },
+      {
+        "href": "/day_responsibles/a1b2a402ed98"
+      },
+      {
+        "href": "/day_responsibles/a6462d35b185"
+      },
+      {
+        "href": "/day_responsibles/c60d37e48966"
+      },
+      {
+        "href": "/day_responsibles/cb5726304025"
+      },
+      {
+        "href": "/day_responsibles/d42c79cf45d1"
+      }
+    ],
+    "_meta": {
+      "self": "/day_responsibles?day.period=%2Fapi%2Fperiods%2F88f1f55a69d7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklists/ebbd0c61eb85/checklist_items": {
+    "totalItems": 31,
+    "items": [
+      {
+        "href": "/checklist_items/0c52c9e3d76e"
+      },
+      {
+        "href": "/checklist_items/103e45908cf8"
+      },
+      {
+        "href": "/checklist_items/18db4adbe9b1"
+      },
+      {
+        "href": "/checklist_items/220e86221558"
+      },
+      {
+        "href": "/checklist_items/2466b1775468"
+      },
+      {
+        "href": "/checklist_items/2526365b41bd"
+      },
+      {
+        "href": "/checklist_items/2d852f508228"
+      },
+      {
+        "href": "/checklist_items/4f5f857dd79c"
+      },
+      {
+        "href": "/checklist_items/5a636c05a4ea"
+      },
+      {
+        "href": "/checklist_items/69b897a3a88a"
+      },
+      {
+        "href": "/checklist_items/7adeeaf021e1"
+      },
+      {
+        "href": "/checklist_items/892d52359de7"
+      },
+      {
+        "href": "/checklist_items/8df77c33eb17"
+      },
+      {
+        "href": "/checklist_items/9603344533d2"
+      },
+      {
+        "href": "/checklist_items/9c7f2bef2b46"
+      },
+      {
+        "href": "/checklist_items/9c9f75e6354a"
+      },
+      {
+        "href": "/checklist_items/a343d952c7b3"
+      },
+      {
+        "href": "/checklist_items/a7a0b22553eb"
+      },
+      {
+        "href": "/checklist_items/b451128bb144"
+      },
+      {
+        "href": "/checklist_items/b4e7fb5a8ccb"
+      },
+      {
+        "href": "/checklist_items/b603b7455075"
+      },
+      {
+        "href": "/checklist_items/b64e29d134ab"
+      },
+      {
+        "href": "/checklist_items/bc505beba987"
+      },
+      {
+        "href": "/checklist_items/c1ae205f695c"
+      },
+      {
+        "href": "/checklist_items/c3821307f292"
+      },
+      {
+        "href": "/checklist_items/d89bc5e145fc"
+      },
+      {
+        "href": "/checklist_items/d8becc2dbd1d"
+      },
+      {
+        "href": "/checklist_items/e04ccc274611"
+      },
+      {
+        "href": "/checklist_items/e36bf8ea1eaa"
+      },
+      {
+        "href": "/checklist_items/e6fcf0036360"
+      },
+      {
+        "href": "/checklist_items/facdd937ab38"
+      }
+    ],
+    "_meta": {
+      "self": "/checklists/ebbd0c61eb85/checklist_items",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/profiles/0870635edda6": {
+    "email": "idefix@example.com",
+    "firstname": "Tremaine",
+    "surname": "Kohler",
+    "nickname": "Idefix",
+    "language": "en",
+    "color": null,
+    "abbreviation": null,
+    "id": "0870635edda6",
+    "legalName": "Tremaine Kohler",
+    "user": {
+      "href": "/users/48f00685a292"
+    },
+    "_meta": {
+      "self": "/profiles/0870635edda6",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/profiles/22dce794d4e2": {
+    "email": "snoopy@example.com",
+    "firstname": "Pat",
+    "surname": "Fadel",
+    "nickname": "Snoopy",
+    "language": "en",
+    "color": null,
+    "abbreviation": null,
+    "id": "22dce794d4e2",
+    "legalName": "Pat Fadel",
+    "user": {
+      "href": "/users/130684395770"
+    },
+    "_meta": {
+      "self": "/profiles/22dce794d4e2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/profiles/7d03c967be7e": {
+    "email": "castor@example.com",
+    "firstname": "Hans",
+    "surname": "Muster",
+    "nickname": "Castor",
+    "language": "de",
+    "color": null,
+    "abbreviation": "C",
+    "id": "7d03c967be7e",
+    "legalName": "Hans Muster",
+    "user": {
+      "href": "/users/caeba9f7e728"
+    },
+    "_meta": {
+      "self": "/profiles/7d03c967be7e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/profiles/d46337a76a2c": {
+    "email": "salamander@example.com",
+    "firstname": "Fritz",
+    "surname": "Müller",
+    "nickname": "Salamander",
+    "language": "de",
+    "color": null,
+    "abbreviation": null,
+    "id": "d46337a76a2c",
+    "legalName": "Fritz Müller",
+    "user": {
+      "href": "/users/bee7cf5b3871"
+    },
+    "_meta": {
+      "self": "/profiles/d46337a76a2c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/profiles/f9f1a2f9af25": {
+    "email": "baghira@example.com",
+    "firstname": "Zora",
+    "surname": "Steuber",
+    "nickname": "Baghira",
+    "language": "en",
+    "color": null,
+    "abbreviation": null,
+    "id": "f9f1a2f9af25",
+    "legalName": "Zora Steuber",
+    "user": {
+      "href": "/users/bae69a1c9fcc"
+    },
+    "_meta": {
+      "self": "/profiles/f9f1a2f9af25",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/a4211c11211c": {
+    "name": "Checklist",
+    "active": true,
+    "id": "a4211c11211c",
+    "contentNodes": {
+      "href": "/content_node/checklist_nodes?contentType=%2Fapi%2Fcontent_types%2Fa4211c11211c"
+    },
+    "_meta": {
+      "self": "/content_types/a4211c11211c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/c462edd869f3": {
+    "name": "LearningObjectives",
+    "active": true,
+    "id": "c462edd869f3",
+    "contentNodes": {
+      "href": "/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2Fc462edd869f3"
+    },
+    "_meta": {
+      "self": "/content_types/c462edd869f3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/5e2028c55ee4": {
+    "name": "LearningTopics",
+    "active": true,
+    "id": "5e2028c55ee4",
+    "contentNodes": {
+      "href": "/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F5e2028c55ee4"
+    },
+    "_meta": {
+      "self": "/content_types/5e2028c55ee4",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/186994977e47": {
+    "name": "Baumarkt",
+    "id": "186994977e47",
+    "itemCount": 0,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2F186994977e47"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": null,
+    "_meta": {
+      "self": "/material_lists/186994977e47",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/308765cf5631": {
+    "name": "Coop",
+    "id": "308765cf5631",
+    "itemCount": 6,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2F308765cf5631"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": null,
+    "_meta": {
+      "self": "/material_lists/308765cf5631",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/049b1890fb94": {
+    "name": "J+S",
+    "id": "049b1890fb94",
+    "itemCount": 3,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2F049b1890fb94"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": null,
+    "_meta": {
+      "self": "/material_lists/049b1890fb94",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/b6f53a71078f": {
+    "name": "Packliste",
+    "id": "b6f53a71078f",
+    "itemCount": 1,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2Fb6f53a71078f"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": null,
+    "_meta": {
+      "self": "/material_lists/b6f53a71078f",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/f4268fba5b4b": {
+    "name": "Pfadiheim",
+    "id": "f4268fba5b4b",
+    "itemCount": 4,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2Ff4268fba5b4b"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": null,
+    "_meta": {
+      "self": "/material_lists/f4268fba5b4b",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/e06677070032": {
+    "name": "Bi-Pi",
+    "id": "e06677070032",
+    "itemCount": 5,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2Fe06677070032"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/146c0608237f"
+    },
+    "_meta": {
+      "self": "/material_lists/e06677070032",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/2a66659e9aa5": {
+    "name": "Snoopy",
+    "id": "2a66659e9aa5",
+    "itemCount": 3,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2F2a66659e9aa5"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/4b0f654bf743"
+    },
+    "_meta": {
+      "self": "/material_lists/2a66659e9aa5",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/235d4e49db04": {
+    "name": "Castor",
+    "id": "235d4e49db04",
+    "itemCount": 1,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2F235d4e49db04"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/d03003838720"
+    },
+    "_meta": {
+      "self": "/material_lists/235d4e49db04",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/6e3d8bf92360": {
+    "name": "Salamander",
+    "id": "6e3d8bf92360",
+    "itemCount": 4,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2F6e3d8bf92360"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/e64284adf2f2"
+    },
+    "_meta": {
+      "self": "/material_lists/6e3d8bf92360",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/fc33f57a7198": {
+    "name": "Baghira",
+    "id": "fc33f57a7198",
+    "itemCount": 1,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2Ffc33f57a7198"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/83cdbbe00f85"
+    },
+    "_meta": {
+      "self": "/material_lists/fc33f57a7198",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/material_lists/cc18aaa03b18": {
+    "name": "Idefix",
+    "id": "cc18aaa03b18",
+    "itemCount": 1,
+    "materialItems": {
+      "href": "/material_items?materialList=%2Fapi%2Fmaterial_lists%2Fcc18aaa03b18"
+    },
+    "camp": {
+      "href": "/camps/5d28f99890bc"
+    },
+    "campCollaboration": {
+      "href": "/camp_collaborations/af9f868f0a48"
+    },
+    "_meta": {
+      "self": "/material_lists/cc18aaa03b18",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/0c52c9e3d76e": {
+    "text": "Funktion sowie Rechte und Pflichten als Mitglied eines Leitungsteams der Wolfsstufe",
+    "position": 0,
+    "id": "0c52c9e3d76e",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b451128bb144"
+    },
+    "children": {
+      "href": "/checklist_items/0c52c9e3d76e#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/0c52c9e3d76e#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/0c52c9e3d76e",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/0c52c9e3d76e#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/0c52c9e3d76e#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/0c52c9e3d76e",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/0c52c9e3d76e#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/3157182811bb"
+      },
+      {
+        "href": "/content_node/checklist_nodes/503cf893fa56"
+      },
+      {
+        "href": "/content_node/checklist_nodes/42a32ff460d3"
+      },
+      {
+        "href": "/content_node/checklist_nodes/1a2905b61cff"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/0c52c9e3d76e#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/0c52c9e3d76e",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/103e45908cf8": {
+    "text": "Angebote und Anlaufstellen des Kantonalverbands / der Region sowie Krisenkonzept",
+    "position": 4,
+    "id": "103e45908cf8",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b451128bb144"
+    },
+    "children": {
+      "href": "/checklist_items/103e45908cf8#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/103e45908cf8#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/103e45908cf8",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/103e45908cf8#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/103e45908cf8#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/103e45908cf8",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/103e45908cf8#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/1a2905b61cff"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/103e45908cf8#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/103e45908cf8",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/18db4adbe9b1": {
+    "text": "Der Kurs vermittelt den TN die Pfadigrundlagen.",
+    "position": 0,
+    "id": "18db4adbe9b1",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": null,
+    "children": {
+      "href": "/checklist_items/18db4adbe9b1#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/18db4adbe9b1#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/18db4adbe9b1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/18db4adbe9b1#children": {
+    "items": [
+      {
+        "href": "/checklist_items/9603344533d2"
+      },
+      {
+        "href": "/checklist_items/d89bc5e145fc"
+      },
+      {
+        "href": "/checklist_items/b603b7455075"
+      },
+      {
+        "href": "/checklist_items/2526365b41bd"
+      },
+      {
+        "href": "/checklist_items/e36bf8ea1eaa"
+      },
+      {
+        "href": "/checklist_items/4f5f857dd79c"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/18db4adbe9b1#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/18db4adbe9b1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/18db4adbe9b1#checklistNodes": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/18db4adbe9b1#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/18db4adbe9b1",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/220e86221558": {
+    "text": "Regeln für konstruktive Gespräche im Leitungsteam",
+    "position": 6,
+    "id": "220e86221558",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b451128bb144"
+    },
+    "children": {
+      "href": "/checklist_items/220e86221558#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/220e86221558#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/220e86221558",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/220e86221558#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/220e86221558#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/220e86221558",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/220e86221558#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/1a2905b61cff"
+      },
+      {
+        "href": "/content_node/checklist_nodes/503cf893fa56"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/220e86221558#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/220e86221558",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/2466b1775468": {
+    "text": "Arbeiten mit Gesetz und Versprechen auf der Wolfsstufe",
+    "position": 1,
+    "id": "2466b1775468",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b64e29d134ab"
+    },
+    "children": {
+      "href": "/checklist_items/2466b1775468#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/2466b1775468#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/2466b1775468",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/2466b1775468#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/2466b1775468#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/2466b1775468",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/2466b1775468#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/946afc306e3b"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/2466b1775468#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/2466b1775468",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/2526365b41bd": {
+    "text": "Persönliche Auseinandersetzung mit Gesetz und Versprechen der Roverstufe",
+    "position": 2,
+    "id": "2526365b41bd",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/18db4adbe9b1"
+    },
+    "children": {
+      "href": "/checklist_items/2526365b41bd#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/2526365b41bd#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/2526365b41bd",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/2526365b41bd#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/2526365b41bd#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/2526365b41bd",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/2526365b41bd#checklistNodes": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/2526365b41bd#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/2526365b41bd",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/2d852f508228": {
+    "text": "Quartalsprogramm planen",
+    "position": 2,
+    "id": "2d852f508228",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/d8becc2dbd1d"
+    },
+    "children": {
+      "href": "/checklist_items/2d852f508228#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/2d852f508228#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/2d852f508228",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/2d852f508228#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/2d852f508228#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/2d852f508228",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/2d852f508228#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/d8e5da1e3d52"
+      },
+      {
+        "href": "/content_node/checklist_nodes/3157182811bb"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/2d852f508228#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/2d852f508228",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/4f5f857dd79c": {
+    "text": "Wolfsstufensymbolik",
+    "position": 1,
+    "id": "4f5f857dd79c",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/18db4adbe9b1"
+    },
+    "children": {
+      "href": "/checklist_items/4f5f857dd79c#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/4f5f857dd79c#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/4f5f857dd79c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/4f5f857dd79c#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/4f5f857dd79c#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/4f5f857dd79c",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/4f5f857dd79c#checklistNodes": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/4f5f857dd79c#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/4f5f857dd79c",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/5a636c05a4ea": {
+    "text": "Inklusive Gestaltung des Programms, damit sich alle Wölfe wohlfühlen und ihre Persönlichkeiten individuell entwickeln können",
+    "position": 7,
+    "id": "5a636c05a4ea",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/d8becc2dbd1d"
+    },
+    "children": {
+      "href": "/checklist_items/5a636c05a4ea#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/5a636c05a4ea#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/5a636c05a4ea",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/5a636c05a4ea#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/5a636c05a4ea#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/5a636c05a4ea",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/5a636c05a4ea#checklistNodes": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/5a636c05a4ea#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/5a636c05a4ea",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/69b897a3a88a": {
+    "text": "Pfadimethode „Persönlicher Fortschritt fördern\": Inhalte der Etappen und Spezialitäten in Aktivitäten der Wolfsstufe einbauen",
+    "position": 0,
+    "id": "69b897a3a88a",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b64e29d134ab"
+    },
+    "children": {
+      "href": "/checklist_items/69b897a3a88a#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/69b897a3a88a#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/69b897a3a88a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/69b897a3a88a#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/69b897a3a88a#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/69b897a3a88a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/69b897a3a88a#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/946afc306e3b"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/69b897a3a88a#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/69b897a3a88a",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/7adeeaf021e1": {
+    "text": "Planen, Durchführen und Auswerten von Wanderungen für die Wolfsstufe",
+    "position": 6,
+    "id": "7adeeaf021e1",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/d8becc2dbd1d"
+    },
+    "children": {
+      "href": "/checklist_items/7adeeaf021e1#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/7adeeaf021e1#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/7adeeaf021e1",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/7adeeaf021e1#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/7adeeaf021e1#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/7adeeaf021e1",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/7adeeaf021e1#checklistNodes": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/7adeeaf021e1#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/7adeeaf021e1",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/892d52359de7": {
+    "text": "Vertiefen der Kenntnisse und stufengerechtes Vermitteln der Wolfsstufentechnik",
+    "position": 3,
+    "id": "892d52359de7",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b64e29d134ab"
+    },
+    "children": {
+      "href": "/checklist_items/892d52359de7#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/892d52359de7#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/892d52359de7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/892d52359de7#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/892d52359de7#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/892d52359de7",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/892d52359de7#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/bf4fc1e44a0b"
+      },
+      {
+        "href": "/content_node/checklist_nodes/946afc306e3b"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/892d52359de7#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/892d52359de7",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/8df77c33eb17": {
+    "text": "Gestaltung von Lagerfeuern auf der Wolfsstufe",
+    "position": 2,
+    "id": "8df77c33eb17",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b64e29d134ab"
+    },
+    "children": {
+      "href": "/checklist_items/8df77c33eb17#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/8df77c33eb17#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/8df77c33eb17",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/8df77c33eb17#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/8df77c33eb17#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/8df77c33eb17",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/8df77c33eb17#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/3f48816bccae"
+      },
+      {
+        "href": "/content_node/checklist_nodes/946afc306e3b"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/8df77c33eb17#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/8df77c33eb17",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/9603344533d2": {
+    "text": "Ausgestaltung der sieben Pfadimethoden und fünf Pfadibeziehungen auf der Wolfsstufe",
+    "position": 5,
+    "id": "9603344533d2",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/18db4adbe9b1"
+    },
+    "children": {
+      "href": "/checklist_items/9603344533d2#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/9603344533d2#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/9603344533d2",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/9603344533d2#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/9603344533d2#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/9603344533d2",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/9603344533d2#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/3f48816bccae"
+      },
+      {
+        "href": "/content_node/checklist_nodes/3157182811bb"
+      },
+      {
+        "href": "/content_node/checklist_nodes/d8e5da1e3d52"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/9603344533d2#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/9603344533d2",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/9c7f2bef2b46": {
+    "text": "Sicherheitskonzepte für sicherheitsrelevante Aktivitäten planen und umsetzen",
+    "position": 3,
+    "id": "9c7f2bef2b46",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b451128bb144"
+    },
+    "children": {
+      "href": "/checklist_items/9c7f2bef2b46#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/9c7f2bef2b46#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/9c7f2bef2b46",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/9c7f2bef2b46#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/9c7f2bef2b46#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/9c7f2bef2b46",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/9c7f2bef2b46#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/42a32ff460d3"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/9c7f2bef2b46#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/9c7f2bef2b46",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/9c9f75e6354a": {
+    "text": "Einkleidung von Aktivitäten und Quartalsprogrammen",
+    "position": 0,
+    "id": "9c9f75e6354a",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/d8becc2dbd1d"
+    },
+    "children": {
+      "href": "/checklist_items/9c9f75e6354a#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/9c9f75e6354a#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/9c9f75e6354a",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/9c9f75e6354a#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/9c9f75e6354a#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/9c9f75e6354a",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/9c9f75e6354a#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/d8e5da1e3d52"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/9c9f75e6354a#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/9c9f75e6354a",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/a343d952c7b3": {
+    "text": "wesentliche Punkte beim Organisieren von Weekends",
+    "position": 4,
+    "id": "a343d952c7b3",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/d8becc2dbd1d"
+    },
+    "children": {
+      "href": "/checklist_items/a343d952c7b3#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/a343d952c7b3#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/a343d952c7b3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/a343d952c7b3#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/a343d952c7b3#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/a343d952c7b3",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/a343d952c7b3#checklistNodes": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/a343d952c7b3#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/a343d952c7b3",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/a7a0b22553eb": {
+    "text": "Abenteuer als Alternative zum Quartalsprogramm und als Form der Mitbestimmung auf der Wolfsstufe",
+    "position": 3,
+    "id": "a7a0b22553eb",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/d8becc2dbd1d"
+    },
+    "children": {
+      "href": "/checklist_items/a7a0b22553eb#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/a7a0b22553eb#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/a7a0b22553eb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/a7a0b22553eb#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/a7a0b22553eb#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/a7a0b22553eb",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/a7a0b22553eb#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/d8e5da1e3d52"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/a7a0b22553eb#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/a7a0b22553eb",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b451128bb144": {
+    "text": "Der Kurs bildet die TN zu verantwortungsbewussten Mitgliedern eines Leitungsteams aus.",
+    "position": 2,
+    "id": "b451128bb144",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": null,
+    "children": {
+      "href": "/checklist_items/b451128bb144#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/b451128bb144#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/b451128bb144",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b451128bb144#children": {
+    "items": [
+      {
+        "href": "/checklist_items/b4e7fb5a8ccb"
+      },
+      {
+        "href": "/checklist_items/facdd937ab38"
+      },
+      {
+        "href": "/checklist_items/9c7f2bef2b46"
+      },
+      {
+        "href": "/checklist_items/c3821307f292"
+      },
+      {
+        "href": "/checklist_items/e04ccc274611"
+      },
+      {
+        "href": "/checklist_items/0c52c9e3d76e"
+      },
+      {
+        "href": "/checklist_items/220e86221558"
+      },
+      {
+        "href": "/checklist_items/c1ae205f695c"
+      },
+      {
+        "href": "/checklist_items/103e45908cf8"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/b451128bb144#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/b451128bb144",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b451128bb144#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/946afc306e3b"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/b451128bb144#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/b451128bb144",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b4e7fb5a8ccb": {
+    "text": "Sexuelle Ausbeutung und Grenzverletzungen, mögliche heikle Situationen in Aktivitäten und vorbeugende Massnahmen",
+    "position": 8,
+    "id": "b4e7fb5a8ccb",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b451128bb144"
+    },
+    "children": {
+      "href": "/checklist_items/b4e7fb5a8ccb#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/b4e7fb5a8ccb#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/b4e7fb5a8ccb",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b4e7fb5a8ccb#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/b4e7fb5a8ccb#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/b4e7fb5a8ccb",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b4e7fb5a8ccb#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/1a2905b61cff"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/b4e7fb5a8ccb#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/b4e7fb5a8ccb",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b603b7455075": {
+    "text": "Bezug der Pfadigrundlagen zum Pfadialltag",
+    "position": 3,
+    "id": "b603b7455075",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/18db4adbe9b1"
+    },
+    "children": {
+      "href": "/checklist_items/b603b7455075#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/b603b7455075#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/b603b7455075",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b603b7455075#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/b603b7455075#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/b603b7455075",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b603b7455075#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/3157182811bb"
+      },
+      {
+        "href": "/content_node/checklist_nodes/d8e5da1e3d52"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/b603b7455075#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/b603b7455075",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b64e29d134ab": {
+    "text": "Der Kurs befähigt die TN, Aktivitäten wolfsstufengerecht zu gestalten.",
+    "position": 3,
+    "id": "b64e29d134ab",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": null,
+    "children": {
+      "href": "/checklist_items/b64e29d134ab#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/b64e29d134ab#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/b64e29d134ab",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b64e29d134ab#children": {
+    "items": [
+      {
+        "href": "/checklist_items/69b897a3a88a"
+      },
+      {
+        "href": "/checklist_items/892d52359de7"
+      },
+      {
+        "href": "/checklist_items/2466b1775468"
+      },
+      {
+        "href": "/checklist_items/8df77c33eb17"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/b64e29d134ab#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/b64e29d134ab",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/b64e29d134ab#checklistNodes": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/b64e29d134ab#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/b64e29d134ab",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/bc505beba987": {
+    "text": "Methoden zur Planung, Durchführung und Auswertung von Programmen",
+    "position": 1,
+    "id": "bc505beba987",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/d8becc2dbd1d"
+    },
+    "children": {
+      "href": "/checklist_items/bc505beba987#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/bc505beba987#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/bc505beba987",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/bc505beba987#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/bc505beba987#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/bc505beba987",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/bc505beba987#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/bf4fc1e44a0b"
+      },
+      {
+        "href": "/content_node/checklist_nodes/d8e5da1e3d52"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/bc505beba987#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/bc505beba987",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/c1ae205f695c": {
+    "text": "eigene Leiterpersönlichkeit und Rolle im Team",
+    "position": 5,
+    "id": "c1ae205f695c",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b451128bb144"
+    },
+    "children": {
+      "href": "/checklist_items/c1ae205f695c#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/c1ae205f695c#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/c1ae205f695c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/c1ae205f695c#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/c1ae205f695c#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/c1ae205f695c",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/c1ae205f695c#checklistNodes": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/c1ae205f695c#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/c1ae205f695c",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/c3821307f292": {
+    "text": "Umgang mit Wölfen mit herausforderndem Verhalten",
+    "position": 2,
+    "id": "c3821307f292",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b451128bb144"
+    },
+    "children": {
+      "href": "/checklist_items/c3821307f292#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/c3821307f292#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/c3821307f292",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/c3821307f292#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/c3821307f292#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/c3821307f292",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/c3821307f292#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/1a2905b61cff"
+      },
+      {
+        "href": "/content_node/checklist_nodes/3157182811bb"
+      },
+      {
+        "href": "/content_node/checklist_nodes/42a32ff460d3"
+      },
+      {
+        "href": "/content_node/checklist_nodes/503cf893fa56"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/c3821307f292#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/c3821307f292",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/d89bc5e145fc": {
+    "text": "Entwicklungsstand und Bedürfnisse der Kinder der Wolfsstufe",
+    "position": 0,
+    "id": "d89bc5e145fc",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/18db4adbe9b1"
+    },
+    "children": {
+      "href": "/checklist_items/d89bc5e145fc#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/d89bc5e145fc#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/d89bc5e145fc",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/d89bc5e145fc#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/d89bc5e145fc#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/d89bc5e145fc",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/d89bc5e145fc#checklistNodes": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/d89bc5e145fc#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/d89bc5e145fc",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/d8becc2dbd1d": {
+    "text": "Der Kurs bildet die TN aus, ein Programm für die Wolfsstufe zu planen, durchzuführen und auszuwerten.",
+    "position": 1,
+    "id": "d8becc2dbd1d",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": null,
+    "children": {
+      "href": "/checklist_items/d8becc2dbd1d#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/d8becc2dbd1d#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/d8becc2dbd1d",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/d8becc2dbd1d#children": {
+    "items": [
+      {
+        "href": "/checklist_items/5a636c05a4ea"
+      },
+      {
+        "href": "/checklist_items/7adeeaf021e1"
+      },
+      {
+        "href": "/checklist_items/e6fcf0036360"
+      },
+      {
+        "href": "/checklist_items/a343d952c7b3"
+      },
+      {
+        "href": "/checklist_items/a7a0b22553eb"
+      },
+      {
+        "href": "/checklist_items/2d852f508228"
+      },
+      {
+        "href": "/checklist_items/bc505beba987"
+      },
+      {
+        "href": "/checklist_items/9c9f75e6354a"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/d8becc2dbd1d#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/d8becc2dbd1d",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/d8becc2dbd1d#checklistNodes": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/d8becc2dbd1d#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/d8becc2dbd1d",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/e04ccc274611": {
+    "text": "Leitwölfe betreuen",
+    "position": 1,
+    "id": "e04ccc274611",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b451128bb144"
+    },
+    "children": {
+      "href": "/checklist_items/e04ccc274611#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/e04ccc274611#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/e04ccc274611",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/e04ccc274611#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/e04ccc274611#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/e04ccc274611",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/e04ccc274611#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/3157182811bb"
+      },
+      {
+        "href": "/content_node/checklist_nodes/42a32ff460d3"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/e04ccc274611#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/e04ccc274611",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/e36bf8ea1eaa": {
+    "text": "Stufenmodell und Abgrenzung zw. Biber-, Wolfs- und Pfadistufe",
+    "position": 4,
+    "id": "e36bf8ea1eaa",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/18db4adbe9b1"
+    },
+    "children": {
+      "href": "/checklist_items/e36bf8ea1eaa#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/e36bf8ea1eaa#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/e36bf8ea1eaa",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/e36bf8ea1eaa#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/e36bf8ea1eaa#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/e36bf8ea1eaa",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/e36bf8ea1eaa#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/d8e5da1e3d52"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/e36bf8ea1eaa#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/e36bf8ea1eaa",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/e6fcf0036360": {
+    "text": "Planen, Durchführen und Auswerten von J+S Aktivitäten für die Wolfsstufe",
+    "position": 5,
+    "id": "e6fcf0036360",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/d8becc2dbd1d"
+    },
+    "children": {
+      "href": "/checklist_items/e6fcf0036360#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/e6fcf0036360#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/e6fcf0036360",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/e6fcf0036360#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/e6fcf0036360#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/e6fcf0036360",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/e6fcf0036360#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/3f48816bccae"
+      },
+      {
+        "href": "/content_node/checklist_nodes/3157182811bb"
+      },
+      {
+        "href": "/content_node/checklist_nodes/bf4fc1e44a0b"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/e6fcf0036360#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/e6fcf0036360",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/facdd937ab38": {
+    "text": "Möglichkeiten der Aus- und Weiterbildung",
+    "position": 7,
+    "id": "facdd937ab38",
+    "checklist": {
+      "href": "/checklists/ebbd0c61eb85"
+    },
+    "parent": {
+      "href": "/checklist_items/b451128bb144"
+    },
+    "children": {
+      "href": "/checklist_items/facdd937ab38#children",
+      "virtual": true
+    },
+    "checklistNodes": {
+      "href": "/checklist_items/facdd937ab38#checklistNodes",
+      "virtual": true
+    },
+    "_meta": {
+      "self": "/checklist_items/facdd937ab38",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/facdd937ab38#children": {
+    "items": [],
+    "_meta": {
+      "self": "/checklist_items/facdd937ab38#children",
+      "virtual": true,
+      "owningResource": "/checklist_items/facdd937ab38",
+      "owningRelation": "children",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/checklist_items/facdd937ab38#checklistNodes": {
+    "items": [
+      {
+        "href": "/content_node/checklist_nodes/3f48816bccae"
+      },
+      {
+        "href": "/content_node/checklist_nodes/9e95b10e3cb0"
+      }
+    ],
+    "_meta": {
+      "self": "/checklist_items/facdd937ab38#checklistNodes",
+      "virtual": true,
+      "owningResource": "/checklist_items/facdd937ab38",
+      "owningRelation": "checklistNodes",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  }
+}

--- a/pdf/src/renderer/__tests__/fullCampStoreContent.json
+++ b/pdf/src/renderer/__tests__/fullCampStoreContent.json
@@ -9250,8 +9250,11 @@
     }
   },
   "/content_types": {
-    "totalItems": 7,
+    "totalItems": 11,
     "items": [
+      {
+        "href": "/content_types/a4211c11211c"
+      },
       {
         "href": "/content_types/f17470519474"
       },
@@ -9259,10 +9262,19 @@
         "href": "/content_types/1a0f84e322c8"
       },
       {
+        "href": "/content_types/c462edd869f3"
+      },
+      {
+        "href": "/content_types/5e2028c55ee4"
+      },
+      {
         "href": "/content_types/3ef17bd1df72"
       },
       {
         "href": "/content_types/4f0c657fecef"
+      },
+      {
+        "href": "/content_types/a4211c112939"
       },
       {
         "href": "/content_types/44dcc7493c65"
@@ -9863,6 +9875,62 @@
     "campCollaboration": null,
     "_meta": {
       "self": "/material_lists/38a28bc6e4b7",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/a4211c11211c": {
+    "name": "Checklist",
+    "active": true,
+    "id": "a4211c11211c",
+    "contentNodes": {
+      "href": "/content_node/checklist_nodes?contentType=%2Fapi%2Fcontent_types%2Fa4211c11211c"
+    },
+    "_meta": {
+      "self": "/content_types/a4211c11211c",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/a4211c112939": {
+    "name": "ResponsiveLayout",
+    "active": true,
+    "id": "a4211c112939",
+    "contentNodes": {
+      "href": "/content_node/responsive_layouts?contentType=%2Fapi%2Fcontent_types%2Fa4211c112939"
+    },
+    "_meta": {
+      "self": "/content_types/a4211c112939",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/c462edd869f3": {
+    "name": "LearningObjectives",
+    "active": true,
+    "id": "c462edd869f3",
+    "contentNodes": {
+      "href": "/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2Fc462edd869f3"
+    },
+    "_meta": {
+      "self": "/content_types/c462edd869f3",
+      "loading": false,
+      "reloading": false,
+      "load": "{}"
+    }
+  },
+  "/content_types/5e2028c55ee4": {
+    "name": "LearningTopics",
+    "active": true,
+    "id": "5e2028c55ee4",
+    "contentNodes": {
+      "href": "/content_node/single_texts?contentType=%2Fapi%2Fcontent_types%2F5e2028c55ee4"
+    },
+    "_meta": {
+      "self": "/content_types/5e2028c55ee4",
       "loading": false,
       "reloading": false,
       "load": "{}"

--- a/pdf/src/renderer/__tests__/vueRenderer.spec.js
+++ b/pdf/src/renderer/__tests__/vueRenderer.spec.js
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, it, describe } from 'vitest'
 import wrap from './minimalHalJsonVuex.js'
 import fullCampStoreContent from './fullCampStoreContent.json'
+import courseActivityListStoreContent from './courseActivityListStoreContent.json'
 import activityWithSingleText from './activityWithSingleText.json'
 import { renderVueToPdfStructure } from '../vueRenderer.js'
 import SimpleDocument from './SimpleDocument.vue'
@@ -232,6 +233,37 @@ describe('rendering a full camp', () => {
 
     // then
     expect(result).toMatchFileSnapshot('./__snapshots__/table_of_contents.spec.json.snap')
+  })
+})
+
+describe('rendering a course activity list', () => {
+  it('renders the activity list', async () => {
+    // given
+    const store = wrap(courseActivityListStoreContent)
+
+    // when
+    const result = renderVueToPdfStructure(CampPrint, {
+      store,
+      $tc: tcMock,
+      locale: 'de',
+      config: {
+        language: 'de',
+        documentName: 'Basiskurs.pdf',
+        options: { pageNumbers: false },
+        camp: store.get('/camps/5d28f99890bc'),
+        contents: [
+          {
+            type: 'ActivityList',
+            options: {
+              periods: ['/periods/88f1f55a69d7'],
+            },
+          },
+        ],
+      },
+    })
+
+    // then
+    expect(result).toMatchFileSnapshot('./__snapshots__/activity_list.spec.json.snap')
   })
 })
 


### PR DESCRIPTION
The activity list was not yet providing the camp, as opposed to the ScheduleEntry.vue component.
This was broken in #8126, but only now some courses have started to use this printout to import the list of activities into Qualix.