### PR TITLE
api: fix deprecation notice for eraseCredentials

### DIFF
--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -182,6 +182,12 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
         $this->comments = new ArrayCollection();
     }
 
+    public function __serialize(): array {
+        $this->prepareForSerialization();
+
+        return (array) $this;
+    }
+
     /**
      * A displayable name of the user.
      */
@@ -239,8 +245,7 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
      */
     #[\Deprecated]
     public function eraseCredentials(): void {
-        // If you store any temporary, sensitive data on the user, clear it here
-        $this->plainPassword = null;
+        $this->prepareForSerialization();
     }
 
     public function getEmail(): ?string {
@@ -321,5 +326,10 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
         }
 
         return $this;
+    }
+
+    public function prepareForSerialization(): void {
+        // If you store any temporary, sensitive data on the user, clear it here
+        $this->plainPassword = null;
     }
 }

--- a/api/src/State/UserCreateProcessor.php
+++ b/api/src/State/UserCreateProcessor.php
@@ -38,7 +38,7 @@ class UserCreateProcessor extends AbstractPersistProcessor {
         $data->state = User::STATE_REGISTERED;
         if ($data->plainPassword) {
             $data->password = $this->userPasswordHasher->hashPassword($data, $data->plainPassword);
-            $data->eraseCredentials();
+            $data->prepareForSerialization();
         }
         $data->activationKey = IdGenerator::generateRandomHexString(64);
         $data->activationKeyHash = md5($data->activationKey);

--- a/api/src/State/UserUpdateProcessor.php
+++ b/api/src/State/UserUpdateProcessor.php
@@ -26,7 +26,7 @@ class UserUpdateProcessor extends AbstractPersistProcessor {
     public function onBefore($data, Operation $operation, array $uriVariables = [], array $context = []): User {
         if ($data->plainPassword) {
             $data->password = $this->userPasswordHasher->hashPassword($data, $data->plainPassword);
-            $data->eraseCredentials();
+            $data->prepareForSerialization();
         }
 
         return $data;

--- a/api/tests/Entity/UserTest.php
+++ b/api/tests/Entity/UserTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+use function PHPUnit\Framework\assertThat;
+use function PHPUnit\Framework\equalTo;
+use function PHPUnit\Framework\isNull;
+
+/**
+ * @internal
+ */
+class UserTest extends TestCase {
+    public function testSerialize() {
+        $user = new User();
+        $user->state = User::ACTIVATE;
+        $user->plainPassword = 'plainpassword';
+
+        $serializedUser = serialize($user);
+        $deserializeUser = unserialize($serializedUser);
+
+        assertThat($deserializeUser->plainPassword, isNull());
+        assertThat($deserializeUser->state, equalTo(User::ACTIVATE));
+    }
+}


### PR DESCRIPTION
Extract functionality to shared function.
Use __serialize as proposed by the deprecation notice. https://github.com/symfony/symfony/pull/59682#issue-2828155264