### PR TITLE
bugfix picasso: do not set Entry-color, is handled in PicassoEntry

### DIFF
--- a/frontend/src/components/program/picasso/Picasso.vue
+++ b/frontend/src/components/program/picasso/Picasso.vue
@@ -269,7 +269,6 @@ export default {
             ? entry.activity().category().short + ': '
             : '') +
           entry.activity().title,
-        color: entry.activity().category().color,
         allDay: false,
       }))
 


### PR DESCRIPTION
there it can be transparent, if schedule-entry is not matched by filter

<img width="782" height="407" alt="image" src="https://github.com/user-attachments/assets/b1320b8e-e9ba-4b54-a222-90dacc69670e" />
