### PR TITLE
frontend: allow to delete materialItem on mobile

### DIFF
--- a/frontend/src/components/material/DialogMaterialItemEdit.vue
+++ b/frontend/src/components/material/DialogMaterialItemEdit.vue
@@ -15,7 +15,7 @@
 
     <template #moreActions>
       <PromptEntityDelete
-        :entity="entityUri"
+        :entity="materialItemUri"
         :warning-text-entity="materialItem.article"
         align="left"
         position="top"


### PR DESCRIPTION
The entity warning text is still empty, but at least you can delete.