### PR TITLE
fix null object display in print config

### DIFF
--- a/frontend/src/components/print/config/ActivityConfig.vue
+++ b/frontend/src/components/print/config/ActivityConfig.vue
@@ -2,7 +2,7 @@
   <div class="px-md-4">
     <e-select
       v-if="!loading"
-      v-model="optionsScheduleEntry"
+      :v-model="optionsScheduleEntry.activity ? optionsScheduleEntry : null"
       path="optionsScheduleEntry"
       :items="scheduleEntries"
       :label="$t('components.print.config.activityConfig.activity')"


### PR DESCRIPTION
fixes "Object [object]" display when adding single activity print config

<img width="407" height="525" alt="image" src="https://github.com/user-attachments/assets/6555ee13-09af-403e-bf12-d7ed3cc6e278" />
