### PR TITLE
DialogActivityCreate - fix copy content checkbox

### DIFF
--- a/frontend/src/components/program/DialogActivityCreate.vue
+++ b/frontend/src/components/program/DialogActivityCreate.vue
@@ -66,9 +66,8 @@
           <template #append>
             <v-list-item-action>
               <e-checkbox
-                :model-value="entityData.copyActivitySource !== null"
+                v-model="copyContent"
                 :label="$t('components.program.dialogActivityCreate.copyActivityContent')"
-                @input="setCopyContentCheckbox"
               />
             </v-list-item-action>
           </template>


### PR DESCRIPTION
Create Activity from Copy-Source
Checkbox 'Copy Content' is working again

<img width="640" height="216" alt="image" src="https://github.com/user-attachments/assets/8798a20b-5d21-46e7-bc18-e6dbdbdebfa0" />
