### PR TITLE
Fix client printing story context

### DIFF
--- a/pdf/src/campPrint/summary/SafetyConsiderations.vue
+++ b/pdf/src/campPrint/summary/SafetyConsiderations.vue
@@ -5,6 +5,7 @@
       v-for="period in periods"
       :id="id"
       :period="period"
+      :type="content.type"
       :content-type="content.options.contentType"
       :filter="content.options.filter"
     />

--- a/pdf/src/campPrint/summary/Story.vue
+++ b/pdf/src/campPrint/summary/Story.vue
@@ -5,7 +5,8 @@
       v-for="period in periods"
       :id="id"
       :period="period"
-      :content-type="content.type"
+      :type="content.type"
+      :content-type="content.options.contentType"
       :filter="content.options.filter"
     />
   </Page>

--- a/pdf/src/campPrint/summary/SummaryPeriod.vue
+++ b/pdf/src/campPrint/summary/SummaryPeriod.vue
@@ -29,6 +29,7 @@ export default {
   extends: PdfComponent,
   props: {
     period: { type: Object, required: true },
+    type: { type: String, required: true },
     contentType: { type: String, required: true },
     filter: { type: Object, default: () => ({}) },
   },
@@ -48,7 +49,7 @@ export default {
       return sortBy(days, (day) => this.$date.utc(day.start).unix())
     },
     title() {
-      return this.$tc('print.' + this.camelCase(this.contentType) + '.title')
+      return this.$tc('print.' + this.camelCase(this.type) + '.title')
     },
   },
   methods: { camelCase },

