### PR TITLE
Add f5 ingress

### DIFF
--- a/.github/workflows/deploy-ingress.yml
+++ b/.github/workflows/deploy-ingress.yml
@@ -7,12 +7,23 @@ on:
         description: 'Choose environment'
         type: environment
         default: dev
+      action:
+        description: "Choose action"
+        type: choice
+        required: true
+        default: diff
+        options:
+          - diff
+          - deploy
   push:
     branches:
       - devel
     paths:
       - .github/workflows/deploy-ingress.yml
       - .ops/ingress/**
+
+env:
+  action: ${{ github.event.inputs.action || 'deploy' }}
 
 jobs:
   deploy-ingress:
@@ -37,6 +48,7 @@ jobs:
         working-directory: .ops/ingress
 
       - name: Deploy
+        if: env.action == 'deploy'
         run: |
           ./deploy.sh deploy
         working-directory: .ops/ingress

--- a/.github/workflows/deploy-ingress.yml
+++ b/.github/workflows/deploy-ingress.yml
@@ -42,6 +42,10 @@ jobs:
           helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
           helm repo update
 
+      - name: Login to ghcr.io ocr registry
+        run: |
+          helm registry login -u ${{ github.actor }} ghcr.io --password  ${{ secrets.GITHUB_TOKEN }}
+
       - name: Diff deployment
         run: |
           ./deploy.sh diff || true

--- a/.helm/ecamp3/templates/_helpers.tpl
+++ b/.helm/ecamp3/templates/_helpers.tpl
@@ -183,14 +183,34 @@ Ingress basic auth secret name
 {{- printf "%s-basic-auth" (include "app.name" .) }}
 {{- end }}
 
+{{- define "ingress.pathType" -}}
+{{- if eq .Values.ingress.className "f5-nginx-ingress" }}
+{{- "Prefix" }}
+{{- else if eq .Values.ingress.className "nginx" }}
+{{- "ImplementationSpecific" }}
+{{- else }}
+{{- fail (printf "Unkown ingress className %s" .Values.ingress.className) }}
+{{- end }}
+{{- end }}
+
+{{- define "ingress.annotation.path" -}}
+{{- if eq .Values.ingress.className "f5-nginx-ingress" }}
+{{- "nginx.org/" }}
+{{- else if eq .Values.ingress.className "nginx" }}
+{{- "nginx.ingress.kubernetes.io/" }}
+{{- else }}
+{{- fail (printf "Unkown ingress className %s" .Values.ingress.className) }}
+{{- end }}
+{{- end }}
+
 {{/*
 Ingress annotations for basic auth
 */}}
 {{- define "ingress.basicAuth.annotations" -}}
 {{- if .Values.ingress.basicAuth.enabled }}
-nginx.ingress.kubernetes.io/auth-type: "basic"
-nginx.ingress.kubernetes.io/auth-secret: {{ include "ingress.basicAuth.secret.name" . | quote }}
-nginx.ingress.kubernetes.io/auth-realm: {{ printf "Authentication Required - %s is protected and needs authentication" .Values.domain | quote }}
+{{ include "ingress.annotation.path" }}auth-type: "basic"
+{{ include "ingress.annotation.path" }}auth-secret: {{ include "ingress.basicAuth.secret.name" . | quote }}
+{{ include "ingress.annotation.path" }}auth-realm: {{ printf "Authentication Required - %s is protected and needs authentication" .Values.domain | quote }}
 {{- end }}
 {{- end }}
 

--- a/.helm/ecamp3/templates/api_ingress.yaml
+++ b/.helm/ecamp3/templates/api_ingress.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.ingress.enabled -}}
+{{- $apiPath := .Values.api.subpath }}
+{{- if eq .Values.ingress.className "nginx" }}
+{{- $apiPath = printf "%s(/|$)(.*)" $apiPath }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -11,8 +15,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- include "ingress.basicAuth.annotations" . | nindent 4 }}
+    {{- if eq .Values.ingress.className "f5-nginx-ingress" }}
+    nginx.org/rewrites: "serviceName={{ if .Values.apiCache.enabled }}{{ include "apiCache.name" . }}{{ else }}{{ include "api.name" . }}{{ end }} rewrite=/"
+    {{- else if eq .Values.ingress.className "nginx" }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/x-forwarded-prefix: {{ .Values.api.subpath }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}
@@ -25,8 +33,8 @@ spec:
     - host: {{ .Values.domain | quote }}
       http:
         paths:
-          - path: {{ .Values.api.subpath }}(/|$)(.*)
-            pathType: ImplementationSpecific
+          - path: {{ $apiPath }}
+            pathType: {{ include "ingress.pathType" . }}
             backend:
               service:
                 {{- if .Values.apiCache.enabled }}

--- a/.helm/ecamp3/templates/mail_ingress.yaml
+++ b/.helm/ecamp3/templates/mail_ingress.yaml
@@ -25,7 +25,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.mail.subpath }}
-            pathType: ImplementationSpecific
+            pathType: {{ include "ingress.pathType" . }}
             backend:
               service:
                 name: {{ include "mail.name" . }}

