### PR TITLE
Keep ordering of checklist items when copying from prototype

### DIFF
--- a/api/src/Entity/Checklist.php
+++ b/api/src/Entity/Checklist.php
@@ -187,7 +187,7 @@ class Checklist extends BaseEntity implements BelongsToCampInterface, CopyFromPr
         // deep copy ChecklistItems
         foreach ($prototype->getChecklistItems() as $checklistItemPrototype) {
             // deep copy root ChecklistItems
-            // skip non-root ChecklistItems as these are copyed by there parent
+            // skip non-root ChecklistItems as these are copied by their parent
             if (null == $checklistItemPrototype->parent) {
                 $checklistItem = new ChecklistItem();
                 $this->addChecklistItem($checklistItem);

--- a/api/src/Entity/ChecklistItem.php
+++ b/api/src/Entity/ChecklistItem.php
@@ -242,6 +242,7 @@ class ChecklistItem extends BaseEntity implements BelongsToCampInterface, CopyFr
 
         // copy ChecklistItem base properties
         $this->text = $prototype->text;
+        $this->position = $prototype->position;
 
         // deep copy ChecklistItems
         foreach ($prototype->getChildren() as $childPrototype) {

--- a/api/tests/Entity/ChecklistItemTest.php
+++ b/api/tests/Entity/ChecklistItemTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\Camp;
+use App\Entity\Checklist;
+use App\Entity\ChecklistItem;
+use App\Util\EntityMap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class ChecklistItemTest extends TestCase {
+    private Camp $camp;
+    private Checklist $checklist;
+    private ChecklistItem $itemPrototype1;
+    private ChecklistItem $itemPrototype2;
+    private ChecklistItem $itemPrototype3;
+
+    public function setUp(): void {
+        $this->camp = new Camp();
+        $this->checklist = new Checklist();
+        $this->checklist->name = 'checklist1';
+        $this->camp->addChecklist($this->checklist);
+
+        $this->itemPrototype1 = new ChecklistItem();
+        $this->itemPrototype1->text = 'item1';
+        $this->itemPrototype1->position = 0;
+        $this->checklist->addChecklistItem($this->itemPrototype1);
+        $this->itemPrototype2 = new ChecklistItem();
+        $this->itemPrototype2->text = 'item2';
+        $this->itemPrototype2->position = 1;
+        $this->checklist->addChecklistItem($this->itemPrototype2);
+        $this->itemPrototype3 = new ChecklistItem();
+        $this->itemPrototype3->text = 'item3';
+        $this->itemPrototype3->position = 1337;
+        $this->itemPrototype2->addChild($this->itemPrototype3);
+    }
+
+    public function testCopyFromPrototypeCopiesTextAndPosition() {
+        // given
+        $copiedChecklist = new Checklist();
+
+        // when
+        $copiedChecklist->copyFromPrototype($this->checklist, new EntityMap($this->camp));
+
+        // then
+        $this->assertCount(3, $copiedChecklist->getChecklistItems());
+        $item1 = $copiedChecklist->getChecklistItems()[0];
+        $item2 = $copiedChecklist->getChecklistItems()[1];
+        $this->assertEquals($this->itemPrototype1->text, $item1->text);
+        $this->assertEquals($this->itemPrototype1->position, $item1->position);
+        $this->assertEquals($this->itemPrototype2->text, $item2->text);
+        $this->assertEquals($this->itemPrototype2->position, $item2->position);
+        $this->assertCount(1, $item2->getChildren());
+        $item3 = $item2->getChildren()[0];
+        $this->assertEquals($item2, $item3->parent);
+        $this->assertEquals($this->itemPrototype3->text, $item3->text);
+        $this->assertEquals($this->itemPrototype3->position, $item3->position);
+    }
+}


### PR DESCRIPTION
Previously, we didn't copy the `position` attribute from ChecklistItem prototypes. If the items were created in order (and you were lucky), the DB would return the items in order during `Checklist#copyFromPrototype`. But if some of the items in the checklist prototype were created or reordered later, it was not guaranteed that the order of the copied checklist items matches the order of the prototype checklist items.

Since the numbering of the checklist items is quite important for PBS courses, this is a problem.