### PR TITLE
Switch to a better maintained twemoji library 🪎

### DIFF
--- a/frontend/scripts/install-twemoji.sh
+++ b/frontend/scripts/install-twemoji.sh
@@ -10,10 +10,10 @@ if [ ! -d "public/twemoji" ]
 then
   echo 'downloading twemoji images from GitHub...'
   # Clone as little as possible. No past revisions and only the image files we are interested in.
-  git clone --depth 1 --no-checkout --filter=blob:none --sparse https://github.com/twitter/twemoji.git public/twemoji
+  git clone --depth 1 --no-checkout --filter=blob:none --sparse https://github.com/jdecked/twemoji.git public/twemoji
   cd public/twemoji
   git sparse-checkout set assets/72x72
-  git checkout master
+  git checkout main
 else
   echo 'twemoji are already present, updating them to the latest version...'
   cd public/twemoji


### PR DESCRIPTION
This fork is maintained by former twitter employees, and supports up to version 17 instead of version 14 of the emoji standard. See:
https://github.com/jdecked/twemoji
https://github.com/jdecked/twemoji/releases/tag/v14.1.0

Since the project structure is identical, this should be a drop-in replacement with a lot more emoji becoming available instantly. This way, we have support for emoji even newer than my browser supports. E.g. the treasure chest emoji in the title of this PR is already supported: https://github.com/jdecked/twemoji/blob/main/assets/72x72/1fa8e.png