### PR TITLE
aws-setup: fix deprecations

### DIFF
--- a/.ops/aws-setup/index.ts
+++ b/.ops/aws-setup/index.ts
@@ -1,5 +1,11 @@
 import { AccessKey, Policy, User, UserPolicyAttachment } from '@pulumi/aws/iam'
-import { Bucket } from '@pulumi/aws/s3'
+import {
+  Bucket,
+  BucketAcl,
+  BucketLifecycleConfiguration,
+  BucketObjectLockConfiguration,
+  BucketVersioning,
+} from '@pulumi/aws/s3'
 import { Config, interpolate } from '@pulumi/pulumi'
 
 const config = new Config()
@@ -24,25 +30,41 @@ if (environment === 'dev') {
   objectLockRetentionDays = 8
 }
 
-const backupBucket = new Bucket(`ecamp3-${environment}-bucket`, {
+const backupBucket = new Bucket(`ecamp3-${environment}-bucket`, {})
+
+new BucketAcl(`ecamp3-${environment}-bucket-acl`, {
+  bucket: backupBucket.id,
   acl: 'private',
-  versioning: {
-    enabled: true,
+})
+
+new BucketVersioning(`ecamp3-${environment}-bucket-versioning`, {
+  bucket: backupBucket.id,
+  versioningConfiguration: {
+    status: 'Enabled',
   },
-  lifecycleRules: [
+})
+
+new BucketLifecycleConfiguration(`ecamp3-${environment}-bucket-lifecycle`, {
+  bucket: backupBucket.id,
+  rules: [
     {
-      enabled: true,
-      abortIncompleteMultipartUploadDays: 1,
+      id: 'retention',
+      status: 'Enabled',
+      filter: {},
+      abortIncompleteMultipartUpload: {
+        daysAfterInitiation: 1,
+      },
       ...retentionPolicies,
     },
   ],
-  objectLockConfiguration: {
-    objectLockEnabled: 'Enabled',
-    rule: {
-      defaultRetention: {
-        mode: 'GOVERNANCE',
-        days: objectLockRetentionDays,
-      },
+})
+
+new BucketObjectLockConfiguration(`ecamp3-${environment}-bucket-object-lock`, {
+  bucket: backupBucket.id,
+  rule: {
+    defaultRetention: {
+      mode: 'GOVERNANCE',
+      days: objectLockRetentionDays,
     },
   },
 })


### PR DESCRIPTION
Deprecations were:
 aws:s3:Bucket (ecamp3-staging-bucket):
    warning: urn:pulumi:staging::ecamp-core::aws:s3/bucket:Bucket::ecamp3-staging-bucket verification warning: property "versioning" is deprecated: versioning is deprecated. Use the aws_s3_bucket_versioning resource instead.
    warning: urn:pulumi:staging::ecamp-core::aws:s3/bucket:Bucket::ecamp3-staging-bucket verification warning: property "objectLockConfiguration.objectLockEnabled" is deprecated: objectLockEnabled is deprecated. Use the top-level parameter objectLockEnabled instead.
    warning: urn:pulumi:staging::ecamp-core::aws:s3/bucket:Bucket::ecamp3-staging-bucket verification warning: property "objectLockConfiguration.rule" is deprecated: rule is deprecated. Use the aws_s3_bucket_object_lock_configuration resource instead.
    warning: urn:pulumi:staging::ecamp-core::aws:s3/bucket:Bucket::ecamp3-staging-bucket verification warning: property "objectLockConfiguration" is deprecated: objectLockConfiguration is deprecated. Use the top-level parameter objectLockEnabled and the aws_s3_bucket_object_lock_configuration resource instead.
    warning: urn:pulumi:staging::ecamp-core::aws:s3/bucket:Bucket::ecamp3-staging-bucket verification warning: property "acl" is deprecated: acl is deprecated. Use the aws_s3_bucket_acl resource instead.
    warning: urn:pulumi:staging::ecamp-core::aws:s3/bucket:Bucket::ecamp3-staging-bucket verification warning: property "lifecycleRules" is deprecated: lifecycleRules is deprecated. Use the aws_s3_bucket_lifecycle_configuration resource instead.

Checked against staging with.
$ docker compose run --rm aws-setup pulumi preview
     Type                                     Name                               Plan       Info
     pulumi:pulumi:Stack                      ecamp-core-staging
 ~   ├─ aws:s3:Bucket                         ecamp3-staging-bucket              update     [diff: +tagsAll]
 +   ├─ aws:s3:BucketVersioning               ecamp3-staging-bucket-versioning   create
 +   ├─ aws:s3:BucketObjectLockConfiguration  ecamp3-staging-bucket-object-lock  create
 +   ├─ aws:s3:BucketAcl                      ecamp3-staging-bucket-acl          create
 +   └─ aws:s3:BucketLifecycleConfiguration   ecamp3-staging-bucket-lifecycle    create

But did not apply it.

It will anyway need caution if we ever run this again.