### PR TITLE
feat: enable caching for /activities/{activityId}

### DIFF
--- a/api/config/packages/http_cache.yaml
+++ b/api/config/packages/http_cache.yaml
@@ -1,5 +1,5 @@
 parameters:
-    app.httpCache.matchPath: '^/?($|index.jsonhal$|content_types|camps/[0-9a-f]*/categories|periods/[0-9a-f]*/schedule_entries|camps/[0-9a-f]*/activities|camps/[0-9a-f]*/checklists)'
+    app.httpCache.matchPath: '^/?($|index.jsonhal$|content_types|camps/[0-9a-f]*/categories|periods/[0-9a-f]*/schedule_entries|camps/[0-9a-f]*/activities|camps/[0-9a-f]*/checklists|activities/[0-9a-f]*)'
 
 fos_http_cache:
     debug:
@@ -17,19 +17,17 @@ fos_http_cache:
         rules:
             # matches /content_types endpoint
             # matches /camps/133/categories endpoint
-            -
-                match:
-                    path: '%app.httpCache.matchPath%'
-                headers:
-                    overwrite: true
-                    cache_control: { public: true, max_age: 0, s_maxage: 3600 }
-                    vary: [Accept, Content-Type, Authorization, Origin]
+            - match:
+                  path: '%app.httpCache.matchPath%'
+              headers:
+                  overwrite: true
+                  cache_control: { public: true, max_age: 0, s_maxage: 3600 }
+                  vary: [Accept, Content-Type, Authorization, Origin]
 
             # match everything else to set defaults
-            -
-                match:
-                    path: ^/
-                headers:
-                    overwrite: true
-                    cache_control: { no-cache: true, private: true }
-                    vary: [Accept, Content-Type, Authorization, Origin]
+            - match:
+                  path: ^/
+              headers:
+                  overwrite: true
+                  cache_control: { no-cache: true, private: true }
+                  vary: [Accept, Content-Type, Authorization, Origin]

