### PR TITLE
api: set framework.profile.collect_serializer_data to true

### DIFF
--- a/api/config/packages/dev/web_profiler.yaml
+++ b/api/config/packages/dev/web_profiler.yaml
@@ -5,4 +5,4 @@ web_profiler:
 framework:
     profiler:
         only_exceptions: false
-        collect_serializer_data: false
+        collect_serializer_data: true


### PR DESCRIPTION
Since symfony/framework-bundle 7.3: Not setting the "framework.profiler.collect_serializer_data" config option to "true" is deprecated. This is the only allowed value with symfony 8.