### PR TITLE
Optimize camp list view with many periods

### DIFF
--- a/frontend/src/components/camp/CampListItem.vue
+++ b/frontend/src/components/camp/CampListItem.vue
@@ -27,6 +27,9 @@
 import { campRoute } from '@/router.js'
 import { componentI18n } from '@/plugins/i18n/index.js'
 import groupBy from 'lodash-es/groupBy.js'
+
+const YEAR_JOINER = '-'
+
 export default {
   name: 'CampListItem',
   props: {
@@ -45,7 +48,7 @@ export default {
     },
     date() {
       return Object.entries(this.groupedPeriods).map(([key, periods]) => {
-        if (key.includes('-'))
+        if (key.includes(YEAR_JOINER))
           return periods
             .map(({ start, end }) => this.formatMY.formatRange(start, end))
             .join(' | ')
@@ -72,7 +75,7 @@ export default {
       return groupBy(this.datePeriods, (period) => {
         if (period.start.getFullYear() === period.end.getFullYear())
           return '' + period.start.getFullYear()
-        else return period.start.getFullYear() + '-' + period.end.getFullYear()
+        else return period.start.getFullYear() + YEAR_JOINER + period.end.getFullYear()
       })
     },
   },

--- a/frontend/src/components/camp/CampListItem.vue
+++ b/frontend/src/components/camp/CampListItem.vue
@@ -8,8 +8,7 @@
         class="align-self-center px-1 v-btn--has-bg"
         >{{ $t('components.camp.campListItem.public') }}</v-chip
       >
-      <span class="flex-grow-1"></span>
-      <span class="whitespace-normal max-w-60vw text-right">
+      <span class="ec-camp-list-item-date whitespace-normal max-w-60vw text-right">
         <template v-for="(group, i) in date" :key="i">
           <template v-if="!!i"> | </template>
           <span class="break-inside-avoid">{{ group }}</span>

--- a/frontend/src/components/camp/CampListItem.vue
+++ b/frontend/src/components/camp/CampListItem.vue
@@ -27,6 +27,7 @@
 import { campRoute } from '@/router.js'
 import { componentI18n } from '@/plugins/i18n/index.js'
 import groupBy from 'lodash-es/groupBy.js'
+import uniq from 'lodash-es/uniq.js'
 
 const YEAR_JOINER = '-'
 
@@ -54,9 +55,9 @@ export default {
             .join(' | ')
         else
           return (
-            periods
-              .map(({ start, end }) => this.formatM.formatRange(start, end))
-              .join(', ') +
+            uniq(
+              periods.map(({ start, end }) => this.formatM.formatRange(start, end))
+            ).join(', ') +
             ' ' +
             key
           )
@@ -64,19 +65,26 @@ export default {
     },
     datePeriods() {
       return this.periods
-        .map((period) => ({
-          ...period,
-          start: new Date(period.start),
-          end: new Date(period.end),
-        }))
-        .toSorted((a, b) => a.start - b.start)
+        .map((period) => {
+          const start = new Date(period.start)
+          const end = new Date(period.end)
+          const sameYear = start.getFullYear() === end.getFullYear()
+
+          return {
+            ...period,
+            start,
+            end,
+            key: start.getFullYear() + (sameYear ? '' : YEAR_JOINER + end.getFullYear()),
+          }
+        })
+        .toSorted((a, b) => {
+          const diff = a.start - b.start
+          if (diff !== 0) return diff
+          return a.end - b.end
+        })
     },
     groupedPeriods() {
-      return groupBy(this.datePeriods, (period) => {
-        if (period.start.getFullYear() === period.end.getFullYear())
-          return '' + period.start.getFullYear()
-        else return period.start.getFullYear() + YEAR_JOINER + period.end.getFullYear()
-      })
+      return groupBy(this.datePeriods, 'key')
     },
   },
   methods: { campRoute },

--- a/frontend/src/components/camp/CampListItem.vue
+++ b/frontend/src/components/camp/CampListItem.vue
@@ -50,8 +50,8 @@ export default {
       return Object.entries(this.groupedPeriods).map(([key, periods]) => {
         if (key.includes(YEAR_JOINER))
           return periods
-            .map(({ start, end }) => this.formatMY.formatRange(start, end))
-            .join(' | ')
+            .slice(0, 1)
+            .map(({ start, end }) => this.formatMY.formatRange(start, end))[0]
         else
           return (
             uniq(

--- a/frontend/src/components/camp/CampListItem.vue
+++ b/frontend/src/components/camp/CampListItem.vue
@@ -9,7 +9,12 @@
         >{{ $t('components.camp.campListItem.public') }}</v-chip
       >
       <span class="flex-grow-1"></span>
-      <span>{{ date }}</span>
+      <span class="whitespace-normal max-w-60vw text-right">
+        <template v-for="(group, i) in date" :key="i">
+          <template v-if="!!i"> | </template>
+          <span class="break-inside-avoid">{{ group }}</span>
+        </template>
+      </span>
     </v-list-item-title>
     <v-list-item-subtitle class="d-flex gap-2 flex-wrap-reverse justify-space-between">
       <span class="whitespace-normal">{{ camp.motto }}</span>
@@ -21,6 +26,7 @@
 <script>
 import { campRoute } from '@/router.js'
 import { componentI18n } from '@/plugins/i18n/index.js'
+import groupBy from 'lodash-es/groupBy.js'
 export default {
   name: 'CampListItem',
   props: {
@@ -28,18 +34,46 @@ export default {
     periods: { type: Array, default: () => [] },
   },
   computed: {
-    date() {
-      if (!this.periods.length) return
-      const formatMY = new Intl.DateTimeFormat(componentI18n.locale, {
+    formatMY() {
+      return new Intl.DateTimeFormat(componentI18n.locale, {
         year: 'numeric',
         month: 'short',
       })
-      return [...this.periods]
-        .sort((a, b) => new Date(a.start) - new Date(b.start))
-        .map((period) => {
-          return formatMY.formatRange(new Date(period.start), new Date(period.end))
-        })
-        .join(' | ')
+    },
+    formatM() {
+      return new Intl.DateTimeFormat(componentI18n.locale, { month: 'short' })
+    },
+    date() {
+      return Object.entries(this.groupedPeriods).map(([key, periods]) => {
+        if (key.includes('-'))
+          return periods
+            .map(({ start, end }) => this.formatMY.formatRange(start, end))
+            .join(' | ')
+        else
+          return (
+            periods
+              .map(({ start, end }) => this.formatM.formatRange(start, end))
+              .join(', ') +
+            ' ' +
+            key
+          )
+      })
+    },
+    datePeriods() {
+      return this.periods
+        .map((period) => ({
+          ...period,
+          start: new Date(period.start),
+          end: new Date(period.end),
+        }))
+        .toSorted((a, b) => a.start - b.start)
+    },
+    groupedPeriods() {
+      return groupBy(this.datePeriods, (period) => {
+        if (period.start.getFullYear() === period.end.getFullYear())
+          return '' + period.start.getFullYear()
+        else return period.start.getFullYear() + '-' + period.end.getFullYear()
+      })
     },
   },
   methods: { campRoute },

--- a/frontend/src/components/camp/__tests__/CampListItem.spec.js
+++ b/frontend/src/components/camp/__tests__/CampListItem.spec.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CampListItem from '../CampListItem.vue'
+
+// Mock dependencies
+vi.mock('@/router.js', () => ({
+  campRoute: vi.fn((camp) => `/camps/${camp.id}`),
+}))
+
+vi.mock('@/plugins/i18n/index.js', () => ({
+  componentI18n: {
+    locale: 'en-US', // Fixed locale for consistent date formatting assertions
+  },
+}))
+
+describe('CampListItem.vue - Date Display', () => {
+  const defaultCamp = {
+    id: 1,
+    title: 'Sommerlager 2026',
+    motto: 'Verflixte Zeitreisen',
+    organizer: 'Doctor Who',
+    isShared: false,
+  }
+
+  const mountComponent = (props = {}) => {
+    return mount(CampListItem, {
+      props: {
+        camp: defaultCamp,
+        ...props,
+      },
+      global: {
+        stubs: {
+          'v-list-item': {
+            template: '<div class="v-list-item" :data-to="to"><slot /></div>',
+            props: ['to'],
+          },
+          'v-list-item-title': {
+            template: '<div class="v-list-item-title"><slot /></div>',
+          },
+          'v-list-item-subtitle': {
+            template: '<div class="v-list-item-subtitle"><slot /></div>',
+          },
+          'v-chip': { template: '<span class="v-chip"><slot /></span>' },
+        },
+        mocks: {
+          $t: (msg) => msg,
+        },
+      },
+    })
+      .get('.ec-camp-list-item-date')
+      .text()
+      .replace(/\s+/g, ' ')
+      .trim()
+  }
+
+  it('renders nothing for the date if no periods are provided', () => {
+    const listItemDate = mountComponent({ periods: [] })
+
+    expect(listItemDate).toBe('')
+  })
+
+  it('calculates and formats a single period within the same year correctly', () => {
+    const listItemDate = mountComponent({
+      periods: [{ start: '2026-07-15T00:00:00Z', end: '2026-07-22T00:00:00Z' }],
+    })
+
+    expect(listItemDate).toBe('Jul 2026')
+  })
+
+  it('calculates and formats multiple periods within the same year correctly', () => {
+    const listItemDate = mountComponent({
+      periods: [
+        { start: '2026-07-15T00:00:00Z', end: '2026-07-22T00:00:00Z' },
+        { start: '2026-08-10T00:00:00Z', end: '2026-08-15T00:00:00Z' },
+      ],
+    })
+
+    expect(listItemDate).toBe('Jul, Aug 2026')
+  })
+
+  it('calculates and formats cross-year periods correctly', () => {
+    const listItemDate = mountComponent({
+      periods: [{ start: '2025-12-28T00:00:00Z', end: '2026-01-04T00:00:00Z' }],
+    })
+
+    expect(listItemDate).toBe('Dec 2025 – Jan 2026')
+  })
+
+  it('groups and separates same-year and cross-year periods with a pipe', () => {
+    const listItemDate = mountComponent({
+      periods: [
+        { start: '2025-12-28T00:00:00Z', end: '2026-01-04T00:00:00Z' },
+        { start: '2026-07-15T00:00:00Z', end: '2026-07-22T00:00:00Z' },
+      ],
+    })
+
+    expect(listItemDate).toBe('Jul 2026 | Dec 2025 – Jan 2026')
+  })
+})

--- a/frontend/src/components/camp/__tests__/CampListItem.spec.js
+++ b/frontend/src/components/camp/__tests__/CampListItem.spec.js
@@ -9,7 +9,7 @@ vi.mock('@/router.js', () => ({
 
 vi.mock('@/plugins/i18n/index.js', () => ({
   componentI18n: {
-    locale: 'en-US', // Fixed locale for consistent date formatting assertions
+    locale: 'en-US',
   },
 }))
 

--- a/frontend/src/scss/tailwind.scss
+++ b/frontend/src/scss/tailwind.scss
@@ -14,12 +14,20 @@
   white-space: normal;
 }
 
+.break-inside-avoid {
+  break-inside: avoid;
+}
+
 .min-h-full {
   min-height: 100%;
 }
 
 .max-w-screen {
   max-width: 100vw;
+}
+
+.max-w-60vw {
+  max-width: 60vw;
 }
 
 .w-0 {


### PR DESCRIPTION
| <img width="423" height="597" alt="Bildschirmfoto 2026-04-27 um 15 54 03" src="https://github.com/user-attachments/assets/6d572228-34dd-494f-bf84-b4eb52ba0fbb" /> | <img width="425" height="536" alt="Bildschirmfoto 2026-04-27 um 15 52 33" src="https://github.com/user-attachments/assets/8e81c2a2-c315-48b1-8565-12e30cba640a" /> |
| - | - |
| before | after |
