### PR TITLE
renovate.json: group playwright updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -88,6 +88,14 @@
       "matchDepNames": ["cypress", "cypress/included"],
       "automerge": false,
       "groupName": "cypress"
+    },
+    {
+      "groupName": "playwright",
+      "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"]
+    },
+    {
+      "matchPackageNames": ["mcr.microsoft.com/playwright"],
+      "minimumReleaseAge": "0 days"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
They have to be updated together.
The mcr registry does not offer minimumReleaesAge, so we have to remove the minimumReleaseAge requirement for the docker image.

See the result here:
https://github.com/BacLuc/ecamp3/pull/324