### PR TITLE
PurgeHttpCacheListener: remove unnecessary null check

### DIFF
--- a/api/src/HttpCache/PurgeHttpCacheListener.php
+++ b/api/src/HttpCache/PurgeHttpCacheListener.php
@@ -224,7 +224,7 @@ final readonly class PurgeHttpCacheListener {
         $associationMappings = $this->em->getClassMetadata(ClassUtils::getClass($entity))->getAssociationMappings();
 
         foreach ($associationMappings as $property => $associationMapping) {
-            if ($associationMapping instanceof AssociationMapping && ($associationMapping->targetEntity ?? null) && !$this->resourceClassResolver->isResourceClass($associationMapping->targetEntity)) {
+            if ($associationMapping instanceof AssociationMapping && $associationMapping->targetEntity && !$this->resourceClassResolver->isResourceClass($associationMapping->targetEntity)) {
                 return;
             }
 


### PR DESCRIPTION
Fixes phpstan check:
Line   HttpCache/PurgeHttpCacheListener.php
 ------ --------------------------------------------------------------------------------------------------------------------
  227    Property Doctrine\ORM\Mapping\AssociationMapping::$targetEntity (class-string) on left side of ?? is not nullable.
         🪪  nullCoalesce.property