--- a/e2e/test-data/httpCache/activities_entity.json
+++ b/e2e/test-data/httpCache/activities_entity.json
@@ -1,0 +1,335 @@
+{
+    "_links": {
+        "self": {
+            "href": "/api/activities/a13fadc97610"
+        },
+        "scheduleEntries": {
+            "href": "/api/schedule_entries?activity=%2Fapi%2Factivities%2Fa13fadc97610"
+        },
+        "camp": {
+            "href": "/api/camps/70ca971c992f"
+        },
+        "category": {
+            "href": "/api/categories/eddb2cd8cee0"
+        },
+        "progressLabel": {
+            "href": "/api/activity_progress_labels/af92782262d7"
+        },
+        "comments": {
+            "href": "/api/activities/a13fadc97610/comments"
+        },
+        "activityResponsibles": {
+            "href": "/api/activity_responsibles?activity=%2Fapi%2Factivities%2Fa13fadc97610"
+        },
+        "rootContentNode": {
+            "href": "/api/content_node/column_layouts/160f007bd04f"
+        },
+        "contentNodes": {
+            "href": "/api/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F160f007bd04f"
+        }
+    },
+    "_embedded": {
+        "category": {
+            "_links": {
+                "self": {
+                    "href": "/api/categories/eddb2cd8cee0"
+                },
+                "camp": {
+                    "href": "/api/camps/70ca971c992f"
+                },
+                "preferredContentTypes": {
+                    "href": "/api/content_types?categories=%2Fapi%2Fcategories%2Feddb2cd8cee0"
+                },
+                "rootContentNode": {
+                    "href": "/api/content_node/column_layouts/3d0e24f5a2c7"
+                },
+                "contentNodes": {
+                    "href": "/api/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F3d0e24f5a2c7"
+                }
+            },
+            "short": "Snwb",
+            "name": "Snowboard",
+            "color": "#248DB3",
+            "numberingStyle": "A",
+            "id": "eddb2cd8cee0"
+        },
+        "progressLabel": {
+            "_links": {
+                "self": {
+                    "href": "/api/activity_progress_labels/af92782262d7"
+                },
+                "camp": {
+                    "href": "/api/camps/70ca971c992f"
+                }
+            },
+            "position": 3,
+            "title": "Rudolf OK",
+            "id": "af92782262d7"
+        },
+        "contentNodes": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "/api/content_node/storyboards/9ace4f6be500"
+                    },
+                    "root": {
+                        "href": "/api/content_node/column_layouts/160f007bd04f"
+                    },
+                    "parent": {
+                        "href": "/api/content_node/column_layouts/160f007bd04f"
+                    },
+                    "children": [],
+                    "contentType": {
+                        "href": "/api/content_types/cfccaecd4bad"
+                    }
+                },
+                "data": {
+                    "sections": {
+                        "04c80fd3-153c-473c-9135-9e80c8fc1e86": {
+                            "column1": "Später",
+                            "column3": "",
+                            "position": 3,
+                            "column2Html": "<p>Heimreise🤩</p>"
+                        },
+                        "453f6f8d-88b8-4e3d-9ef2-5c2c0c92458a": {
+                            "column1": "von Morgen früh bis Spät am Abed",
+                            "column3": "Rudolf😶🌫️",
+                            "position": 0,
+                            "column2Html": "<p>Snowboard Fahren</p>"
+                        },
+                        "90ea5950-37ac-47df-a52c-ad674de0a05a": {
+                            "column1": "Zwischenzeit",
+                            "column3": "",
+                            "position": 2,
+                            "column2Html": "<p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p>"
+                        },
+                        "a9f263c9-2ff6-4332-9ed5-a5cb96a15399": {
+                            "column1": "",
+                            "column3": "",
+                            "position": 7,
+                            "column2Html": "<ol start=\"12\"><li><p>Fortsetzung </p></li><li><p>Teil 3</p><ol><li><p> 😱</p></li><li><p>C</p><ol><li><p>😱</p></li></ol></li></ol></li></ol>"
+                        },
+                        "c46f0d28-0b3b-4f38-8ef2-9541025eb231": {
+                            "column1": "",
+                            "column3": "",
+                            "position": 6,
+                            "column2Html": "<ul><li><p>A</p><ul><li><p>AA</p></li><li><p>AB</p><ul><li><p>AC</p><ul><li><p>AD</p><ul><li><p>Ef</p></li></ul></li><li><p>GH</p></li><li><p>ADD</p><ul><li><p>Pow</p><ul><li><p>Pew</p></li></ul></li></ul></li></ul></li></ul></li></ul></li><li><p>B</p></li><li><p>C</p></li></ul>"
+                        },
+                        "d09f61f6-aea4-469c-94a4-b9d7c535f58f": {
+                            "column1": "am Ende",
+                            "column3": "",
+                            "position": 5,
+                            "column2Html": "<ol start=\"3\"><li><p>Snowboard versorgen</p></li><li><p>Validieren</p></li><li><p>???</p></li><li><p>Vom erfolgreichen Versorgen berichten</p></li><li><p>Kleider in den Trocknungsraum</p></li><li><p>Ausrüstung kontrollieren</p></li><li><p>Fisch für Folgetag bereitlegen</p></li><li><p>Weitere Dinge</p></li><li><p>Fortsetzung Folgt</p></li></ol>"
+                        },
+                        "f5e393db-7ad5-44df-b653-6cf09959b35f": {
+                            "column1": "",
+                            "column3": "",
+                            "position": 4,
+                            "column2Html": "<p></p><p></p><p></p><p></p>"
+                        }
+                    }
+                },
+                "slot": "1",
+                "position": 2,
+                "instanceName": null,
+                "id": "9ace4f6be500",
+                "contentTypeName": "Storyboard"
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "/api/content_node/single_texts/0f20419761b6"
+                    },
+                    "root": {
+                        "href": "/api/content_node/column_layouts/160f007bd04f"
+                    },
+                    "parent": {
+                        "href": "/api/content_node/column_layouts/160f007bd04f"
+                    },
+                    "children": [],
+                    "contentType": {
+                        "href": "/api/content_types/318e064ea0c9"
+                    }
+                },
+                "data": {
+                    "html": "<p>Am Fuße des gewaltigen Berges \"Weiße Wächter\" lag das kleine Dorf Schneetal, umgeben von tiefen Wäldern und rauschenden Flüssen. Die Bewohner waren stolze Bergbewohner, die die Geschichten und Legenden ihrer Vorfahren über Generationen hinweg weitergaben. Eine solche Legende handelte vom \"Schneezauberer\", einem mystischen Wesen, das auf einem magischen Snowboard die Hänge hinunterfuhr und bei jeder Abfahrt funkelnde Eiskristalle in der Luft zurückließ.</p><p>Liam, ein neugieriger Junge von 16 Jahren, war besonders fasziniert von dieser Legende. Sein größter Wunsch war es, das Snowboarden zu erlernen und vielleicht sogar dem Schneezauberer selbst zu begegnen. Unter dem Vorwand, Holz für den Winter zu sammeln, schlich er sich oft in den Wald, um auf alten Holzbrettern zu üben und den Dreh rauszubekommen.</p><p>Eines Tages, nach einem heftigen Schneefall, folgte Liam einer Reihe von funkelnden Eiskristallen, die er am Morgen entdeckt hatte. Die Spur führte ihn zu einer versteckten Lichtung, auf der ein wunderschönes Snowboard lag - schimmernd und mit komplizierten Mustern verziert, genau wie es die Legenden beschrieben hatten. </p><p>Liam war fasziniert und konnte nicht widerstehen. Er band seine Füße an das Board und plötzlich spürte er eine Energie, die durch ihn hindurchströmte. Mit einem Adrenalinschub fuhr er die Hänge hinunter, schneller und geschmeidiger, als er es sich je hätte vorstellen können. Jeder Schwung, jede Drehung fühlte sich an, als würde er mit dem Wind tanzen. Die Bäume verschwammen zu grünen Schatten, während der Schnee unter ihm aufspritzte und das Lachen des Jungen in der kalten Winterluft widerhallte.</p><p>Die Freude und das Adrenalin, das Snowboarden mit sich brachte, waren berauschend. Es war, als hätte das Snowboard seine eigenen Geheimnisse, die es nur mit demjenigen teilte, der es ritt. Liam fühlte sich lebendiger als je zuvor. Er verstand nun, warum der Schneezauberer so oft in den Legenden auftauchte.</p><p>Nach stundenlangem Fahren erreichte Liam den Fuß des Berges, wo er auf eine Gruppe Dorfbewohner stieß, die ihn mit staunenden Blicken beobachteten. Unter ihnen war auch seine kleine Schwester Mia, die begeistert rief: \"Du sahst aus wie der Schneezauberer!\"</p><p>Erschöpft, aber glücklich, erkannte Liam, dass das Snowboarden nicht nur ein Sport war. Es war eine Kunst, ein Abenteuer und ein Gefühl der Freiheit, das seinesgleichen suchte. Das Snowboard, das er gefunden hatte, gab ihm nicht nur die Fähigkeit, den Berg hinunterzufahren, sondern auch eine tiefe Verbindung zur Natur und zu den Legenden seines Volkes.</p><p>Von diesem Tag an wurde Liam zu einer Legende in Schneetal, bekannt als der Junge, der den Zauber des Snowboardens entdeckte und die Freuden und Abenteuer, die es mit sich brachte, mit allen teilte. Und während die Jahre vergingen, wurde seine Geschichte zu einer weiteren Legende, die in den kalten Winternächten erzählt wurde, wenn der Schnee leise fiel und Kinder von ihren eigenen Abenteuern auf den Hängen des \"Weißen Wächters\" träumten.</p><p>In den folgenden Jahren entwickelte sich Schneetal zu einem lebhaften Treffpunkt für Snowboarder aus der ganzen Welt. Sie alle wollten die Pisten des \"Weißen Wächters\" erkunden, inspiriert von den Geschichten über Liam und den Schneezauberer.</p><p>Liam selbst war mittlerweile erwachsen geworden und hatte seine eigene Snowboardschule gegründet. Er lehrte nicht nur die Technik des Snowboardens, sondern auch die Wertschätzung für die Natur und die Bedeutung der alten Legenden. Mia, seine Schwester, war ihm stets an der Seite und unterstützte ihn als talentierte Snowboardlehrerin.</p><p>Eines Tages erreichte ein Brief aus einem fernen Land Schneetal. Es war eine Einladung für Liam und Mia, an einem internationalen Snowboard-Wettbewerb teilzunehmen, bei dem die besten Snowboarder der Welt gegeneinander antreten sollten. Das Turnier sollte auf dem legendären \"Drachenberg\" stattfinden, einem Ort, an dem, wie es hieß, die Grenzen zwischen Realität und Magie verschwammen.</p><p>Mit brennender Neugier und dem Wunsch, ihre Fähigkeiten zu testen, machten sich Liam und Mia auf den Weg zum \"Drachenberg\". Das Turnier war ein Spektakel. Snowboarder zeigten unglaubliche Tricks und Manöver, und die Atmosphäre war elektrisierend.</p><p>Während des Turniers bemerkten Liam und Mia, dass einige der Pisten des Drachenbergs funkelnde Eiskristalle aufwiesen, ähnlich denen, die Liam einst zum magischen Snowboard geführt hatten. Getrieben von Neugier und dem Gefühl, dass dies kein Zufall sein konnte, beschlossen sie, diesen Pisten nach Sonnenuntergang zu folgen.</p><p>Die Spur führte sie zu einer verborgenen Höhle im Berg. In ihrem Inneren fanden sie eine riesige Halle voller Snowboards, die alle genauso schimmerten wie Liams erstes Board. In der Mitte der Halle stand eine alte Frau mit langen weißen Haaren und funkelnden Augen.</p><p>\"Ich habe auf euch gewartet\", sagte sie mit einer sanften Stimme. \"Ich bin die Hüterin der Berge und die Bewahrerin der magischen Snowboards. Euer Herz und eure Leidenschaft haben euch hierher geführt.\"</p><p>Sie erzählte ihnen von der Geschichte der magischen Snowboards und wie sie dazu bestimmt waren, von den wahren Liebhabern des Sports gefunden zu werden. Diese Boards besaßen nicht nur magische Kräfte, sondern trugen auch das Erbe und die Weisheit der Berge in sich.</p><p>Die Hüterin bot Liam und Mia an, zwei dieser besonderen Snowboards auszusuchen, um ihre Fähigkeiten und ihr Wissen weiterzugeben. Mit diesen neuen Boards kehrten sie zum Turnier zurück und zeigten eine Performance, die so beeindruckend war, dass selbst die erfahrensten Snowboarder in Ehrfurcht verstummten.</p><p>Nach dem Turnier kehrten Liam und Mia nach Schneetal zurück, ihre Herzen erfüllt von Abenteuer und dem Wissen, dass die Legenden wahr waren. Sie erkannten, dass das Snowboarden nicht nur ein Sport, sondern auch eine Reise war, eine Reise, die sie immer wieder zu neuen Entdeckungen und Wundern führen würde.</p><p>Und so, während Schneetal weiter wuchs und blühte, wurde die Legende des Schneezauberers und der magischen Snowboards von Generation zu Generation weitergegeben, ein Symbol für Abenteuer, Leidenschaft und die unendlichen Möglichkeiten, die in den verschneiten Hängen der Berge verborgen liegen.</p><p>Jahre vergingen, und Schneetal wuchs von einem kleinen Dorf zu einer florierenden Stadt heran. Das Snowboardfieber hatte sich weltweit verbreitet, und jedes Jahr reisten Tausende von Menschen an, um die magischen Hänge des \"Weißen Wächters\" zu erleben.</p><p>Liam und Mia hatten mittlerweile Familien gegründet und ihre eigenen Kinder heranwachsen sehen. Diese jungen Abenteurer waren mit Geschichten von magischen Snowboards, verschneiten Pisten und fernen Bergen aufgewachsen. Liams ältester Sohn, Noah, war besonders fasziniert von den Geschichten des \"Drachenbergs\". Er verbrachte Stunden damit, die Tagebücher seines Vaters zu lesen und von den Abenteuern zu träumen, die noch vor ihm lagen.</p><p>Mit 18 Jahren beschloss Noah, zusammen mit einigen Freunden, eine Expedition zum Drachenberg zu starten. Sie wollten die Höhlen erkunden und herausfinden, ob es noch weitere Geheimnisse gab, die entdeckt werden wollten.</p><p>Nach tagelanger Reise erreichten sie den Fuß des Drachenbergs und begannen ihren Aufstieg. Als sie den Eingang zur Höhle erreichten, entdeckten sie, dass sich das Innere verändert hatte. Anstatt einer riesigen Halle fanden sie ein komplexes Netzwerk von Tunneln und Kammern, die in das Herz des Berges führten.</p><p>Während ihrer Erkundung stolperten sie über eine alte Karte, die von einem noch höheren Gipfel sprach, dem \"Himmelstanz\". Dieser Berg war auf keiner modernen Karte verzeichnet und schien nur in dieser alten Legende zu existieren.</p><p>Getrieben von Neugier und dem Wunsch, diese neue Entdeckung zu erforschen, machte sich die Gruppe auf den Weg. Ihre Reise war voller Gefahren: schwindelerregende Klippen, eisige Temperaturen und plötzliche Schneestürme. Doch ihr Mut und ihre Entschlossenheit führten sie schließlich zum Gipfel des Himmelstanzes.</p><p>Dort fanden sie ein weiteres magisches Snowboard, das inmitten eines kreisförmigen Steinarrangements lag. Auf dem Board waren Symbole eingraviert, die auf ein noch größeres Geheimnis hindeuteten - eine Verbindung zwischen den Bergen dieser Welt und einer anderen, unbekannten Dimension.</p><p>Als Noah das Snowboard berührte, spürte er eine starke Energie, die durch ihn hindurchströmte. Plötzlich öffnete sich ein Portal, und die Gruppe fand sich in einer Welt wieder, in der die Berge lebten und atmeten, in der die Pisten aus glitzernden Sternenstaub bestanden und der Himmel von leuchtenden Polarlichtern erhellt wurde.</p><p>Hier, in dieser magischen Dimension, erfuhren sie die wahre Geschichte der magischen Snowboards und ihrer Verbindung zu den Bergen. Sie lernten von den Hütern dieser Welt und ihrer Mission, das Gleichgewicht zwischen den Dimensionen zu bewahren.</p><p>Nach vielen Abenteuern und Entdeckungen kehrte die Gruppe nach Schneetal zurück, ihre Herzen erfüllt von Staunen und der Erkenntnis, dass die Welt voller Wunder ist, die nur darauf warten, entdeckt zu werden.</p><p>Noah setzte die Tradition seines Vaters fort und gründete eine Schule, um das Wissen über die magische Dimension und die Bedeutung der Snowboards weiterzugeben. Und während die Jahre vergingen, wuchs die Legende weiter, inspirierte neue Generationen und erinnerte alle daran, dass das Leben ein Abenteuer ist, das es zu erkunden gilt.😶</p><p>Im Herzen von Schneetal stand die Snowboard-Schule, die Liam und Mia gegründet hatten, mittlerweile als ein Denkmal für Abenteuerlust und Entdeckung. Doch mit Noah an der Spitze und den Geschichten aus der magischen Dimension wurde sie zu einem globalen Zentrum für Lernende, die mehr über die Verbindung zwischen den Dimensionen erfahren wollten.</p><p>Zusammen mit einigen der besten Snowboarder und Wissenschaftlern der Welt baute Noah ein Forschungsteam auf, um das Portal und seine Funktionsweise besser zu verstehen. Sie wollten wissen, wie sie sicher zwischen den Welten reisen und wie sie die Geheimnisse und Energien beider Welten zum Wohl aller nutzen könnten.</p><p>Währenddessen begannen merkwürdige Dinge in Schneetal zu geschehen. Tiere, die in der magischen Dimension beheimatet waren, tauchten in den Wäldern auf, und gelegentlich schimmerte der Himmel in den gleichen leuchtenden Farben, die sie in der anderen Welt gesehen hatten. Es wurde klar, dass die Aktivität rund um das Portal die Grenzen zwischen den Dimensionen verschwimmen ließ.</p><p>Eine junge Snowboarderin namens Elara, die sich besonders für die magische Dimension interessierte, begann, Visionen zu haben. Sie sah eine dunkle Kraft, die sich in der magischen Dimension ausbreitete und drohte, beide Welten ins Chaos zu stürzen.</p><p>Zusammen mit Noah und einer Gruppe mutiger Snowboarder machte sich Elara auf den Weg, um die Quelle dieser dunklen Energie zu finden und die Harmonie zwischen den Dimensionen wiederherzustellen.</p><p>Ihre Reise führte sie zu den entlegensten Teilen der magischen Dimension, wo sie auf uralte Wesen stießen, die Hüter des Gleichgewichts. Diese Wesen offenbarten, dass die dunkle Energie von einem verbannten Hüter stammte, der die Macht der magischen Snowboards für sich beanspruchen wollte.</p><p>Es wurde klar, dass nur ein vereintes Team aus Snowboardern, die die Energien beider Welten verstanden, diese Bedrohung stoppen konnte. Nach monatelanger Vorbereitung und mit der Unterstützung der Hüter stellten sie sich dem verbannten Wesen in einem epischen Kampf, bei dem Snowboarding und Magie miteinander verschmolzen.</p><p>Nach einem intensiven Duell gelang es Elara, mithilfe eines besonders mächtigen Snowboards, das Licht und Dunkelheit in Einklang brachte, die dunkle Energie zu besänftigen und den verbannten Hüter zu beruhigen.</p><p>Mit der Wiederherstellung des Gleichgewichts kehrte Frieden in beide Dimensionen zurück. Elara und ihr Team wurden als Helden gefeiert, und ihr Abenteuer wurde eine weitere inspirierende Geschichte in den Annalen von Schneetal.</p><p>Noah, inspiriert durch diese Ereignisse, gründete eine neue Abteilung in seiner Schule, die sich auf die Vermischung von Snowboarding und Magie konzentrierte, um zukünftige Generationen auf die Wunder und Gefahren vorzubereiten, die das Reisen zwischen den Welten mit sich bringen könnte.</p><p>Schneetal blühte weiterhin als Symbol für Abenteuer, Entdeckung und die unzerbrechliche Verbindung zwischen Menschen und der Natur. Und während die Sonne hinter den majestätischen Gipfeln des \"Weißen Wächters\" unterging, erzählten die Bewohner Geschichten von den mutigen Helden, die den Tag gerettet hatten, und träumten von den unzähligen Abenteuern, die noch vor ihnen lagen.</p>"
+                },
+                "slot": "1",
+                "position": 1,
+                "instanceName": null,
+                "id": "0f20419761b6",
+                "contentTypeName": "Storycontext"
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "/api/content_node/column_layouts/160f007bd04f"
+                    },
+                    "root": {
+                        "href": "/api/content_node/column_layouts/160f007bd04f"
+                    },
+                    "parent": null,
+                    "children": [
+                        {
+                            "href": "/api/content_node/single_texts/aa0738bc61de"
+                        },
+                        {
+                            "href": "/api/content_node/single_texts/0f20419761b6"
+                        },
+                        {
+                            "href": "/api/content_node/storyboards/9ace4f6be500"
+                        }
+                    ],
+                    "contentType": {
+                        "href": "/api/content_types/f17470519474"
+                    }
+                },
+                "data": {
+                    "columns": [
+                        {
+                            "slot": "1",
+                            "width": 12
+                        }
+                    ]
+                },
+                "slot": null,
+                "position": 0,
+                "instanceName": null,
+                "id": "160f007bd04f",
+                "contentTypeName": "ColumnLayout"
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "/api/content_node/single_texts/aa0738bc61de"
+                    },
+                    "root": {
+                        "href": "/api/content_node/column_layouts/160f007bd04f"
+                    },
+                    "parent": {
+                        "href": "/api/content_node/column_layouts/160f007bd04f"
+                    },
+                    "children": [],
+                    "contentType": {
+                        "href": "/api/content_types/44dcc7493c65"
+                    }
+                },
+                "data": {
+                    "html": "<p>1. Vorbereitung🤗</p><p>1.1. Ausrüstung überprüfen: Stelle sicher, dass dein Snowboard und die Bindungen in gutem Zustand und ordnungsgemäß eingestellt sind.</p><p>1.2. Kleidung: Trage immer wetterangepasste Kleidung in mehreren Schichten. Dies ermöglicht es dir, Schichten hinzuzufügen oder zu entfernen, je nachdem wie kalt oder warm es ist.</p><p>1.3. Geeignete Schutzausrüstung:</p><p>Helm: Ein Helm kann vor schweren Kopfverletzungen schützen.</p><p>Schutzbrille: Schützt die Augen vor UV-Strahlen, Wind, Schnee und reflektiertem Licht.</p><p>Handgelenkschützer: Snowboarder sind besonders anfällig für Handgelenksverletzungen.</p><p>Knieschoner und Steißbeinschützer können zusätzlichen Schutz bieten.</p><p>Rückenprotektor: Für Fahrer, die in schwierigem Gelände oder im Snowpark fahren.</p><p>2. Wissen über die Umgebung</p><p>2.1. Pistenkennzeichnung beachten: Informiere dich über die Schwierigkeitsgrade der Pisten (blau, rot, schwarz) und wähle Routen, die deinem Können entsprechen.</p><p>2.2. Wetterbedingungen: Überprüfe den Wetterbericht und sei dir über mögliche Änderungen während des Tages bewusst.</p><p>2.3. Avalanche-Bericht: Bei Tiefschneefahrten abseits der Piste immer den Lawinenbericht beachten und gegebenenfalls Lawinenausrüstung mitnehmen (Schaufel, Sonde, LVS-Gerät).</p><p>3. Verhalten auf der Piste</p><p>3.1. FIS-Regeln beachten: Die FIS-Regeln (Internationale Skiverbandsregeln) geben wichtige Verhaltenshinweise für alle Wintersportler.</p><p>3.2. Geschwindigkeit kontrollieren: Fahre immer in einer Geschwindigkeit, bei der du rechtzeitig reagieren kannst.</p><p>3.3. Rücksichtnahme: Passe deine Fahrweise den Bedingungen und deinem Können an. Beachte andere Snowboarder und Skifahrer.</p><p>3.4. Überholen: Überhole nur, wenn du genügend Platz hast und niemanden gefährdest.</p><p>4. Snowpark und Off-Piste</p><p>4.1. Erkundung: Bevor du Hindernisse wie Kicker oder Rails angehst, schaue sie dir erst einmal an und mache dich mit der Landung vertraut.</p><p>4.2. Gefährliche Bereiche meiden: Vermeide Bereiche mit Lawinengefahr oder unsicheren Bedingungen.</p><p>4.3. Immer zu zweit unterwegs: Besonders abseits der Piste solltest du nie alleine unterwegs sein.</p><p>5. Erste Hilfe</p><p>5.1. Kenntnisse auffrischen: Es ist immer gut, wenn du Grundkenntnisse in Erster Hilfe hast.</p><p>5.2. Notfallausrüstung: Trage immer ein kleines Erste-Hilfe-Set bei dir.</p><p>5.3. Notruf: Kenne die Notrufnummer des Gebietes und habe einen geladenen Handyakku dabei.</p>"
+                },
+                "slot": "1",
+                "position": 0,
+                "instanceName": "🤗🤗🤗",
+                "id": "aa0738bc61de",
+                "contentTypeName": "SafetyConsiderations"
+            }
+        ],
+        "scheduleEntries": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "/api/schedule_entries/29c9e9a07d82"
+                    },
+                    "period": {
+                        "href": "/api/periods/7fa4564a5d5d"
+                    },
+                    "activity": {
+                        "href": "/api/activities/a13fadc97610"
+                    },
+                    "day": {
+                        "href": "/api/days/5dc6586312e0"
+                    }
+                },
+                "left": 0,
+                "width": 1,
+                "id": "29c9e9a07d82",
+                "start": "2031-01-26T08:00:00+00:00",
+                "end": "2031-01-26T19:00:00+00:00",
+                "dayNumber": 3,
+                "scheduleEntryNumber": 1,
+                "number": "3.A"
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "/api/schedule_entries/f08d69cae18a"
+                    },
+                    "period": {
+                        "href": "/api/periods/7fa4564a5d5d"
+                    },
+                    "activity": {
+                        "href": "/api/activities/a13fadc97610"
+                    },
+                    "day": {
+                        "href": "/api/days/755cbc1d9852"
+                    }
+                },
+                "left": 0,
+                "width": 1,
+                "id": "f08d69cae18a",
+                "start": "2031-01-28T08:00:00+00:00",
+                "end": "2031-01-28T19:00:00+00:00",
+                "dayNumber": 5,
+                "scheduleEntryNumber": 1,
+                "number": "5.A"
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "/api/schedule_entries/7e8086d94633"
+                    },
+                    "period": {
+                        "href": "/api/periods/7fa4564a5d5d"
+                    },
+                    "activity": {
+                        "href": "/api/activities/a13fadc97610"
+                    },
+                    "day": {
+                        "href": "/api/days/3a84cfaf795c"
+                    }
+                },
+                "left": 0,
+                "width": 1,
+                "id": "7e8086d94633",
+                "start": "2031-01-29T08:00:00+00:00",
+                "end": "2031-01-29T19:00:00+00:00",
+                "dayNumber": 6,
+                "scheduleEntryNumber": 1,
+                "number": "6.A"
+            }
+        ],
+        "activityResponsibles": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "/api/activity_responsibles/06743ccfeedd"
+                    },
+                    "activity": {
+                        "href": "/api/activities/a13fadc97610"
+                    },
+                    "campCollaboration": {
+                        "href": "/api/camp_collaborations/10d8f02ce5b4"
+                    }
+                },
+                "id": "06743ccfeedd"
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "/api/activity_responsibles/21bc6661c569"
+                    },
+                    "activity": {
+                        "href": "/api/activities/a13fadc97610"
+                    },
+                    "campCollaboration": {
+                        "href": "/api/camp_collaborations/5b24ce470d9f"
+                    }
+                },
+                "id": "21bc6661c569"
+            }
+        ]
+    },
+    "title": "Snowboardfahren",
+    "location": "Auf dem Anderen Berg",
+    "id": "a13fadc97610"
+}

