### PR TITLE
fix regex for composer updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -158,7 +158,7 @@
       "depNameTemplate": "composer",
       "packageNameTemplate": "composer/composer",
       "datasourceTemplate": "github-tags",
-      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+).*?$"
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<prerelease>\\w+))?$"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
Fixes composer regex to properly identify prereleases

Hope this fixes automatic composer updates in our workflows