### PR TITLE
Complete passing on v-model to v-autocomplete

### DIFF
--- a/frontend/src/components/form/base/EAutocomplete.vue
+++ b/frontend/src/components/form/base/EAutocomplete.vue
@@ -8,6 +8,7 @@
     class="e-form-container"
   >
     <v-autocomplete
+      v-model:search="search"
       :class="[inputClass]"
       :custom-filter="tokensFilter"
       :error-messages="(veeErrors ?? []).concat(errorMessages)"
@@ -17,8 +18,8 @@
       item-title="text"
       item-value="value"
       :readonly="readonly"
-      v-model:search="search"
       v-bind="$attrs"
+      @update:model-value="$emit('update:modelValue', $event)"
     >
       <template #item="{ item, props }">
         <v-list-item v-bind="{ ...props, title: undefined }">


### PR DESCRIPTION
Now that we declare emitting the update:modelValue event, it is no longer part of the $attrs. So we need to explicitly emit the event when relevant.