### PR TITLE
fix: correct loading order for Checklist ContentNode

### DIFF
--- a/frontend/src/components/activity/content/Checklist.vue
+++ b/frontend/src/components/activity/content/Checklist.vue
@@ -16,16 +16,23 @@
             :disabled="layoutMode"
             v-bind="props"
           >
-            <v-skeleton-loader v-if="!itemsLoaded" class="px-4 pb-4" type="paragraph" />
-            <v-list-item v-else-if="checkedItems.length === 0">
-              <v-list-item-title>
-                {{ $t('global.button.edit') }}
-              </v-list-item-title>
-            </v-list-item>
-            <ChecklistDisplaySelectedItems
-              :checklists="checklists"
-              :layout-mode="layoutMode"
+           <v-skeleton-loader
+            v-if="!itemsLoaded"
+            class="px-4 pb-4"
+            type="paragraph"
             />
+
+          <v-list-item v-else-if="checkedItems.length === 0">
+            <v-list-item-title>
+              {{ $t('global.button.edit') }}
+            </v-list-item-title>
+          </v-list-item>
+
+          <ChecklistDisplaySelectedItems
+            v-else
+            :checklists="checklists"
+            :layout-mode="layoutMode"
+          />
           </button>
         </template>
         <div class="ma-n4">


### PR DESCRIPTION
### Fix Checklist ContentNode loading behaviour
This PR fixes an issue where checklist items and the "Edit" label were rendered before the skeleton loader.

### Problem
`ChecklistDisplaySelectedItems` was always rendered, even when `itemsLoaded` was false, causing incorrect UI order.

### Solution

Updated conditional rendering logic to:
* Show skeleton loader while loading
* Show "Edit" label when no items are selected
* Show selected items otherwise

### Result
Correct rendering order:

1. Skeleton loader
2. Edit label OR selected items

Closes #9462