--- a/e2e/test-data/httpCache/activities_entity.json
+++ b/e2e/test-data/httpCache/activities_entity.json
@@ -1,335 +1,335 @@
 {
-    "_links": {
+  "_links": {
+    "self": {
+      "href": "/api/activities/a13fadc97610"
+    },
+    "scheduleEntries": {
+      "href": "/api/schedule_entries?activity=%2Fapi%2Factivities%2Fa13fadc97610"
+    },
+    "camp": {
+      "href": "/api/camps/70ca971c992f"
+    },
+    "category": {
+      "href": "/api/categories/eddb2cd8cee0"
+    },
+    "progressLabel": {
+      "href": "/api/activity_progress_labels/af92782262d7"
+    },
+    "comments": {
+      "href": "/api/activities/a13fadc97610/comments"
+    },
+    "activityResponsibles": {
+      "href": "/api/activity_responsibles?activity=%2Fapi%2Factivities%2Fa13fadc97610"
+    },
+    "rootContentNode": {
+      "href": "/api/content_node/column_layouts/160f007bd04f"
+    },
+    "contentNodes": {
+      "href": "/api/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F160f007bd04f"
+    }
+  },
+  "_embedded": {
+    "category": {
+      "_links": {
         "self": {
-            "href": "/api/activities/a13fadc97610"
-        },
-        "scheduleEntries": {
-            "href": "/api/schedule_entries?activity=%2Fapi%2Factivities%2Fa13fadc97610"
+          "href": "/api/categories/eddb2cd8cee0"
         },
         "camp": {
-            "href": "/api/camps/70ca971c992f"
+          "href": "/api/camps/70ca971c992f"
         },
-        "category": {
-            "href": "/api/categories/eddb2cd8cee0"
-        },
-        "progressLabel": {
-            "href": "/api/activity_progress_labels/af92782262d7"
-        },
-        "comments": {
-            "href": "/api/activities/a13fadc97610/comments"
-        },
-        "activityResponsibles": {
-            "href": "/api/activity_responsibles?activity=%2Fapi%2Factivities%2Fa13fadc97610"
+        "preferredContentTypes": {
+          "href": "/api/content_types?categories=%2Fapi%2Fcategories%2Feddb2cd8cee0"
         },
         "rootContentNode": {
-            "href": "/api/content_node/column_layouts/160f007bd04f"
+          "href": "/api/content_node/column_layouts/3d0e24f5a2c7"
         },
         "contentNodes": {
-            "href": "/api/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F160f007bd04f"
+          "href": "/api/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F3d0e24f5a2c7"
         }
+      },
+      "short": "Snwb",
+      "name": "Snowboard",
+      "color": "#248DB3",
+      "numberingStyle": "A",
+      "id": "eddb2cd8cee0"
     },
-    "_embedded": {
-        "category": {
-            "_links": {
-                "self": {
-                    "href": "/api/categories/eddb2cd8cee0"
-                },
-                "camp": {
-                    "href": "/api/camps/70ca971c992f"
-                },
-                "preferredContentTypes": {
-                    "href": "/api/content_types?categories=%2Fapi%2Fcategories%2Feddb2cd8cee0"
-                },
-                "rootContentNode": {
-                    "href": "/api/content_node/column_layouts/3d0e24f5a2c7"
-                },
-                "contentNodes": {
-                    "href": "/api/content_nodes?root=%2Fapi%2Fcontent_node%2Fcolumn_layouts%2F3d0e24f5a2c7"
-                }
-            },
-            "short": "Snwb",
-            "name": "Snowboard",
-            "color": "#248DB3",
-            "numberingStyle": "A",
-            "id": "eddb2cd8cee0"
+    "progressLabel": {
+      "_links": {
+        "self": {
+          "href": "/api/activity_progress_labels/af92782262d7"
         },
-        "progressLabel": {
-            "_links": {
-                "self": {
-                    "href": "/api/activity_progress_labels/af92782262d7"
-                },
-                "camp": {
-                    "href": "/api/camps/70ca971c992f"
-                }
-            },
-            "position": 3,
-            "title": "Rudolf OK",
-            "id": "af92782262d7"
-        },
-        "contentNodes": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "/api/content_node/storyboards/9ace4f6be500"
-                    },
-                    "root": {
-                        "href": "/api/content_node/column_layouts/160f007bd04f"
-                    },
-                    "parent": {
-                        "href": "/api/content_node/column_layouts/160f007bd04f"
-                    },
-                    "children": [],
-                    "contentType": {
-                        "href": "/api/content_types/cfccaecd4bad"
-                    }
-                },
-                "data": {
-                    "sections": {
-                        "04c80fd3-153c-473c-9135-9e80c8fc1e86": {
-                            "column1": "Später",
-                            "column3": "",
-                            "position": 3,
-                            "column2Html": "<p>Heimreise🤩</p>"
-                        },
-                        "453f6f8d-88b8-4e3d-9ef2-5c2c0c92458a": {
-                            "column1": "von Morgen früh bis Spät am Abed",
-                            "column3": "Rudolf😶🌫️",
-                            "position": 0,
-                            "column2Html": "<p>Snowboard Fahren</p>"
-                        },
-                        "90ea5950-37ac-47df-a52c-ad674de0a05a": {
-                            "column1": "Zwischenzeit",
-                            "column3": "",
-                            "position": 2,
-                            "column2Html": "<p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p>"
-                        },
-                        "a9f263c9-2ff6-4332-9ed5-a5cb96a15399": {
-                            "column1": "",
-                            "column3": "",
-                            "position": 7,
-                            "column2Html": "<ol start=\"12\"><li><p>Fortsetzung </p></li><li><p>Teil 3</p><ol><li><p> 😱</p></li><li><p>C</p><ol><li><p>😱</p></li></ol></li></ol></li></ol>"
-                        },
-                        "c46f0d28-0b3b-4f38-8ef2-9541025eb231": {
-                            "column1": "",
-                            "column3": "",
-                            "position": 6,
-                            "column2Html": "<ul><li><p>A</p><ul><li><p>AA</p></li><li><p>AB</p><ul><li><p>AC</p><ul><li><p>AD</p><ul><li><p>Ef</p></li></ul></li><li><p>GH</p></li><li><p>ADD</p><ul><li><p>Pow</p><ul><li><p>Pew</p></li></ul></li></ul></li></ul></li></ul></li></ul></li><li><p>B</p></li><li><p>C</p></li></ul>"
-                        },
-                        "d09f61f6-aea4-469c-94a4-b9d7c535f58f": {
-                            "column1": "am Ende",
-                            "column3": "",
-                            "position": 5,
-                            "column2Html": "<ol start=\"3\"><li><p>Snowboard versorgen</p></li><li><p>Validieren</p></li><li><p>???</p></li><li><p>Vom erfolgreichen Versorgen berichten</p></li><li><p>Kleider in den Trocknungsraum</p></li><li><p>Ausrüstung kontrollieren</p></li><li><p>Fisch für Folgetag bereitlegen</p></li><li><p>Weitere Dinge</p></li><li><p>Fortsetzung Folgt</p></li></ol>"
-                        },
-                        "f5e393db-7ad5-44df-b653-6cf09959b35f": {
-                            "column1": "",
-                            "column3": "",
-                            "position": 4,
-                            "column2Html": "<p></p><p></p><p></p><p></p>"
-                        }
-                    }
-                },
-                "slot": "1",
-                "position": 2,
-                "instanceName": null,
-                "id": "9ace4f6be500",
-                "contentTypeName": "Storyboard"
-            },
-            {
-                "_links": {
-                    "self": {
-                        "href": "/api/content_node/single_texts/0f20419761b6"
-                    },
-                    "root": {
-                        "href": "/api/content_node/column_layouts/160f007bd04f"
-                    },
-                    "parent": {
-                        "href": "/api/content_node/column_layouts/160f007bd04f"
-                    },
-                    "children": [],
-                    "contentType": {
-                        "href": "/api/content_types/318e064ea0c9"
-                    }
-                },
-                "data": {
-                    "html": "<p>Am Fuße des gewaltigen Berges \"Weiße Wächter\" lag das kleine Dorf Schneetal, umgeben von tiefen Wäldern und rauschenden Flüssen. Die Bewohner waren stolze Bergbewohner, die die Geschichten und Legenden ihrer Vorfahren über Generationen hinweg weitergaben. Eine solche Legende handelte vom \"Schneezauberer\", einem mystischen Wesen, das auf einem magischen Snowboard die Hänge hinunterfuhr und bei jeder Abfahrt funkelnde Eiskristalle in der Luft zurückließ.</p><p>Liam, ein neugieriger Junge von 16 Jahren, war besonders fasziniert von dieser Legende. Sein größter Wunsch war es, das Snowboarden zu erlernen und vielleicht sogar dem Schneezauberer selbst zu begegnen. Unter dem Vorwand, Holz für den Winter zu sammeln, schlich er sich oft in den Wald, um auf alten Holzbrettern zu üben und den Dreh rauszubekommen.</p><p>Eines Tages, nach einem heftigen Schneefall, folgte Liam einer Reihe von funkelnden Eiskristallen, die er am Morgen entdeckt hatte. Die Spur führte ihn zu einer versteckten Lichtung, auf der ein wunderschönes Snowboard lag - schimmernd und mit komplizierten Mustern verziert, genau wie es die Legenden beschrieben hatten. </p><p>Liam war fasziniert und konnte nicht widerstehen. Er band seine Füße an das Board und plötzlich spürte er eine Energie, die durch ihn hindurchströmte. Mit einem Adrenalinschub fuhr er die Hänge hinunter, schneller und geschmeidiger, als er es sich je hätte vorstellen können. Jeder Schwung, jede Drehung fühlte sich an, als würde er mit dem Wind tanzen. Die Bäume verschwammen zu grünen Schatten, während der Schnee unter ihm aufspritzte und das Lachen des Jungen in der kalten Winterluft widerhallte.</p><p>Die Freude und das Adrenalin, das Snowboarden mit sich brachte, waren berauschend. Es war, als hätte das Snowboard seine eigenen Geheimnisse, die es nur mit demjenigen teilte, der es ritt. Liam fühlte sich lebendiger als je zuvor. Er verstand nun, warum der Schneezauberer so oft in den Legenden auftauchte.</p><p>Nach stundenlangem Fahren erreichte Liam den Fuß des Berges, wo er auf eine Gruppe Dorfbewohner stieß, die ihn mit staunenden Blicken beobachteten. Unter ihnen war auch seine kleine Schwester Mia, die begeistert rief: \"Du sahst aus wie der Schneezauberer!\"</p><p>Erschöpft, aber glücklich, erkannte Liam, dass das Snowboarden nicht nur ein Sport war. Es war eine Kunst, ein Abenteuer und ein Gefühl der Freiheit, das seinesgleichen suchte. Das Snowboard, das er gefunden hatte, gab ihm nicht nur die Fähigkeit, den Berg hinunterzufahren, sondern auch eine tiefe Verbindung zur Natur und zu den Legenden seines Volkes.</p><p>Von diesem Tag an wurde Liam zu einer Legende in Schneetal, bekannt als der Junge, der den Zauber des Snowboardens entdeckte und die Freuden und Abenteuer, die es mit sich brachte, mit allen teilte. Und während die Jahre vergingen, wurde seine Geschichte zu einer weiteren Legende, die in den kalten Winternächten erzählt wurde, wenn der Schnee leise fiel und Kinder von ihren eigenen Abenteuern auf den Hängen des \"Weißen Wächters\" träumten.</p><p>In den folgenden Jahren entwickelte sich Schneetal zu einem lebhaften Treffpunkt für Snowboarder aus der ganzen Welt. Sie alle wollten die Pisten des \"Weißen Wächters\" erkunden, inspiriert von den Geschichten über Liam und den Schneezauberer.</p><p>Liam selbst war mittlerweile erwachsen geworden und hatte seine eigene Snowboardschule gegründet. Er lehrte nicht nur die Technik des Snowboardens, sondern auch die Wertschätzung für die Natur und die Bedeutung der alten Legenden. Mia, seine Schwester, war ihm stets an der Seite und unterstützte ihn als talentierte Snowboardlehrerin.</p><p>Eines Tages erreichte ein Brief aus einem fernen Land Schneetal. Es war eine Einladung für Liam und Mia, an einem internationalen Snowboard-Wettbewerb teilzunehmen, bei dem die besten Snowboarder der Welt gegeneinander antreten sollten. Das Turnier sollte auf dem legendären \"Drachenberg\" stattfinden, einem Ort, an dem, wie es hieß, die Grenzen zwischen Realität und Magie verschwammen.</p><p>Mit brennender Neugier und dem Wunsch, ihre Fähigkeiten zu testen, machten sich Liam und Mia auf den Weg zum \"Drachenberg\". Das Turnier war ein Spektakel. Snowboarder zeigten unglaubliche Tricks und Manöver, und die Atmosphäre war elektrisierend.</p><p>Während des Turniers bemerkten Liam und Mia, dass einige der Pisten des Drachenbergs funkelnde Eiskristalle aufwiesen, ähnlich denen, die Liam einst zum magischen Snowboard geführt hatten. Getrieben von Neugier und dem Gefühl, dass dies kein Zufall sein konnte, beschlossen sie, diesen Pisten nach Sonnenuntergang zu folgen.</p><p>Die Spur führte sie zu einer verborgenen Höhle im Berg. In ihrem Inneren fanden sie eine riesige Halle voller Snowboards, die alle genauso schimmerten wie Liams erstes Board. In der Mitte der Halle stand eine alte Frau mit langen weißen Haaren und funkelnden Augen.</p><p>\"Ich habe auf euch gewartet\", sagte sie mit einer sanften Stimme. \"Ich bin die Hüterin der Berge und die Bewahrerin der magischen Snowboards. Euer Herz und eure Leidenschaft haben euch hierher geführt.\"</p><p>Sie erzählte ihnen von der Geschichte der magischen Snowboards und wie sie dazu bestimmt waren, von den wahren Liebhabern des Sports gefunden zu werden. Diese Boards besaßen nicht nur magische Kräfte, sondern trugen auch das Erbe und die Weisheit der Berge in sich.</p><p>Die Hüterin bot Liam und Mia an, zwei dieser besonderen Snowboards auszusuchen, um ihre Fähigkeiten und ihr Wissen weiterzugeben. Mit diesen neuen Boards kehrten sie zum Turnier zurück und zeigten eine Performance, die so beeindruckend war, dass selbst die erfahrensten Snowboarder in Ehrfurcht verstummten.</p><p>Nach dem Turnier kehrten Liam und Mia nach Schneetal zurück, ihre Herzen erfüllt von Abenteuer und dem Wissen, dass die Legenden wahr waren. Sie erkannten, dass das Snowboarden nicht nur ein Sport, sondern auch eine Reise war, eine Reise, die sie immer wieder zu neuen Entdeckungen und Wundern führen würde.</p><p>Und so, während Schneetal weiter wuchs und blühte, wurde die Legende des Schneezauberers und der magischen Snowboards von Generation zu Generation weitergegeben, ein Symbol für Abenteuer, Leidenschaft und die unendlichen Möglichkeiten, die in den verschneiten Hängen der Berge verborgen liegen.</p><p>Jahre vergingen, und Schneetal wuchs von einem kleinen Dorf zu einer florierenden Stadt heran. Das Snowboardfieber hatte sich weltweit verbreitet, und jedes Jahr reisten Tausende von Menschen an, um die magischen Hänge des \"Weißen Wächters\" zu erleben.</p><p>Liam und Mia hatten mittlerweile Familien gegründet und ihre eigenen Kinder heranwachsen sehen. Diese jungen Abenteurer waren mit Geschichten von magischen Snowboards, verschneiten Pisten und fernen Bergen aufgewachsen. Liams ältester Sohn, Noah, war besonders fasziniert von den Geschichten des \"Drachenbergs\". Er verbrachte Stunden damit, die Tagebücher seines Vaters zu lesen und von den Abenteuern zu träumen, die noch vor ihm lagen.</p><p>Mit 18 Jahren beschloss Noah, zusammen mit einigen Freunden, eine Expedition zum Drachenberg zu starten. Sie wollten die Höhlen erkunden und herausfinden, ob es noch weitere Geheimnisse gab, die entdeckt werden wollten.</p><p>Nach tagelanger Reise erreichten sie den Fuß des Drachenbergs und begannen ihren Aufstieg. Als sie den Eingang zur Höhle erreichten, entdeckten sie, dass sich das Innere verändert hatte. Anstatt einer riesigen Halle fanden sie ein komplexes Netzwerk von Tunneln und Kammern, die in das Herz des Berges führten.</p><p>Während ihrer Erkundung stolperten sie über eine alte Karte, die von einem noch höheren Gipfel sprach, dem \"Himmelstanz\". Dieser Berg war auf keiner modernen Karte verzeichnet und schien nur in dieser alten Legende zu existieren.</p><p>Getrieben von Neugier und dem Wunsch, diese neue Entdeckung zu erforschen, machte sich die Gruppe auf den Weg. Ihre Reise war voller Gefahren: schwindelerregende Klippen, eisige Temperaturen und plötzliche Schneestürme. Doch ihr Mut und ihre Entschlossenheit führten sie schließlich zum Gipfel des Himmelstanzes.</p><p>Dort fanden sie ein weiteres magisches Snowboard, das inmitten eines kreisförmigen Steinarrangements lag. Auf dem Board waren Symbole eingraviert, die auf ein noch größeres Geheimnis hindeuteten - eine Verbindung zwischen den Bergen dieser Welt und einer anderen, unbekannten Dimension.</p><p>Als Noah das Snowboard berührte, spürte er eine starke Energie, die durch ihn hindurchströmte. Plötzlich öffnete sich ein Portal, und die Gruppe fand sich in einer Welt wieder, in der die Berge lebten und atmeten, in der die Pisten aus glitzernden Sternenstaub bestanden und der Himmel von leuchtenden Polarlichtern erhellt wurde.</p><p>Hier, in dieser magischen Dimension, erfuhren sie die wahre Geschichte der magischen Snowboards und ihrer Verbindung zu den Bergen. Sie lernten von den Hütern dieser Welt und ihrer Mission, das Gleichgewicht zwischen den Dimensionen zu bewahren.</p><p>Nach vielen Abenteuern und Entdeckungen kehrte die Gruppe nach Schneetal zurück, ihre Herzen erfüllt von Staunen und der Erkenntnis, dass die Welt voller Wunder ist, die nur darauf warten, entdeckt zu werden.</p><p>Noah setzte die Tradition seines Vaters fort und gründete eine Schule, um das Wissen über die magische Dimension und die Bedeutung der Snowboards weiterzugeben. Und während die Jahre vergingen, wuchs die Legende weiter, inspirierte neue Generationen und erinnerte alle daran, dass das Leben ein Abenteuer ist, das es zu erkunden gilt.😶</p><p>Im Herzen von Schneetal stand die Snowboard-Schule, die Liam und Mia gegründet hatten, mittlerweile als ein Denkmal für Abenteuerlust und Entdeckung. Doch mit Noah an der Spitze und den Geschichten aus der magischen Dimension wurde sie zu einem globalen Zentrum für Lernende, die mehr über die Verbindung zwischen den Dimensionen erfahren wollten.</p><p>Zusammen mit einigen der besten Snowboarder und Wissenschaftlern der Welt baute Noah ein Forschungsteam auf, um das Portal und seine Funktionsweise besser zu verstehen. Sie wollten wissen, wie sie sicher zwischen den Welten reisen und wie sie die Geheimnisse und Energien beider Welten zum Wohl aller nutzen könnten.</p><p>Währenddessen begannen merkwürdige Dinge in Schneetal zu geschehen. Tiere, die in der magischen Dimension beheimatet waren, tauchten in den Wäldern auf, und gelegentlich schimmerte der Himmel in den gleichen leuchtenden Farben, die sie in der anderen Welt gesehen hatten. Es wurde klar, dass die Aktivität rund um das Portal die Grenzen zwischen den Dimensionen verschwimmen ließ.</p><p>Eine junge Snowboarderin namens Elara, die sich besonders für die magische Dimension interessierte, begann, Visionen zu haben. Sie sah eine dunkle Kraft, die sich in der magischen Dimension ausbreitete und drohte, beide Welten ins Chaos zu stürzen.</p><p>Zusammen mit Noah und einer Gruppe mutiger Snowboarder machte sich Elara auf den Weg, um die Quelle dieser dunklen Energie zu finden und die Harmonie zwischen den Dimensionen wiederherzustellen.</p><p>Ihre Reise führte sie zu den entlegensten Teilen der magischen Dimension, wo sie auf uralte Wesen stießen, die Hüter des Gleichgewichts. Diese Wesen offenbarten, dass die dunkle Energie von einem verbannten Hüter stammte, der die Macht der magischen Snowboards für sich beanspruchen wollte.</p><p>Es wurde klar, dass nur ein vereintes Team aus Snowboardern, die die Energien beider Welten verstanden, diese Bedrohung stoppen konnte. Nach monatelanger Vorbereitung und mit der Unterstützung der Hüter stellten sie sich dem verbannten Wesen in einem epischen Kampf, bei dem Snowboarding und Magie miteinander verschmolzen.</p><p>Nach einem intensiven Duell gelang es Elara, mithilfe eines besonders mächtigen Snowboards, das Licht und Dunkelheit in Einklang brachte, die dunkle Energie zu besänftigen und den verbannten Hüter zu beruhigen.</p><p>Mit der Wiederherstellung des Gleichgewichts kehrte Frieden in beide Dimensionen zurück. Elara und ihr Team wurden als Helden gefeiert, und ihr Abenteuer wurde eine weitere inspirierende Geschichte in den Annalen von Schneetal.</p><p>Noah, inspiriert durch diese Ereignisse, gründete eine neue Abteilung in seiner Schule, die sich auf die Vermischung von Snowboarding und Magie konzentrierte, um zukünftige Generationen auf die Wunder und Gefahren vorzubereiten, die das Reisen zwischen den Welten mit sich bringen könnte.</p><p>Schneetal blühte weiterhin als Symbol für Abenteuer, Entdeckung und die unzerbrechliche Verbindung zwischen Menschen und der Natur. Und während die Sonne hinter den majestätischen Gipfeln des \"Weißen Wächters\" unterging, erzählten die Bewohner Geschichten von den mutigen Helden, die den Tag gerettet hatten, und träumten von den unzähligen Abenteuern, die noch vor ihnen lagen.</p>"
-                },
-                "slot": "1",
-                "position": 1,
-                "instanceName": null,
-                "id": "0f20419761b6",
-                "contentTypeName": "Storycontext"
-            },
-            {
-                "_links": {
-                    "self": {
-                        "href": "/api/content_node/column_layouts/160f007bd04f"
-                    },
-                    "root": {
-                        "href": "/api/content_node/column_layouts/160f007bd04f"
-                    },
-                    "parent": null,
-                    "children": [
-                        {
-                            "href": "/api/content_node/single_texts/aa0738bc61de"
-                        },
-                        {
-                            "href": "/api/content_node/single_texts/0f20419761b6"
-                        },
-                        {
-                            "href": "/api/content_node/storyboards/9ace4f6be500"
-                        }
-                    ],
-                    "contentType": {
-                        "href": "/api/content_types/f17470519474"
-                    }
-                },
-                "data": {
-                    "columns": [
-                        {
-                            "slot": "1",
-                            "width": 12
-                        }
-                    ]
-                },
-                "slot": null,
-                "position": 0,
-                "instanceName": null,
-                "id": "160f007bd04f",
-                "contentTypeName": "ColumnLayout"
-            },
-            {
-                "_links": {
-                    "self": {
-                        "href": "/api/content_node/single_texts/aa0738bc61de"
-                    },
-                    "root": {
-                        "href": "/api/content_node/column_layouts/160f007bd04f"
-                    },
-                    "parent": {
-                        "href": "/api/content_node/column_layouts/160f007bd04f"
-                    },
-                    "children": [],
-                    "contentType": {
-                        "href": "/api/content_types/44dcc7493c65"
-                    }
-                },
-                "data": {
-                    "html": "<p>1. Vorbereitung🤗</p><p>1.1. Ausrüstung überprüfen: Stelle sicher, dass dein Snowboard und die Bindungen in gutem Zustand und ordnungsgemäß eingestellt sind.</p><p>1.2. Kleidung: Trage immer wetterangepasste Kleidung in mehreren Schichten. Dies ermöglicht es dir, Schichten hinzuzufügen oder zu entfernen, je nachdem wie kalt oder warm es ist.</p><p>1.3. Geeignete Schutzausrüstung:</p><p>Helm: Ein Helm kann vor schweren Kopfverletzungen schützen.</p><p>Schutzbrille: Schützt die Augen vor UV-Strahlen, Wind, Schnee und reflektiertem Licht.</p><p>Handgelenkschützer: Snowboarder sind besonders anfällig für Handgelenksverletzungen.</p><p>Knieschoner und Steißbeinschützer können zusätzlichen Schutz bieten.</p><p>Rückenprotektor: Für Fahrer, die in schwierigem Gelände oder im Snowpark fahren.</p><p>2. Wissen über die Umgebung</p><p>2.1. Pistenkennzeichnung beachten: Informiere dich über die Schwierigkeitsgrade der Pisten (blau, rot, schwarz) und wähle Routen, die deinem Können entsprechen.</p><p>2.2. Wetterbedingungen: Überprüfe den Wetterbericht und sei dir über mögliche Änderungen während des Tages bewusst.</p><p>2.3. Avalanche-Bericht: Bei Tiefschneefahrten abseits der Piste immer den Lawinenbericht beachten und gegebenenfalls Lawinenausrüstung mitnehmen (Schaufel, Sonde, LVS-Gerät).</p><p>3. Verhalten auf der Piste</p><p>3.1. FIS-Regeln beachten: Die FIS-Regeln (Internationale Skiverbandsregeln) geben wichtige Verhaltenshinweise für alle Wintersportler.</p><p>3.2. Geschwindigkeit kontrollieren: Fahre immer in einer Geschwindigkeit, bei der du rechtzeitig reagieren kannst.</p><p>3.3. Rücksichtnahme: Passe deine Fahrweise den Bedingungen und deinem Können an. Beachte andere Snowboarder und Skifahrer.</p><p>3.4. Überholen: Überhole nur, wenn du genügend Platz hast und niemanden gefährdest.</p><p>4. Snowpark und Off-Piste</p><p>4.1. Erkundung: Bevor du Hindernisse wie Kicker oder Rails angehst, schaue sie dir erst einmal an und mache dich mit der Landung vertraut.</p><p>4.2. Gefährliche Bereiche meiden: Vermeide Bereiche mit Lawinengefahr oder unsicheren Bedingungen.</p><p>4.3. Immer zu zweit unterwegs: Besonders abseits der Piste solltest du nie alleine unterwegs sein.</p><p>5. Erste Hilfe</p><p>5.1. Kenntnisse auffrischen: Es ist immer gut, wenn du Grundkenntnisse in Erster Hilfe hast.</p><p>5.2. Notfallausrüstung: Trage immer ein kleines Erste-Hilfe-Set bei dir.</p><p>5.3. Notruf: Kenne die Notrufnummer des Gebietes und habe einen geladenen Handyakku dabei.</p>"
-                },
-                "slot": "1",
-                "position": 0,
-                "instanceName": "🤗🤗🤗",
-                "id": "aa0738bc61de",
-                "contentTypeName": "SafetyConsiderations"
-            }
-        ],
-        "scheduleEntries": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "/api/schedule_entries/29c9e9a07d82"
-                    },
-                    "period": {
-                        "href": "/api/periods/7fa4564a5d5d"
-                    },
-                    "activity": {
-                        "href": "/api/activities/a13fadc97610"
-                    },
-                    "day": {
-                        "href": "/api/days/5dc6586312e0"
-                    }
-                },
-                "left": 0,
-                "width": 1,
-                "id": "29c9e9a07d82",
-                "start": "2031-01-26T08:00:00+00:00",
-                "end": "2031-01-26T19:00:00+00:00",
-                "dayNumber": 3,
-                "scheduleEntryNumber": 1,
-                "number": "3.A"
-            },
-            {
-                "_links": {
-                    "self": {
-                        "href": "/api/schedule_entries/f08d69cae18a"
-                    },
-                    "period": {
-                        "href": "/api/periods/7fa4564a5d5d"
-                    },
-                    "activity": {
-                        "href": "/api/activities/a13fadc97610"
-                    },
-                    "day": {
-                        "href": "/api/days/755cbc1d9852"
-                    }
-                },
-                "left": 0,
-                "width": 1,
-                "id": "f08d69cae18a",
-                "start": "2031-01-28T08:00:00+00:00",
-                "end": "2031-01-28T19:00:00+00:00",
-                "dayNumber": 5,
-                "scheduleEntryNumber": 1,
-                "number": "5.A"
-            },
-            {
-                "_links": {
-                    "self": {
-                        "href": "/api/schedule_entries/7e8086d94633"
-                    },
-                    "period": {
-                        "href": "/api/periods/7fa4564a5d5d"
-                    },
-                    "activity": {
-                        "href": "/api/activities/a13fadc97610"
-                    },
-                    "day": {
-                        "href": "/api/days/3a84cfaf795c"
-                    }
-                },
-                "left": 0,
-                "width": 1,
-                "id": "7e8086d94633",
-                "start": "2031-01-29T08:00:00+00:00",
-                "end": "2031-01-29T19:00:00+00:00",
-                "dayNumber": 6,
-                "scheduleEntryNumber": 1,
-                "number": "6.A"
-            }
-        ],
-        "activityResponsibles": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "/api/activity_responsibles/06743ccfeedd"
-                    },
-                    "activity": {
-                        "href": "/api/activities/a13fadc97610"
-                    },
-                    "campCollaboration": {
-                        "href": "/api/camp_collaborations/10d8f02ce5b4"
-                    }
-                },
-                "id": "06743ccfeedd"
-            },
-            {
-                "_links": {
-                    "self": {
-                        "href": "/api/activity_responsibles/21bc6661c569"
-                    },
-                    "activity": {
-                        "href": "/api/activities/a13fadc97610"
-                    },
-                    "campCollaboration": {
-                        "href": "/api/camp_collaborations/5b24ce470d9f"
-                    }
-                },
-                "id": "21bc6661c569"
-            }
-        ]
+        "camp": {
+          "href": "/api/camps/70ca971c992f"
+        }
+      },
+      "position": 3,
+      "title": "Rudolf OK",
+      "id": "af92782262d7"
     },
