### PR TITLE
api: set framework.profiler.collect_serializer_data to true in test

### DIFF
--- a/api/config/packages/test/web_profiler.yaml
+++ b/api/config/packages/test/web_profiler.yaml
@@ -3,4 +3,6 @@ web_profiler:
     intercept_redirects: false
 
 framework:
-    profiler: { collect: false }
+    profiler:
+        collect: false
+        collect_serializer_data: true


### PR DESCRIPTION
1) /app/vendor/symfony/deprecation-contracts/function.php:25 Since symfony/framework-bundle 7.3: Not setting the "framework.profiler.collect_serializer_data" config option to "true" is deprecated.

Why? no idea.
Only thing i found:
https://symfony.com/blog/new-in-symfony-6-1-serializer-profiling#comment-25013