### PR TITLE
Fix richtext on macOS not updating

### DIFF
--- a/frontend/src/components/form/api/ApiRichtext.vue
+++ b/frontend/src/components/form/api/ApiRichtext.vue
@@ -13,7 +13,7 @@ Displays a field as a e-textarea + write access via API wrapper
       :error-messages="wrapper.errorMessages"
       :loading="wrapper.isSaving || wrapper.isLoading ? 'secondary' : false"
       :variant="variant"
-      @tiptap-update="wrapper.on.input"
+      @update:model-value="wrapper.on.input"
       @blur="wrapper.on.blur"
     >
       <template #append-inner>

--- a/frontend/src/components/form/api/ApiRichtext.vue
+++ b/frontend/src/components/form/api/ApiRichtext.vue
@@ -13,7 +13,7 @@ Displays a field as a e-textarea + write access via API wrapper
       :error-messages="wrapper.errorMessages"
       :loading="wrapper.isSaving || wrapper.isLoading ? 'secondary' : false"
       :variant="variant"
-      @input="wrapper.on.input"
+      @tiptap-update="wrapper.on.input"
       @blur="wrapper.on.blur"
     >
       <template #append-inner>

--- a/frontend/src/components/form/api/ApiTextarea.vue
+++ b/frontend/src/components/form/api/ApiTextarea.vue
@@ -14,7 +14,7 @@ Displays a field as a e-textarea + write access via API wrapper
       :loading="wrapper.isSaving || wrapper.isLoading ? 'secondary' : false"
       :variant
       :density
-      @input="wrapper.on.input"
+      @update:model-value="wrapper.on.input"
       @blur="wrapper.on.blur"
     >
       <template #append-inner>

--- a/frontend/src/components/form/base/ERichtext.vue
+++ b/frontend/src/components/form/base/ERichtext.vue
@@ -1,6 +1,6 @@
 <template>
   <Field
-    v-slot="{ errors: veeErrors }"
+    v-slot="{ handleChange, errors: veeErrors }"
     as="div"
     :label="validationLabel"
     :name="veeId ?? path ?? validationLabel"
@@ -14,6 +14,7 @@
       :with-extensions="true"
       v-bind="$attrs"
       :center-affix="false"
+      @update:model-value="$emit('update:modelValue', $event) && handleChange($event)"
     >
       <!-- passing through all slots -->
       <template v-for="(_, slot) of $slots" #[slot]="slotData">
@@ -36,5 +37,6 @@ export default {
     VTiptapEditor,
   },
   mixins: [formComponentPropsMixin, formComponentMixin],
+  emits: ['update:modelValue'],
 }
 </script>

--- a/frontend/src/components/form/base/ERichtext.vue
+++ b/frontend/src/components/form/base/ERichtext.vue
@@ -1,6 +1,6 @@
 <template>
   <Field
-    v-slot="{ handleChange, errors: veeErrors }"
+    v-slot="{ errors: veeErrors }"
     as="div"
     :label="validationLabel"
     :name="veeId ?? path ?? validationLabel"
@@ -11,12 +11,6 @@
       :class="[inputClass]"
       :error-messages="(veeErrors ?? []).concat(errorMessages)"
       :hide-details="hideDetails"
-      :on-input="
-        ($event) => {
-          handleChange($event)
-          $emit('update:model-value', $event)
-        }
-      "
       :with-extensions="true"
       v-bind="$attrs"
       :center-affix="false"

--- a/frontend/src/components/form/base/ETextarea.vue
+++ b/frontend/src/components/form/base/ETextarea.vue
@@ -11,14 +11,9 @@
       :hide-details="hideDetails"
       :label="labelOrEntityFieldLabel"
       :with-extensions="false"
-      :on-input="
-        ($event) => {
-          handleChange($event)
-          $emit('update:model-value', $event)
-        }
-      "
       v-bind="$attrs"
       :center-affix="false"
+      @update:model-value="$emit('update:modelValue', $event) && handleChange($event)"
     >
       <!-- passing through all slots -->
       <template v-for="(_, slot) of $slots" #[slot]="slotData">
@@ -41,5 +36,6 @@ export default {
     VTiptapEditor,
   },
   mixins: [formComponentPropsMixin, formComponentMixin],
+  emits: ['update:modelValue'],
 }
 </script>

--- a/frontend/src/components/form/tiptap/TiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/TiptapEditor.vue
@@ -169,7 +169,7 @@ export default {
       default: true,
     },
   },
-  emits: ['input', 'focus', 'blur'],
+  emits: ['tiptapUpdate', 'focus', 'blur'],
   data() {
     const placeholder = Placeholder.configure({
       emptyEditorClass: 'is-editor-empty',
@@ -302,7 +302,7 @@ export default {
       this.editor.commands.focus()
     },
     onUpdate() {
-      this.$emit('input', this.html)
+      this.$emit('tiptapUpdate', this.html)
     },
     specialKeyListeners(event) {
       this.hoverCursor = event.metaKey || event.ctrlKey

--- a/frontend/src/components/form/tiptap/VTiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/VTiptapEditor.vue
@@ -14,10 +14,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    onInput: {
-      type: Function,
-      required: true,
-    },
     modelValue: {
       type: String,
       default: '',

--- a/frontend/src/components/form/tiptap/VTiptapEditor.vue
+++ b/frontend/src/components/form/tiptap/VTiptapEditor.vue
@@ -40,6 +40,7 @@ export default {
         reactive({
           ...toRefs(props),
           ...ctx.attrs,
+          onTiptapUpdate: (value) => ctx.emit('update:modelValue', value),
           editable: computed(() => !readonlyRef.value && !disabledRef.value),
         }),
         ctx.slots


### PR DESCRIPTION
Rename emit of tiptap to tiptapUpdate

> [!NOTE]
> Currently the validation of richtexts are not implemented and are also not used