### PR TITLE
Order more entity relations by default

### DIFF
--- a/api/src/Entity/Activity.php
+++ b/api/src/Entity/Activity.php
@@ -189,6 +189,7 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
     )]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'activity')]
+    #[ORM\OrderBy(['createTime' => 'ASC'])]
     public Collection $comments;
 
     /**
@@ -197,6 +198,7 @@ class Activity extends BaseEntity implements BelongsToCampInterface {
     #[ApiProperty(writable: false)]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: ActivityResponsible::class, mappedBy: 'activity', orphanRemoval: true)]
+    #[ORM\OrderBy(['createTime' => 'ASC'])]
     private Collection $activityResponsibles;
 
     public function __construct() {

--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -80,6 +80,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[SerializedName('campCollaborations')]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: CampCollaboration::class, mappedBy: 'camp', orphanRemoval: true)]
+    #[ORM\OrderBy(['status' => 'ASC', 'role' => 'ASC', 'createTime' => 'ASC'])]
     public Collection $collaborations;
 
     /**
@@ -116,6 +117,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     )]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: Category::class, mappedBy: 'camp', cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\OrderBy(['short' => 'ASC', 'createTime' => 'ASC'])]
     public Collection $categories;
 
     /**
@@ -128,6 +130,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     )]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: ActivityProgressLabel::class, mappedBy: 'camp', cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\OrderBy(['position' => 'ASC'])]
     public Collection $progressLabels;
 
     /**
@@ -141,6 +144,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     )]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: Activity::class, mappedBy: 'camp', orphanRemoval: true)]
+    #[ORM\OrderBy(['title' => 'ASC', 'createTime' => 'ASC'])]
     public Collection $activities;
 
     /**
@@ -150,12 +154,14 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[ApiProperty(writable: false, example: '["/material_lists/1a2b3c4d"]')]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: MaterialList::class, mappedBy: 'camp', cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\OrderBy(['name' => 'ASC', 'createTime' => 'ASC'])]
     public Collection $materialLists;
 
     /**
      * List of MaterialItems that belong to this Camp.
      */
     #[ORM\OneToMany(targetEntity: MaterialItem::class, mappedBy: 'camp', cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\OrderBy(['article' => 'ASC', 'createTime' => 'ASC'])]
     public Collection $materialItems;
 
     /**
@@ -165,6 +171,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
     #[ApiProperty(writable: false, uriTemplate: Checklist::CAMP_SUBRESOURCE_URI_TEMPLATE)]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: Checklist::class, mappedBy: 'camp', cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\OrderBy(['name' => 'ASC', 'createTime' => 'ASC'])]
     public Collection $checklists;
 
     /**
@@ -445,6 +452,7 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      */
     #[ApiProperty(readable: false, writable: false)]
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'camp', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[ORM\OrderBy(['createTime' => 'ASC'])]
     public Collection $comments;
 
     public function __construct() {

--- a/api/src/Entity/ChecklistItem.php
+++ b/api/src/Entity/ChecklistItem.php
@@ -123,6 +123,7 @@ class ChecklistItem extends BaseEntity implements BelongsToCampInterface, CopyFr
     #[ApiProperty(writable: false, example: '["/checklist_items/1a2b3c4d"]')]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: ChecklistItem::class, mappedBy: 'parent', cascade: ['persist'])]
+    #[ORM\OrderBy(['position' => 'ASC'])]
     public Collection $children;
 
     /**

--- a/api/src/Entity/ContentNode.php
+++ b/api/src/Entity/ContentNode.php
@@ -98,6 +98,7 @@ abstract class ContentNode extends BaseEntity implements BelongsToCampInterface,
     #[ApiProperty(writable: false, example: '["/content_nodes/1a2b3c4d"]')]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: ContentNode::class, mappedBy: 'parent', cascade: ['persist'])]
+    #[ORM\OrderBy(['slot' => 'ASC', 'position' => 'ASC'])]
     public Collection $children;
 
     /**

--- a/api/src/Entity/ContentNode/MaterialNode.php
+++ b/api/src/Entity/ContentNode/MaterialNode.php
@@ -56,6 +56,7 @@ class MaterialNode extends ContentNode {
     #[ApiProperty(readableLink: true, writableLink: false)]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: MaterialItem::class, mappedBy: 'materialNode', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[ORM\OrderBy(['article' => 'ASC', 'createTime' => 'ASC'])]
     public Collection $materialItems;
 
     public function __construct() {

--- a/api/src/Entity/Day.php
+++ b/api/src/Entity/Day.php
@@ -88,6 +88,7 @@ class Day extends BaseEntity implements BelongsToCampInterface {
     )]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: DayResponsible::class, mappedBy: 'day', orphanRemoval: true)]
+    #[ORM\OrderBy(['createTime' => 'ASC'])]
     public Collection $dayResponsibles;
 
     /**

--- a/api/src/Entity/MaterialList.php
+++ b/api/src/Entity/MaterialList.php
@@ -65,6 +65,7 @@ class MaterialList extends BaseEntity implements BelongsToCampInterface, CopyFro
     #[ApiProperty(writable: false, example: '["/material_items/1a2b3c4d"]')]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: MaterialItem::class, mappedBy: 'materialList')]
+    #[ORM\OrderBy(['article' => 'ASC', 'createTime' => 'ASC'])]
     public Collection $materialItems;
 
     /**

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -104,6 +104,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
      * activities.
      */
     #[ORM\OneToMany(targetEntity: MaterialItem::class, mappedBy: 'period')]
+    #[ORM\OrderBy(['article' => 'ASC', 'createTime' => 'ASC'])]
     public Collection $materialItems;
 
     /**

--- a/api/src/Entity/Period.php
+++ b/api/src/Entity/Period.php
@@ -96,7 +96,7 @@ class Period extends BaseEntity implements BelongsToCampInterface {
     )]
     #[Groups(['read'])]
     #[ORM\OneToMany(targetEntity: ScheduleEntry::class, mappedBy: 'period')]
-    #[ORM\OrderBy(['startOffset' => 'ASC', 'left' => 'ASC', 'endOffset' => 'DESC', 'id' => 'ASC'])]
+    #[ORM\OrderBy(['startOffset' => 'ASC', 'left' => 'ASC', 'endOffset' => 'DESC', 'createTime' => 'ASC'])]
     public Collection $scheduleEntries;
 
     /**

--- a/api/src/Entity/ScheduleEntry.php
+++ b/api/src/Entity/ScheduleEntry.php
@@ -318,8 +318,15 @@ class ScheduleEntry extends BaseEntity implements BelongsToCampInterface, CanGen
                     return true;
                 }
                 if ($scheduleEntry->endOffset === $this->endOffset) {
-                    // for scheduleEntries starting at same time & same left value & same duration: ID as fallback comparison
-                    if ($scheduleEntry->getId() < $this->getId()) {
+                    // for scheduleEntries starting at same time & same left value & same duration:
+                    // sort by createTime, so that the users have the ability to choose which one comes first
+                    if ($scheduleEntry->createTime < $this->createTime) {
+                        return true;
+                    }
+
+                    // as a last resort fallback, sort by ID
+                    if ($scheduleEntry->createTime == $this->createTime
+                        && $scheduleEntry->getId() < $this->getId()) {
                         return true;
                     }
                 }

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -79,6 +79,7 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
      */
     #[ApiProperty(readable: false, writable: false)]
     #[ORM\OneToMany(targetEntity: Camp::class, mappedBy: 'owner')]
+    #[ORM\OrderBy(['createTime' => 'ASC'])]
     public Collection $ownedCamps;
 
     /**
@@ -86,6 +87,7 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
      */
     #[ApiProperty(readable: false, writable: false)]
     #[ORM\OneToMany(targetEntity: CampCollaboration::class, mappedBy: 'user', orphanRemoval: true)]
+    #[ORM\OrderBy(['createTime' => 'ASC'])]
     public Collection $collaborations;
 
     /**
@@ -172,6 +174,7 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
      */
     #[ApiProperty(readable: false, writable: false)]
     #[ORM\OneToMany(targetEntity: Comment::class, mappedBy: 'author')]
+    #[ORM\OrderBy(['createTime' => 'ASC'])]
     public Collection $comments;
 
     public function __construct() {

--- a/api/src/Repository/ScheduleEntryRepository.php
+++ b/api/src/Repository/ScheduleEntryRepository.php
@@ -32,6 +32,7 @@ class ScheduleEntryRepository extends ServiceEntityRepository implements CanFilt
             ->addOrderBy($alias.'.startOffset', 'ASC')
             ->addOrderBy($alias.'.left', 'ASC')
             ->addOrderBy($alias.'.endOffset', 'DESC')
+            ->addOrderBy($alias.'.createTime', 'ASC')
             ->addOrderBy($alias.'.id', 'ASC')
         ;
 

--- a/api/tests/Entity/ScheduleEntryTest.php
+++ b/api/tests/Entity/ScheduleEntryTest.php
@@ -40,6 +40,10 @@ class ScheduleEntryTest extends TestCase {
         $this->scheduleEntry2->startOffset = 960;
         $this->scheduleEntry2->endOffset = 960 + 90;
         $this->period->addScheduleEntry($this->scheduleEntry2);
+        $reflection = new \ReflectionClass($this->scheduleEntry2);
+        $property = $reflection->getProperty('createTime');
+        $date = new \DateTime('2026-01-01 10:00:00');
+        $property->setValue($this->scheduleEntry2, $date);
 
         $this->scheduleEntry3 = new ScheduleEntry();
         $this->scheduleEntry3->startOffset = 2400;
@@ -50,6 +54,10 @@ class ScheduleEntryTest extends TestCase {
         $this->scheduleEntry1->startOffset = 420;
         $this->scheduleEntry1->endOffset = 420 + 30;
         $this->period->addScheduleEntry($this->scheduleEntry1);
+        $reflection = new \ReflectionClass($this->scheduleEntry1);
+        $property = $reflection->getProperty('createTime');
+        $date = new \DateTime('2026-11-11 10:00:00');
+        $property->setValue($this->scheduleEntry1, $date);
     }
 
     public function testGetStart() {
@@ -133,10 +141,23 @@ class ScheduleEntryTest extends TestCase {
         $this->assertSame('1.2', $this->scheduleEntry1->getNumber());
     }
 
-    public function testGetNumberOrdersSamePeriodOffsetAndLeftAndLengthById() {
+    public function testGetNumberOrdersSamePeriodOffsetAndLeftAndLengthByCreateTime() {
         $this->scheduleEntry1->startOffset = $this->scheduleEntry2->startOffset;
         $this->scheduleEntry1->left = $this->scheduleEntry2->left;
         $this->scheduleEntry1->endOffset = $this->scheduleEntry2->endOffset;
+
+        $this->assertSame('1.1', $this->scheduleEntry2->getNumber());
+        $this->assertSame('1.2', $this->scheduleEntry1->getNumber());
+    }
+
+    public function testGetNumberOrdersSamePeriodOffsetAndLeftAndLengthAndCreateTimeById() {
+        $this->scheduleEntry1->startOffset = $this->scheduleEntry2->startOffset;
+        $this->scheduleEntry1->left = $this->scheduleEntry2->left;
+        $this->scheduleEntry1->endOffset = $this->scheduleEntry2->endOffset;
+
+        $reflection = new \ReflectionClass($this->scheduleEntry2);
+        $property = $reflection->getProperty('createTime');
+        $property->setValue($this->scheduleEntry1, $property->getValue($this->scheduleEntry2));
 
         if ($this->scheduleEntry1->getId() < $this->scheduleEntry2->getId()) {
             $this->assertSame('1.1', $this->scheduleEntry1->getNumber());


### PR DESCRIPTION
Prompted by a request via email, which pointed out that the activity responsibles are ordered randomly (but consistently when reloading the page). They proposed alphabetical ordering or allowing users to choose the ordering.

This PR adds ordering by createTime to many entity relations, and some other common-sense ordering to other relations. We don't order every single association yet, but these are the ones I think could have an impact in the frontend. Any ordering is better than the random ordering by random ID. In some cases which are not yet covered, ordering correctly might require joining additional tables or even calculating values (e.g. ordering by activity number), which is a complexity I didn't want to introduce yet.

Closes #3884
Closes #2466

Second commit fixes #3663, by adding an ORDER BY createTime to schedule entries (and applying the same ordering rule to schedule entry numbering).