### PR TITLE
api: use named parameters for Assert\Choice in Profile

### DIFF
--- a/api/src/Entity/Profile.php
+++ b/api/src/Entity/Profile.php
@@ -168,7 +168,7 @@ class Profile extends BaseEntity {
      */
     #[InputFilter\Trim]
     #[ApiProperty(example: self::EXAMPLE_LANGUAGE)]
-    #[Assert\Choice(Languages::SUPPORTED_LANGUAGES)]
+    #[Assert\Choice(choices: Languages::SUPPORTED_LANGUAGES)]
     #[Groups(['read', 'write'])]
     #[ORM\Column(type: 'string', length: 20, nullable: true)]
     public ?string $language = null;


### PR DESCRIPTION
5) /app/vendor/symfony/deprecation-contracts/function.php:25 Since symfony/validator 7.4: Support for passing the choices as the first argument to Symfony\Component\Validator\Constraints\Choice is deprecated.