### PR TITLE
api: fix method Request::get is deprecated

### DIFF
--- a/api/src/Controller/CevidbController.php
+++ b/api/src/Controller/CevidbController.php
@@ -17,7 +17,7 @@ class CevidbController extends AbstractController {
     public function connect(Request $request) {
         return $this->clientRegistry
             ->getClient('cevidb') // key used in config/packages/knpu_oauth2_client.yaml
-            ->redirect([], ['additionalData' => ['callback' => $request->get('callback')]])
+            ->redirect([], ['additionalData' => ['callback' => $request->query->get('callback')]])
         ;
     }
 

--- a/api/src/Controller/GoogleController.php
+++ b/api/src/Controller/GoogleController.php
@@ -17,7 +17,7 @@ class GoogleController extends AbstractController {
     public function connect(Request $request) {
         return $this->clientRegistry
             ->getClient('google') // key used in config/packages/knpu_oauth2_client.yaml
-            ->redirect([], ['additionalData' => ['callback' => $request->get('callback')]])
+            ->redirect([], ['additionalData' => ['callback' => $request->query->get('callback')]])
         ;
     }
 

--- a/api/src/Controller/JubladbController.php
+++ b/api/src/Controller/JubladbController.php
@@ -17,7 +17,7 @@ class JubladbController extends AbstractController {
     public function connect(Request $request) {
         return $this->clientRegistry
             ->getClient('jubladb') // key used in config/packages/knpu_oauth2_client.yaml
-            ->redirect([], ['additionalData' => ['callback' => $request->get('callback')]])
+            ->redirect([], ['additionalData' => ['callback' => $request->query->get('callback')]])
         ;
     }
 

--- a/api/src/Controller/PbsmidataController.php
+++ b/api/src/Controller/PbsmidataController.php
@@ -17,7 +17,7 @@ class PbsmidataController extends AbstractController {
     public function connect(Request $request) {
         return $this->clientRegistry
             ->getClient('pbsmidata') // key used in config/packages/knpu_oauth2_client.yaml
-            ->redirect([], ['additionalData' => ['callback' => $request->get('callback')]])
+            ->redirect([], ['additionalData' => ['callback' => $request->query->get('callback')]])
         ;
     }
 


### PR DESCRIPTION
since Symfony 7.4, use properties `->attributes`, `query` or `request` directly instead