### PR TITLE
fix reactivity when creating new schedule entries

### DIFF
--- a/frontend/src/components/activity/dialog/FormScheduleEntryList.vue
+++ b/frontend/src/components/activity/dialog/FormScheduleEntryList.vue
@@ -71,11 +71,6 @@ export default {
       required: true,
     },
   },
-  data() {
-    return {
-      localScheduleEntries: this.scheduleEntries,
-    }
-  },
   computed: {
     scheduleEntriesWithoutDeleted() {
       return this.scheduleEntries.filter((entry) => !entry.deleted)

--- a/frontend/src/components/activity/dialog/FormScheduleEntryList.vue
+++ b/frontend/src/components/activity/dialog/FormScheduleEntryList.vue
@@ -81,7 +81,7 @@ export default {
       return this.scheduleEntries.filter((entry) => !entry.deleted)
     },
     lastScheduleEntry() {
-      return this.localScheduleEntries[this.localScheduleEntries.length - 1]
+      return this.scheduleEntries[this.scheduleEntries.length - 1]
     },
     lastScheduleEntryStart() {
       return dayjs.utc(this.lastScheduleEntry.start)
@@ -102,7 +102,7 @@ export default {
         ? proposedStart
         : dayjs.utc(this.period.start).add(7, 'hour')
       const end = start.add(this.lastScheduleEntryDuration)
-      this.localScheduleEntries.push({
+      this.scheduleEntries.push({
         period: () => this.period,
         start: start.format(),
         end: end.format(),


### PR DESCRIPTION
No refactoring for now, but at least the reactivity is now fixed again

Behavior before fix: In the DialogActivityCreate4, no scheduleEntries could be added, once the Dialog is opened for a 2nd time