### PR TITLE
fix: typo 'then' -> 'than' in AssertGreaterThanOrEqualToLastScheduleEntryEnd message

### DIFF
--- a/api/src/Validator/Period/AssertGreaterThanOrEqualToLastScheduleEntryEnd.php
+++ b/api/src/Validator/Period/AssertGreaterThanOrEqualToLastScheduleEntryEnd.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class AssertGreaterThanOrEqualToLastScheduleEntryEnd extends Constraint {
     public function __construct(
-        public readonly string $message = 'Due to existing schedule entries, end-date can not be earlier then {{ endDate }}',
+        public readonly string $message = 'Due to existing schedule entries, end-date can not be earlier than {{ endDate }}',
         ?array $groups = null,
         $payload = null
     ) {

--- a/api/tests/Api/Periods/UpdatePeriodTest.php
+++ b/api/tests/Api/Periods/UpdatePeriodTest.php
@@ -549,7 +549,7 @@ at position 10: Trailing data',
             'violations' => [
                 [
                     'propertyPath' => 'end',
-                    'message' => 'Due to existing schedule entries, end-date can not be earlier then 2023-03-25',
+                    'message' => 'Due to existing schedule entries, end-date can not be earlier than 2023-03-25',
                 ],
             ],
         ]);


### PR DESCRIPTION


Fixes https://github.com/ecamp/ecamp3/issues/9016