### PR TITLE
api: remove enable_link_security

### DIFF
--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -2,7 +2,6 @@ api_platform:
     title: eCamp v3
     version: 1.0.0
     show_webby: false
-    enable_link_security: true
     mapping:
         paths:
             - '%kernel.project_dir%/src/Entity'


### PR DESCRIPTION
Since api-platform/symfony 4.2: This option is always enabled and will be removed in API Platform 5.0. https://github.com/api-platform/core/blob/2d6e47460c1d0e4e79fda9cec8783b5277835a3c/src/Symfony/Bundle/DependencyInjection/Configuration.php#L135

- https://github.com/api-platform/core/pull/7641