### PR TITLE
renovate: separate metadata openapi api platform

### DIFF
--- a/.github/workflows/check-renovate-config.yml
+++ b/.github/workflows/check-renovate-config.yml
@@ -1,0 +1,19 @@
+name: check-renovate-config.yml
+on:
+  push:
+    paths:
+      - .github/workflows/check-renovate-config.yml
+      - renovate.json
+  pull_request:
+    paths:
+      - .github/workflows/check-renovate-config.yml
+      - renovate.json
+
+jobs:
+  validate-renovate-config:
+    name: 'renovate: validate config'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - run: docker run --rm -e LOG_LEVEL=debug -v "$PWD:/workspace" -w /workspace renovate/renovate:43.25.6 --platform=local

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,23 @@
       "automerge": true
     },
     {
+      "groupName": "api-platform packages",
+      "groupSlug": "api-platform",
+      "matchDatasources": [
+        "packagist"
+      ],
+      "matchPackageNames": [
+        "api-platform/*",
+        "!api-platform/admin-meta",
+        "!api-platform/admin-pack",
+        "!api-platform/api-pack",
+        "!api-platform/api-platform",
+        "!api-platform/parameter-validator",
+        "!api-platform/postman-collection-generator",
+        "!api-platform/schema-generator"
+      ]
+    },
+    {
       "extends": ["monorepo:vue"],
       "matchUpdateTypes": ["major"],
       "matchFileNames": ["print/package.json", "pdf/package.json"],

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
     "config:recommended",
     ":prConcurrentLimitNone"
   ],
+  "ignorePresets": [
+    "group:apiPlatform"
+  ],
   "constraints": {
     "node": "24.13.1",
     "php": "8.5.2"
@@ -36,6 +39,8 @@
         "!api-platform/admin-pack",
         "!api-platform/api-pack",
         "!api-platform/api-platform",
+        "!api-platform/metadata",
+        "!api-platform/openapi",
         "!api-platform/parameter-validator",
         "!api-platform/postman-collection-generator",
         "!api-platform/schema-generator"


### PR DESCRIPTION
The often lead to breaking changes which need manual intervention.
See result here: https://github.com/BacLuc/ecamp3/issues/316

Also add workflow to validate renovate config.