### PR TITLE
Add Icon to 'ChangeMail'-Dialog

### DIFF
--- a/frontend/src/components/user/DialogChangeMail.vue
+++ b/frontend/src/components/user/DialogChangeMail.vue
@@ -1,6 +1,7 @@
 <template>
   <dialog-form
     v-model="showDialog"
+    icon="mdi-email-outline"
     :title="$t('components.user.dialogChangeMail.title')"
     :submit-action="status === 'initial' ? sendChangeMailRequest : null"
     :cancel-action="close"


### PR DESCRIPTION
Current:
<img width="610" height="256" alt="image" src="https://github.com/user-attachments/assets/20a354e0-81b7-4fcc-b7d6-e24bc565d20b" />


New:
<img width="607" height="257" alt="image" src="https://github.com/user-attachments/assets/3a29d7d3-49e4-4842-a57c-645393d5ee29" />
