### PR TITLE
Revert "api: suppress InvalidAttribute rule in psalm.xml"

### DIFF
--- a/api/psalm.xml
+++ b/api/psalm.xml
@@ -18,6 +18,5 @@
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
-        <InvalidAttribute errorLevel="suppress" />
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
This reverts commit a6be084ba239c5ab0f87257cb2e5e7c61d2a480a.
This is not needed anymore after the fix in psalm.