### PR TITLE
chore(deps): update mheap/github-action-required-labels digest to 0ac…

### DIFF
--- a/.github/workflows/pull-request-rules.yml
+++ b/.github/workflows/pull-request-rules.yml
@@ -13,7 +13,7 @@ jobs:
     name: No "Meeting Discuss" label
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@8afbe8ae6ab7647d0c9f0cfa7c2f939650d22509 # v5
+      - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
         if: github.event_name == 'pull_request'
         with:
           mode: exactly


### PR DESCRIPTION
…283b

Renovate stabilityDays is broken, so we do this by ourselves. 
https://github.com/ecamp/ecamp3/pull/9228