### PR TITLE
Center PeriodSelector in CardTitle

### DIFF
--- a/frontend/src/components/layout/ContentCard.vue
+++ b/frontend/src/components/layout/ContentCard.vue
@@ -19,7 +19,7 @@ Displays the content wrapped inside a card.
       </v-toolbar-items>
 
       <slot name="title">
-        <v-toolbar-title tag="h1" class="font-weight-bold">
+        <v-toolbar-title tag="h1" class="font-weight-bold flex-none">
           {{ title }}
         </v-toolbar-title>
       </slot>

--- a/frontend/src/scss/tailwind.scss
+++ b/frontend/src/scss/tailwind.scss
@@ -4,6 +4,10 @@
   display: flex;
 }
 
+.flex-none {
+  flex: none;
+}
+
 .whitespace-normal {
   white-space: normal;
 }


### PR DESCRIPTION
Current:
<img width="1130" height="210" alt="image" src="https://github.com/user-attachments/assets/0f2df1d6-4443-4cd0-a1e9-499c8397f875" />



Fixed:
<img width="1136" height="256" alt="image" src="https://github.com/user-attachments/assets/8c38d217-1504-4a41-bcad-36ffa11d5429" />