-    "title": "Snowboardfahren",
-    "location": "Auf dem Anderen Berg",
-    "id": "a13fadc97610"
+    "contentNodes": [
+      {
+        "_links": {
+          "self": {
+            "href": "/api/content_node/storyboards/9ace4f6be500"
+          },
+          "root": {
+            "href": "/api/content_node/column_layouts/160f007bd04f"
+          },
+          "parent": {
+            "href": "/api/content_node/column_layouts/160f007bd04f"
+          },
+          "children": [],
+          "contentType": {
+            "href": "/api/content_types/cfccaecd4bad"
+          }
+        },
+        "data": {
+          "sections": {
+            "04c80fd3-153c-473c-9135-9e80c8fc1e86": {
+              "column1": "Später",
+              "column3": "",
+              "position": 3,
+              "column2Html": "<p>Heimreise🤩</p>"
+            },
+            "453f6f8d-88b8-4e3d-9ef2-5c2c0c92458a": {
+              "column1": "von Morgen früh bis Spät am Abed",
+              "column3": "Rudolf😶🌫️",
+              "position": 0,
+              "column2Html": "<p>Snowboard Fahren</p>"
+            },
+            "90ea5950-37ac-47df-a52c-ad674de0a05a": {
+              "column1": "Zwischenzeit",
+              "column3": "",
+              "position": 2,
+              "column2Html": "<p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p>"
+            },
+            "a9f263c9-2ff6-4332-9ed5-a5cb96a15399": {
+              "column1": "",
+              "column3": "",
+              "position": 7,
+              "column2Html": "<ol start=\"12\"><li><p>Fortsetzung </p></li><li><p>Teil 3</p><ol><li><p> 😱</p></li><li><p>C</p><ol><li><p>😱</p></li></ol></li></ol></li></ol>"
+            },
+            "c46f0d28-0b3b-4f38-8ef2-9541025eb231": {
+              "column1": "",
+              "column3": "",
+              "position": 6,
+              "column2Html": "<ul><li><p>A</p><ul><li><p>AA</p></li><li><p>AB</p><ul><li><p>AC</p><ul><li><p>AD</p><ul><li><p>Ef</p></li></ul></li><li><p>GH</p></li><li><p>ADD</p><ul><li><p>Pow</p><ul><li><p>Pew</p></li></ul></li></ul></li></ul></li></ul></li></ul></li><li><p>B</p></li><li><p>C</p></li></ul>"
+            },
+            "d09f61f6-aea4-469c-94a4-b9d7c535f58f": {
+              "column1": "am Ende",
+              "column3": "",
+              "position": 5,
+              "column2Html": "<ol start=\"3\"><li><p>Snowboard versorgen</p></li><li><p>Validieren</p></li><li><p>???</p></li><li><p>Vom erfolgreichen Versorgen berichten</p></li><li><p>Kleider in den Trocknungsraum</p></li><li><p>Ausrüstung kontrollieren</p></li><li><p>Fisch für Folgetag bereitlegen</p></li><li><p>Weitere Dinge</p></li><li><p>Fortsetzung Folgt</p></li></ol>"
+            },
+            "f5e393db-7ad5-44df-b653-6cf09959b35f": {
+              "column1": "",
+              "column3": "",
+              "position": 4,
+              "column2Html": "<p></p><p></p><p></p><p></p>"
+            }
+          }
+        },
+        "slot": "1",
+        "position": 2,
+        "instanceName": null,
+        "id": "9ace4f6be500",
+        "contentTypeName": "Storyboard"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "/api/content_node/single_texts/0f20419761b6"
+          },
+          "root": {
+            "href": "/api/content_node/column_layouts/160f007bd04f"
+          },
+          "parent": {
+            "href": "/api/content_node/column_layouts/160f007bd04f"
+          },
+          "children": [],
+          "contentType": {
+            "href": "/api/content_types/318e064ea0c9"
+          }
+        },
+        "data": {
+          "html": "<p>Am Fuße des gewaltigen Berges \"Weiße Wächter\" lag das kleine Dorf Schneetal, umgeben von tiefen Wäldern und rauschenden Flüssen. Die Bewohner waren stolze Bergbewohner, die die Geschichten und Legenden ihrer Vorfahren über Generationen hinweg weitergaben. Eine solche Legende handelte vom \"Schneezauberer\", einem mystischen Wesen, das auf einem magischen Snowboard die Hänge hinunterfuhr und bei jeder Abfahrt funkelnde Eiskristalle in der Luft zurückließ.</p><p>Liam, ein neugieriger Junge von 16 Jahren, war besonders fasziniert von dieser Legende. Sein größter Wunsch war es, das Snowboarden zu erlernen und vielleicht sogar dem Schneezauberer selbst zu begegnen. Unter dem Vorwand, Holz für den Winter zu sammeln, schlich er sich oft in den Wald, um auf alten Holzbrettern zu üben und den Dreh rauszubekommen.</p><p>Eines Tages, nach einem heftigen Schneefall, folgte Liam einer Reihe von funkelnden Eiskristallen, die er am Morgen entdeckt hatte. Die Spur führte ihn zu einer versteckten Lichtung, auf der ein wunderschönes Snowboard lag - schimmernd und mit komplizierten Mustern verziert, genau wie es die Legenden beschrieben hatten. </p><p>Liam war fasziniert und konnte nicht widerstehen. Er band seine Füße an das Board und plötzlich spürte er eine Energie, die durch ihn hindurchströmte. Mit einem Adrenalinschub fuhr er die Hänge hinunter, schneller und geschmeidiger, als er es sich je hätte vorstellen können. Jeder Schwung, jede Drehung fühlte sich an, als würde er mit dem Wind tanzen. Die Bäume verschwammen zu grünen Schatten, während der Schnee unter ihm aufspritzte und das Lachen des Jungen in der kalten Winterluft widerhallte.</p><p>Die Freude und das Adrenalin, das Snowboarden mit sich brachte, waren berauschend. Es war, als hätte das Snowboard seine eigenen Geheimnisse, die es nur mit demjenigen teilte, der es ritt. Liam fühlte sich lebendiger als je zuvor. Er verstand nun, warum der Schneezauberer so oft in den Legenden auftauchte.</p><p>Nach stundenlangem Fahren erreichte Liam den Fuß des Berges, wo er auf eine Gruppe Dorfbewohner stieß, die ihn mit staunenden Blicken beobachteten. Unter ihnen war auch seine kleine Schwester Mia, die begeistert rief: \"Du sahst aus wie der Schneezauberer!\"</p><p>Erschöpft, aber glücklich, erkannte Liam, dass das Snowboarden nicht nur ein Sport war. Es war eine Kunst, ein Abenteuer und ein Gefühl der Freiheit, das seinesgleichen suchte. Das Snowboard, das er gefunden hatte, gab ihm nicht nur die Fähigkeit, den Berg hinunterzufahren, sondern auch eine tiefe Verbindung zur Natur und zu den Legenden seines Volkes.</p><p>Von diesem Tag an wurde Liam zu einer Legende in Schneetal, bekannt als der Junge, der den Zauber des Snowboardens entdeckte und die Freuden und Abenteuer, die es mit sich brachte, mit allen teilte. Und während die Jahre vergingen, wurde seine Geschichte zu einer weiteren Legende, die in den kalten Winternächten erzählt wurde, wenn der Schnee leise fiel und Kinder von ihren eigenen Abenteuern auf den Hängen des \"Weißen Wächters\" träumten.</p><p>In den folgenden Jahren entwickelte sich Schneetal zu einem lebhaften Treffpunkt für Snowboarder aus der ganzen Welt. Sie alle wollten die Pisten des \"Weißen Wächters\" erkunden, inspiriert von den Geschichten über Liam und den Schneezauberer.</p><p>Liam selbst war mittlerweile erwachsen geworden und hatte seine eigene Snowboardschule gegründet. Er lehrte nicht nur die Technik des Snowboardens, sondern auch die Wertschätzung für die Natur und die Bedeutung der alten Legenden. Mia, seine Schwester, war ihm stets an der Seite und unterstützte ihn als talentierte Snowboardlehrerin.</p><p>Eines Tages erreichte ein Brief aus einem fernen Land Schneetal. Es war eine Einladung für Liam und Mia, an einem internationalen Snowboard-Wettbewerb teilzunehmen, bei dem die besten Snowboarder der Welt gegeneinander antreten sollten. Das Turnier sollte auf dem legendären \"Drachenberg\" stattfinden, einem Ort, an dem, wie es hieß, die Grenzen zwischen Realität und Magie verschwammen.</p><p>Mit brennender Neugier und dem Wunsch, ihre Fähigkeiten zu testen, machten sich Liam und Mia auf den Weg zum \"Drachenberg\". Das Turnier war ein Spektakel. Snowboarder zeigten unglaubliche Tricks und Manöver, und die Atmosphäre war elektrisierend.</p><p>Während des Turniers bemerkten Liam und Mia, dass einige der Pisten des Drachenbergs funkelnde Eiskristalle aufwiesen, ähnlich denen, die Liam einst zum magischen Snowboard geführt hatten. Getrieben von Neugier und dem Gefühl, dass dies kein Zufall sein konnte, beschlossen sie, diesen Pisten nach Sonnenuntergang zu folgen.</p><p>Die Spur führte sie zu einer verborgenen Höhle im Berg. In ihrem Inneren fanden sie eine riesige Halle voller Snowboards, die alle genauso schimmerten wie Liams erstes Board. In der Mitte der Halle stand eine alte Frau mit langen weißen Haaren und funkelnden Augen.</p><p>\"Ich habe auf euch gewartet\", sagte sie mit einer sanften Stimme. \"Ich bin die Hüterin der Berge und die Bewahrerin der magischen Snowboards. Euer Herz und eure Leidenschaft haben euch hierher geführt.\"</p><p>Sie erzählte ihnen von der Geschichte der magischen Snowboards und wie sie dazu bestimmt waren, von den wahren Liebhabern des Sports gefunden zu werden. Diese Boards besaßen nicht nur magische Kräfte, sondern trugen auch das Erbe und die Weisheit der Berge in sich.</p><p>Die Hüterin bot Liam und Mia an, zwei dieser besonderen Snowboards auszusuchen, um ihre Fähigkeiten und ihr Wissen weiterzugeben. Mit diesen neuen Boards kehrten sie zum Turnier zurück und zeigten eine Performance, die so beeindruckend war, dass selbst die erfahrensten Snowboarder in Ehrfurcht verstummten.</p><p>Nach dem Turnier kehrten Liam und Mia nach Schneetal zurück, ihre Herzen erfüllt von Abenteuer und dem Wissen, dass die Legenden wahr waren. Sie erkannten, dass das Snowboarden nicht nur ein Sport, sondern auch eine Reise war, eine Reise, die sie immer wieder zu neuen Entdeckungen und Wundern führen würde.</p><p>Und so, während Schneetal weiter wuchs und blühte, wurde die Legende des Schneezauberers und der magischen Snowboards von Generation zu Generation weitergegeben, ein Symbol für Abenteuer, Leidenschaft und die unendlichen Möglichkeiten, die in den verschneiten Hängen der Berge verborgen liegen.</p><p>Jahre vergingen, und Schneetal wuchs von einem kleinen Dorf zu einer florierenden Stadt heran. Das Snowboardfieber hatte sich weltweit verbreitet, und jedes Jahr reisten Tausende von Menschen an, um die magischen Hänge des \"Weißen Wächters\" zu erleben.</p><p>Liam und Mia hatten mittlerweile Familien gegründet und ihre eigenen Kinder heranwachsen sehen. Diese jungen Abenteurer waren mit Geschichten von magischen Snowboards, verschneiten Pisten und fernen Bergen aufgewachsen. Liams ältester Sohn, Noah, war besonders fasziniert von den Geschichten des \"Drachenbergs\". Er verbrachte Stunden damit, die Tagebücher seines Vaters zu lesen und von den Abenteuern zu träumen, die noch vor ihm lagen.</p><p>Mit 18 Jahren beschloss Noah, zusammen mit einigen Freunden, eine Expedition zum Drachenberg zu starten. Sie wollten die Höhlen erkunden und herausfinden, ob es noch weitere Geheimnisse gab, die entdeckt werden wollten.</p><p>Nach tagelanger Reise erreichten sie den Fuß des Drachenbergs und begannen ihren Aufstieg. Als sie den Eingang zur Höhle erreichten, entdeckten sie, dass sich das Innere verändert hatte. Anstatt einer riesigen Halle fanden sie ein komplexes Netzwerk von Tunneln und Kammern, die in das Herz des Berges führten.</p><p>Während ihrer Erkundung stolperten sie über eine alte Karte, die von einem noch höheren Gipfel sprach, dem \"Himmelstanz\". Dieser Berg war auf keiner modernen Karte verzeichnet und schien nur in dieser alten Legende zu existieren.</p><p>Getrieben von Neugier und dem Wunsch, diese neue Entdeckung zu erforschen, machte sich die Gruppe auf den Weg. Ihre Reise war voller Gefahren: schwindelerregende Klippen, eisige Temperaturen und plötzliche Schneestürme. Doch ihr Mut und ihre Entschlossenheit führten sie schließlich zum Gipfel des Himmelstanzes.</p><p>Dort fanden sie ein weiteres magisches Snowboard, das inmitten eines kreisförmigen Steinarrangements lag. Auf dem Board waren Symbole eingraviert, die auf ein noch größeres Geheimnis hindeuteten - eine Verbindung zwischen den Bergen dieser Welt und einer anderen, unbekannten Dimension.</p><p>Als Noah das Snowboard berührte, spürte er eine starke Energie, die durch ihn hindurchströmte. Plötzlich öffnete sich ein Portal, und die Gruppe fand sich in einer Welt wieder, in der die Berge lebten und atmeten, in der die Pisten aus glitzernden Sternenstaub bestanden und der Himmel von leuchtenden Polarlichtern erhellt wurde.</p><p>Hier, in dieser magischen Dimension, erfuhren sie die wahre Geschichte der magischen Snowboards und ihrer Verbindung zu den Bergen. Sie lernten von den Hütern dieser Welt und ihrer Mission, das Gleichgewicht zwischen den Dimensionen zu bewahren.</p><p>Nach vielen Abenteuern und Entdeckungen kehrte die Gruppe nach Schneetal zurück, ihre Herzen erfüllt von Staunen und der Erkenntnis, dass die Welt voller Wunder ist, die nur darauf warten, entdeckt zu werden.</p><p>Noah setzte die Tradition seines Vaters fort und gründete eine Schule, um das Wissen über die magische Dimension und die Bedeutung der Snowboards weiterzugeben. Und während die Jahre vergingen, wuchs die Legende weiter, inspirierte neue Generationen und erinnerte alle daran, dass das Leben ein Abenteuer ist, das es zu erkunden gilt.😶</p><p>Im Herzen von Schneetal stand die Snowboard-Schule, die Liam und Mia gegründet hatten, mittlerweile als ein Denkmal für Abenteuerlust und Entdeckung. Doch mit Noah an der Spitze und den Geschichten aus der magischen Dimension wurde sie zu einem globalen Zentrum für Lernende, die mehr über die Verbindung zwischen den Dimensionen erfahren wollten.</p><p>Zusammen mit einigen der besten Snowboarder und Wissenschaftlern der Welt baute Noah ein Forschungsteam auf, um das Portal und seine Funktionsweise besser zu verstehen. Sie wollten wissen, wie sie sicher zwischen den Welten reisen und wie sie die Geheimnisse und Energien beider Welten zum Wohl aller nutzen könnten.</p><p>Währenddessen begannen merkwürdige Dinge in Schneetal zu geschehen. Tiere, die in der magischen Dimension beheimatet waren, tauchten in den Wäldern auf, und gelegentlich schimmerte der Himmel in den gleichen leuchtenden Farben, die sie in der anderen Welt gesehen hatten. Es wurde klar, dass die Aktivität rund um das Portal die Grenzen zwischen den Dimensionen verschwimmen ließ.</p><p>Eine junge Snowboarderin namens Elara, die sich besonders für die magische Dimension interessierte, begann, Visionen zu haben. Sie sah eine dunkle Kraft, die sich in der magischen Dimension ausbreitete und drohte, beide Welten ins Chaos zu stürzen.</p><p>Zusammen mit Noah und einer Gruppe mutiger Snowboarder machte sich Elara auf den Weg, um die Quelle dieser dunklen Energie zu finden und die Harmonie zwischen den Dimensionen wiederherzustellen.</p><p>Ihre Reise führte sie zu den entlegensten Teilen der magischen Dimension, wo sie auf uralte Wesen stießen, die Hüter des Gleichgewichts. Diese Wesen offenbarten, dass die dunkle Energie von einem verbannten Hüter stammte, der die Macht der magischen Snowboards für sich beanspruchen wollte.</p><p>Es wurde klar, dass nur ein vereintes Team aus Snowboardern, die die Energien beider Welten verstanden, diese Bedrohung stoppen konnte. Nach monatelanger Vorbereitung und mit der Unterstützung der Hüter stellten sie sich dem verbannten Wesen in einem epischen Kampf, bei dem Snowboarding und Magie miteinander verschmolzen.</p><p>Nach einem intensiven Duell gelang es Elara, mithilfe eines besonders mächtigen Snowboards, das Licht und Dunkelheit in Einklang brachte, die dunkle Energie zu besänftigen und den verbannten Hüter zu beruhigen.</p><p>Mit der Wiederherstellung des Gleichgewichts kehrte Frieden in beide Dimensionen zurück. Elara und ihr Team wurden als Helden gefeiert, und ihr Abenteuer wurde eine weitere inspirierende Geschichte in den Annalen von Schneetal.</p><p>Noah, inspiriert durch diese Ereignisse, gründete eine neue Abteilung in seiner Schule, die sich auf die Vermischung von Snowboarding und Magie konzentrierte, um zukünftige Generationen auf die Wunder und Gefahren vorzubereiten, die das Reisen zwischen den Welten mit sich bringen könnte.</p><p>Schneetal blühte weiterhin als Symbol für Abenteuer, Entdeckung und die unzerbrechliche Verbindung zwischen Menschen und der Natur. Und während die Sonne hinter den majestätischen Gipfeln des \"Weißen Wächters\" unterging, erzählten die Bewohner Geschichten von den mutigen Helden, die den Tag gerettet hatten, und träumten von den unzähligen Abenteuern, die noch vor ihnen lagen.</p>"
+        },
+        "slot": "1",
+        "position": 1,
+        "instanceName": null,
+        "id": "0f20419761b6",
+        "contentTypeName": "Storycontext"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "/api/content_node/column_layouts/160f007bd04f"
+          },
+          "root": {
+            "href": "/api/content_node/column_layouts/160f007bd04f"
+          },
+          "parent": null,
+          "children": [
+            {
+              "href": "/api/content_node/single_texts/aa0738bc61de"
+            },
+            {
+              "href": "/api/content_node/single_texts/0f20419761b6"
+            },
+            {
+              "href": "/api/content_node/storyboards/9ace4f6be500"
+            }
+          ],
+          "contentType": {
+            "href": "/api/content_types/f17470519474"
+          }
+        },
+        "data": {
+          "columns": [
+            {
+              "slot": "1",
+              "width": 12
+            }
+          ]
+        },
+        "slot": null,
+        "position": 0,
+        "instanceName": null,
+        "id": "160f007bd04f",
+        "contentTypeName": "ColumnLayout"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "/api/content_node/single_texts/aa0738bc61de"
+          },
+          "root": {
+            "href": "/api/content_node/column_layouts/160f007bd04f"
+          },
+          "parent": {
+            "href": "/api/content_node/column_layouts/160f007bd04f"
+          },
+          "children": [],
+          "contentType": {
+            "href": "/api/content_types/44dcc7493c65"
+          }
+        },
+        "data": {
+          "html": "<p>1. Vorbereitung🤗</p><p>1.1. Ausrüstung überprüfen: Stelle sicher, dass dein Snowboard und die Bindungen in gutem Zustand und ordnungsgemäß eingestellt sind.</p><p>1.2. Kleidung: Trage immer wetterangepasste Kleidung in mehreren Schichten. Dies ermöglicht es dir, Schichten hinzuzufügen oder zu entfernen, je nachdem wie kalt oder warm es ist.</p><p>1.3. Geeignete Schutzausrüstung:</p><p>Helm: Ein Helm kann vor schweren Kopfverletzungen schützen.</p><p>Schutzbrille: Schützt die Augen vor UV-Strahlen, Wind, Schnee und reflektiertem Licht.</p><p>Handgelenkschützer: Snowboarder sind besonders anfällig für Handgelenksverletzungen.</p><p>Knieschoner und Steißbeinschützer können zusätzlichen Schutz bieten.</p><p>Rückenprotektor: Für Fahrer, die in schwierigem Gelände oder im Snowpark fahren.</p><p>2. Wissen über die Umgebung</p><p>2.1. Pistenkennzeichnung beachten: Informiere dich über die Schwierigkeitsgrade der Pisten (blau, rot, schwarz) und wähle Routen, die deinem Können entsprechen.</p><p>2.2. Wetterbedingungen: Überprüfe den Wetterbericht und sei dir über mögliche Änderungen während des Tages bewusst.</p><p>2.3. Avalanche-Bericht: Bei Tiefschneefahrten abseits der Piste immer den Lawinenbericht beachten und gegebenenfalls Lawinenausrüstung mitnehmen (Schaufel, Sonde, LVS-Gerät).</p><p>3. Verhalten auf der Piste</p><p>3.1. FIS-Regeln beachten: Die FIS-Regeln (Internationale Skiverbandsregeln) geben wichtige Verhaltenshinweise für alle Wintersportler.</p><p>3.2. Geschwindigkeit kontrollieren: Fahre immer in einer Geschwindigkeit, bei der du rechtzeitig reagieren kannst.</p><p>3.3. Rücksichtnahme: Passe deine Fahrweise den Bedingungen und deinem Können an. Beachte andere Snowboarder und Skifahrer.</p><p>3.4. Überholen: Überhole nur, wenn du genügend Platz hast und niemanden gefährdest.</p><p>4. Snowpark und Off-Piste</p><p>4.1. Erkundung: Bevor du Hindernisse wie Kicker oder Rails angehst, schaue sie dir erst einmal an und mache dich mit der Landung vertraut.</p><p>4.2. Gefährliche Bereiche meiden: Vermeide Bereiche mit Lawinengefahr oder unsicheren Bedingungen.</p><p>4.3. Immer zu zweit unterwegs: Besonders abseits der Piste solltest du nie alleine unterwegs sein.</p><p>5. Erste Hilfe</p><p>5.1. Kenntnisse auffrischen: Es ist immer gut, wenn du Grundkenntnisse in Erster Hilfe hast.</p><p>5.2. Notfallausrüstung: Trage immer ein kleines Erste-Hilfe-Set bei dir.</p><p>5.3. Notruf: Kenne die Notrufnummer des Gebietes und habe einen geladenen Handyakku dabei.</p>"
+        },
+        "slot": "1",
+        "position": 0,
+        "instanceName": "🤗🤗🤗",
+        "id": "aa0738bc61de",
+        "contentTypeName": "SafetyConsiderations"
+      }
+    ],
+    "scheduleEntries": [
+      {
+        "_links": {
+          "self": {
+            "href": "/api/schedule_entries/29c9e9a07d82"
+          },
+          "period": {
+            "href": "/api/periods/7fa4564a5d5d"
+          },
+          "activity": {
+            "href": "/api/activities/a13fadc97610"
+          },
+          "day": {
+            "href": "/api/days/5dc6586312e0"
+          }
+        },
+        "left": 0,
+        "width": 1,
+        "id": "29c9e9a07d82",
+        "start": "2031-01-26T08:00:00+00:00",
+        "end": "2031-01-26T19:00:00+00:00",
+        "dayNumber": 3,
+        "scheduleEntryNumber": 1,
+        "number": "3.A"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "/api/schedule_entries/f08d69cae18a"
+          },
+          "period": {
+            "href": "/api/periods/7fa4564a5d5d"
+          },
+          "activity": {
+            "href": "/api/activities/a13fadc97610"
+          },
+          "day": {
+            "href": "/api/days/755cbc1d9852"
+          }
+        },
+        "left": 0,
+        "width": 1,
+        "id": "f08d69cae18a",
+        "start": "2031-01-28T08:00:00+00:00",
+        "end": "2031-01-28T19:00:00+00:00",
+        "dayNumber": 5,
+        "scheduleEntryNumber": 1,
+        "number": "5.A"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "/api/schedule_entries/7e8086d94633"
+          },
+          "period": {
+            "href": "/api/periods/7fa4564a5d5d"
+          },
+          "activity": {
+            "href": "/api/activities/a13fadc97610"
+          },
+          "day": {
+            "href": "/api/days/3a84cfaf795c"
+          }
+        },
+        "left": 0,
+        "width": 1,
+        "id": "7e8086d94633",
+        "start": "2031-01-29T08:00:00+00:00",
+        "end": "2031-01-29T19:00:00+00:00",
+        "dayNumber": 6,
+        "scheduleEntryNumber": 1,
+        "number": "6.A"
+      }
+    ],
+    "activityResponsibles": [
+      {
+        "_links": {
+          "self": {
+            "href": "/api/activity_responsibles/06743ccfeedd"
+          },
+          "activity": {
+            "href": "/api/activities/a13fadc97610"
+          },
+          "campCollaboration": {
+            "href": "/api/camp_collaborations/10d8f02ce5b4"
+          }
+        },
+        "id": "06743ccfeedd"
+      },
+      {
+        "_links": {
+          "self": {
+            "href": "/api/activity_responsibles/21bc6661c569"
+          },
+          "activity": {
+            "href": "/api/activities/a13fadc97610"
+          },
+          "campCollaboration": {
+            "href": "/api/camp_collaborations/5b24ce470d9f"
+          }
+        },
+        "id": "21bc6661c569"
+      }
+    ]
+  },
+  "title": "Snowboardfahren",
+  "location": "Auf dem Anderen Berg",
+  "id": "a13fadc97610"
 }

