### PR TITLE
api: add command to generate data

### DIFF
--- a/.helm/ecamp3/templates/api_pod_db_generate_camps.yaml
+++ b/.helm/ecamp3/templates/api_pod_db_generate_camps.yaml
@@ -1,0 +1,45 @@
+{{- if eq .Values.api.generateRandomCamps "true" }}
+#
+# Generates camps to mimic the data volume of a production database
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "app.name" . }}-db-generate-camps"
+  labels:
+    {{- include "api.selectorLabels" . | nindent 4 }}
+    {{- include "app.commonLabels" . | nindent 4 }}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: db-generate-data-job
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 12 }}
+      image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Values.imageTag }}"
+      imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+      env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "api.name" . }}
+              key: database-url
+      command:
+        - sh
+        - -c
+        - |
+          # sleep until the migrations are hopefully through.
+          sleep 60
+          export API_CACHE_ENABLED=false
+          php -d memory_limit=-1 -d max_execution_time=0 bin/console app:generate-data 1000 --replace=true
+  volumes:
+  - name: php-socket
+    emptyDir: {}
+  - name: jwt-keypair
+    secret:
+      secretName: {{ include "api.name" . }}
+      items:
+        - key: jwt-public-key
+          path: public.pem
+        - key: jwt-private-key
+          path: private.pem
+{{- end }}

--- a/.helm/ecamp3/values.yaml.gotmpl
+++ b/.helm/ecamp3/values.yaml.gotmpl
@@ -83,6 +83,7 @@ api:
     limits:
       cpu: {{ $phpCpuLimit | quote }}
     {{ end }}
+  generateRandomCamps: {{ .Environment.Values | getOrNil "GENERATE_RANDOM_CAMPS" | default false | quote }}
 
 frontend:
   image:

--- a/api/composer.json
+++ b/api/composer.json
@@ -23,6 +23,7 @@
     "doctrine/doctrine-migrations-bundle": "4.0.0",
     "doctrine/orm": "3.6.4",
     "exercise/htmlpurifier-bundle": "5.2",
+    "fakerphp/faker": "1.24.1",
     "friendsofsymfony/http-cache": "3.2.0",
     "friendsofsymfony/http-cache-bundle": "3.4.0",
     "gesdinet/jwt-refresh-token-bundle": "2.0.0",
@@ -141,6 +142,10 @@
       "Composer\\Config::disableProcessTimeout",
       "UPDATE_SNAPSHOTS=true vendor/bin/phpunit -d memory_limit=-1 tests/Api/SnapshotTests",
       "UPDATE_SNAPSHOTS=true vendor/bin/phpunit -d memory_limit=-1 tests/Util/ArrayDeepSortTest.php"
+    ],
+    "generate-data": [
+      "Composer\\Config::disableProcessTimeout",
+      "API_CACHE_ENABLED=false php -d memory_limit=-1 bin/console app:generate-data"
     ],
     "auto-scripts": {
       "cache:clear": "symfony-cmd",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1719e8b9a927c45a1562600f16d5927",
+    "content-hash": "b552016a0f0fd8de9fcadb73c772beae",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2990,6 +2990,69 @@
                 "source": "https://github.com/ezyang/htmlpurifier/tree/v4.19.0"
             },
             "time": "2025-10-17T16:34:55+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "friendsofsymfony/http-cache",
@@ -12068,69 +12131,6 @@
                 "source": "https://github.com/igorw/evenement/tree/v3.0.2"
             },
             "time": "2023-08-08T05:53:35+00:00"
