### PR TITLE
api: remove options from validators

### DIFF
--- a/api/src/Validator/AllowTransition/AssertAllowTransitions.php
+++ b/api/src/Validator/AllowTransition/AssertAllowTransitions.php
@@ -13,20 +13,14 @@ use Symfony\Component\Validator\Constraint;
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 class AssertAllowTransitions extends Constraint {
-    public array $transitions;
-
     public function __construct(
-        ?array $transitions = null,
-        ?array $options = null,
+        public readonly ?array $transitions = null,
         ?array $groups = null,
         $payload = null
     ) {
-        $transitionsValue = $transitions ?? $options['transitions'] ?? null;
-        if (null === $transitionsValue) {
-            throw new \InvalidArgumentException('The "transitions" option is required.');
+        if (null === $transitions) {
+            throw new \InvalidArgumentException('transitions is required.');
         }
-        $this->transitions = $transitionsValue;
-
         parent::__construct(null, $groups, $payload);
     }
 

--- a/api/src/Validator/AssertContainsAtLeastOneManager.php
+++ b/api/src/Validator/AssertContainsAtLeastOneManager.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertContainsAtLeastOneManager extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'must have at least one manager.';
-
+    public function __construct(
+        public readonly string $message = 'must have at least one manager.',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/AssertJsonSchema.php
+++ b/api/src/Validator/AssertJsonSchema.php
@@ -6,16 +6,14 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertJsonSchema extends Constraint {
-    public string $message;
-
-    public array $schema;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $schema = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? "Provided JSON doesn't match required schema ({{ schemaError }}).";
-        $this->schema = $schema ?? $options['schema'] ?? [
+    public function __construct(
+        public readonly string $message = "Provided JSON doesn't match required schema ({{ schemaError }}).",
+        public readonly array $schema = [
             'type' => 'object',
-        ];
-
+        ],
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/AssertLastCollectionItemIsNotDeleted.php
+++ b/api/src/Validator/AssertLastCollectionItemIsNotDeleted.php
@@ -7,16 +7,12 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class AssertLastCollectionItemIsNotDeleted extends Constraint {
     public const IS_EMPTY_ERROR = 'IS_EMPTY_ERROR';
-    public string $message;
 
     public function __construct(
-        ?array $options = null,
-        ?string $message = null,
+        public readonly string $message = 'Cannot delete the last entry.',
         ?array $groups = null,
         mixed $payload = null
     ) {
-        $this->message = $message ?? $options['message'] ?? 'Cannot delete the last entry.';
-
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/AssertNoLoop.php
+++ b/api/src/Validator/AssertNoLoop.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertNoLoop extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'Must not form a loop of parent-child relations.';
-
+    public function __construct(
+        public readonly string $message = 'Must not form a loop of parent-child relations.',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/ChecklistItem/AssertBelongsToSameCamp.php
+++ b/api/src/Validator/ChecklistItem/AssertBelongsToSameCamp.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertBelongsToSameCamp extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'Must belong to the same camp.';
-
+    public function __construct(
+        public readonly string $message = 'Must belong to the same camp.',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/ChecklistItem/AssertBelongsToSameChecklist.php
+++ b/api/src/Validator/ChecklistItem/AssertBelongsToSameChecklist.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertBelongsToSameChecklist extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'Must belong to the same checklist.';
-
+    public function __construct(
+        public readonly string $message = 'Must belong to the same checklist.',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/ColumnLayout/AssertColumWidthsSumTo12.php
+++ b/api/src/Validator/ColumnLayout/AssertColumWidthsSumTo12.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertColumWidthsSumTo12 extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'Expected column widths to sum to 12, but got a sum of {{ sum }}';
-
+    public function __construct(
+        public readonly string $message = 'Expected column widths to sum to 12, but got a sum of {{ sum }}',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/ColumnLayout/AssertNoOrphanChildren.php
+++ b/api/src/Validator/ColumnLayout/AssertNoOrphanChildren.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertNoOrphanChildren extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'The following slots still have child contents and should be present in the columns: {{ slots }}';
-
+    public function __construct(
+        public readonly string $message = 'The following slots still have child contents and should be present in the columns: {{ slots }}',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/ContentNode/AssertAttachedToRoot.php
+++ b/api/src/Validator/ContentNode/AssertAttachedToRoot.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertAttachedToRoot extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'Must be attached to the root layout.';
-
+    public function __construct(
+        public readonly string $message = 'Must be attached to the root layout.',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/ContentNode/AssertContentTypeCompatible.php
+++ b/api/src/Validator/ContentNode/AssertContentTypeCompatible.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertContentTypeCompatible extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'Selected contentType {{ contentTypeName }} is incompatible with entity of type {{ givenEntityClass }} (it can only be used with entities of type {{ expectedEntityClass }}).';
-
+    public function __construct(
+        public readonly string $message = 'Selected contentType {{ contentTypeName }} is incompatible with entity of type {{ givenEntityClass }} (it can only be used with entities of type {{ expectedEntityClass }}).',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/ContentNode/AssertNoRootChange.php
+++ b/api/src/Validator/ContentNode/AssertNoRootChange.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertNoRootChange extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'Must belong to the same root.';
-
+    public function __construct(
+        public readonly string $message = 'Must belong to the same root.',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/ContentNode/AssertSlotSupportedByParent.php
+++ b/api/src/Validator/ContentNode/AssertSlotSupportedByParent.php
@@ -10,22 +10,13 @@ class AssertSlotSupportedByParent extends Constraint {
     public const NO_PARENT_MESSAGE = 'This value must be null because this content_node has no parent.';
     public const PARENT_DOES_NOT_SUPPORT_CHILDREN = 'The parent of this content_node does not support children.';
 
-    public readonly string $message;
-    public readonly string $noParentMessage;
-    public readonly string $parentDoesNotSupportChildrenMessage;
-
     public function __construct(
-        ?string $message = null,
-        ?string $noParentMessage = null,
-        ?string $parentDoesNotSupportChildrenMessage = null,
-        ?array $options = null,
+        public readonly string $message = self::MESSAGE,
+        public readonly string $noParentMessage = self::NO_PARENT_MESSAGE,
+        public readonly string $parentDoesNotSupportChildrenMessage = self::PARENT_DOES_NOT_SUPPORT_CHILDREN,
         ?array $groups = null,
         $payload = null
     ) {
-        $this->message = $message ?? $options['message'] ?? self::MESSAGE;
-        $this->noParentMessage = $noParentMessage ?? $options['noParentMessage'] ?? self::NO_PARENT_MESSAGE;
-        $this->parentDoesNotSupportChildrenMessage = $parentDoesNotSupportChildrenMessage ?? $options['parentDoesNotSupportChildrenMessage'] ?? self::PARENT_DOES_NOT_SUPPORT_CHILDREN;
-
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/Period/AssertGreaterThanOrEqualToLastScheduleEntryEnd.php
+++ b/api/src/Validator/Period/AssertGreaterThanOrEqualToLastScheduleEntryEnd.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertGreaterThanOrEqualToLastScheduleEntryEnd extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'Due to existing schedule entries, end-date can not be earlier then {{ endDate }}';
-
+    public function __construct(
+        public readonly string $message = 'Due to existing schedule entries, end-date can not be earlier then {{ endDate }}',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/Period/AssertLessThanOrEqualToEarliestScheduleEntryStart.php
+++ b/api/src/Validator/Period/AssertLessThanOrEqualToEarliestScheduleEntryStart.php
@@ -6,11 +6,11 @@ use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
 class AssertLessThanOrEqualToEarliestScheduleEntryStart extends Constraint {
-    public string $message;
-
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? 'Due to existing schedule entries, start-date can not be later then {{ startDate }}';
-
+    public function __construct(
+        public readonly string $message = 'Due to existing schedule entries, start-date can not be later then {{ startDate }}',
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }

--- a/api/src/Validator/Period/AssertNotOverlappingWithOtherPeriods.php
+++ b/api/src/Validator/Period/AssertNotOverlappingWithOtherPeriods.php
@@ -7,11 +7,12 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 class AssertNotOverlappingWithOtherPeriods extends Constraint {
     public const DEFAULT_MESSAGE = 'Periods must not overlap.';
-    public string $message;
 
-    public function __construct(?array $options = null, ?string $message = null, ?array $groups = null, $payload = null) {
-        $this->message = $message ?? $options['message'] ?? self::DEFAULT_MESSAGE;
-
+    public function __construct(
+        public readonly string $message = self::DEFAULT_MESSAGE,
+        ?array $groups = null,
+        $payload = null
+    ) {
         parent::__construct(null, $groups, $payload);
     }
 }


### PR DESCRIPTION
See
- https://github.com/ecamp/ecamp3/pull/9013#discussion_r2849027845

We don't use the options array.
We could have made the deprecation fix easier, but like this the diff is easy.