### PR TITLE
frontend: fix development setup

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -119,6 +119,7 @@ export default defineConfig(({ mode }) => ({
       // 'vuetify/es5/components/VCalendar/modes/column.js',
       // 'vuetify/es5/components/VCalendar/util/events.js',
     ],
+    exclude: ['vue-i18n'],
   },
   build: {
     sourcemap: true,


### PR DESCRIPTION
After an update of either vite or vue-i18n, we can't optimize vue-i18n anymore.