--- a/pdf/src/renderer/__tests__/__snapshots__/safety_considerations.spec.json.snap
+++ b/pdf/src/renderer/__tests__/__snapshots__/safety_considerations.spec.json.snap
@@ -1,0 +1,1038 @@
+{
+  "box": {},
+  "children": [
+    {
+      "box": {},
+      "children": [
+        {
+          "box": {},
+          "children": [],
+          "parent": [Circular],
+          "props": {
+            "render": [Function],
+          },
+          "style": {},
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "parent": [Circular],
+              "type": "TEXT_INSTANCE",
+              "value": "Safety considerations: Hauptlager",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "bookmark": {
+              "fit": true,
+              "title": "Safety considerations: Hauptlager",
+            },
+            "class": "summary-period-title",
+            "id": "entry-0-16b2fcffdd8e",
+          },
+          "style": {
+            "fontSize": "10pt",
+            "fontWeight": "bold",
+            "textAlign": "center",
+          },
+          "type": "TEXT",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Day 1",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "summary-day-title",
+              },
+              "style": {
+                "fontSize": "14",
+                "fontWeight": "semibold",
+                "margin": "10pt 0 3pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Fr 05/10/2024",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "summary-day-date",
+              },
+              "style": {
+                "fontSize": "11pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-day-title-container",
+            "id": "entry-0-16b2fcffdd8e-f036e9302f67",
+          },
+          "style": {
+            "alignItems": "baseline",
+            "borderBottom": "2pt solid #aaaaaa",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": "1pt",
+            "paddingBottom": "2pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LP",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#90B7E4",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#90B7E4",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "1.4 Takeoff",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-b12d0af13de0",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Apotheke in Aufenthaltszelt oder Matzelt (Nach SIKO)",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Day 2",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "summary-day-title",
+              },
+              "style": {
+                "fontSize": "14",
+                "fontWeight": "semibold",
+                "margin": "10pt 0 3pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Sa 05/11/2024",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "summary-day-date",
+              },
+              "style": {
+                "fontSize": "11pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-day-title-container",
+            "id": "entry-0-16b2fcffdd8e-f036e9302f68",
+          },
+          "style": {
+            "alignItems": "baseline",
+            "borderBottom": "2pt solid #aaaaaa",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": "1pt",
+            "paddingBottom": "2pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LS",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#4DBB52",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#4DBB52",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "2.6 Angriff der Aborigines",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-9c5b963da5e1",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Apotheke mitnehmen, Gelände vorher absuchen wegen Gefahren",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LP",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#90B7E4",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#90B7E4",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "2.7 Pfadiversprechen",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-f2923b997126",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Apotheke im Aufenthalts / Matzelt (Nach SIKO)",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LP",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#90B7E4",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#90B7E4",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "2.9 Essen zurückerobern",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-3da4545af722",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Gelende vorher Rekken (wespenneste etc)",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Apotheke und handy dabei",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Day 3",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "summary-day-title",
+              },
+              "style": {
+                "fontSize": "14",
+                "fontWeight": "semibold",
+                "margin": "10pt 0 3pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Su 05/12/2024",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "summary-day-date",
+              },
+              "style": {
+                "fontSize": "11pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-day-title-container",
+            "id": "entry-0-16b2fcffdd8e-f036e9302f69",
+          },
+          "style": {
+            "alignItems": "baseline",
+            "borderBottom": "2pt solid #aaaaaa",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": "1pt",
+            "paddingBottom": "2pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LA",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#FF9800",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#FF9800",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "3.A Pfadiversprechen",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-6ee7b9aa5f9b",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Apotheke und Handy vor Ort",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LS",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#4DBB52",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#4DBB52",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "3.5 Abschluss geländegame",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-501abe71a6ab",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Apotheke mitnehmen, Gelände vorher absuchen wegen Gefahren. Drei mal Pfeifen = besammeln beim neutralen Posten.",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Day 4",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "summary-day-title",
+              },
+              "style": {
+                "fontSize": "14",
+                "fontWeight": "semibold",
+                "margin": "10pt 0 3pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Mo 05/13/2024",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "summary-day-date",
+              },
+              "style": {
+                "fontSize": "11pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-day-title-container",
+            "id": "entry-0-16b2fcffdd8e-f036e9302f70",
+          },
+          "style": {
+            "alignItems": "baseline",
+            "borderBottom": "2pt solid #aaaaaa",
+            "display": "flex",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": "1pt",
+            "paddingBottom": "2pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LS",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#4DBB52",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#4DBB52",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "4.1 Morgenturnen",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-c76ea4bae834",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Handy bei leiter",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Aputheke ist auf lagergelende vorhanden",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+      ],
+      "parent": [Circular],
+      "props": {
+        "class": "page",
+        "id": "entry-0",
+      },
+      "style": {
+        "display": "flex",
+        "flexDirection": "column",
+        "fontFamily": "InterDisplay",
+        "fontSize": "12",
+        "padding": "30",
+      },
+      "type": "PAGE",
+    },
+  ],
+  "parent": null,
+  "props": {
+    "locale": "de",
+    "pdfVersion": "1.7",
+    "store": {
+      "get": [Function],
+      "href": [Function],
+    },
+    "tc": [Function],
+  },
+  "style": {},
+  "type": "DOCUMENT",
+}

--- a/pdf/src/renderer/__tests__/__snapshots__/story_overview.spec.json.snap
+++ b/pdf/src/renderer/__tests__/__snapshots__/story_overview.spec.json.snap
@@ -106,6 +106,306 @@
                 {
                   "parent": [Circular],
                   "type": "TEXT_INSTANCE",
+                  "value": "LS",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#4DBB52",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#4DBB52",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "1.1 Stadt Game 🐭",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-4bc1873a73f2",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Unsere Flugtickets sind davongeflogen (Wind) wir müssen sie wieder einsammeln",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LP",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#90B7E4",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#90B7E4",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "1.4 Takeoff",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-b12d0af13de0",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Wir fliegen Ab. Die Flugbegleiter erklären uns wie wir in Notfallsituationen handeln müssen.",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LP",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#90B7E4",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#90B7E4",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "1.5 Flugzeugabsturz",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-4b4f2d67ee32",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Wir stürzen ab. Der Pilot verlässt das Flugzeug früher, weil die Steuerung nicht mehr funktioniert und er der Meinung ist, dass wir in die Insel stürzen würden und er nicht sterben will. oder so ähnlch de Pilot isch denn eifach verscholle",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
                   "value": "Day 2",
                 },
               ],
@@ -164,6 +464,406 @@
                 {
                   "parent": [Circular],
                   "type": "TEXT_INSTANCE",
+                  "value": "LS",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#4DBB52",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#4DBB52",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "2.4 Insel erkunden",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-46cad2b11017",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Wir müssen die Insel erkunden",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LS",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#4DBB52",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#4DBB52",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "2.6 Angriff der Aborigines",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-9c5b963da5e1",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Die eingeborenen greifen uns an und klauen uns unser essen.",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LP",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#90B7E4",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#90B7E4",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "2.7 Pfadiversprechen",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-f2923b997126",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Pfadigesetzt und Pfadiversprechen durch verschiedene Methoden lernen",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LP",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#90B7E4",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#90B7E4",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "2.9 Essen zurückerobern",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-3da4545af722",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "wir müssen uns unser Essen zurückholen (evtl. Lasergame oder suscht was Geils)",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
                   "value": "Day 3",
                 },
               ],
