### PR TITLE
hook_db_create.yaml: set owner of new database

### DIFF
--- a/.helm/ecamp3/templates/hook_db_create.yaml
+++ b/.helm/ecamp3/templates/hook_db_create.yaml
@@ -24,7 +24,11 @@ spec:
       containers:
         - name: db-create-job
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Values.imageTag }}"
-          command: ["php", "bin/console", "doctrine:database:create", "--if-not-exists"]
+          command:
+            - sh
+            - "-c"
+            - |
+              php bin/console dbal:run-sql 'CREATE DATABASE "{{ .Values.postgresql.dbName }}" OWNER "{{ .Values.postgresql.user }}"'
           env:
             - name: DATABASE_URL
               valueFrom:

--- a/.helm/ecamp3/templates/hook_db_drop.yaml
+++ b/.helm/ecamp3/templates/hook_db_drop.yaml
@@ -24,7 +24,11 @@ spec:
       containers:
         - name: db-drop-job
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Values.imageTag }}"
-          command: ["php", "bin/console", "doctrine:database:drop", "--if-exists", "-f"]
+          command:
+            - sh
+            - "-c"
+            - |
+              php bin/console dbal:run-sql 'DROP DATABASE "{{ .Values.postgresql.dbName }}"'
           env:
             - name: DATABASE_URL
               valueFrom:

--- a/.helm/ecamp3/values.yaml.gotmpl
+++ b/.helm/ecamp3/values.yaml.gotmpl
@@ -168,10 +168,12 @@ postgresql:
   # An uri with privileges to create and drop a database for the application.
   # Can be left empty if the required database specified in postgresql.url already exists.
   {{ if .Environment.Values | getOrNil "POSTGRES_ADMIN_URL" | default false }}
-  adminUrl: "{{ .Environment.Values | getOrNil "POSTGRES_ADMIN_URL" }}/ecamp3{{ $name }}?sslmode=require"
+  adminUrl: "{{ .Environment.Values | getOrNil "POSTGRES_ADMIN_URL" }}/postgres?sslmode=require"
   {{ else }}
   adminUrl:
   {{ end }}
+  user: "{{ .Environment.Values | getOrNil "POSTGRES_DEPLOYMENT_USER" | default "ecamp3dev" }}"
+  dbName: "ecamp3{{ $dbNameSuffix }}"
   dbBackupRestoreImage:
     repository: "docker.io/{{ $dockerUser }}/ecamp3-db-backup-restore"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
With the change of digitalocean to the postgres service,
you must be owner of the database to create extensions.
digitalocean seems hesitant to revert to its previous behavior.
For that to work, the DATABASE_ADMIN_URL needs an existing database in the url, else we have the error that the database to connect to doesn't exist.

fixes #9857