### PR TITLE
e2e: ignore ResizeObserver exceptions in tests

### DIFF
--- a/e2e/support/index.js
+++ b/e2e/support/index.js
@@ -20,6 +20,11 @@ import installLogsCollector from 'cypress-terminal-report/src/installLogsCollect
 installLogsCollector({
   commandTimings: 'seconds',
 })
+Cypress.on('uncaught:exception', (err) => {
+  if (err.message.includes('ResizeObserver')) {
+    return false
+  }
+})
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
It seems way better:  https://github.com/BacLuc/ecamp3/actions/runs/24293563560

Just once in 66 runs the Chrome render engine crashed.
For edge the render engine crashed 6 times, so we don't enable edge.