@@ -210,6 +910,206 @@
             "justifyContent": "space-between",
             "marginBottom": "1pt",
             "paddingBottom": "2pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LP",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#90B7E4",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#90B7E4",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "3.3 Atelier",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-69226b3e49d7",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Was könnte man machen um Rettung zu holen? Blubb meint wir sollten warten bis wir gerettet werden und uns ein wenig die Zeit vertreiben",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "LS",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "category-label",
+                "style": {
+                  "backgroundColor": "#4DBB52",
+                  "color": "#000",
+                  "font-size": "10pt",
+                },
+              },
+              "style": {
+                "alignSelf": "center",
+                "backgroundColor": "#4DBB52",
+                "borderRadius": "18pt",
+                "color": "#000",
+                "fontSize": "10pt",
+                "padding": "2pt 8pt",
+              },
+              "type": "TEXT",
+            },
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "3.5 Abschluss geländegame",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "id": "entry-0-16b2fcffdd8e-501abe71a6ab",
+                "style": {
+                  "margin": "0 3pt",
+                },
+              },
+              "style": {
+                "margin": "0 3pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "class": "summary-chapter-title",
+            "minPresenceAhead": 30,
+          },
+          "style": {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "fontWeight": "bold",
+            "margin": "10pt 0 4.5pt",
+          },
+          "type": "VIEW",
+        },
+        {
+          "box": {},
+          "children": [
+            {
+              "box": {},
+              "children": [
+                {
+                  "parent": [Circular],
+                  "type": "TEXT_INSTANCE",
+                  "value": "Plottwist der Pilot hat sich zum Anführer der eingeborenen hochgekämpft. und wir müssen ein Notsignal senden",
+                },
+              ],
+              "parent": [Circular],
+              "props": {
+                "class": "p",
+              },
+              "style": {
+                "marginBottom": "2pt",
+              },
+              "type": "TEXT",
+            },
+          ],
+          "parent": [Circular],
+          "props": {
+            "style": {
+              "line-height": "1",
+            },
+          },
+          "style": {
+            "lineHeight": "1",
           },
           "type": "VIEW",
         },

--- a/pdf/src/renderer/__tests__/vueRenderer.spec.js
+++ b/pdf/src/renderer/__tests__/vueRenderer.spec.js
@@ -150,6 +150,38 @@ describe('rendering a full camp', () => {
     expect(result).toMatchFileSnapshot('./__snapshots__/story_overview.spec.json.snap')
   })
 
+  it('renders the safety considerations overview', async () => {
+    // given
+    const store = wrap(fullCampStoreContent)
+
+    // when
+    const result = renderVueToPdfStructure(CampPrint, {
+      store,
+      $tc: tcMock,
+      locale: 'de',
+      config: {
+        language: 'de',
+        documentName: 'Pfila 2023.pdf',
+        options: { pageNumbers: false },
+        camp: store.get('/camps/c4cca3a51342'),
+        contents: [
+          {
+            type: 'SafetyConsiderations',
+            options: {
+              periods: ['/periods/16b2fcffdd8e'],
+              contentType: 'SafetyConsiderations',
+            },
+          },
+        ],
+      },
+    })
+
+    // then
+    expect(result).toMatchFileSnapshot(
+      './__snapshots__/safety_considerations.spec.json.snap'
+    )
+  })
+
   it('renders the program', async () => {
     // given
     const store = wrap(fullCampStoreContent)

--- a/pdf/src/renderer/__tests__/vueRenderer.spec.js
+++ b/pdf/src/renderer/__tests__/vueRenderer.spec.js
@@ -139,6 +139,7 @@ describe('rendering a full camp', () => {
             type: 'Story',
             options: {
               periods: ['/periods/16b2fcffdd8e'],
+              contentType: 'Storycontext',
             },
           },
         ],


### PR DESCRIPTION
We named our contentType "Storycontext", but the PDF building block "Story". This led to confusion on my side in #8002.

The snapshots now correctly include the storycontext texts.

I also added a snapshot test for the safety considerations overview.