### PR TITLE
api: remove non existing service App\Validator\ColumnLayout\ColumnLayoutGroupSequence

### DIFF
--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -38,9 +38,6 @@ services:
     App\Validator\MaterialItemUpdateGroupSequence:
         public: true
 
-    App\Validator\ColumnLayout\ColumnLayoutGroupSequence:
-        public: true
-
     # Since the input filter classes are resolved at runtime instead
     # of with constructor dependency injection, we create a service
     # locator that will serve all the required classes


### PR DESCRIPTION


Was added in commit: 8469c1e
renamed in commit: b9beea8
removed in commit: f3957e3

3) /app/vendor/symfony/deprecation-contracts/function.php:25 Since symfony/dependency-injection 7.4: Service id "App\Validator\ColumnLayout\ColumnLayoutGroupSequence" looks like a FQCN but no corresponding class or interface exists. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class or interface.