### PR TITLE
e2e: disable zz-createCamp.cy.js for edge

### DIFF
--- a/e2e/specs/zz-createCamp.cy.js
+++ b/e2e/specs/zz-createCamp.cy.js
@@ -8,7 +8,12 @@ in2Days.setDate(in2Days.getDate() + 2)
 
 const campTitle = 'title'
 describe('create new camp', () => {
-  it('without prototype', () => {
+  it('without prototype', function () {
+    if (Cypress.browser.name === 'edge') {
+      console.log('edge has problems since the update to vue3.')
+      this.skip()
+    }
+
     cy.login(bipiUser)
 
     cy.visit('/camps')


### PR DESCRIPTION
edge has a higher failure rate than the other browsers, see the Action insights.

"'Job" | "'Workflow" | "'Failure rate" | "'Avg run time" | "'Avg queue time" | "'Runner type" | "'Runner labels" | "'Job runs"
-- | -- | -- | -- | -- | -- | -- | --
"'Tests: End-to-end run / Tests: End-to-end (edge)" | "'.github/workflows/continuous-integration.yml" | 28.57 | 332898 | 59976 | "'hosted" | "'ubuntu-latest" | 28
"'Continuous integration / Tests: End-to-end run / Tests: End-to-end (edge)" | "'.github/workflows/deployment-devel.yml" | 20 | 348541 | 70111 | "'hosted" | "'ubuntu-latest" | 5
"'Continuous integration / workflow-success" | "'.github/workflows/deployment-devel.yml" | 16.67 | 3305 | 2131 | "'hosted" | "'ubuntu-latest" | 6
"'Tests: End-to-end run / Tests: End-to-end (chrome)" | "'.github/workflows/continuous-integration.yml" | 14.81 | 320504 | 57153 | "'hosted" | "'ubuntu-latest" | 27
"'Tests: API" | "'.github/workflows/continuous-integration.yml" | 10.53 | 171481 | 35581 | "'hosted" | "'ubuntu-latest" | 19
"'Lint: API (php-cs-fixer)" | "'.github/workflows/continuous-integration.yml" | 10.53 | 29943 | 34996 | "'hosted" | "'ubuntu-latest" | 19
"'Tests: End-to-end build / Tests: End-to-end (build job)" | "'.github/workflows/continuous-integration.yml" | 6.9 | 47631 | 19268 | "'hosted" | "'ubuntu-latest" | 29
"'API: validate migrations" | "'.github/workflows/continuous-integration-optional.yml" | 4.35 | 55099 | 17090 | "'hosted" | "'ubuntu-latest" | 46
"'Lint: API (psalm)" | "'.github/workflows/continuous-integration-optional.yml" | 4.35 | 32385 | 23946 | "'hosted" | "'ubuntu-latest" | 46
"'Lint: API (phpstan)" | "'.github/workflows/continuous-integration-optional.yml" | 4.35 | 29021 | 24534 | "'hosted" | "'ubuntu-latest" | 46
"'Validate Api Platform composer.lock" | "'.github/workflows/continuous-integration-optional.yml" | 4.35 | 11565 | 29465 | "'hosted" | "'ubuntu-latest" | 46


</body>

</html>