--- a/.helm/ecamp3/templates/print_ingress.yaml
+++ b/.helm/ecamp3/templates/print_ingress.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.ingress.enabled -}}
+{{- $printPath := .Values.print.subpath }}
+{{- if eq .Values.ingress.className "nginx" }}
+{{- $printPath = printf "%s(/|$)(.*)" $printPath }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -11,9 +15,13 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- include "ingress.basicAuth.annotations" . | nindent 4 }}
-    {{- if not (.Values.print.ingress.readTimeoutSeconds | empty) }}
+    {{- if eq .Values.ingress.className "f5-nginx-ingress" }}
+    nginx.org/rewrites: "serviceName={{ include "print.name" . }} rewrite=/"
+    {{- else if eq .Values.ingress.className "nginx" }}
     nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.print.ingress.readTimeoutSeconds | quote }}
+    {{- end }}
+    {{- if not (.Values.print.ingress.readTimeoutSeconds | empty) }}
+    {{ include "ingress.annotation.path" . }}proxy-read-timeout: {{ .Values.print.ingress.readTimeoutSeconds | quote }}
     {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -27,8 +35,8 @@ spec:
     - host: {{ .Values.domain | quote }}
       http:
         paths:
-          - path: {{ .Values.print.subpath }}(/|$)(.*)
-            pathType: ImplementationSpecific
+          - path: {{ $printPath }}
+            pathType: {{ include "ingress.pathType" . }}
             backend:
               service:
                 name: {{ include "print.name" . }}

--- a/.helm/ecamp3/values.yaml.gotmpl
+++ b/.helm/ecamp3/values.yaml.gotmpl
@@ -228,7 +228,7 @@ ingress:
     password: {{ .Environment.Values | getOrNil "BASIC_AUTH_PASSWORD" | quote }}
   annotations:
   # kubernetes.io/tls-acme: "true"
-  className: nginx
+  className: {{ .Environment.Values | getOrNil "INGRESS_CLASS_NAME" | default "nginx" }}
   tls:
 
 apiCache:

--- a/.helm/ecamp3/values.yaml.gotmpl
+++ b/.helm/ecamp3/values.yaml.gotmpl
@@ -228,7 +228,7 @@ ingress:
     password: {{ .Environment.Values | getOrNil "BASIC_AUTH_PASSWORD" | quote }}
   annotations:
   # kubernetes.io/tls-acme: "true"
-  className: {{ .Environment.Values | getOrNil "INGRESS_CLASS_NAME" | default "nginx" }}
+  className: {{ .Environment.Values | getOrNil "INGRESS_CLASS_NAME" | default "f5-nginx-ingress" }}
   tls:
 
 apiCache:

--- a/.ops/ingress/Chart.lock
+++ b/.ops/ingress/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.14.3
-digest: sha256:1244dafdb3897abc361ad238afa9b52c9b16046eb23a93e5420693bebe7feea9
-generated: "2026-02-10T00:58:56.13260691Z"
+- name: nginx-ingress
+  repository: oci://ghcr.io/nginx/charts
+  version: 2.4.4
+digest: sha256:640132e82d912f9f90696a008865b87a5620d55015ee33586792b73ad3ee06f6
+generated: "2026-03-14T12:07:42.574307025+01:00"

--- a/.ops/ingress/Chart.yaml
+++ b/.ops/ingress/Chart.yaml
@@ -27,3 +27,7 @@ dependencies:
   - name: ingress-nginx
     version: 4.14.3
     repository: https://kubernetes.github.io/ingress-nginx
+  - name: nginx-ingress
+    version: 2.4.4
+    repository: oci://ghcr.io/nginx/charts
+    alias: f5-nginx-ingress

--- a/.ops/ingress/README.md
+++ b/.ops/ingress/README.md
@@ -13,6 +13,30 @@ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
 ```
 
+And you need to log in to the GitHub ocr registry.
+For that you need a GitHub personal access token with the following scopes:
+`Read access to artifact metadata, code, and metadata`
+
+```shell
+helm registry login -u $GITHUB_USERNAME ghcr.io
+```
+
+### CRD
+
+Somehow the upgrade command did not install the CRD.
+I did that manually:
+
+```shell
+cd /tmp
+mkdir nginx-ingress
+cd nginx-ingress
+helm pull oci://ghcr.io/nginx/charts/nginx-ingress --untar --version 2.4.4
+# Pulled: ghcr.io/nginx/charts/nginx-ingress:2.4.4
+# Digest: sha256:ab4376a132fd44c4aaae1d60069d71a8315be0bc747b7a3c5af56537da579680
+cd nginx-ingress/crds
+kubectl apply -f ./
+```
+
 ## Deployment
 
 First, check what is currently applied:

--- a/.ops/ingress/templates/_helpers.tpl
+++ b/.ops/ingress/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/*
+Create a default fully qualified app name.
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "app.name" -}}
+{{- if contains .Chart.Name .Release.Name }}
+{{- .Release.Name | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name (include "chart.name" .) | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "app.commonLabels" -}}
+chart: {{ .Chart.Name }}
+helm.sh/chart: {{ .Chart.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Common selector labels
+*/}}
+{{- define "app.commonSelectorLabels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ .Chart.Name }}
+chart: {{ .Chart.Name }}
+{{- end }}

--- a/.ops/ingress/templates/main-service.yaml
+++ b/.ops/ingress/templates/main-service.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    # hardcoded to steal the existing load balancer
+    kubernetes.digitalocean.com/load-balancer-id: 912873cb-ddf7-4800-a70c-61efc6f2ab59
+    meta.helm.sh/release-name: ecamp3-ingress
+    meta.helm.sh/release-namespace: ingress-nginx
+    service.beta.kubernetes.io/do-loadbalancer-type: REGIONAL
+  labels:
+    app.kubernetes.io/component: controller
+  # hardcoded to steal the existing load balancer
+  name: ingress-nginx-controller
+spec:
+  type: LoadBalancer
+  allocateLoadBalancerNodePorts: true
+  ports:
+    - appProtocol: http
+      name: http
+      nodePort: 32638
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - appProtocol: https
+      name: https
+      nodePort: 32189
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ecamp3-ingress
+    app.kubernetes.io/name: ingress-nginx
+  sessionAffinity: None

--- a/.ops/ingress/templates/replacement-service.yaml
+++ b/.ops/ingress/templates/replacement-service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    {{ include "app.commonLabels" . | nindent 4 }}
+    {{ include "app.commonSelectorLabels" . | nindent 4 }}
+  name: {{ include "app.name" . }}-replacement-service
+spec:
+  type: LoadBalancer
+  allocateLoadBalancerNodePorts: true
+  ports:
+    - appProtocol: http
+      name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - appProtocol: https
+      name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    deployment: f5-nginx-ingress
+  sessionAffinity: None

--- a/.ops/ingress/values.yaml
+++ b/.ops/ingress/values.yaml
@@ -1,6 +1,8 @@
 ingress-nginx:
   fullnameOverride: ingress-nginx
   controller:
+    service:
+      enabled: false
     metrics:
       enabled: true
     podAnnotations:
@@ -10,3 +12,23 @@ ingress-nginx:
       log-format-escape-json: true
       log-format-upstream: |
         {"timestamp":"$time_iso8601","requestID":"$req_id","proxyUpstreamName":"$proxy_upstream_name","proxyAlternativeUpstreamName":"$proxy_alternative_upstream_name","upstreamStatus":$upstream_status,"upstreamAddr":"$upstream_addr","httpRequest":{"requestMethod":"$request_method","requestUrl":"$host$request_uri","status":$status,"requestSize":"$request_length","responseSize":"$upstream_response_length","userAgent":"$http_user_agent","remoteIp":"$remote_addr","referer":"$http_referer","request_time_seconds":$upstream_response_time,"protocol":"$server_protocol"}}
+f5-nginx-ingress:
+  controller:
+    ingressClass:
+      name: f5-nginx-ingress
+    kind: deployment
+    nginxplus: false
+    service:
+      create: false
+    selectorLabels:
+      deployment: f5-nginx-ingress
+    podAnnotations:
+      "prometheus.io/scrape": "true"
+      "prometheus.io/port": "9113"
+    prometheus:
+      create: true
+      port: 9113
+    config:
+      entries:
+        log-format: |
+          {"timestamp":"$time_iso8601","requestID":"$request_id","proxyUpstreamName":"$upstream_addr","upstreamStatus":$upstream_status,"upstreamAddr":"$upstream_addr","httpRequest":{"requestMethod":"$request_method","requestUrl":"$host$request_uri","status":$status,"requestSize":"$request_length","responseSize":"$upstream_response_length","userAgent":"$http_user_agent","remoteIp":"$remote_addr","referer":"$http_referer","request_time_seconds":$upstream_response_time,"protocol":"$server_protocol"}}


### PR DESCRIPTION
Doesn't seem to work.
the old ingress steals the hosts of the new ingress.
The new ingress doesn't want to take these hosts.
external-dns chooses a completely different ip to set.
...aaah?

It looks like ingress-nginx was a bad choice for an ingress controller you want to migrate away from.