### PR TITLE
api: fix more notices about using stubs instead of mocks

### DIFF
--- a/api/tests/Api/ResetPassword/UpdatePasswordTest.php
+++ b/api/tests/Api/ResetPassword/UpdatePasswordTest.php
@@ -7,6 +7,7 @@ use App\Security\ReCaptcha\ReCaptchaWrapper;
 use App\Tests\Api\ECampApiTestCase;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use ReCaptcha\Response;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
@@ -40,6 +41,7 @@ class UpdatePasswordTest extends ECampApiTestCase {
         ;
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testPatchResetPasswordValidatesBlankPassword() {
         $this->mockRecaptcha();
         $this->client->request('PATCH', '/auth/reset_password/'.$this->passwordResetKey, ['json' => [
@@ -57,6 +59,7 @@ class UpdatePasswordTest extends ECampApiTestCase {
         ]);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testPatchResetPasswordValidatesShortPassword() {
         $this->mockRecaptcha();
         $this->client->request('PATCH', '/auth/reset_password/'.$this->passwordResetKey, ['json' => [
@@ -74,6 +77,7 @@ class UpdatePasswordTest extends ECampApiTestCase {
         ]);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testPatchResetPasswordAllowsLongPassword() {
         $this->mockRecaptcha();
         $this->client->request('PATCH', '/auth/reset_password/'.$this->passwordResetKey, ['json' => [
@@ -83,6 +87,7 @@ class UpdatePasswordTest extends ECampApiTestCase {
         $this->assertResponseStatusCodeSame(200);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testPatchResetPasswordValidatesUnreasonablyLongPassword() {
         $this->mockRecaptcha();
         $this->client->request('PATCH', '/auth/reset_password/'.$this->passwordResetKey, ['json' => [
@@ -105,6 +110,7 @@ class UpdatePasswordTest extends ECampApiTestCase {
      * @throws TransportExceptionInterface
      * @throws NoResultException
      */
+    #[AllowMockObjectsWithoutExpectations]
     public function testPatchResetPasswordActivatesUser() {
         $this->mockRecaptcha();
         $this->getEntityManager()->createQueryBuilder()

--- a/api/tests/Serializer/Denormalizer/InputFilterDenormalizerTest.php
+++ b/api/tests/Serializer/Denormalizer/InputFilterDenormalizerTest.php
@@ -8,6 +8,7 @@ use App\InputFilter\InputFilter;
 use App\Serializer\Denormalizer\InputFilterDenormalizer;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -26,7 +27,7 @@ class InputFilterDenormalizerTest extends TestCase {
     private $decoratedMock;
 
     protected function setUp(): void {
-        $inputFilterLocatorMock = $this->createMock(ServiceLocator::class);
+        $inputFilterLocatorMock = $this->createStub(ServiceLocator::class);
         $inputFilterLocatorMock->method('get')->willReturnCallback(function (string $name): mixed {
             return new $name();
         });
@@ -58,6 +59,7 @@ class InputFilterDenormalizerTest extends TestCase {
         $this->assertEquals(['ab' => 'xxxAB', 'ba' => 'yyyBA'], $result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testSupportsValidArray() {
         $this->assertTrue(
             $this->denormalizer->supportsDenormalization(
@@ -69,6 +71,7 @@ class InputFilterDenormalizerTest extends TestCase {
         );
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testDoesntSupportNonArray() {
         $this->assertFalse(
             $this->denormalizer->supportsDenormalization(

--- a/api/tests/Serializer/Normalizer/CollectionItemsNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/CollectionItemsNormalizerTest.php
@@ -24,7 +24,7 @@ class CollectionItemsNormalizerTest extends TestCase {
         $this->decoratedMock = $this->createMock(NormalizerInterface::class);
 
         $this->normalizer = new CollectionItemsNormalizer($this->decoratedMock);
-        $this->normalizer->setNormalizer($this->createMock(NormalizerInterface::class));
+        $this->normalizer->setNormalizer($this->createStub(NormalizerInterface::class));
     }
 
     public function testDelegatesSupportCheckToDecorated() {
@@ -59,6 +59,7 @@ class CollectionItemsNormalizerTest extends TestCase {
         $this->assertSame($delegatedResult, $result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeReplacesEmbeddedAndLinkedItemWithItems() {
         // given
         $resource = [];
@@ -85,6 +86,7 @@ class CollectionItemsNormalizerTest extends TestCase {
         ], $result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeAddsEmptyEmbeddedItemsIfTotalItemsIsZero() {
         // given
         $resource = [];

--- a/api/tests/Serializer/Normalizer/ContentTypeNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/ContentTypeNormalizerTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\Serializer\SerializerInterface;
 /**
  * @internal
  */
-#[AllowMockObjectsWithoutExpectations]
 class ContentTypeNormalizerTest extends TestCase {
     private ContentTypeNormalizer $normalizer;
 
@@ -27,7 +26,7 @@ class ContentTypeNormalizerTest extends TestCase {
     protected function setUp(): void {
         $this->decoratedMock = $this->createMock(NormalizerInterface::class);
 
-        $iriConverter = $this->createMock(IriConverterInterface::class);
+        $iriConverter = $this->createStub(IriConverterInterface::class);
         $this->uriTemplate = $this->createMock(UriTemplate::class);
         $this->uriTemplateFactory = $this->createMock(UriTemplateFactory::class);
 
@@ -37,9 +36,10 @@ class ContentTypeNormalizerTest extends TestCase {
             $this->uriTemplateFactory,
             $iriConverter,
         );
-        $this->normalizer->setSerializer($this->createMock(SerializerInterface::class));
+        $this->normalizer->setSerializer($this->createStub(SerializerInterface::class));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testDelegatesSupportCheckToDecorated() {
         $this->decoratedMock
             ->expects($this->exactly(2))
@@ -51,6 +51,7 @@ class ContentTypeNormalizerTest extends TestCase {
         $this->assertFalse($this->normalizer->supportsNormalization([]));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testDelegatesNormalizeToDecorated() {
         // given
         $resource = new \stdClass();

--- a/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Serializer\Normalizer;
 use ApiPlatform\Doctrine\Common\Filter\SearchFilterInterface;
 use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -22,6 +23,7 @@ use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Rize\UriTemplate;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -35,20 +37,19 @@ use Symfony\Component\Serializer\SerializerInterface;
 /**
  * @internal
  */
-#[AllowMockObjectsWithoutExpectations]
 class RelatedCollectionLinkNormalizerTest extends TestCase {
     private RelatedCollectionLinkNormalizer $normalizer;
 
     private MockObject|NormalizerInterface $decoratedMock;
-    private MockObject|NameConverterInterface $nameConverterMock;
+    private NameConverterInterface|Stub $nameConverterMock;
     private MockObject|UriTemplate $uriTemplate;
     private MockObject|UriTemplateFactory $uriTemplateFactory;
-    private MockObject|RouterInterface $routerMock;
-    private IriConverterInterface|MockObject $iriConverterMock;
-    private ManagerRegistry|MockObject $managerRegistryMock;
-    private MockObject|ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactoryMock;
-    private MockObject|PropertyAccessorInterface $propertyAccessor;
-    private EntityManagerInterface|MockObject $entityManager;
+    private RouterInterface|Stub $routerMock;
+    private IriConverterInterface|Stub $iriConverterMock;
+    private ManagerRegistry|Stub $managerRegistryMock;
+    private ResourceMetadataCollectionFactoryInterface|Stub $resourceMetadataCollectionFactoryMock;
+    private PropertyAccessorInterface|Stub $propertyAccessor;
+    private EntityManagerInterface|Stub $entityManager;
 
     private DateFilter|SearchFilterInterface|null $filterInstance = null;
 
@@ -87,6 +88,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->normalizer->setSerializer($this->createStub(SerializerInterface::class));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testDelegatesSupportCheckToDecorated() {
         $this->decoratedMock
             ->expects($this->exactly(2))
@@ -98,6 +100,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->assertFalse($this->normalizer->supportsNormalization([]));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testDelegatesNormalizeToDecorated() {
         // given
         $resource = new ParentEntity();
@@ -119,6 +122,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->assertSame($delegatedResult, $result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testHandlesDecoratedNormalizerReturningAnIRIString() {
         // given
         $resource = new ParentEntity();
@@ -135,6 +139,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->assertSame($delegatedResult, $result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testFallsBackToObjectClassWhenResourceClassIsMissingInContext() {
         // given
         $resource = new ParentEntity();
@@ -156,6 +161,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->assertSame($delegatedResult, $result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeReplacesLinkArrayWithSingleFilteredCollectionLink() {
         // given
         $resource = new ParentEntity();
@@ -179,6 +185,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->shouldReplaceChildrenWithLink($result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeReplacesLinkArrayWithSingleFilteredCollectionLinkBasedOnAttribute() {
         // given
         $resource = new ParentEntity();
@@ -220,6 +227,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         ], $result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeReplacesSerializedNameLinkArray() {
         // given
         $resource = new ParentEntity();
@@ -260,6 +268,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         ], $result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeDoesntReplaceWhenFilterDoesntApplyToMappedProperty() {
         // given
         $resource = new ParentEntity();
@@ -282,6 +291,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->shouldNotReplaceChildren($result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeDoesntReplaceWhenEmptyFiltersArray() {
         // given
         $resource = new ParentEntity();
@@ -304,6 +314,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->shouldNotReplaceChildren($result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeDoesntReplaceWhenNoFilters() {
         // given
         $resource = new ParentEntity();
@@ -326,6 +337,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->shouldNotReplaceChildren($result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeDoesntReplaceWhenTargetEntityIsMissing() {
         // given
         $resource = new ParentEntity();
@@ -348,13 +360,14 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->shouldNotReplaceChildren($result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeDoesntReplaceWhenNotADoctrineAssociation() {
         // given
         $resource = new ParentEntity();
         $this->mockDecoratedNormalizer();
         $this->mockNameConverter();
 
-        $classMetadata = $this->createMock(ORM\ClassMetadata::class);
+        $classMetadata = $this->createStub(ORM\ClassMetadata::class);
         $classMetadata->method('getAssociationMapping')->willThrowException(new ORM\MappingException('test exception'));
         $this->entityManager->method('getClassMetadata')->willReturn($classMetadata);
         $this->managerRegistryMock->method('getManagerForClass')->willReturn($this->entityManager);
@@ -370,6 +383,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->shouldNotReplaceChildren($result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeDoesntReplaceWhenMappedByIsMissing() {
         // given
         $resource = new ParentEntity();
@@ -391,6 +405,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->shouldNotReplaceChildren($result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeDoesntReplaceWhenFilterDoesntExistInContainer() {
         // given
         $resource = new ParentEntity();
@@ -413,6 +428,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->shouldNotReplaceChildren($result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeDoesntReplaceWhenFilterIsNotSearchFilter() {
         // given
         $resource = new ParentEntity();
@@ -435,6 +451,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->shouldNotReplaceChildren($result);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testNormalizeDoesntReplaceWhenMissingGetCollectionOperation() {
         // given
         $resource = new ParentEntity();
@@ -474,7 +491,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
     }
 
     protected function mockAssociationMetadata($relationMetadata) {
-        $classMetadata = $this->createMock(ORM\ClassMetadata::class);
+        $classMetadata = $this->createStub(ORM\ClassMetadata::class);
         $classMetadata->method('getAssociationMapping')->willReturn($relationMetadata);
         $classMetadata->method('hasAssociation')->willReturn(true);
 

--- a/api/tests/Serializer/Normalizer/UriTemplateNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/UriTemplateNormalizerTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\String\Inflector\EnglishInflector;
 /**
  * @internal
  */
-#[AllowMockObjectsWithoutExpectations]
 class UriTemplateNormalizerTest extends TestCase {
     private UriTemplateNormalizer $uriTemplateNormalizer;
     private MockObject|NormalizerInterface $decorated;
@@ -85,6 +84,7 @@ class UriTemplateNormalizerTest extends TestCase {
         ];
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCreateNotTemplatedLinkIfNoParameters() {
         // given
         $this->decorated->expects($this->once())->method('normalize')->willReturn(['_links' => [
@@ -113,6 +113,7 @@ class UriTemplateNormalizerTest extends TestCase {
         ));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCreateTemplatedLinkIfPathParameters() {
         // given
         $this->decorated->expects($this->once())->method('normalize')->willReturn(['_links' => [
@@ -142,6 +143,7 @@ class UriTemplateNormalizerTest extends TestCase {
         ));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCreateTemplatedLinkForQueryParameters() {
         // given
         $this->decorated->expects($this->once())->method('normalize')->willReturn(['_links' => [
@@ -171,6 +173,7 @@ class UriTemplateNormalizerTest extends TestCase {
         ));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testMergePathAndQueryParameter() {
         // given
         $this->decorated->expects($this->once())->method('normalize')->willReturn(['_links' => [

--- a/api/tests/Serializer/SerializerContextBuilderTest.php
+++ b/api/tests/Serializer/SerializerContextBuilderTest.php
@@ -28,7 +28,7 @@ class SerializerContextBuilderTest extends TestCase {
     }
 
     public function testAddsSkipNullValuesFalseWhenNormalizing() {
-        $request = $this->createMock(Request::class);
+        $request = $this->createStub(Request::class);
         $this->decoratedMock
             ->expects($this->exactly(1))
             ->method('createFromRequest')
@@ -47,7 +47,7 @@ class SerializerContextBuilderTest extends TestCase {
     }
 
     public function testDoesntAddSkipNullValuesFalseWhenDenormalizing() {
-        $request = $this->createMock(Request::class);
+        $request = $this->createStub(Request::class);
         $this->decoratedMock
             ->expects($this->exactly(1))
             ->method('createFromRequest')
@@ -60,7 +60,7 @@ class SerializerContextBuilderTest extends TestCase {
     }
 
     public function testDoesntAddAllowExtraAttributesFalseWhenNormalizing() {
-        $request = $this->createMock(Request::class);
+        $request = $this->createStub(Request::class);
         $this->decoratedMock
             ->expects($this->exactly(1))
             ->method('createFromRequest')
@@ -73,7 +73,7 @@ class SerializerContextBuilderTest extends TestCase {
     }
 
     public function testAddsAllowExtraAttributesFalseWhenDenormalizing() {
-        $request = $this->createMock(Request::class);
+        $request = $this->createStub(Request::class);
         $this->decoratedMock
             ->expects($this->exactly(1))
             ->method('createFromRequest')

--- a/api/tests/State/ActivityRemoveProcessorTest.php
+++ b/api/tests/State/ActivityRemoveProcessorTest.php
@@ -20,7 +20,7 @@ class ActivityRemoveProcessorTest extends TestCase {
     private EntityManagerInterface|MockObject $em;
 
     protected function setUp(): void {
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
 
         $this->activity = new Activity();

--- a/api/tests/State/CampCollaborationCreateProcessorTest.php
+++ b/api/tests/State/CampCollaborationCreateProcessorTest.php
@@ -25,7 +25,6 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 /**
  * @internal
  */
-#[AllowMockObjectsWithoutExpectations]
 class CampCollaborationCreateProcessorTest extends TestCase {
     use CampCollaborationTestTrait;
 
@@ -65,14 +64,14 @@ class CampCollaborationCreateProcessorTest extends TestCase {
         $this->profile->user = $this->user;
         $this->user->profile = $this->profile;
 
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
         $this->security = $this->createMock(Security::class);
         $this->security->expects(self::any())->method('getUser')->willReturn($this->user);
-        $pwHashFactory = $this->createMock(PasswordHasherFactory::class);
+        $pwHashFactory = $this->createStub(PasswordHasherFactory::class);
         $this->profileRepository = $this->createMock(ProfileRepository::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
         $this->mailService = $this->createMock(MailService::class);
-        $validator = $this->createMock(ValidatorInterface::class);
+        $validator = $this->createStub(ValidatorInterface::class);
 
         $this->processor = new CampCollaborationCreateProcessor(
             $decoratedProcessor,
@@ -85,6 +84,7 @@ class CampCollaborationCreateProcessorTest extends TestCase {
         );
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testAfterCreateSendsEmailIfInviteEmailSet() {
         $this->campCollaboration->inviteEmail = 'e@mail.com';
 
@@ -94,6 +94,7 @@ class CampCollaborationCreateProcessorTest extends TestCase {
         $this->processor->onAfter($result, new Post());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testAfterCreateCreatesMaterialList() {
         $this->campCollaboration->inviteEmail = 'e@mail.com';
         $this->security->expects(self::once())->method('getUser')->willReturn($this->user);
@@ -108,6 +109,7 @@ class CampCollaborationCreateProcessorTest extends TestCase {
         $this->processor->onAfter($result, new Post());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testAfterCreateSendsEmailIfUserSet() {
         $this->campCollaboration->inviteEmail = 'e@mail.com';
         $this->profileRepository
@@ -124,6 +126,7 @@ class CampCollaborationCreateProcessorTest extends TestCase {
         $this->processor->onAfter($result, new Post());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testAfterCreateDoesNotSendEmailIfNoInviteEmailSet() {
         $this->mailService->expects(self::never())->method('sendInviteToCampMail');
 
@@ -131,6 +134,7 @@ class CampCollaborationCreateProcessorTest extends TestCase {
         $this->processor->onAfter($result, new Post());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     #[DataProvider('notInvitedStatuses')]
     public function testAfterCreateDoesNotSendEmailIfStatusNotInvited(string $status) {
         $this->campCollaboration->inviteEmail = 'e@mail.com';

--- a/api/tests/State/CampCollaborationResendInvitationProcessorTest.php
+++ b/api/tests/State/CampCollaborationResendInvitationProcessorTest.php
@@ -51,10 +51,10 @@ class CampCollaborationResendInvitationProcessorTest extends TestCase {
         $profile->user = $this->user;
         $this->user->profile = $profile;
 
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
-        $security = $this->createMock(Security::class);
-        $security->expects(self::any())->method('getUser')->willReturn($this->user);
-        $pwHashFactory = $this->createMock(PasswordHasherFactory::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($this->user);
+        $pwHashFactory = $this->createStub(PasswordHasherFactory::class);
         $this->mailService = $this->createMock(MailService::class);
 
         $this->processor = new CampCollaborationResendInvitationProcessor(

--- a/api/tests/State/CampCollaborationUpdateProcessorTest.php
+++ b/api/tests/State/CampCollaborationUpdateProcessorTest.php
@@ -19,7 +19,6 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 /**
  * @internal
  */
-#[AllowMockObjectsWithoutExpectations]
 class CampCollaborationUpdateProcessorTest extends TestCase {
     use CampCollaborationTestTrait;
 
@@ -53,10 +52,10 @@ class CampCollaborationUpdateProcessorTest extends TestCase {
         $profile->user = $this->user;
         $this->user->profile = $profile;
 
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
         $security = $this->createMock(Security::class);
         $security->expects(self::any())->method('getUser')->willReturn($this->user);
-        $pwHashFactory = $this->createMock(PasswordHasherFactory::class);
+        $pwHashFactory = $this->createStub(PasswordHasherFactory::class);
         $this->mailService = $this->createMock(MailService::class);
 
         $this->processor = new CampCollaborationUpdateProcessor(
@@ -67,6 +66,7 @@ class CampCollaborationUpdateProcessorTest extends TestCase {
         );
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testDoesNothingOnStatusChangeWhenNoInviteEmail() {
         $this->mailService->expects(self::never())->method('sendInviteToCampMail');
 
@@ -78,6 +78,7 @@ class CampCollaborationUpdateProcessorTest extends TestCase {
         self::assertThat($result->inviteKey, self::equalTo(self::INITIAL_INVITE_KEY));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     #[DataProvider('notInvitedStatuses')]
     public function testOnStatusChangeDoesNothingIfStatusIsNotInvited(string $status) {
         $this->campCollaboration->inviteEmail = 'e@mail.com';
@@ -93,6 +94,7 @@ class CampCollaborationUpdateProcessorTest extends TestCase {
         self::assertThat($result->inviteKey, self::equalTo(self::INITIAL_INVITE_KEY));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testSendsInviteEmailIfStatusChangesToInvitedAndInviteEmailPresent() {
         $this->campCollaboration->inviteEmail = 'e@mail.com';
         $this->mailService->expects(self::once())->method('sendInviteToCampMail');
@@ -103,6 +105,7 @@ class CampCollaborationUpdateProcessorTest extends TestCase {
         self::assertThat($result->inviteKey, self::logicalNot(self::isNull()));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testSendsInviteEmailIfStatusChangesToInvitedAndUserPresent() {
         $this->campCollaboration->user = $this->user;
         $this->mailService->expects(self::once())->method('sendInviteToCampMail');

--- a/api/tests/State/CampCreateProcessorTest.php
+++ b/api/tests/State/CampCreateProcessorTest.php
@@ -11,8 +11,9 @@ use App\Entity\Profile;
 use App\Entity\User;
 use App\State\CampCreateProcessor;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Constraint\Callback;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 
@@ -21,19 +22,20 @@ use Symfony\Bundle\SecurityBundle\Security;
  */
 class CampCreateProcessorTest extends TestCase {
     private CampCreateProcessor $processor;
-    private MockObject|Security $security;
+    private Security|Stub $security;
     private EntityManagerInterface|MockObject $em;
     private Camp $camp;
 
     protected function setUp(): void {
         $this->camp = new Camp();
 
-        $this->security = $this->createMock(Security::class);
+        $this->security = $this->createStub(Security::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
         $this->processor = new CampCreateProcessor($decoratedProcessor, $this->security, $this->em);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testSetsCreatorAndOwnerOnCreate() {
         // given
         $user = new User();

--- a/api/tests/State/CampRemoveProcessorTest.php
+++ b/api/tests/State/CampRemoveProcessorTest.php
@@ -25,7 +25,7 @@ class CampRemoveProcessorTest extends TestCase {
         $this->camp = new Camp();
 
         $this->em = $this->createMock(EntityManagerInterface::class);
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
         $this->processor = new CampRemoveProcessor($decoratedProcessor, $this->em);
     }
 

--- a/api/tests/State/CategoryCreateProcessorTest.php
+++ b/api/tests/State/CategoryCreateProcessorTest.php
@@ -9,7 +9,7 @@ use App\Entity\ContentType;
 use App\State\CategoryCreateProcessor;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,30 +17,30 @@ use PHPUnit\Framework\TestCase;
  */
 class CategoryCreateProcessorTest extends TestCase {
     private CategoryCreateProcessor $processor;
-    private EntityManagerInterface|MockObject $entityManagerMock;
+    private EntityManagerInterface|Stub $entityManagerStub;
     private Category $category;
 
     protected function setUp(): void {
         $this->category = new Category();
 
-        $this->entityManagerMock = $this->createMock(EntityManagerInterface::class);
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $this->entityManagerStub = $this->createStub(EntityManagerInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
         $this->processor = new CategoryCreateProcessor(
             $decoratedProcessor,
-            $this->entityManagerMock
+            $this->entityManagerStub
         );
     }
 
     public function testCreatesNewContentNodeBeforeCreate() {
         // given
-        $repositoryMock = $this->createMock(EntityRepository::class);
+        $repositoryMock = $this->createStub(EntityRepository::class);
         $repositoryMock->method('findOneBy')->willReturnCallback(function (array $criteria): object {
             $result = new ContentType();
             $result->name = $criteria['name'];
 
             return $result;
         });
-        $this->entityManagerMock->method('getRepository')->willReturn($repositoryMock);
+        $this->entityManagerStub->method('getRepository')->willReturn($repositoryMock);
 
         // when
         /** @var Category $data */

--- a/api/tests/State/CategoryRemoveProcessorTest.php
+++ b/api/tests/State/CategoryRemoveProcessorTest.php
@@ -20,7 +20,7 @@ class CategoryRemoveProcessorTest extends TestCase {
     private EntityManagerInterface|MockObject $em;
 
     protected function setUp(): void {
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
 
         $this->category = new Category();

--- a/api/tests/State/ContentNodes/ContentNodePersistProcessorTest.php
+++ b/api/tests/State/ContentNodes/ContentNodePersistProcessorTest.php
@@ -18,7 +18,7 @@ class ContentNodePersistProcessorTest extends TestCase {
     private ColumnLayout $contentNode;
 
     protected function setUp(): void {
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
 
         $this->contentNode = new ColumnLayout();
 

--- a/api/tests/State/ContentNodes/MultiSelectCreateProcessorTest.php
+++ b/api/tests/State/ContentNodes/MultiSelectCreateProcessorTest.php
@@ -20,7 +20,7 @@ class MultiSelectCreateProcessorTest extends TestCase {
     private MultiSelect $contentNode;
 
     protected function setUp(): void {
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
         $this->contentNode = new MultiSelect();
 
         $this->root = new ColumnLayout();

--- a/api/tests/State/ContentNodes/SingleTextPersistProcessorTest.php
+++ b/api/tests/State/ContentNodes/SingleTextPersistProcessorTest.php
@@ -28,8 +28,8 @@ class SingleTextPersistProcessorTest extends TestCase {
      * @throws Exception
      */
     protected function setUp(): void {
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
-        $cleanHTMLFilter = $this->createMock(CleanHTMLFilter::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
+        $cleanHTMLFilter = $this->createStub(CleanHTMLFilter::class);
         $cleanHTMLFilter->method('applyTo')->willReturnCallback(
             function (array $object, string $property): array {
                 $object[$property] = '***sanitizedHTML***';

--- a/api/tests/State/ContentNodes/StoryboardPersistProcessorTest.php
+++ b/api/tests/State/ContentNodes/StoryboardPersistProcessorTest.php
@@ -21,9 +21,9 @@ class StoryboardPersistProcessorTest extends TestCase {
     private Storyboard $contentNode;
 
     protected function setUp(): void {
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
 
-        $cleanHTMLFilter = $this->createMock(CleanHTMLFilter::class);
+        $cleanHTMLFilter = $this->createStub(CleanHTMLFilter::class);
         $cleanHTMLFilter->method('applyTo')->willReturnCallback(
             function (array $object, string $property): array {
                 $object[$property] = '***sanitizedHTML***';
@@ -32,7 +32,7 @@ class StoryboardPersistProcessorTest extends TestCase {
             }
         );
 
-        $cleanTextFilter = $this->createMock(CleanTextFilter::class);
+        $cleanTextFilter = $this->createStub(CleanTextFilter::class);
         $cleanTextFilter->method('applyTo')->willReturnCallback(
             function (array $object, string $property): array {
                 $object[$property] = '***sanitizedText***';
@@ -127,7 +127,6 @@ class StoryboardPersistProcessorTest extends TestCase {
         /** @var Storyboard $data */
         $data = $this->processor->onBefore($this->contentNode, new Patch());
 
-        // then
         // then
         $this->assertEquals(['sections' => [
             '37bbd7b8-441e-403e-b227-70ea52170b9b' => [

--- a/api/tests/State/PeriodPersistProcessorTest.php
+++ b/api/tests/State/PeriodPersistProcessorTest.php
@@ -48,7 +48,7 @@ class PeriodPersistProcessorTest extends TestCase {
         $this->dayResponsible = new DayResponsible();
         $day2->addDayResponsible($this->dayResponsible);
 
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
 
         $this->processor = new PeriodPersistProcessor(
             $decoratedProcessor

--- a/api/tests/State/ProfileUpdateProcessorTest.php
+++ b/api/tests/State/ProfileUpdateProcessorTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 /**
  * @internal
  */
-#[AllowMockObjectsWithoutExpectations]
 class ProfileUpdateProcessorTest extends TestCase {
     private ProfileUpdateProcessor $processor;
     private MockObject|PasswordHasherInterface $pwHasher;
@@ -37,7 +36,7 @@ class ProfileUpdateProcessorTest extends TestCase {
         $pwHasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
         $this->pwHasher = $this->createMock(PasswordHasherInterface::class);
         $this->mailService = $this->createMock(MailService::class);
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
 
         $pwHasherFactory->expects(self::any())
             ->method('getPasswordHasher')
@@ -48,12 +47,13 @@ class ProfileUpdateProcessorTest extends TestCase {
             $decoratedProcessor,
             $pwHasherFactory,
             $this->mailService,
-            $this->createMock(Security::class),
-            $this->createMock(UserRepository::class),
-            $this->createMock(ClaimInvitationService::class),
+            $this->createStub(Security::class),
+            $this->createStub(UserRepository::class),
+            $this->createStub(ClaimInvitationService::class),
         );
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testSetNewEmail() {
         // given
         $this->pwHasher->expects(self::once())
@@ -71,6 +71,7 @@ class ProfileUpdateProcessorTest extends TestCase {
         $this->assertNotNull($this->profile->untrustedEmailKeyHash);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testSendVerificationMail() {
         // given
         $this->profile->untrustedEmailKey = 'abc';
@@ -83,6 +84,7 @@ class ProfileUpdateProcessorTest extends TestCase {
         $this->assertNull($this->profile->untrustedEmailKey);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testChangeEmail() {
         // given
         $this->pwHasher->expects(self::once())

--- a/api/tests/State/ResendActivationProcessorTest.php
+++ b/api/tests/State/ResendActivationProcessorTest.php
@@ -10,6 +10,7 @@ use App\Security\ReCaptcha\ReCaptchaWrapper;
 use App\Service\MailService;
 use App\State\ResendActivationProcessor;
 use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -41,7 +42,7 @@ class ResendActivationProcessorTest extends TestCase {
 
         $this->recaptchaResponse = $this->createMock(Response::class);
         $recaptcha = $this->createMock(ReCaptchaWrapper::class);
-        $entityManager = $this->createMock(EntityManager::class);
+        $entityManager = $this->createStub(EntityManager::class);
         $this->userRepository = $this->createMock(UserRepository::class);
         $this->mailService = $this->createMock(MailService::class);
 
@@ -58,6 +59,7 @@ class ResendActivationProcessorTest extends TestCase {
         );
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCreateRequiresReCaptcha() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')
@@ -69,6 +71,7 @@ class ResendActivationProcessorTest extends TestCase {
         $this->processor->process($this->userActivation, new Post());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCreateWithUnknownEmailDoesNothing() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')
@@ -90,6 +93,7 @@ class ResendActivationProcessorTest extends TestCase {
         self::assertThat($data, self::isNull());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     #[TestWith([User::STATE_REGISTERED])]
     public function testCreateWithInactiveUserResendsActivationeMail(string $state) {
         $this->recaptchaResponse->expects(self::once())
@@ -119,6 +123,7 @@ class ResendActivationProcessorTest extends TestCase {
         self::assertThat($data, self::isNull());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     #[TestWith([User::STATE_NONREGISTERED])]
     #[TestWith([User::STATE_ACTIVATED])]
     #[TestWith([User::STATE_DELETED])]

--- a/api/tests/State/ResetPasswordCreateProcessorTest.php
+++ b/api/tests/State/ResetPasswordCreateProcessorTest.php
@@ -10,6 +10,7 @@ use App\Security\ReCaptcha\ReCaptchaWrapper;
 use App\Service\MailService;
 use App\State\ResetPasswordCreateProcessor;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReCaptcha\Response;
@@ -38,7 +39,7 @@ class ResetPasswordCreateProcessorTest extends TestCase {
 
         $this->recaptchaResponse = $this->createMock(Response::class);
         $recaptcha = $this->createMock(ReCaptchaWrapper::class);
-        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager = $this->createStub(EntityManagerInterface::class);
         $this->userRepository = $this->createMock(UserRepository::class);
         $pwHasherFactory = $this->createMock(PasswordHasherFactory::class);
         $this->pwHasher = $this->createMock(PasswordHasherInterface::class);
@@ -63,6 +64,7 @@ class ResetPasswordCreateProcessorTest extends TestCase {
         );
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCreateRequiresReCaptcha() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')
@@ -74,6 +76,7 @@ class ResetPasswordCreateProcessorTest extends TestCase {
         $this->processor->process($this->resetPassword, new Post());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCreateWithUnknownEmailDoesNotCreateResetKey() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')
@@ -95,6 +98,7 @@ class ResetPasswordCreateProcessorTest extends TestCase {
         self::assertThat($data, self::isNull());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCreateWithKnowneMailCreatesResetKey() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')

--- a/api/tests/State/ResetPasswordUpdateProcessorTest.php
+++ b/api/tests/State/ResetPasswordUpdateProcessorTest.php
@@ -9,6 +9,7 @@ use App\Repository\UserRepository;
 use App\Security\ReCaptcha\ReCaptchaWrapper;
 use App\State\ResetPasswordUpdateProcessor;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -38,7 +39,7 @@ class ResetPasswordUpdateProcessorTest extends TestCase {
 
         $this->recaptchaResponse = $this->createMock(Response::class);
         $recaptcha = $this->createMock(ReCaptchaWrapper::class);
-        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager = $this->createStub(EntityManagerInterface::class);
         $this->userRepository = $this->createMock(UserRepository::class);
         $pwHasherFactory = $this->createMock(PasswordHasherFactory::class);
         $this->pwHasher = $this->createMock(PasswordHasherInterface::class);
@@ -61,6 +62,7 @@ class ResetPasswordUpdateProcessorTest extends TestCase {
         );
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testUpdateRequiresReCaptcha() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')
@@ -72,6 +74,7 @@ class ResetPasswordUpdateProcessorTest extends TestCase {
         $this->processor->process($this->resetPassword, new Patch());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testUpdateWithUnknownEmailThrowsException() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')
@@ -89,6 +92,7 @@ class ResetPasswordUpdateProcessorTest extends TestCase {
         $this->processor->process($this->resetPassword, new Patch());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testUpdateWithUserHasNoResetKeyThrowsException() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')
@@ -108,6 +112,7 @@ class ResetPasswordUpdateProcessorTest extends TestCase {
         $this->processor->process($this->resetPassword, new Patch());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testUpdateWithWrongResetKeyThrowsException() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')
@@ -133,6 +138,7 @@ class ResetPasswordUpdateProcessorTest extends TestCase {
         $this->processor->process($this->resetPassword, new Patch());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testUpdateWithCorrectResetKey() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')
@@ -167,6 +173,7 @@ class ResetPasswordUpdateProcessorTest extends TestCase {
         self::assertThat($user->state, self::equalTo(User::STATE_ACTIVATED));
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     #[TestWith([User::STATE_DELETED])]
     #[TestWith([User::STATE_ACTIVATED])]
     public function testUpdateWithCorrectResetKeyDoesNotChangeActivatedOrDeletedUsers(string $state) {

--- a/api/tests/State/UserCreateProcessorTest.php
+++ b/api/tests/State/UserCreateProcessorTest.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Security\ReCaptcha\ReCaptchaWrapper;
 use App\Service\MailService;
 use App\State\UserCreateProcessor;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReCaptcha\Response;
@@ -39,7 +40,7 @@ class UserCreateProcessorTest extends TestCase {
 
         $this->userPasswordHasher = $this->createMock(UserPasswordHasher::class);
         $this->mailService = $this->createMock(MailService::class);
-        $decoratedProcessor = $this->createMock(ProcessorInterface::class);
+        $decoratedProcessor = $this->createStub(ProcessorInterface::class);
         $this->processor = new UserCreateProcessor(
             $decoratedProcessor,
             $recaptcha,
@@ -48,6 +49,7 @@ class UserCreateProcessorTest extends TestCase {
         );
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCreateRequiresReCaptcha() {
         $this->recaptchaResponse->expects(self::once())
             ->method('isSuccess')
@@ -58,6 +60,7 @@ class UserCreateProcessorTest extends TestCase {
         $this->processor->onBefore($this->user, new Post());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testDoesNotHashWhenNoPasswordIsSet() {
         // given
         $this->recaptchaResponse->expects(self::once())
@@ -75,6 +78,7 @@ class UserCreateProcessorTest extends TestCase {
         $this->assertNull($data->plainPassword);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testHashesPasswordWhenPlainPasswordIsSet() {
         // given
         $this->recaptchaResponse->expects(self::once())
@@ -93,6 +97,7 @@ class UserCreateProcessorTest extends TestCase {
         $this->assertNull($data->plainPassword);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCreateAndSendActivationKey() {
         // given
         $this->recaptchaResponse->expects(self::once())
@@ -110,6 +115,7 @@ class UserCreateProcessorTest extends TestCase {
         $this->assertNotNull($data->activationKeyHash);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testSetsStateToRegisteredBeforeCreate() {
         // when
         $this->recaptchaResponse->expects(self::once())

--- a/api/tests/State/Util/AbstractPersistProcessorTest.php
+++ b/api/tests/State/Util/AbstractPersistProcessorTest.php
@@ -9,7 +9,7 @@ use ApiPlatform\State\ProcessorInterface;
 use App\Entity\BaseEntity;
 use App\State\Util\AbstractPersistProcessor;
 use App\State\Util\PropertyChangeListener;
-use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -72,12 +72,14 @@ class AbstractPersistProcessorTest extends TestCase {
     /**
      * @throws Exception
      */
+    #[AllowMockObjectsWithoutExpectations]
     public function testThrowsIfOnePropertyChangeListenerIsOfWrongType() {
         $this->expectException(\InvalidArgumentException::class);
 
-        new MyEntityPersistProcessor($this->createMock(ProcessorInterface::class), [$this->propertyChangeListener, new \stdClass()], $this->onBefore, $this->onAfter);
+        new MyEntityPersistProcessor($this->createStub(ProcessorInterface::class), [$this->propertyChangeListener, new \stdClass()], $this->onBefore, $this->onAfter);
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     public function testCallsOnBeforeCreateAndOnAfterCreateOnPost() {
         $toPersist = new MyEntity();
 
@@ -92,6 +94,7 @@ class AbstractPersistProcessorTest extends TestCase {
     /**
      * @throws \ReflectionException
      */
+    #[AllowMockObjectsWithoutExpectations]
     public function testNotCallPropertyChangeListenerIfDataWasNullBefore() {
         $toPersist = new MyEntity();
 
@@ -109,6 +112,7 @@ class AbstractPersistProcessorTest extends TestCase {
     /**
      * @throws \ReflectionException
      */
+    #[AllowMockObjectsWithoutExpectations]
     public function testThrowErrorIfExtractPropertyFails() {
         $toPersist = new MyEmptyEntity();
 
@@ -126,6 +130,7 @@ class AbstractPersistProcessorTest extends TestCase {
     /**
      * @throws \ReflectionException
      */
+    #[AllowMockObjectsWithoutExpectations]
     public function testNotCallPropertyChangeListenerIfPropertyDidNotChange() {
         $toPersist = new MyEntity();
         $toPersist->name = null;
@@ -144,6 +149,7 @@ class AbstractPersistProcessorTest extends TestCase {
     /**
      * @throws \ReflectionException
      */
+    #[AllowMockObjectsWithoutExpectations]
     public function testCallPropertyChangeListenerIfPropertyDidChange() {
         $oldData = new MyEntity();
         $oldData->name = null;


### PR DESCRIPTION
See:
* No expectations were configured for the mock object for xy. Consider refactoring your test code to use a test stub instead. The #[AllowMockObjectsWithoutExpectations] attribute can be used to opt out of this check.

There were so many notices, you wouldn't find different output anymore. This was done with the support of ai.