### PR TITLE
fix: typo 'then' -> 'than' in AssertLessThanOrEqualToEarliestScheduleEntryStart message

### DIFF
--- a/api/src/Validator/Period/AssertLessThanOrEqualToEarliestScheduleEntryStart.php
+++ b/api/src/Validator/Period/AssertLessThanOrEqualToEarliestScheduleEntryStart.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class AssertLessThanOrEqualToEarliestScheduleEntryStart extends Constraint {
     public function __construct(
-        public readonly string $message = 'Due to existing schedule entries, start-date can not be later then {{ startDate }}',
+        public readonly string $message = 'Due to existing schedule entries, start-date can not be later than {{ startDate }}',
         ?array $groups = null,
         $payload = null
     ) {

--- a/api/tests/Api/Periods/UpdatePeriodTest.php
+++ b/api/tests/Api/Periods/UpdatePeriodTest.php
@@ -527,7 +527,7 @@ at position 10: Trailing data',
             'violations' => [
                 [
                     'propertyPath' => 'start',
-                    'message' => 'Due to existing schedule entries, start-date can not be later then 2023-03-25',
+                    'message' => 'Due to existing schedule entries, start-date can not be later than 2023-03-25',
                 ],
             ],
         ]);


### PR DESCRIPTION


Fixes https://github.com/ecamp/ecamp3/issues/9017