--- a/e2e/tests/9-behavior-tests/httpCache/activity.spec.js
+++ b/e2e/tests/9-behavior-tests/httpCache/activity.spec.js
@@ -1,0 +1,283 @@
+import { test, expect } from '@playwright/test'
+import {
+  bipiUser,
+  bruceWayneUser,
+  felicitySmoakUser,
+  grgrPeriodId,
+} from '../../../utils/constants'
+import entityResponse from '../../../test-data/httpCache/activities_entity.json'
+import {
+  getAuthContext,
+  expectCacheHit,
+  expectCacheMiss,
+  waitForCacheMiss,
+  apiGet,
+  apiPatch,
+  apiPost,
+  apiDelete,
+} from '../../../utils/helpers'
+
+const collectionXKeys =
+  /* campCollaboration for bipiUser */
+  '10d8f02ce5b4 ' +
+  /* activity "Snowboardfahren" + embedded relations */
+  'a13fadc97610 a13fadc97610#scheduleEntries a13fadc97610#camp a13fadc97610#category a13fadc97610#progressLabel a13fadc97610#activityResponsibles a13fadc97610#rootContentNode ' +
+  /* category "Snowboard" */
+  'eddb2cd8cee0 eddb2cd8cee0#camp eddb2cd8cee0#preferredContentTypes eddb2cd8cee0#rootContentNode eddb2cd8cee0#emptyContentNodesForIriGeneration a13fadc97610#embeddedCategory ' +
+  /* progressLabel "Rudolf OK" */
+  'af92782262d7 af92782262d7#camp a13fadc97610#embeddedProgressLabel ' +
+  /* contentNodes */
+  '9ace4f6be500 9ace4f6be500#root 9ace4f6be500#parent 9ace4f6be500#children 9ace4f6be500#contentType ' +
+  '0f20419761b6 0f20419761b6#root 0f20419761b6#parent 0f20419761b6#children 0f20419761b6#contentType ' +
+  '160f007bd04f 160f007bd04f#root 160f007bd04f#parent 160f007bd04f#children 160f007bd04f#contentType ' +
+  'aa0738bc61de aa0738bc61de#root aa0738bc61de#parent aa0738bc61de#children aa0738bc61de#contentType ' +
+  'a13fadc97610#embeddedContentNodes ' +
+  /* scheduleEntries */
+  /* (the first schedule entry also includes the period id) */
+  '29c9e9a07d82 7fa4564a5d5d 29c9e9a07d82#period 29c9e9a07d82#activity 29c9e9a07d82#day ' +
+  'f08d69cae18a f08d69cae18a#period f08d69cae18a#activity f08d69cae18a#day ' +
+  '7e8086d94633 7e8086d94633#period 7e8086d94633#activity 7e8086d94633#day ' +
+  'a13fadc97610#embeddedScheduleEntries ' +
+  /* activityResponsible */
+  '06743ccfeedd 06743ccfeedd#activity 06743ccfeedd#campCollaboration ' +
+  '21bc6661c569 21bc6661c569#activity 21bc6661c569#campCollaboration ' +
+  'a13fadc97610#embeddedActivityResponsibles ' +
+  'a13fadc97610#emptyContentNodesForIriGeneration'
+
+test.describe('cache test: /camps/{campId}/activities', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test('caches /activities/{activitiyId} separately for each login', async () => {
+    const snowboardfahrenActivityId = 'a13fadc97610'
+    const uri = `/api/activities/${snowboardfahrenActivityId}`
+
+    const bipiApi = await getAuthContext(bipiUser)
+
+    // first request is a cache miss
+    const request = await apiGet(bipiApi, uri)
+    const headers = request.headers()
+    expect(headers['xkey']).toBe(collectionXKeys)
+    expect(headers['x-cache']).toBe('MISS')
+    expect(await request.json()).toEqual(entityResponse)
+
+    // second request is a cache hit
+    await expectCacheHit(bipiApi, uri)
+
+    // request with a new user is a cache miss
+    const bruceApi = await getAuthContext(bruceWayneUser)
+    await expectCacheMiss(bruceApi, uri)
+  })
+
+  test('invalidates /activities/{activitiyId} for all users on activity patch', async () => {
+    const activityId = '3d1e5c91ceb2'
+    const uri = `/api/activities/${activityId}`
+
+    // bring data into defined state
+    const bruceApi = await getAuthContext(bruceWayneUser)
+    await apiPatch(bruceApi, `/api/activities/${activityId}`, {
+      title: 'Breakfast',
+    })
+
+    // warm up cache
+    await apiGet(bruceApi, uri)
+    await expectCacheHit(bruceApi, uri)
+
+    const felicityApi = await getAuthContext(felicitySmoakUser)
+    await expectCacheMiss(felicityApi, uri)
+    await expectCacheHit(felicityApi, uri)
+
+    // touch activity
+    await apiPatch(bruceApi, `/api/activities/${activityId}`, {
+      title: 'Frühstück',
+    })
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bruceApi, uri)
+    await expectCacheHit(bruceApi, uri)
+
+    const bruceApi2 = await getAuthContext(bruceWayneUser)
+    await expectCacheMiss(bruceApi2, uri)
+  })
+
+  test('invalidates /activities/{activitiyId} when adding a scheduleEntry', async () => {
+    const activityId = 'ffd08c52288c'
+    const uri = `/api/activities/${activityId}`
+
+    const bipiApi = await getAuthContext(bipiUser)
+
+    // warm up cache
+    await apiGet(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // add new scheduleEntry
+    const postRes = await apiPost(bipiApi, '/api/schedule_entries', {
+      activity: `/activities/${activityId}`,
+      end: '2026-05-11T06:00:00+00:00',
+      period: '/periods/76be24bce434',
+      start: '2026-05-11T05:00:00+00:00',
+    })
+    const body = await postRes.json()
+    const newScheduleEntryUri = body._links.self.href
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // delete newly created scheduleEntry
+    await apiDelete(bipiApi, newScheduleEntryUri)
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+  })
+
+  test('invalidates /activities/{activitiyId}  when patching a progress label', async () => {
+    const activityId = '130f9a87373b'
+    const progressLabelId = '82547049ea38'
+    const uri = `/api/activities/${activityId}`
+
+    // bring data into defined state
+    const bipiApi = await getAuthContext(bipiUser)
+    await apiPatch(bipiApi, `/api/activity_progress_labels/${progressLabelId}`, {
+      title: 'Planned',
+    })
+
+    // warm up cache
+    await apiGet(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // touch progress label
+    await apiPatch(bipiApi, `/api/activity_progress_labels/${progressLabelId}`, {
+      title: 'Geplant',
+    })
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+  })
+
+  test('invalidates /activities/{activitiyId}  when adding an activity responsible', async () => {
+    const activityId = 'ffd08c52288c'
+    const uri = `/api/activities/${activityId}`
+
+    const bipiApi = await getAuthContext(bipiUser)
+
+    // warm up cache
+    await apiGet(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // add new activity responsible
+    const postRes = await apiPost(bipiApi, '/api/activity_responsibles', {
+      activity: `/activities/${activityId}`,
+      campCollaboration: '/camp_collaborations/b0bdb7202a9d',
+    })
+    const body = await postRes.json()
+    const newActivityResponsibleUri = body._links.self.href
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // delete newly created activity responsible
+    await apiDelete(bipiApi, newActivityResponsibleUri)
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+  })
+
+  test('invalidates /activities/{activitiyId} when changing the period dates (moveScheduleEntries: true)', async () => {
+    const activityId = '130f9a87373b'
+    const uri = `/api/activities/${activityId}`
+
+    const bipiApi = await getAuthContext(bipiUser)
+
+    // warm up cache
+    await apiGet(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // move period start date
+    await apiPatch(bipiApi, `/api/periods/${grgrPeriodId}`, {
+      start: '2026-05-09',
+      end: '2026-05-12',
+      moveScheduleEntries: true,
+    })
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // move period start date again
+    await apiPatch(bipiApi, `/api/periods/${grgrPeriodId}`, {
+      start: '2026-05-10',
+      end: '2026-05-13',
+      moveScheduleEntries: true,
+    })
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+  })
+
+  test('invalidates /activities/{activitiyId} when changing the period dates (moveScheduleEntries: false)', async () => {
+    const activityId = '130f9a87373b'
+    const uri = `/api/activities/${activityId}`
+
+    const bipiApi = await getAuthContext(bipiUser)
+
+    // warm up cache
+    await apiGet(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // move period start date
+    await apiPatch(bipiApi, `/api/periods/${grgrPeriodId}`, {
+      start: '2026-05-09',
+      moveScheduleEntries: false,
+    })
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // move period start date again
+    await apiPatch(bipiApi, `/api/periods/${grgrPeriodId}`, {
+      start: '2026-05-10',
+      moveScheduleEntries: false,
+    })
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+  })
+
+  test('invalidates /activities/{activitiyId}  when adding a contentNode', async () => {
+    const activityId = '130f9a87373b'
+    const uri = `/api/activities/${activityId}`
+
+    const bipiApi = await getAuthContext(bipiUser)
+
+    // warm up cache
+    await apiGet(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // add new contentNode
+    const postRes = await apiPost(bipiApi, '/api/content_node/single_texts', {
+      contentType: '/content_types/4f0c657fecef',
+      parent: '/content_node/column_layouts/0cc124cdd9f6',
+      slot: '1',
+    })
+    const body = await postRes.json()
+    const newContentNodeUri = body._links.self.href
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+
+    // delete newly created contentNode
+    await apiDelete(bipiApi, newContentNodeUri)
+
+    // ensure cache was invalidated
+    await waitForCacheMiss(bipiApi, uri)
+    await expectCacheHit(bipiApi, uri)
+  })
+})


### PR DESCRIPTION
Most of the tests are very similar to the corresponding tests for the activities collection endpoint:
https://github.com/ecamp/ecamp3/blob/devel/e2e/tests/9-behavior-tests/httpCache/activities.spec.js