### PR TITLE
Ignore duplicated navigation on init page refresh

### DIFF
--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -4,6 +4,7 @@ import { hasLoggedOutFromLocalStorage } from '@/plugins/store/auth.js'
 import router from '@/router'
 import Cookies from 'js-cookie'
 import { getEnv } from '@/environment.js'
+import { isNavigationFailure, NavigationFailureType } from 'vue-router'
 
 axios.interceptors.response.use(null, (error) => {
   if (error.status === 401) {
@@ -37,7 +38,12 @@ export async function initRefresh() {
   }
   rescheduleRefresh()
   if (refreshedSuccessfully) {
-    await router.replace(originalTarget)
+    await router.replace(originalTarget).catch((e) => {
+      // Silently ignore if we are already at that target
+      if (!isNavigationFailure(e, NavigationFailureType.duplicated)) {
+        return Promise.reject(e)
+      }
+    })
   }
 }
 


### PR DESCRIPTION
Hopefully fixes many many sentry issues:
https://ecamp.sentry.io/issues/?project=5602507&project=5912620&query=is%253Aunresolved%20NavigationDuplicated

I couldn't reproduce it locally, but they happen all the time.
We already do something similar (but not identical) in [PersonalInvitations.vue](https://github.com/ecamp/ecamp3/blob/devel/frontend/src/components/personal_invitations/PersonalInvitations.vue#L108)