### PR TITLE
api: set framework.property_info.with_constructor_extractor to false

### DIFF
--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -19,6 +19,9 @@ framework:
     #esi: true
     #fragments: true
 
+    property_info:
+        with_constructor_extractor: false
+
 when@test:
     framework:
         test: true


### PR DESCRIPTION
true will be the default value in symfony 8.
https://symfony.com/doc/current/reference/configuration/framework.html#property-info We currently don't use constructor arguments to define DTO or entities, so we must not use it and thus have less code running.