### PR TITLE
Fix autocomplete for checklist template selection

### DIFF
--- a/frontend/src/components/form/base/EAutocomplete.vue
+++ b/frontend/src/components/form/base/EAutocomplete.vue
@@ -17,6 +17,7 @@
       item-title="text"
       item-value="value"
       :readonly="readonly"
+      v-model:search="search"
       v-bind="$attrs"
     >
       <template #item="{ item, props }">
@@ -57,6 +58,7 @@ export default {
   data() {
     return {
       fuzzy: new uFuzzy({ intraMode: 1 }),
+      search: null,
       searchInfos: new Map(),
     }
   },
@@ -68,10 +70,10 @@ export default {
     },
 
     renderHighlighted(item) {
-      if (this.searchInfos.size > 0) {
+      if (this.search && this.searchInfos.size > 0) {
         if (this.searchInfos.has(item.title)) {
           const info = this.searchInfos.get(item.title)
-          if (info) {
+          if (info && info.ranges) {
             return uFuzzy.highlight(
               item.title,
               info.ranges[0],

--- a/frontend/src/components/form/base/EAutocomplete.vue
+++ b/frontend/src/components/form/base/EAutocomplete.vue
@@ -17,7 +17,6 @@
       item-title="text"
       item-value="value"
       :readonly="readonly"
-      :search.sync="search"
       v-bind="$attrs"
     >
       <template #item="{ item, props }">
@@ -54,10 +53,10 @@ export default {
     skipIfEmpty: { type: Boolean, default: true },
     readonly: { type: Boolean, default: false },
   },
+  emits: ['update:model-value'],
   data() {
     return {
       fuzzy: new uFuzzy({ intraMode: 1 }),
-      search: null,
       searchInfos: new Map(),
     }
   },

--- a/frontend/src/components/form/base/EAutocomplete.vue
+++ b/frontend/src/components/form/base/EAutocomplete.vue
@@ -20,7 +20,7 @@
       v-bind="$attrs"
     >
       <template #item="{ item, props }">
-        <v-list-item v-bind="props">
+        <v-list-item v-bind="{ ...props, title: undefined }">
           <v-list-item-title>
             <span v-for="(part, idx) in renderHighlighted(item)" :key="idx">
               <mark v-if="part.h">{{ part.text }}</mark>


### PR DESCRIPTION
Fixes ~~two~~ three issues:
- When just opening the autocomplete and selecting a value, everything worked fine. But when first typing into the search field and then selecting a value, the search field's value was used in the POST request instead of the URI of the selected checklist template.
  vee-validate's `<Field>` behaves very strangely when we put a `v-autocomplete` inside it. When selecting a value from the autocomplete dropdown, the `<Field>` does not receive the `update:modelValue` event. But when typing into the autocomplete's search bar, the `<Field>` does get (and re-emit) those `update:modelValue` events, even though the `v-autocomplete` already catches these events and emits them as `update:search`. So for now, we cannot put any sensible validations on an e-autocomplete, because they would only apply to the search bar, not to the value selected in the dropdown menu.
- When opening the autocomplete, the title of each item would be displayed twice. Once from our `#item` slot, and once from the `title` entry which seems to be in the `props` now... We can just overwrite `props.title` with `undefined` to fix this.
- When typing into the search field and then deleting it (using backspace), a console error was occuring and the autocomplete could no longer be used, selecting values from the dropdown was broken from then on.