### PR TITLE
api: use php configs for routes instead of xml or wdt

### DIFF
--- a/api/config/routes/dev/web_profiler.yaml
+++ b/api/config/routes/dev/web_profiler.yaml
@@ -1,7 +1,7 @@
 web_profiler_wdt:
-    resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+    resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
     prefix: /_wdt
 
 web_profiler_profiler:
-    resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+    resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
     prefix: /_profiler

--- a/api/config/routes/framework.yaml
+++ b/api/config/routes/framework.yaml
@@ -1,4 +1,4 @@
 when@dev:
   _errors:
-    resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+    resource: '@FrameworkBundle/Resources/config/routing/errors.php'
     prefix: /_error


### PR DESCRIPTION
WebProfileBundle doesn't ship the xml anymore with symfony 8.