### PR TITLE
Fix filtering performance

### DIFF
--- a/e2e/tests/5-cross-browser-tests/persistDashboardFilter.spec.js
+++ b/e2e/tests/5-cross-browser-tests/persistDashboardFilter.spec.js
@@ -5,8 +5,8 @@ test.describe('The filters in the dashboard', () => {
   test.beforeEach(async ({ page, request }) => {
     await loginAndSetCookie(page, request, 'test@example.com')
     await page.goto('/camps')
-    await page.locator('a:has-text("GRGR")').click()
-    await expect(page.locator('body')).toContainText('Hauptlager')
+    await page.getByRole('link', { name: 'GRGR' }).click()
+    await expect(page.getByRole('link', { name: 'Hauptlager' })).toBeVisible()
   })
 
   test.afterEach(async ({ page }) => {

--- a/frontend/src/components/dashboard/SelectFilter.vue
+++ b/frontend/src/components/dashboard/SelectFilter.vue
@@ -101,7 +101,9 @@ export default {
     },
     labelValue() {
       if (this.multiple) {
-        const list = (this.modelValue || []).map((item) => this.processedItems[item].text)
+        const list = (this.modelValue || [])
+          .map((item) => this.processedItems[item]?.text)
+          .filter(Boolean)
         const lang = this.$store.state.lang.language
         if ('Intl' in window && 'ListFormat' in Intl) {
           const listFormat = new Intl.ListFormat(lang, {

--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -158,6 +158,11 @@ export default {
     TocConfig,
     ActivityListConfig,
   },
+  provide() {
+    return {
+      loadingEndpoints: this.loadingEndpoints,
+    }
+  },
   props: {
     camp: {
       type: Object,
@@ -168,6 +173,15 @@ export default {
     return {
       loading: true,
       cnf: null,
+      loadingEndpoints: {
+        activities: true,
+        categories: true,
+        periods: true,
+        days: true,
+        campCollaborations: true,
+        progressLabels: true,
+        scheduleEntries: true,
+      },
       prettyConfig: '',
       previewTab: null,
     }
@@ -224,27 +238,45 @@ export default {
     },
   },
   async mounted() {
-    await this.camp.periods().$reload()
-    await Promise.all([
-      ...this.camp
-        .periods()
-        .items.flatMap((period) => [
-          period.days().$reload(),
-          period.contentNodes().$reload(),
-        ]),
-      this.camp.activities().$reload(),
-      this.camp.categories().$reload(),
-    ])
+    await this.loadEndpointData('periods')
     this.setRepairedConfig(this.currentConfig)
     this.loading = false
+    await this.loadRemainingPrintData()
   },
   methods: {
+    async loadRemainingPrintData() {
+      const periods = this.camp.periods().items
+      await Promise.all([
+        this.loadEndpointData(
+          'scheduleEntries',
+          Promise.all(periods.map((period) => period.scheduleEntries()._meta.load))
+        ),
+        this.loadEndpointData('activities'),
+      ])
+
+      await Promise.all([
+        this.loadEndpointData(
+          'days',
+          Promise.all(periods.map((period) => period.days()._meta.load))
+        ),
+        Promise.all(periods.map((period) => period.contentNodes()._meta.load)),
+        this.loadEndpointData('categories'),
+        this.loadEndpointData('campCollaborations'),
+        this.loadEndpointData('progressLabels'),
+      ])
+
+      this.setRepairedConfig(this.cnf)
+    },
     setRepairedConfig(config) {
       const repaired = this.repairConfig(config)
       this.cnf = repaired
       if (jsonStringifyReactiveValue(config) !== jsonStringifyReactiveValue(repaired)) {
         this.onChange()
       }
+    },
+    async loadEndpointData(endpoint, load = this.camp[endpoint]()._meta.load) {
+      await load
+      this.loadingEndpoints[endpoint] = false
     },
     createConfig() {
       return this.repairConfig(this.currentConfig)

--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -167,6 +167,7 @@ export default {
   data() {
     return {
       loading: true,
+      prettyConfig: '',
       previewTab: null,
     }
   },
@@ -205,9 +206,6 @@ export default {
     },
     isDev() {
       return getEnv().FEATURE_DEVELOPER ?? false
-    },
-    prettyConfig() {
-      return jsonStringifyReactiveValue(this.cnf, 2)
     },
   },
   watch: {
@@ -292,6 +290,9 @@ export default {
           printConfig: cloneDeep(JSON.parse(jsonStringifyReactiveValue(this.cnf))),
         })
       })
+      if (this.isDev) {
+        this.prettyConfig = jsonStringifyReactiveValue(this.cnf, 2)
+      }
     },
     onChangeContentConfig(index, value) {
       this.cnf.contents[index].options = value

--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -167,6 +167,7 @@ export default {
   data() {
     return {
       loading: true,
+      cnf: null,
       prettyConfig: '',
       previewTab: null,
     }
@@ -187,16 +188,20 @@ export default {
     lang() {
       return this.$store.state.lang.language
     },
-    cnf() {
-      return this.repairConfig(
-        this.$store.getters.getLastPrintConfig(this.camp._meta.self, {
-          language: this.lang,
-          documentName: campShortTitle(this.camp),
-          options: { pageNumbers: false, pageSize: 'A4' },
-          camp: this.camp._meta.self,
-          contents: this.defaultContents(),
-        })
-      )
+    lastPrintConfig() {
+      return this.$store.getters.getLastPrintConfig(this.camp._meta.self, null)
+    },
+    currentConfig() {
+      return this.lastPrintConfig ?? this.defaultConfig
+    },
+    defaultConfig() {
+      return {
+        language: this.lang,
+        documentName: campShortTitle(this.camp),
+        options: { pageNumbers: false, pageSize: 'A4' },
+        camp: this.camp._meta.self,
+        contents: this.defaultContents(),
+      }
     },
     pageSizes() {
       return ['A5', 'A4'].map((size) => ({
@@ -211,7 +216,9 @@ export default {
   watch: {
     lang: {
       handler(language) {
+        if (!this.cnf) return
         this.cnf.language = language
+        this.onChange()
       },
       immediate: true,
     },
@@ -228,14 +235,26 @@ export default {
       this.camp.activities().$reload(),
       this.camp.categories().$reload(),
     ])
+    this.setRepairedConfig(this.currentConfig)
     this.loading = false
   },
   methods: {
+    setRepairedConfig(config) {
+      const repaired = this.repairConfig(config)
+      this.cnf = repaired
+      if (jsonStringifyReactiveValue(config) !== jsonStringifyReactiveValue(repaired)) {
+        this.onChange()
+      }
+    },
+    createConfig() {
+      return this.repairConfig(this.currentConfig)
+    },
     resetConfig() {
       this.$store.commit('setLastPrintConfig', {
         campUri: this.camp._meta.self,
         printConfig: undefined,
       })
+      this.cnf = this.createConfig()
     },
     defaultContents() {
       const contents = [

--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -279,7 +279,7 @@ export default {
       this.loadingEndpoints[endpoint] = false
     },
     createConfig() {
-      return this.repairConfig(this.currentConfig)
+      return this.repairConfig(this.defaultConfig)
     },
     resetConfig() {
       this.$store.commit('setLastPrintConfig', {

--- a/frontend/src/components/print/PrintConfigurator.vue
+++ b/frontend/src/components/print/PrintConfigurator.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-skeleton-loader v-if="loading" type="article" />
+  <v-skeleton-loader v-if="loading" type="article" class="pa-4" />
   <div v-else>
     <PagesOverview v-model="cnf.contents" @update:model-value="onChange">
       <template #item="{ element: content, index: idx }">
@@ -90,23 +90,23 @@
     </v-card-text>
 
     <template v-if="isDev">
-      <v-tabs v-model="previewTab" class="px-4">
-        <v-tab>Nuxt preview</v-tab>
-        <v-tab>Client print preview</v-tab>
+      <v-tabs v-model="previewTab" :mandatory="false" class="px-4">
+        <v-tab value="nuxt">Nuxt preview</v-tab>
+        <v-tab value="client">Client print preview</v-tab>
       </v-tabs>
-      <v-tabs-window v-model="previewTab">
-        <v-tabs-window-item>
+      <v-tabs-window v-if="previewTab" v-model="previewTab">
+        <v-tabs-window-item value="nuxt">
           <print-preview-nuxt
-            v-if="previewTab === 0"
+            v-if="previewTab === 'nuxt'"
             :config="cnf"
             width="100%"
             height="600"
             class="my-4"
           />
         </v-tabs-window-item>
-        <v-tabs-window-item>
+        <v-tabs-window-item value="client">
           <print-preview-client
-            v-if="previewTab === 1"
+            v-if="previewTab === 'client'"
             :config="cnf"
             width="100%"
             height="600"

--- a/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
+++ b/frontend/src/components/print/__tests__/repairPrintConfig.spec.js
@@ -9,15 +9,17 @@ import SafetyConsiderationsConfig from '../config/SafetyConsiderationsConfig.vue
 import TocConfig from '../config/TocConfig.vue'
 import ActivityListConfig from '../config/ActivityListConfig.vue'
 
-describe.skip('repairConfig', () => {
+describe('repairConfig', () => {
   const camp = {
     _meta: { self: '/camps/1a2b3c4d' },
     shortTitle: 'test camp',
     periods: () => ({
+      _meta: { loading: false },
       items: [
         {
           _meta: { self: '/periods/1a2b3c4d' },
           days: () => ({
+            _meta: { loading: false },
             items: [
               {
                 _meta: { self: '/days/1a2b3c4d' },
@@ -28,6 +30,7 @@ describe.skip('repairConfig', () => {
       ],
     }),
     categories: () => ({
+      _meta: { loading: false },
       items: [
         {
           _meta: { self: '/categories/1a2b3c4d' },
@@ -35,6 +38,7 @@ describe.skip('repairConfig', () => {
       ],
     }),
     campCollaborations: () => ({
+      _meta: { loading: false },
       items: [
         {
           _meta: { self: '/camp_collaborations/1a2b3c4d' },
@@ -42,6 +46,7 @@ describe.skip('repairConfig', () => {
       ],
     }),
     progressLabels: () => ({
+      _meta: { loading: false },
       items: [
         {
           _meta: { self: '/progress_labels/1a2b3c4d' },
@@ -52,10 +57,12 @@ describe.skip('repairConfig', () => {
   const multiPeriodCamp = {
     ...camp,
     periods: () => ({
+      _meta: { loading: false },
       items: [
         {
           _meta: { self: '/periods/1a2b3c4d' },
           days: () => ({
+            _meta: { loading: false },
             items: [
               {
                 _meta: { self: '/days/1a2b3c4d' },
@@ -66,6 +73,7 @@ describe.skip('repairConfig', () => {
         {
           _meta: { self: '/periods/11223344' },
           days: () => ({
+            _meta: { loading: false },
             items: [
               {
                 _meta: { self: '/days/bbbbbbbb' },

--- a/frontend/src/components/print/config/ActivityListConfig.vue
+++ b/frontend/src/components/print/config/ActivityListConfig.vue
@@ -50,9 +50,9 @@ export default {
       }))
     },
     selectedPeriods() {
-      if (!this.options.filter.period) return this.camp.periods().items
+      if (!this.options.periods) return this.camp.periods().items
       return this.camp.periods().items.filter((period) => {
-        return this.filter.periods.includes(period._meta.self)
+        return this.options.periods.includes(period._meta.self)
       })
     },
     selectedScheduleEntries() {
@@ -63,6 +63,7 @@ export default {
     return {
       periods:
         camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : [],
+      filter: repairFilterConfig(null, camp),
     }
   },
   methods: {

--- a/frontend/src/components/print/config/DialogScheduleEntryFilter.vue
+++ b/frontend/src/components/print/config/DialogScheduleEntryFilter.vue
@@ -15,6 +15,7 @@
         :color="anyFilter ? 'primary' : 'secondary'"
         border="sm"
         class="align-self-stretch mt-4 mb-4"
+        :class="anyFilter && 'border-current'"
         v-bind="props"
       >
         <v-icon start size="20">mdi-filter</v-icon>

--- a/frontend/src/components/print/config/DialogScheduleEntryFilter.vue
+++ b/frontend/src/components/print/config/DialogScheduleEntryFilter.vue
@@ -63,23 +63,26 @@ export default {
     filteredCount() {
       return this.filterFn(this.localFilter).length
     },
+    totalCount() {
+      return this.filterFn({}).length
+    },
     activatorLabel() {
       if (this.anyFilter)
         return this.$t('components.print.config.dialogScheduleEntryFilter.filterActive', {
           filtered: this.filteredCount,
-          total: this.filterFn({}).length,
+          total: this.totalCount,
         })
       return this.$t(
         'components.print.config.dialogScheduleEntryFilter.filterActivities',
         {
-          total: this.filterFn({}).length,
+          total: this.totalCount,
         }
       )
     },
     resultCountLabel() {
       return this.$t(
         'components.print.config.dialogScheduleEntryFilter.resultCount',
-        { filtered: this.filteredCount, total: this.filterFn({}).length },
+        { filtered: this.filteredCount, total: this.totalCount },
         1
       )
     },

--- a/frontend/src/components/print/config/DialogScheduleEntryFilter.vue
+++ b/frontend/src/components/print/config/DialogScheduleEntryFilter.vue
@@ -119,6 +119,9 @@ export default {
     },
   },
   watch: {
+    modelValue(value) {
+      this.localFilter = value
+    },
     filteredCount: {
       handler(val) {
         if (this.filterDataLoading) return

--- a/frontend/src/components/print/config/DialogScheduleEntryFilter.vue
+++ b/frontend/src/components/print/config/DialogScheduleEntryFilter.vue
@@ -18,21 +18,35 @@
         v-bind="props"
       >
         <v-icon start size="20">mdi-filter</v-icon>
-        <span class="flex-grow-1 text-center">{{ activatorLabel }}</span>
+        <v-skeleton-loader
+          v-if="filterDataLoading"
+          type="text"
+          width="100%"
+          class="v-skeleton-loader--no-margin"
+        />
+        <span v-else class="flex-grow-1 text-center">{{ activatorLabel }}</span>
       </v-chip>
     </template>
     <ScheduleEntryFilters
       v-model="localFilter"
       :camp="camp"
       :filter-fn="filterFn"
-      :loading-endpoints="{}"
+      :loading-endpoints="loadingEndpoints"
       :hide-self-filter="isOutsider"
       :hide-period-filter="hidePeriodFilter"
       :hide-day-filter="hideDayFilter"
-      @update:model-value="$emit('update:modelValue', $event)"
+      @update:model-value="updateLocalFilter"
     />
     <template #moreActions>
-      {{ resultCountLabel }}
+      <v-skeleton-loader
+        v-if="filterDataLoading"
+        type="text"
+        width="20ch"
+        class="v-skeleton-loader--no-margin"
+      />
+      <template v-else>
+        {{ resultCountLabel }}
+      </template>
     </template>
   </DetailPane>
 </template>
@@ -45,6 +59,7 @@ export default {
   name: 'DialogScheduleEntryFilter',
   components: { DetailPane, ScheduleEntryFilters },
   mixins: [campRoleMixin],
+  inject: ['loadingEndpoints'],
   props: {
     camp: { type: Object, required: true },
     filterFn: { type: Function, required: true },
@@ -60,7 +75,11 @@ export default {
     }
   },
   computed: {
+    filterDataLoading() {
+      return Object.values(this.loadingEndpoints).some(Boolean)
+    },
     filteredCount() {
+      if (this.filterDataLoading) return 0
       return this.filterFn(this.localFilter).length
     },
     totalCount() {
@@ -101,13 +120,29 @@ export default {
   watch: {
     filteredCount: {
       handler(val) {
+        if (this.filterDataLoading) return
         this.localFilter.activityCount = val
-        this.$emit('update:modelValue', this.localFilter)
+        if (!this.dialogOpen) {
+          this.$emit('update:modelValue', this.localFilter)
+        }
       },
       immediate: true,
     },
+    filterDataLoading(loading) {
+      if (loading) return
+      this.localFilter.activityCount = this.filteredCount
+      if (!this.dialogOpen) {
+        this.$emit('update:modelValue', this.localFilter)
+      }
+    },
   },
   methods: {
+    updateLocalFilter(filter) {
+      this.localFilter = filter
+      if (!this.filterDataLoading) {
+        this.localFilter.activityCount = this.filteredCount
+      }
+    },
     emit(dialogOpen) {
       if (dialogOpen) return // only emit when closing dialog
       this.$emit('update:modelValue', this.localFilter)

--- a/frontend/src/components/print/config/PicassoConfig.vue
+++ b/frontend/src/components/print/config/PicassoConfig.vue
@@ -72,9 +72,9 @@ export default {
       }))
     },
     selectedPeriods() {
-      if (!this.options.filter.period) return this.camp.periods().items
+      if (!this.options.periods) return this.camp.periods().items
       return this.camp.periods().items.filter((period) => {
-        return this.filter.periods.includes(period._meta.self)
+        return this.options.periods.includes(period._meta.self)
       })
     },
     selectedScheduleEntries() {
@@ -98,6 +98,7 @@ export default {
       periods:
         camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : [],
       orientation: 'L',
+      filter: repairFilterConfig(null, camp),
     }
   },
   design: {

--- a/frontend/src/components/print/config/ProgramConfig.vue
+++ b/frontend/src/components/print/config/ProgramConfig.vue
@@ -56,9 +56,9 @@ export default {
       }))
     },
     selectedPeriods() {
-      if (!this.options.filter.period) return this.camp.periods().items
+      if (!this.options.periods) return this.camp.periods().items
       return this.camp.periods().items.filter((period) => {
-        return this.filter.periods.includes(period._meta.self)
+        return this.options.periods.includes(period._meta.self)
       })
     },
     selectedScheduleEntries() {
@@ -82,6 +82,7 @@ export default {
       periods:
         camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : [],
       dayOverview: true,
+      filter: repairFilterConfig(null, camp),
     }
   },
   design: {

--- a/frontend/src/components/print/config/SafetyConsiderationsConfig.vue
+++ b/frontend/src/components/print/config/SafetyConsiderationsConfig.vue
@@ -38,6 +38,7 @@ export default {
       periods:
         camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : [],
       contentType: 'SafetyConsiderations',
+      filter: repairFilterConfig(null, camp),
     }
   },
   design: {

--- a/frontend/src/components/print/config/StoryConfig.vue
+++ b/frontend/src/components/print/config/StoryConfig.vue
@@ -38,6 +38,7 @@ export default {
       periods:
         camp.periods().items.length === 1 ? [camp.periods().items[0]._meta.self] : [],
       contentType: 'Storycontext',
+      filter: repairFilterConfig(null, camp),
     }
   },
   design: {

--- a/frontend/src/components/print/config/SummaryConfig.vue
+++ b/frontend/src/components/print/config/SummaryConfig.vue
@@ -31,9 +31,9 @@ export default {
       }))
     },
     selectedPeriods() {
-      if (!this.options.filter.period) return this.camp.periods().items
+      if (!this.options.periods) return this.camp.periods().items
       return this.camp.periods().items.filter((period) => {
-        return this.filter.periods.includes(period._meta.self)
+        return this.options.periods.includes(period._meta.self)
       })
     },
     selectedScheduleEntries() {

--- a/frontend/src/components/program/ScheduleEntryFilters.vue
+++ b/frontend/src/components/program/ScheduleEntryFilters.vue
@@ -348,30 +348,9 @@ export default {
       }).length
     },
   },
-  mounted() {
-    if (this.loadingEndpoints !== true) {
-      this.loadEndpointData('categories', 'category')
-      this.loadEndpointData('campCollaborations', 'responsible', true)
-      this.loadEndpointData('progressLabels', 'progressLabel', true)
-    }
-  },
   methods: {
     campCollaborationDisplayName(campCollaboration) {
       return campCollaborationDisplayName(campCollaboration, this.$t.bind(this))
-    },
-    loadEndpointData(endpoint, filterKey, hasNone = false) {
-      this.camp[endpoint]()._meta.load.then(({ allItems }) => {
-        const collection = allItems.map((entry) => entry._meta.self)
-        if (hasNone) {
-          collection.push('none')
-        }
-        this.updateFilter({
-          [filterKey]:
-            this.modelValue[filterKey].filter((value) => collection.includes(value)) ??
-            null,
-        })
-        this.loadingEndpoints[endpoint] = false
-      })
     },
     resetFilter() {
       this.updateFilter({

--- a/frontend/src/components/program/repairFilterConfig.js
+++ b/frontend/src/components/program/repairFilterConfig.js
@@ -3,10 +3,12 @@ import { isEqual } from 'lodash-es'
 export default function repairFilterConfig(filter, camp) {
   if (!filter || typeof filter !== 'object') {
     return {
+      period: null,
       category: [],
       day: [],
       responsible: [],
       progressLabel: [],
+      activityCount: 0,
     }
   }
   if (!filter.period) filter.period = null

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -262,6 +262,11 @@ export default {
     'filter.progressLabel': 'persistRouterState',
   },
   async mounted() {
+    const queryFilters = processRouteQuery(this.$route.query)
+    Object.entries(queryFilters).forEach(([key, value]) => {
+      this.filter[key] = value
+    })
+
     await Promise.all([
       this.camp._meta.load,
       this.period.scheduleEntries()._meta.load,
@@ -273,10 +278,6 @@ export default {
 
     this.loading = false
 
-    const queryFilters = processRouteQuery(this.$route.query)
-    Object.entries(queryFilters).forEach(([key, value]) => {
-      this.filter[key] = value
-    })
   },
   methods: {
     showUnlockReminder(move) {

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -271,15 +271,28 @@ export default {
       this.camp._meta.load,
       this.period.scheduleEntries()._meta.load,
       this.camp.activities()._meta.load,
-      this.camp.categories()._meta.load,
+      this.loadEndpointData('categories', 'category'),
       this.period.days()._meta.load,
       this.period.dayResponsibles()._meta.load,
     ])
 
     this.loading = false
 
+    this.loadEndpointData('campCollaborations', 'responsible', true)
+    this.loadEndpointData('progressLabels', 'progressLabel', true)
   },
   methods: {
+    async loadEndpointData(endpoint, filterKey, hasNone = false) {
+      await this.camp[endpoint]()._meta.load.then(({ allItems }) => {
+        const collection = allItems.map((entry) => entry._meta.self)
+        if (hasNone) {
+          collection.push('none')
+        }
+        this.filter[filterKey] =
+          this.filter[filterKey].filter((value) => collection.includes(value)) ?? null
+        this.loadingEndpoints[endpoint] = false
+      })
+    },
     showUnlockReminder(move) {
       if (this.isOutsider) return
       this.reminderText = move

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -270,21 +270,36 @@ export default {
       this.api.get().days({ 'period.camp': this.camp._meta.self }),
       ...this.camp.periods().items.map((period) => period.scheduleEntries()._meta.load),
       this.camp.activities()._meta.load,
-      this.camp.categories()._meta.load,
-      this.camp.progressLabels()._meta.load,
     ])
 
     this.loading = false
 
-    this.camp.periods()._meta.load.then(({ allItems }) => {
-      const collection = allItems.map((entry) => entry._meta.self)
-      if (!collection.includes(this.filter.period)) {
-        this.filter.period = null
-      }
-      this.loadingEndpoints.periods = false
-    })
+    this.loadEndpointData('categories', 'category')
+    this.loadEndpointData('campCollaborations', 'responsible', true)
+    this.loadEndpointData('progressLabels', 'progressLabel', true)
+    this.loadPeriodsEndpointData()
   },
   methods: {
+    loadEndpointData(endpoint, filterKey, hasNone = false) {
+      this.camp[endpoint]()._meta.load.then(({ allItems }) => {
+        const collection = allItems.map((entry) => entry._meta.self)
+        if (hasNone) {
+          collection.push('none')
+        }
+        this.filter[filterKey] =
+          this.filter[filterKey].filter((value) => collection.includes(value)) ?? null
+        this.loadingEndpoints[endpoint] = false
+      })
+    },
+    loadPeriodsEndpointData() {
+      this.camp.periods()._meta.load.then(({ allItems }) => {
+        const collection = allItems.map((entry) => entry._meta.self)
+        if (!collection.includes(this.filter.period)) {
+          this.filter.period = null
+        }
+        this.loadingEndpoints.periods = false
+      })
+    },
     periodRoute,
     persistRouterState() {
       const query = transformValuesToHalId(this.filter)

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -260,6 +260,11 @@ export default {
     'filter.progressLabel': 'persistRouterState',
   },
   async mounted() {
+    const queryFilters = processRouteQuery(this.$route.query)
+    Object.entries(queryFilters).forEach(([key, value]) => {
+      this.filter[key] = value
+    })
+
     await Promise.all([
       this.camp._meta.load,
       this.api.get().days({ 'period.camp': this.camp._meta.self }),
@@ -270,11 +275,6 @@ export default {
     ])
 
     this.loading = false
-
-    const queryFilters = processRouteQuery(this.$route.query)
-    Object.entries(queryFilters).forEach(([key, value]) => {
-      this.filter[key] = value
-    })
 
     this.camp.periods()._meta.load.then(({ allItems }) => {
       const collection = allItems.map((entry) => entry._meta.self)

--- a/frontend/src/views/camp/Dashboard.vue
+++ b/frontend/src/views/camp/Dashboard.vue
@@ -30,7 +30,7 @@
         hide-day-filter
         :filter-fn="filterFn"
       />
-      <template v-if="!loading">
+      <template v-if="!loading && !scheduleEntriesLoading">
         <table
           v-for="(periodDays, uri) in groupedScheduleEntries"
           :key="uri"
@@ -100,12 +100,16 @@
           </template>
         </table>
         <p
-          v-if="scheduleEntries.length > 0 && filteredScheduleEntries.length === 0"
+          v-if="
+            !scheduleEntriesLoading &&
+            scheduleEntries.length > 0 &&
+            filteredScheduleEntries.length === 0
+          "
           class="ma-4"
         >
           {{ $t('views.camp.dashboard.noEntries') }}
         </p>
-        <p v-if="scheduleEntries.length === 0" class="ma-4">
+        <p v-if="!scheduleEntriesLoading && scheduleEntries.length === 0" class="ma-4">
           {{ $t('views.camp.dashboard.welcome') }}
         </p>
       </template>
@@ -202,6 +206,11 @@ export default {
       return Object.values(this.periods).flatMap(
         (period) => period.scheduleEntries().items
       )
+    },
+    scheduleEntriesLoading() {
+      return this.camp
+        .periods()
+        .items.some((period) => period.scheduleEntries()._meta.loading)
     },
     days() {
       return keyBy(

--- a/frontend/src/views/camp/admin/Print.vue
+++ b/frontend/src/views/camp/admin/Print.vue
@@ -5,7 +5,7 @@ Basic layout for print preview
 <template>
   <content-card :title="$t('views.camp.admin.print.title')" toolbar>
     <template #title-actions>
-      <v-btn variant="text" class="mr-n2" @click="$refs.printConfigurator?.resetConfig()">
+      <v-btn variant="text" @click="$refs.printConfigurator?.resetConfig()">
         <v-icon v-if="$vuetify.display.smAndUp" start>mdi-file-restore-outline</v-icon>
         {{ $t('global.button.reset') }}
       </v-btn>


### PR DESCRIPTION
This PR improves perceived loading performance in dashboard/program/print views while keeping filter state and result counts consistent.

## Changes

- Move `ScheduleEntryFilters` endpoint loading responsibility to parent views.
- Load dashboard/program data in phases so the UI can render earlier without briefly showing unfiltered or incorrectly filtered rows.
- Keep URL query filters applied before endpoint loading starts.
- Prevent the dashboard welcome message from flashing during loading races.
- Make print config local state instead of a computed repair loop to avoid repeated expensive repair/stringify cycles.
- Reuse already available print store data via `_meta.load` instead of forcing reloads.
- Repair/persist print config only when the repaired config actually differs.
- Delay print previews/PDF preview components until their tab/action is active.
- Keep dialog filter edits local while the dialog is open and avoid emitting incomplete result counts.
- Guard against invalid labels causing JS crashes.
- Reactivate and fix `repairPrintConfig` tests.

