### PR TITLE
Add unit tests for materialListRoute and fix typo

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -827,7 +827,7 @@ export function materialListRoute(camp, materialListOrRoute = '/all', query = {}
       query,
     }
   }
-  if (!materialListOrRoute?._meta || materialListOrRoute.meta?.loading) return {}
+  if (!materialListOrRoute?._meta || materialListOrRoute._meta?.loading) return {}
   return {
     name: 'camp/material/detail',
     params: {

--- a/frontend/src/test/router.spec.js
+++ b/frontend/src/test/router.spec.js
@@ -3,8 +3,8 @@ import { materialListRoute } from '../router'
 
 describe('materialListRoute', () => {
   const camp = {
-    id: '123',
-    shortTitle: 'camp-title',
+    id: '42',
+    shortTitle: 'this is irrelevant',
     _meta: { loading: false },
   }
 
@@ -18,8 +18,8 @@ describe('materialListRoute', () => {
     expect(result).toEqual({
       name: 'camp/material/all',
       params: {
-        campId: '123',
-        campShortTitle: 'camp-title',
+        campId: '42',
+        campShortTitle: 'this-is-irreleva',
       },
       query: {},
     })
@@ -30,8 +30,8 @@ describe('materialListRoute', () => {
     expect(result).toEqual({
       name: 'camp/material/unassigned',
       params: {
-        campId: '123',
-        campShortTitle: 'camp-title',
+        campId: '42',
+        campShortTitle: 'this-is-irreleva',
       },
       query: {},
     })
@@ -39,18 +39,18 @@ describe('materialListRoute', () => {
 
   it('returns route for a material list object', () => {
     const materialList = {
-      id: '456',
-      name: 'My List',
+      id: '42',
+      name: 'this is irrelevant',
       _meta: { loading: false },
     }
     const result = materialListRoute(camp, materialList)
     expect(result).toEqual({
       name: 'camp/material/detail',
       params: {
-        campId: '123',
-        campShortTitle: 'camp-title',
-        materialId: '456',
-        materialName: 'My-List',
+        campId: '42',
+        campShortTitle: 'this-is-irreleva',
+        materialId: '42',
+        materialName: 'this-is-irrelevant',
       },
       query: {},
     })
@@ -58,29 +58,32 @@ describe('materialListRoute', () => {
 
   it('returns empty object if material list object is missing _meta', () => {
     const materialList = {
-      id: '456',
-      name: 'My List',
+      id: '42',
+      name: 'this is irrelevant',
     }
     expect(materialListRoute(camp, materialList)).toEqual({})
   })
 
   it('returns empty object if material list is loading', () => {
     const materialList = {
-      id: '456',
-      name: 'My List',
+      id: '42',
+      name: 'this is irrelevant',
       _meta: { loading: true },
     }
     expect(materialListRoute(camp, materialList)).toEqual({})
   })
 
-  it('correctly includes query parameters', () => {
+  it('correctly includes query parameters for /all', () => {
     const query = { search: 'test' }
     const result = materialListRoute(camp, '/all', query)
     expect(result.query).toEqual(query)
+  })
 
+  it('correctly includes query parameters for materialList', () => {
+    const query = { search: 'test' }
     const materialList = {
-      id: '456',
-      name: 'My List',
+      id: '42',
+      name: 'this is irrelevant',
       _meta: { loading: false },
     }
     const resultWithObject = materialListRoute(camp, materialList, query)

--- a/frontend/src/test/router.spec.js
+++ b/frontend/src/test/router.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { materialListRoute } from '../router'
+
+describe('materialListRoute', () => {
+  const camp = {
+    id: '123',
+    shortTitle: 'camp-title',
+    _meta: { loading: false },
+  }
+
+  it('returns empty object if camp is loading', () => {
+    const loadingCamp = { ...camp, _meta: { loading: true } }
+    expect(materialListRoute(loadingCamp)).toEqual({})
+  })
+
+  it('returns route for default string argument "/all"', () => {
+    const result = materialListRoute(camp)
+    expect(result).toEqual({
+      name: 'camp/material/all',
+      params: {
+        campId: '123',
+        campShortTitle: 'camp-title',
+      },
+      query: {},
+    })
+  })
+
+  it('returns route for specific string argument "/unassigned"', () => {
+    const result = materialListRoute(camp, '/unassigned')
+    expect(result).toEqual({
+      name: 'camp/material/unassigned',
+      params: {
+        campId: '123',
+        campShortTitle: 'camp-title',
+      },
+      query: {},
+    })
+  })
+
+  it('returns route for a material list object', () => {
+    const materialList = {
+      id: '456',
+      name: 'My List',
+      _meta: { loading: false },
+    }
+    const result = materialListRoute(camp, materialList)
+    expect(result).toEqual({
+      name: 'camp/material/detail',
+      params: {
+        campId: '123',
+        campShortTitle: 'camp-title',
+        materialId: '456',
+        materialName: 'My-List',
+      },
+      query: {},
+    })
+  })
+
+  it('returns empty object if material list object is missing _meta', () => {
+    const materialList = {
+      id: '456',
+      name: 'My List',
+    }
+    expect(materialListRoute(camp, materialList)).toEqual({})
+  })
+
+  it('returns empty object if material list is loading', () => {
+    const materialList = {
+      id: '456',
+      name: 'My List',
+      _meta: { loading: true },
+    }
+    expect(materialListRoute(camp, materialList)).toEqual({})
+  })
+
+  it('correctly includes query parameters', () => {
+    const query = { search: 'test' }
+    const result = materialListRoute(camp, '/all', query)
+    expect(result.query).toEqual(query)
+
+    const materialList = {
+      id: '456',
+      name: 'My List',
+      _meta: { loading: false },
+    }
+    const resultWithObject = materialListRoute(camp, materialList, query)
+    expect(resultWithObject.query).toEqual(query)
+  })
+})


### PR DESCRIPTION
This PR adds unit tests for materialListRoute and fixes a property access typo.