-        },
-        {
-            "name": "fakerphp/faker",
-            "version": "v1.24.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
-                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0",
-                "psr/container": "^1.0 || ^2.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
-            },
-            "conflict": {
-                "fzaninotto/faker": "*"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.4.1",
-                "doctrine/persistence": "^1.3 || ^2.0",
-                "ext-intl": "*",
-                "phpunit/phpunit": "^9.5.26",
-                "symfony/phpunit-bridge": "^5.4.16"
-            },
-            "suggest": {
-                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
-                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
-                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
-                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
-                "ext-mbstring": "Required for multibyte Unicode string functionality."
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "support": {
-                "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
-            },
-            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",

--- a/api/migrations/schema/Version20260503120000.php
+++ b/api/migrations/schema/Version20260503120000.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260503120000 extends AbstractMigration {
+    public function getDescription(): string {
+        return 'Add randomlyGenerated flag to camp table for identifying generated data';
+    }
+
+    public function up(Schema $schema): void {
+        $this->addSql('ALTER TABLE camp ADD randomlyGenerated BOOLEAN DEFAULT false NOT NULL');
+        $this->addSql('CREATE INDEX IDX_C1944230BBF3963D ON camp (randomlyGenerated)');
+    }
+
+    public function down(Schema $schema): void {
+        $this->addSql('ALTER TABLE camp DROP randomlyGenerated');
+        $this->addSql('DROP INDEX IDX_C1944230BBF3963D');
+    }
+}

--- a/api/src/Command/GenerateDataCommand.php
+++ b/api/src/Command/GenerateDataCommand.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\DataGeneratorService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: self::APP_GENERATE_DATA_COMMAND,
+    description: 'Generate realistic test data for development'
+)]
+class GenerateDataCommand extends Command {
+    public const string APP_GENERATE_DATA_COMMAND = 'app:generate-data';
+    private EntityManagerInterface $entityManager;
+    private DataGeneratorService $dataGeneratorService;
+
+    public function __construct(EntityManagerInterface $entityManager, DataGeneratorService $dataGeneratorService) {
+        parent::__construct();
+        $this->entityManager = $entityManager;
+        $this->dataGeneratorService = $dataGeneratorService;
+    }
+
+    protected function configure(): void {
+        $this
+            ->setDescription('Generate realistic test data for development')
+            ->addArgument('num-camps', InputArgument::OPTIONAL, 'Number of camps to generate', 250)
+            ->addOption('seed', 's', InputOption::VALUE_OPTIONAL, 'Random seed for reproducible data', 12345)
+            ->addOption('activities-per-camp', 'a', InputOption::VALUE_OPTIONAL, 'Number of activities per camp', 20)
+            ->addOption('schedule-entries-per-activity', 'se', InputOption::VALUE_OPTIONAL, 'Number of schedule entries per activity', 1)
+            ->addOption('batch-size', 'b', InputOption::VALUE_OPTIONAL, 'Number of camps to process before flushing', 3)
+            ->addOption('add-user-to-camp', 'autc', InputOption::VALUE_OPTIONAL, 'user to add to generated camps', 'sit@example.com')
+            ->addOption('replace', null, InputOption::VALUE_OPTIONAL, 'Replace the generated camps.', 'false')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int {
+        $io = new SymfonyStyle($input, $output);
+
+        $numCamps = (int) $input->getArgument('num-camps');
+        $seed = (int) $input->getOption('seed');
+        $activitiesPerCamp = (int) $input->getOption('activities-per-camp');
+        $scheduleEntriesPerActivity = (int) $input->getOption('schedule-entries-per-activity');
+        $batchSize = (int) $input->getOption('batch-size');
+        $addUserToCamp = $input->getOption('add-user-to-camp');
+        $replace = $input->getOption('replace');
+
+        if ($numCamps <= 0) {
+            $io->error('Number of camps must be greater than 0.');
+
+            return Command::FAILURE;
+        }
+
+        if ($numCamps > 10000) {
+            $io->warning('Generating more than 10,000 camps may take a very long time.');
+            if (!$io->confirm('Do you want to continue?', false)) {
+                return Command::FAILURE;
+            }
+        }
+
+        if ($activitiesPerCamp <= 0 || $scheduleEntriesPerActivity <= 0 || $batchSize <= 0) {
+            $io->error('All numeric parameters must be greater than 0.');
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Generating Test Data');
+        $io->writeln('Configuration:');
+        $io->writeln("  - Number of camps: {$numCamps}");
+        $io->writeln("  - Random seed: {$seed}");
+        $io->writeln("  - Activities per camp: {$activitiesPerCamp}");
+        $io->writeln("  - Schedule entries per activity: {$scheduleEntriesPerActivity}");
+        $io->writeln("  - Batch size: {$batchSize}");
+        $io->writeln("  - Add user to camp: {$addUserToCamp}");
+        $io->writeln("  - Replace existing camps: {$replace}");
+        $io->newLine();
+
+        $io->progressStart($numCamps + 1);
+
+        if ('true' === $replace) {
+            $this->entityManager->createNativeQuery('
+            WITH camps as (SELECT id FROM camp WHERE randomlygenerated = :randomlyGenerated),
+                checklists as (SELECT id from checklist WHERE campid IN (SELECT id FROM camps)),
+                checklist_items as (SELECT id from checklist_item WHERE checklistid IN (SELECT id FROM checklists)),
+                deletedChecklistnodeChecklistitem as (DELETE FROM checklistnode_checklistitem WHERE checklistitem_id IN (SELECT id FROM checklist_item)),
+                deletedChecklistItems as (DELETE FROM checklist_item WHERE checklistid IN (SELECT id from checklist WHERE campid IN (SELECT id FROM camps))),
+                deletedPeriods as (DELETE FROM period WHERE campid IN (SELECT id FROM camps))
+            DELETE FROM camp WHERE id IN (SELECT id FROM camps);
+            ', new ResultSetMapping())
+                ->setParameter('randomlyGenerated', true)
+                ->execute()
+            ;
+        }
+        $io->progressAdvance();
+
+        $this->dataGeneratorService->initialize($seed, $addUserToCamp);
+
+        try {
+            for ($i = 0; $i < $numCamps; ++$i) {
+                $this->dataGeneratorService->createRealisticCamp(
+                    $activitiesPerCamp,
+                    $scheduleEntriesPerActivity
+                );
+
+                if (($i + 1) % $batchSize === 0) {
+                    $this->entityManager->flush();
+                    $this->entityManager->clear();
+
+                    $this->dataGeneratorService->initialize($seed, $addUserToCamp);
+                }
+
+                $io->progressAdvance();
+            }
+
+            $this->entityManager->flush();
+
+            $io->progressFinish();
+
+            $io->success("Successfully generated {$numCamps} camps with realistic data.");
+
+            $stats = $this->dataGeneratorService->getStatistics();
+            $io->table(['Entity Type', 'Count'], [
+                ['Camps', $stats['camps']],
+                ['Periods', $stats['periods']],
+                ['Days', $stats['days']],
+                ['Categories', $stats['categories']],
+                ['Activities', $stats['activities']],
+                ['Schedule Entries', $stats['scheduleEntries']],
+                ['Content Nodes', $stats['contentNodes']],
+                ['Material Lists', $stats['materialLists']],
+                ['Material Items', $stats['materialItems']],
+                ['Camp Collaborations', $stats['campCollaborations']],
+                ['Checklists', $stats['checklists']],
+                ['Checklist Items', $stats['checklistItems']],
+            ]);
+
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $io->progressFinish();
+            $io->error("Error generating data: {$e->getMessage()}");
+            $io->writeln($e->getTraceAsString());
+
+            return Command::FAILURE;
+        }
+    }
+}

--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -69,6 +69,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Index(columns: ['isPrototype'])]
 #[ORM\Index(columns: ['isShared'])]
 #[ORM\Index(columns: ['isPublic'])]
+#[ORM\Index(columns: ['randomlyGenerated'])]
 #[ORM\Index(columns: ['updateTime'])] // TODO unclear why this is necessary, but doctrine forgot about this index from BaseEntity...
 class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototypeInterface {
     public const ITEM_NORMALIZATION_CONTEXT = [
@@ -242,6 +243,14 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
      */
     #[ORM\Column(type: 'boolean', nullable: false, options: ['default' => false])]
     public bool $isPublic = false;
+
+    /**
+     * Whether this camp was created by the data generator command. Internal flag,
+     * not published through the API. Used to easily identify and clean generated camps.
+     */
+    #[ApiProperty(readable: false, writable: false)]
+    #[ORM\Column(type: 'boolean', nullable: false, options: ['default' => false])]
+    public bool $randomlyGenerated = false;
 
     /**
      * An optional short title for the camp. Can be used in the UI where space is tight. If

--- a/api/src/Service/DataGeneratorService.php
+++ b/api/src/Service/DataGeneratorService.php
@@ -1,0 +1,671 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Activity;
+use App\Entity\Camp;
+use App\Entity\CampCollaboration;
+use App\Entity\Category;
+use App\Entity\Checklist;
+use App\Entity\ChecklistItem;
+use App\Entity\ContentNode\ChecklistNode;
+use App\Entity\ContentNode\ColumnLayout;
+use App\Entity\ContentNode\MaterialNode;
+use App\Entity\ContentNode\ResponsiveLayout;
+use App\Entity\ContentNode\SingleText;
+use App\Entity\ContentNode\Storyboard;
+use App\Entity\ContentType;
+use App\Entity\Day;
+use App\Entity\MaterialItem;
+use App\Entity\MaterialList;
+use App\Entity\Period;
+use App\Entity\Profile;
+use App\Entity\ScheduleEntry;
+use App\Entity\User;
+use App\Util\IdGenerator;
+use Doctrine\ORM\EntityManagerInterface;
+use Faker\Factory as FakerFactory;
+use Faker\Generator;
+
+class DataGeneratorService {
+    private ?Generator $faker = null;
+    private array $contentTypes = [];
+    private ?User $addUserToCamp = null;
+
+    // Statistics tracking
+    private array $stats = [
+        'camps' => 0,
+        'periods' => 0,
+        'days' => 0,
+        'categories' => 0,
+        'activities' => 0,
+        'scheduleEntries' => 0,
+        'contentNodes' => 0,
+        'materialLists' => 0,
+        'materialItems' => 0,
+        'campCollaborations' => 0,
+        'checklists' => 0,
+        'checklistItems' => 0,
+    ];
+
+    // J+S specific data
+    private array $campTypes = [
+        'J+S Kurs',
+    ];
+
+    private array $activityCategories = [
+        ['short' => 'A', 'name' => 'Ausbildung', 'color' => '#FD7A7A'],
+        ['short' => 'ES', 'name' => 'Essen', 'color' => '#BBBBBB'],
+        ['short' => 'LL', 'name' => 'Lernen und lehren', 'color' => '#4DBB52'],
+        ['short' => 'WP', 'name' => 'Wahlprogramm', 'color' => '#90B7E4'],
+    ];
+
+    private array $activityNames = [
+        // Morgenprogram (Morning program)
+        'Morgenrunde', 'Morgengymnastik', 'Frühstück', 'Mittagessen kochen', 'Abendessen vorbereiten',
+
+        // Tagesprogramm (Daily program)
+        'Lagersport', 'Wasserpiele', 'Kletterwand', 'Orientierungslauf',
+        'Wanderung', 'Naturkunde', 'Schwimmen', 'Klettern',
+
+        // Abendprogramm (Evening program)
+        'Abendessen', 'Lagerfeuer', 'Grillen', 'Bastelworkshop',
+        'Theaterstück', 'Musikabend', 'Tanzabend', 'Karaoke',
+
+        // Logistik und Organisation (Logistics and organization)
+        'Zeltaufbau', 'Zeltabbau', 'Lagerplatz reinigen', 'Einkaufsliste erstellen',
+        'Materialliste erstellen', 'Transport organisieren', 'Notfallplan erstellen',
+
+        // Sicherheit und Erste Hilfe (Safety and first aid)
+        'Erste-Hilfe-Kiste kontrollieren', 'Verbandsmaterial prüfen',
+        'Rettungsweg kennen', 'Sicherheitsregeln besprechen', 'Notfallübung durchführen',
+
+        // J+S spezifisch (J+S specific)
+        'J+S Ausbildungsziele definieren', 'Lagerprogramm erstellen', 'Tagesprogramm planen',
+        'Aktivitäten dokumentieren', 'Lagerleitungssitzung', 'Ressourcen planen',
+
+        // Kommunikation (Communication)
+        'Lagerprotokoll führen', 'Fotos machen', 'Bericht schreiben',
+        'Elterninformationen senden', 'Teilnehmerzertifikate erstellen',
+
+        // Weitere Aktivitäten (Other activities)
+        'Naturbeobachtung', 'Sternenhimmelbeobachtung', 'Wetterschutz beachten',
+        'Umweltschutzmaßnahmen', 'Lagerplatz erkunden', 'Geocaching aktivität',
+        'Nachtwanderung vorbereiten', 'Nachtwanderung durchführen',
+    ];
+
+    private array $activityLocations = [
+        // J+S typical locations
+        'Sportplatz', 'Turnhalle', 'Schwimmbad', 'Kletterwand', 'Wiese',
+        'See', 'Fluss', 'Berg', 'Wald', 'Alm', 'Wanderweg',
+        'Lagerplatz', 'Zeltplatz', 'Hütte', 'Biwak', 'Schutzhütte',
+
+        // Specific locations
+        'J+S Zelt', 'Pfadiheim', 'Jugendherberge', 'Sportanlage',
+        'Naturfreundehaus', 'Campwiese', 'Gipfel', 'Bergsee',
+        'Zeltplatz Obwalden', 'Schlucht', 'Spielwiese', 'Klettergrube',
+    ];
+
+    private array $materialItems = [
+        ['article' => 'Fussbälle', 'quantity' => 5, 'unit' => 'Stück'],
+        ['article' => 'Volleybälle', 'quantity' => 3, 'unit' => 'Stück'],
+        ['article' => 'Netz', 'quantity' => 1, 'unit' => 'Stück'],
+        ['article' => 'Schlauchboote', 'quantity' => 4, 'unit' => 'Stück'],
+        ['article' => 'Schwimmwesten', 'quantity' => 20, 'unit' => 'Stück'],
+        ['article' => 'Seile', 'quantity' => 10, 'unit' => 'Meter'],
+        ['article' => 'Karabiner', 'quantity' => 30, 'unit' => 'Stück'],
+        ['article' => 'Helme', 'quantity' => 15, 'unit' => 'Stück'],
+        ['article' => 'Erste-Hilfe-Set', 'quantity' => 2, 'unit' => 'Stück'],
+        ['article' => 'Wasserkannen', 'quantity' => 5, 'unit' => 'Stück'],
+        ['article' => 'Becher', 'quantity' => 50, 'unit' => 'Stück'],
+        ['article' => 'Teller', 'quantity' => 50, 'unit' => 'Stück'],
+        ['article' => 'Besteck', 'quantity' => 50, 'unit' => 'Stück'],
+        ['article' => 'Gaskocher', 'quantity' => 3, 'unit' => 'Stück'],
+        ['article' => 'Gasflaschen', 'quantity' => 6, 'unit' => 'Stück'],
+        ['article' => 'Töpfe', 'quantity' => 5, 'unit' => 'Stück'],
+        ['article' => 'Pfannen', 'quantity' => 3, 'unit' => 'Stück'],
+        ['article' => 'Laternen', 'quantity' => 10, 'unit' => 'Stück'],
+        ['article' => 'Batterien', 'quantity' => 20, 'unit' => 'Stück'],
+        ['article' => 'Karten', 'quantity' => 5, 'unit' => 'Stück'],
+        ['article' => 'Kompass', 'quantity' => 5, 'unit' => 'Stück'],
+        ['article' => 'Zelte', 'quantity' => 10, 'unit' => 'Stück'],
+        ['article' => 'Schlafsäcke', 'quantity' => 40, 'unit' => 'Stück'],
+        ['article' => 'Isomatten', 'quantity' => 40, 'unit' => 'Stück'],
+        ['article' => 'Bastelmaterial', 'quantity' => 1, 'unit' => 'Kiste'],
+        ['article' => 'Farben', 'quantity' => 1, 'unit' => 'Kiste'],
+        ['article' => 'Pinsel', 'quantity' => 20, 'unit' => 'Stück'],
+        ['article' => 'Papier', 'quantity' => 10, 'unit' => 'Bögen'],
+        ['article' => 'Stifte', 'quantity' => 50, 'unit' => 'Stück'],
+        ['article' => 'Klebeband', 'quantity' => 5, 'unit' => 'Rollen'],
+        ['article' => 'Scheren', 'quantity' => 10, 'unit' => 'Stück'],
+    ];
+
+    private array $checklistItems = [
+        // Camp organization
+        'Lagerplatz reservieren', 'Lagerplatz besichtigen', 'Lagerplatz mieten',
+        'Lagerleitung wählen', 'Co-Leitung wählen', 'Küchenleitung wählen',
+        'Teilnehmer einladen', 'Teilnehmerliste erstellen', 'Elternbrief schreiben',
+        'Versicherung prüfen', 'Gesundheitszeugnisse sammeln', 'Ernährungskonzept erstellen',
+        'Einkaufsliste erstellen', 'Materialliste erstellen', 'Transport organisieren',
+        'Notfallplan erstellen', 'Erste-Hilfe-Koffer packen', 'Medikamente organisieren',
+        'Wetterbericht checken', 'Ausrüstung prüfen', 'Zelte prüfen',
+        'Kochutensilien prüfen', 'Sportgeräte prüfen', 'Sicherheitsausrüstung prüfen',
+
+        // Food and kitchen
+        'Frühstück planen', 'Mittagessen kochen', 'Abendessen vorbereiten',
+        'Nachtessen organisieren', 'Snacks einkaufen', 'Getränke besorgen',
+        'Küche aufbauen', 'Spülbecken organisieren', 'Abwasch organisieren',
+        'Essensplan erstellen', 'Allergien beachten', 'Vegetarier berücksichtigen',
+
+        // Program and activities
+        'Morgenrunde durchführen', 'Morgengymnastik', 'Freizeitaktivität planen',
+        'Sportprogramm erstellen', 'Wanderung planen', 'Nachtwanderung vorbereiten',
+        'Lagerfeuer entfachen', 'Grillen organisieren', 'Bastelworkshop vorbereiten',
+        'Theaterstück einüben', 'Tanzabend organisieren', 'Musikworkshop vorbereiten',
+
+        // Safety and first aid
+        'Erste-Hilfe-Kiste kontrollieren', 'Verbandsmaterial prüfen', 'Notfallübung durchführen',
+        'Rettungsweg kennen', 'Sicherheitsregeln besprechen', 'Unfallmeldebogen erstellen',
+        'Feuerschutz beachten', 'Wassersicherheitsregeln', 'Wetterwarnungen beachten',
+
+        // Logistics and cleanup
+        'Zeltaufbau durchführen', 'Zeltabbau planen', 'Lagerplatz reinigen',
+        'Abfallentsorgung organisieren', 'Müll trennen', 'Umweltschutzmaßnahmen',
+        'Materialverpackung organisieren', 'Transport zum Lagerplatz', 'Materialrückgabe planen',
+
+        // Communication and documentation
+        'Lagerprotokoll führen', 'Fotos machen', 'Bericht schreiben',
+        'Elterninformationen senden', 'Teilnehmerzertifikate erstellen', 'Evaluation durchführen',
+        'Feedback einholen', 'Dokumentation archivieren', 'Abschlussfeier organisieren',
+
+        // Equipment and materials
+        'Seile kontrollieren', 'Karabiner prüfen', 'Helme zählen',
+        'Kletterausrüstung prüfen', 'Wanderkarten besorgen', 'Kompass kontrollieren',
+        'Kochgeschirr reinigen', 'Geschirr spülen', 'Materialliste aktualisieren',
+        'Werkzeug organisieren', 'Bastelmaterial vorbereiten', 'Sportgeräte bereitstellen',
+
+        // J+S specific
+        'J+S Ausbildungsziele definieren', 'Lagerprogramm erstellen', 'Tagesprogramm planen',
+        'Aktivitäten dokumentieren', 'Lagerleitungssitzung', 'Ressourcen planen',
+        'Aufgaben verteilen', 'Verantwortlichkeiten klären', 'Absprachen halten',
+    ];
+
+    public function __construct(private readonly EntityManagerInterface $entityManager) {}
+
+    /**
+     * @psalm-suppress InvalidArgument
+     */
+    public function initialize(int $seed, string $addUserToCamp): void {
+        if (null === $this->faker) {
+            $this->faker = FakerFactory::create('de_CH');
+            $this->faker->seed($seed);
+        }
+
+        $contentTypes = $this->entityManager
+            ->getRepository(ContentType::class)
+            ->findAll()
+        ;
+        $this->contentTypes = array_combine(
+            array_column($contentTypes, 'name'),
+            $contentTypes
+        );
+
+        $this->addUserToCamp = $this->findUserToAdd($addUserToCamp);
+    }
+
+    public function createRealisticCamp(int $activitiesPerCamp = 20, int $scheduleEntriesPerActivity = 1): Camp {
+        $owner = $this->createUser();
+
+        $camp = new Camp();
+        $camp->shortTitle = $this->faker->randomElement($this->campTypes).' '.$this->faker->numberBetween(2023, 2026);
+        $camp->title = $this->faker->sentence(3);
+        $camp->motto = $this->faker->sentence(6);
+        $camp->addressName = $this->faker->company();
+        $camp->addressStreet = $this->faker->streetAddress();
+        $camp->addressZipcode = $this->faker->postcode();
+        $camp->addressCity = $this->faker->city();
+        $camp->owner = $owner;
+        $camp->creator = $owner;
+        $camp->isPrototype = false;
+        $camp->isShared = false;
+        $camp->randomlyGenerated = true;
+
+        $this->entityManager->persist($camp);
+        ++$this->stats['camps'];
+
+        $period = $this->createPeriod($camp);
+        ++$this->stats['periods'];
+
+        $categories = $this->createCategories($camp);
+        $this->stats['categories'] += count($categories);
+
+        $materialLists = $this->createMaterialLists($camp);
+        $this->stats['materialLists'] += count($materialLists);
+
+        $checklistItems = $this->createChecklists($camp);
+
+        $activities = $this->createActivities($camp, $categories, $activitiesPerCamp, $period, $scheduleEntriesPerActivity, $checklistItems);
+        $this->stats['activities'] += count($activities);
+
+        $this->createCampCollaborations($camp, $owner);
+        ++$this->stats['campCollaborations'];
+
+        return $camp;
+    }
+
+    public function getStatistics(): array {
+        return $this->stats;
+    }
+
+    private function findUserToAdd($addUserToCamp): User {
+        $profileRepository = $this->entityManager->getRepository(Profile::class);
+        $profile = $profileRepository->findOneBy(['email' => $addUserToCamp]);
+
+        if (null === $profile) {
+            throw new \RuntimeException("{$addUserToCamp} profile not found. Maybe you need run dev-data migrations first.");
+        }
+
+        return $profile->user;
+    }
+
+    private function createPeriod(Camp $camp): Period {
+        $period = new Period();
+        $period->camp = $camp;
+        $period->description = $this->faker->sentence(4);
+
+        // Random start date within next 2 years
+        $startDate = $this->faker->dateTimeBetween('+1 month', '+2 years');
+        $period->start = \DateTime::createFromInterface($startDate);
+
+        // Period length between 5 and 10 days
+        $duration = $this->faker->numberBetween(5, 10);
+        $endDate = (clone $startDate)->modify("+{$duration} days");
+        $period->end = \DateTime::createFromInterface($endDate);
+
+        $this->entityManager->persist($period);
+
+        // Create days
+        $currentDate = clone $startDate;
+        while ($currentDate <= $endDate) {
+            $day = new Day();
+            $day->period = $period;
+            $day->dayOffset = (int) $startDate->diff($currentDate)->days;
+            $this->entityManager->persist($day);
+            ++$this->stats['days'];
+
+            $currentDate->modify('+1 day');
+        }
+
+        return $period;
+    }
+
+    private function createCategories(Camp $camp): array {
+        $categories = [];
+
+        foreach ($this->activityCategories as $categoryData) {
+            $category = new Category();
+            $category->camp = $camp;
+            $category->short = $categoryData['short'];
+            $category->name = $categoryData['name'];
+            $category->color = $categoryData['color'];
+            $category->numberingStyle = $this->faker->randomElement(['1', 'A', 'I', 'a', 'i']);
+
+            $this->entityManager->persist($category);
+            $categories[] = $category;
+
+            $rootContentNode = new ColumnLayout();
+            $rootContentNode->root = $rootContentNode;
+            $rootContentNode->parent = null;
+            $rootContentNode->slot = null;
+            $rootContentNode->position = 0;
+            $rootContentNode->contentType = $this->contentTypes['ColumnLayout'];
+            $rootContentNode->instanceName = $categoryData['name'];
+            $rootContentNode->data = json_decode(ColumnLayout::DATA_DEFAULT, true);
+
+            $this->entityManager->persist($rootContentNode);
+            $category->rootContentNode = $rootContentNode;
+            ++$this->stats['contentNodes'];
+        }
+
+        return $categories;
+    }
+
+    private function createActivities(
+        Camp $camp,
+        array $categories,
+        int $count,
+        Period $period,
+        int $scheduleEntriesPerActivity,
+        array $checklistItems
+    ): array {
+        $activities = [];
+        $days = $period->days->getValues();
+
+        for ($i = 0; $i < $count; ++$i) {
+            $activity = new Activity();
+            $activity->camp = $camp;
+            $activity->title = $this->faker->randomElement($this->activityNames);
+            $activity->location = $this->faker->randomElement($this->activityLocations);
+
+            $activity->category = $this->faker->randomElement($categories);
+
+            $rootContentNode = new ColumnLayout();
+            $rootContentNode->root = $rootContentNode;
+            $rootContentNode->parent = null;
+            $rootContentNode->slot = null;
+            $rootContentNode->position = 0;
+            $rootContentNode->contentType = $this->contentTypes['ColumnLayout'];
+            $rootContentNode->instanceName = $activity->title;
+            $rootContentNode->data = json_decode(ColumnLayout::DATA_DEFAULT, true);
+
+            $this->entityManager->persist($rootContentNode);
+            ++$this->stats['contentNodes'];
+
+            $activity->rootContentNode = $rootContentNode;
+
+            $this->addContentToActivity($rootContentNode, $camp, $checklistItems);
+
+            $this->entityManager->persist($activity);
+            $activities[] = $activity;
+            $numberOfScheduleEntries = $this->faker->numberBetween(max(0, $scheduleEntriesPerActivity - 2), $scheduleEntriesPerActivity + 2);
+
+            for ($j = 0; $j < $numberOfScheduleEntries; ++$j) {
+                $this->createScheduleEntry($activity, $period, $days);
+            }
+        }
+
+        return $activities;
+    }
+
+    private function addContentToActivity(ColumnLayout $rootContentNode, Camp $camp, array $checklistItems): void {
+        $responsiveLayout = new ResponsiveLayout();
+        $responsiveLayout->root = $rootContentNode;
+        $responsiveLayout->parent = $rootContentNode;
+        $responsiveLayout->slot = '1';
+        $responsiveLayout->position = 0;
+        $responsiveLayout->contentType = $this->contentTypes['ResponsiveLayout'];
+        $responsiveLayout->instanceName = 'Responsive Content';
+
+        $this->entityManager->persist($responsiveLayout);
+        ++$this->stats['contentNodes'];
+
+        $singleText = new SingleText();
+        $singleText->root = $rootContentNode;
+        $singleText->parent = $responsiveLayout;
+        $singleText->slot = 'main';
+        $singleText->position = 0;
+        $singleText->contentType = $this->contentTypes['Notes'];
+        $singleText->instanceName = 'Beschreibung';
+        $singleText->data = ['text' => $this->faker->paragraphs(3, true)];
+
+        $this->entityManager->persist($singleText);
+        ++$this->stats['contentNodes'];
+
+        $materialNode = new MaterialNode();
+        $materialNode->root = $rootContentNode;
+        $materialNode->parent = $responsiveLayout;
+        $materialNode->slot = 'aside-top';
+        $materialNode->position = 0;
+        $materialNode->contentType = $this->contentTypes['Material'];
+        $materialNode->instanceName = 'Material';
+
+        $this->entityManager->persist($materialNode);
+        ++$this->stats['contentNodes'];
+
+        $numMaterialItems = $this->faker->numberBetween(2, 5);
+        foreach ($this->faker->randomElements($this->materialItems, $numMaterialItems) as $itemData) {
+            $materialItem = new MaterialItem();
+            $materialItem->camp = $camp;
+            $materialItem->article = $itemData['article'];
+            $materialItem->quantity = $this->faker->numberBetween(1, $itemData['quantity']);
+            $materialItem->unit = $itemData['unit'];
+            $materialItem->materialNode = $materialNode;
+            $this->entityManager->persist($materialItem);
+            ++$this->stats['materialItems'];
+        }
+
+        $storyboard = new Storyboard();
+        $storyboard->root = $rootContentNode;
+        $storyboard->parent = $responsiveLayout;
+        $storyboard->slot = 'aside-bottom';
+        $storyboard->position = 0;
+        $storyboard->contentType = $this->contentTypes['Storyboard'];
+        $storyboard->instanceName = 'Programm';
+        $storyboard->data = ['sections' => [
+            ['position' => 1, 'column1' => '00:00', 'column2' => $this->faker->sentence(5)],
+            ['position' => 2, 'column1' => '00:30', 'column2' => $this->faker->sentence(5)],
+        ]];
+
+        $this->entityManager->persist($storyboard);
+        ++$this->stats['contentNodes'];
+
+        if (count($checklistItems) > 0) {
+            $checklistNode = new ChecklistNode();
+            $checklistNode->root = $rootContentNode;
+            $checklistNode->parent = $rootContentNode;
+            $checklistNode->slot = '2';
+            $checklistNode->position = 0;
+            $checklistNode->contentType = $this->contentTypes['Checklist'];
+
+            $numItems = $this->faker->numberBetween(3, min(8, count($checklistItems)));
+            $selectedItems = $this->faker->randomElements($checklistItems, $numItems);
+            foreach ($selectedItems as $item) {
+                $checklistNode->addChecklistItem($item);
+            }
+
+            $this->entityManager->persist($checklistNode);
+            ++$this->stats['contentNodes'];
+        }
+    }
+
+    private function createScheduleEntry(Activity $activity, Period $period, array $days): ScheduleEntry {
+        $scheduleEntry = new ScheduleEntry();
+        $scheduleEntry->period = $period;
+        $scheduleEntry->activity = $activity;
+
+        $this->faker->randomElement($days);
+
+        $startHour = $this->faker->numberBetween(8, 20);
+        $duration = $this->faker->numberBetween(30, 180);
+        $startOffset = $startHour * 60;
+        $endOffset = $startOffset + $duration;
+
+        $scheduleEntry->startOffset = $startOffset;
+        $scheduleEntry->endOffset = $endOffset;
+
+        $this->entityManager->persist($scheduleEntry);
+        ++$this->stats['scheduleEntries'];
+
+        return $scheduleEntry;
+    }
+
+    private function createMaterialLists(Camp $camp): array {
+        $materialLists = [];
+
+        // Create general material list
+        $generalList = new MaterialList();
+        $generalList->camp = $camp;
+        $generalList->name = 'Allgemeine Materialliste';
+        $this->entityManager->persist($generalList);
+        $materialLists[] = $generalList;
+
+        // Add some material items to general list
+        foreach ($this->faker->randomElements($this->materialItems, 8) as $itemData) {
+            $materialItem = new MaterialItem();
+            $materialItem->camp = $camp;
+            $materialItem->article = $itemData['article'];
+            $materialItem->quantity = $this->faker->numberBetween(1, $itemData['quantity']);
+            $materialItem->unit = $itemData['unit'];
+            $materialItem->materialList = $generalList;
+            $this->entityManager->persist($materialItem);
+            ++$this->stats['materialItems'];
+        }
+
+        $shoppingList = new MaterialList();
+        $shoppingList->camp = $camp;
+        $shoppingList->name = 'Einkaufsliste';
+        $this->entityManager->persist($shoppingList);
+        $materialLists[] = $shoppingList;
+
+        foreach ($this->faker->randomElements($this->materialItems, 4) as $itemData) {
+            $materialItem = new MaterialItem();
+            $materialItem->camp = $camp;
+            $materialItem->article = $itemData['article'];
+            $materialItem->quantity = $this->faker->numberBetween(1, $itemData['quantity']);
+            $materialItem->unit = $itemData['unit'];
+            $materialItem->materialList = $shoppingList;
+            $this->entityManager->persist($materialItem);
+            ++$this->stats['materialItems'];
+        }
+
+        return $materialLists;
+    }
+
+    private function createCampCollaborations(Camp $camp, User $owner): void {
+        $managerCollaboration = new CampCollaboration();
+        $managerCollaboration->camp = $camp;
+        $managerCollaboration->user = $owner;
+        $managerCollaboration->role = 'manager';
+        $managerCollaboration->status = 'established';
+        $managerCollaboration->inviteEmail = $owner->profile->email;
+        $this->entityManager->persist($managerCollaboration);
+
+        $sitCollaboration = new CampCollaboration();
+        $sitCollaboration->camp = $camp;
+        $sitCollaboration->user = $this->addUserToCamp;
+        $sitCollaboration->role = 'manager';
+        $sitCollaboration->status = 'established';
+        $this->entityManager->persist($sitCollaboration);
+
+        $numCollaborators = $this->faker->numberBetween(2, 8);
+        for ($i = 0; $i < $numCollaborators; ++$i) {
+            $collaborator = $this->createUser();
+            $collaboration = new CampCollaboration();
+            $collaboration->camp = $camp;
+            $collaboration->user = $collaborator;
+            $collaboration->role = $this->faker->randomElement(['member', 'guest']);
+            $collaboration->status = 'established';
+            $collaboration->inviteEmail = $collaborator->profile->email;
+            $this->entityManager->persist($collaboration);
+        }
+    }
+
+    /**
+     * @return ChecklistItem[] Flat array of all created ChecklistItems
+     */
+    private function createChecklists(Camp $camp): array {
+        $allChecklistItems = [];
+
+        $jsChecklist = new Checklist();
+        $jsChecklist->camp = $camp;
+        $jsChecklist->name = 'J+S Ausbildungsziele';
+        $this->entityManager->persist($jsChecklist);
+        ++$this->stats['checklists'];
+
+        $items = $this->createChecklistItems($jsChecklist, $this->faker->numberBetween(5, 8));
+        $allChecklistItems = array_merge($allChecklistItems, $items);
+
+        $generalChecklist = new Checklist();
+        $generalChecklist->camp = $camp;
+        $generalChecklist->name = 'Allgemeine Checkliste';
+        $this->entityManager->persist($generalChecklist);
+        ++$this->stats['checklists'];
+
+        $items = $this->createChecklistItems($generalChecklist, $this->faker->numberBetween(4, 6));
+        $allChecklistItems = array_merge($allChecklistItems, $items);
+
+        $logisticsChecklist = new Checklist();
+        $logisticsChecklist->camp = $camp;
+        $logisticsChecklist->name = 'Logistik Checkliste';
+        $this->entityManager->persist($logisticsChecklist);
+        ++$this->stats['checklists'];
+
+        $items = $this->createChecklistItems($logisticsChecklist, $this->faker->numberBetween(3, 5));
+
+        return array_merge($allChecklistItems, $items);
+    }
+
+    /**
+     * Create checklist items for a given checklist
+     * Items are created with a realistic 3-level nested structure.
+     *
+     * @param Checklist $checklist The checklist to add items to
+     * @param int       $itemCount Number of top-level items to create
+     *
+     * @return ChecklistItem[] Flat array of all created ChecklistItems (including children and grandchildren)
+     */
+    private function createChecklistItems(Checklist $checklist, int $itemCount): array {
+        $allItems = [];
+
+        $shuffledItems = $this->faker->shuffle($this->checklistItems);
+        $itemIndex = 0;
+
+        for ($i = 0; $i < $itemCount; ++$i) {
+            if ($itemIndex >= count($shuffledItems)) {
+                $itemIndex = 0;
+            }
+
+            $parentItem = new ChecklistItem();
+            $parentItem->checklist = $checklist;
+            $parentItem->parent = null;
+            $parentItem->position = $i;
+            $parentItem->text = $shuffledItems[$itemIndex++];
+            $this->entityManager->persist($parentItem);
+            ++$this->stats['checklistItems'];
+            $allItems[] = $parentItem;
+
+            $numChildren = $this->faker->numberBetween(2, 4);
+            for ($j = 0; $j < $numChildren; ++$j) {
+                if ($itemIndex >= count($shuffledItems)) {
+                    $itemIndex = 0;
+                }
+
+                $childItem = new ChecklistItem();
+                $childItem->checklist = $checklist;
+                $childItem->parent = $parentItem;
+                $childItem->position = $j;
+                $childItem->text = $shuffledItems[$itemIndex++];
+                $this->entityManager->persist($childItem);
+                ++$this->stats['checklistItems'];
+                $allItems[] = $childItem;
+
+                $numGrandchildren = $this->faker->numberBetween(1, 3);
+                for ($k = 0; $k < $numGrandchildren; ++$k) {
+                    if ($itemIndex >= count($shuffledItems)) {
+                        $itemIndex = 0;
+                    }
+
+                    $grandchildItem = new ChecklistItem();
+                    $grandchildItem->checklist = $checklist;
+                    $grandchildItem->parent = $childItem;
+                    $grandchildItem->position = $k;
+                    $grandchildItem->text = $shuffledItems[$itemIndex++];
+                    $this->entityManager->persist($grandchildItem);
+                    ++$this->stats['checklistItems'];
+                    $allItems[] = $grandchildItem;
+                }
+            }
+        }
+
+        return $allItems;
+    }
+
+    private function createUser(): User {
+        $profile = new Profile();
+        $profile->firstname = $this->faker->firstName();
+        $profile->surname = $this->faker->lastName();
+        $profile->email = $this->faker->firstName().IdGenerator::generateRandomHexString(10).'@'.$this->faker->safeEmailDomain();
+        $profile->nickname = $this->faker->userName();
+        $profile->language = $this->faker->randomElement(['de', 'it', 'fr']);
+
+        $user = new User();
+        $user->state = User::STATE_ACTIVATED;
+        $user->profile = $profile;
+        $user->plainPassword = 'test';
+
+        $this->entityManager->persist($profile);
+        $this->entityManager->persist($user);
+
+        return $user;
+    }
+}

--- a/api/tests/Command/GenerateDataCommandTest.php
+++ b/api/tests/Command/GenerateDataCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\GenerateDataCommand;
+use App\Entity\Profile;
+use App\Tests\Api\ECampApiTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+class GenerateDataCommandTest extends ECampApiTestCase {
+    private CommandTester $commandTester;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $application = new Application(self::$kernel);
+        $application->setAutoExit(false);
+        $command = $application->find(GenerateDataCommand::APP_GENERATE_DATA_COMMAND);
+        $this->commandTester = new CommandTester($command);
+    }
+
+    public function testGenerateData() {
+        /** @var Profile $profile7Manager */
+        $profile7Manager = static::getFixture('profile7manager');
+        $this->commandTester->execute([
+            'num-camps' => '10',
+            '--add-user-to-camp' => $profile7Manager->email,
+        ]);
+
+        $this->commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testReplaceGeneratedData() {
+        /** @var Profile $profile7Manager */
+        $profile7Manager = static::getFixture('profile7manager');
+        $this->commandTester->execute([
+            'num-camps' => '10',
+            '--add-user-to-camp' => $profile7Manager->email,
+            '--replace' => 'true',
+        ]);
+
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $this->commandTester->execute([
+            'num-camps' => '10',
+            '--add-user-to-camp' => $profile7Manager->email,
+            '--replace' => 'true',
+        ]);
+
+        $this->commandTester->assertCommandIsSuccessful();
+    }
+}


### PR DESCRIPTION
api: add command to generate data

That we can reproduce the performance issues we have with the checklists
without using a production dump.
The cascading doesn't work right for the checklist_items,
so I added a loop for them that they can be deleted.
The replace option is for the dev deployment that we can
change the command and then the generated data is updated.
Do not use a hook because generating the data can take a while.
Also use a native query to delete the camps. Using doctrine worked when executing the command,
but didn't work it the test. And it is way faster.