### PR TITLE
Register, fix language initialization

### DIFF
--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -215,7 +215,7 @@ export default {
     },
   },
   mounted() {
-    this.language = navigator.language
+    this.language = navigator.language.split('-')[0]
 
     if (getEnv().RECAPTCHA_SITE_KEY) {
       this.recaptcha = load(getEnv().RECAPTCHA_SITE_KEY, {


### PR DESCRIPTION
navigator.language returns "de-CH" 

``` 
navigator.language.split('-')[0]    =>   'de'
```
