### PR TITLE
feat: add @mature tag to all Playwright tests and split CI e2e runs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -498,6 +498,8 @@ jobs:
     needs:
       - e2e-tests-build
     uses: ./.github/workflows/reusable-e2e-tests-run.yml
+    with:
+      grep-filter: '@mature'
 
   coveralls-finished:
     name: 'Finish coveralls report'

--- a/.github/workflows/e2e-tests-all.yml
+++ b/.github/workflows/e2e-tests-all.yml
@@ -1,0 +1,57 @@
+name: 'Tests: All End-to-End (including non-mature)'
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+  pull_request:
+    types: [labeled]
+    branches:
+      - staging
+      - prod
+  push:
+    branches:
+      - devel
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  check-trigger:
+    name: 'Check if workflow should run'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - id: check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "$BASE_REF" = "staging" ] || [ "$BASE_REF" = "prod" ]; then
+              echo "should_run=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            if [ "$LABEL_NAME" = "run-all-e2e-tests!" ]; then
+              echo "should_run=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          LABEL_NAME: ${{ github.event.label.name }}
+
+  e2e-tests-build:
+    name: 'Tests: All e2e build'
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should_run == 'true'
+    uses: ./.github/workflows/reusable-e2e-tests-build.yml
+
+  e2e-tests-run:
+    name: 'Tests: All e2e run'
+    needs:
+      - check-trigger
+      - e2e-tests-build
+    if: needs.check-trigger.outputs.should_run == 'true'
+    uses: ./.github/workflows/reusable-e2e-tests-run.yml

--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -6,6 +6,11 @@ on:
       run-identifier:
         required: false
         type: string
+      grep-filter:
+        required: false
+        type: string
+        default: ''
+        description: 'Playwright --grep filter, e.g. "@mature". Empty means run all tests.'
 
 jobs:
   e2e-tests-run:
@@ -75,10 +80,11 @@ jobs:
       - run: sh -x wait-for-container-startup.sh
 
       - run: >
-          docker compose --profile e2e run 
-          -e CI=true 
-          -e PLAYWRIGHT_BLOB_OUTPUT_NAME=report-${{ matrix.browser }}${{ inputs.run-identifier != '' && format('-{0}', inputs.run-identifier) || '' }}.zip 
+          docker compose --profile e2e run
+          -e CI=true
+          -e PLAYWRIGHT_BLOB_OUTPUT_NAME=report-${{ matrix.browser }}${{ inputs.run-identifier != '' && format('-{0}', inputs.run-identifier) || '' }}.zip
           --rm e2e npx playwright test --project ${{ matrix.browser }}
+          ${{ inputs.grep-filter != '' && format('--grep "{0}"', inputs.grep-filter) || '' }}
 
       - run: sudo chown -R $USER e2e
         if: always()

--- a/e2e/tests/5-cross-browser-tests/clientPrint.spec.ts
+++ b/e2e/tests/5-cross-browser-tests/clientPrint.spec.ts
@@ -6,7 +6,7 @@ import { loginAndSetCookie, mockDateNow } from '@/utils/helpers'
 
 import { readFileSync } from 'fs'
 
-test.describe('Client print test', () => {
+test.describe('Client print test', { tag: '@mature' }, () => {
   test.beforeEach(async ({ page }) => {
     await mockDateNow(page)
   })

--- a/e2e/tests/5-cross-browser-tests/login.spec.ts
+++ b/e2e/tests/5-cross-browser-tests/login.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { mockDateNow } from '@/utils/helpers'
 
-test.describe('Login test', () => {
+test.describe('Login test', { tag: '@mature' }, () => {
   test.beforeEach(async ({ page }) => {
     await mockDateNow(page)
   })

--- a/e2e/tests/5-cross-browser-tests/persistDashboardFilter.spec.ts
+++ b/e2e/tests/5-cross-browser-tests/persistDashboardFilter.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from '@playwright/test'
 import { loginAndSetCookie, mockDateNow } from '@/utils/helpers'
 
-test.describe('The filters in the dashboard', () => {
+test.describe('The filters in the dashboard', { tag: '@mature' }, () => {
   test.beforeEach(async ({ page, request }) => {
     await loginAndSetCookie(page, request, 'test@example.com')
     await mockDateNow(page)

--- a/e2e/tests/9-behavior-tests/category/create-category.ts
+++ b/e2e/tests/9-behavior-tests/category/create-category.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+import { bipiUser } from '@/utils/constants'
+import {
+  loginAndSetCookie,
+  mockDateNow,
+  createCampViaUI,
+  deleteCampViaUI,
+} from '@/utils/helpers'
+
+const campTitle = 'CatTestCamp'
+
+test.describe('category on new camp', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let campAdminBaseUrl: string
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    await mockDateNow(page)
+    await loginAndSetCookie(page, null, bipiUser)
+    campAdminBaseUrl = await createCampViaUI(page, campTitle)
+    await context.close()
+  })
+
+  test.afterAll(async ({ browser }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    await loginAndSetCookie(page, null, bipiUser)
+    await deleteCampViaUI(page, campAdminBaseUrl, campTitle)
+    await context.close()
+  })
+
+  test('creates a new category on the camp', async ({ page, request }) => {
+    await mockDateNow(page)
+    await loginAndSetCookie(page, request, bipiUser)
+
+    await page.goto(`${campAdminBaseUrl}/activity`)
+
+    await page.getByRole('button', { name: /Block-Kategorie erstellen/i }).click()
+
+    const dialog = page.locator('.v-overlay--active')
+    await expect(dialog).toBeVisible({ timeout: 10000 })
+
+    await dialog.locator('[name="short"] input').fill('TC')
+    await dialog.locator('[name="name"] input').fill('Test Category')
+
+    await dialog.getByRole('button', { name: /Erstellen/i }).click()
+
+    await expect(page.getByText('Test Category')).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/e2e/tests/9-behavior-tests/httpCache/activities.spec.ts
+++ b/e2e/tests/9-behavior-tests/httpCache/activities.spec.ts
@@ -57,7 +57,7 @@ const collectionXKeys =
   /* collection URI (for detecting addition of new activities) */
   '/api/camps/70ca971c992f/activities'
 
-test.describe('cache test: /camps/{campId}/activities', () => {
+test.describe('cache test: /camps/{campId}/activities', { tag: '@mature' }, () => {
   test.describe.configure({ mode: 'serial' })
 
   test('caches /camps/{campId}/activities separately for each login', async () => {

--- a/e2e/tests/9-behavior-tests/httpCache/activity.spec.ts
+++ b/e2e/tests/9-behavior-tests/httpCache/activity.spec.ts
@@ -44,7 +44,7 @@ const collectionXKeys =
   'a13fadc97610#embeddedActivityResponsibles ' +
   'a13fadc97610#emptyContentNodesForIriGeneration'
 
-test.describe('cache test: /camps/{campId}/activities', () => {
+test.describe('cache test: /camps/{campId}/activities', { tag: '@mature' }, () => {
   test.describe.configure({ mode: 'serial' })
 
   test('caches /activities/{activitiyId} separately for each login', async () => {

--- a/e2e/tests/9-behavior-tests/httpCache/camps.spec.ts
+++ b/e2e/tests/9-behavior-tests/httpCache/camps.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test'
 import { loginAndSetCookie, expectCachePass } from '@/utils/helpers'
 
-test("doesn't cache /camps", async ({ page, request }) => {
+test("doesn't cache /camps", { tag: '@mature' }, async ({ page, request }) => {
   const uri = '/api/camps'
   await loginAndSetCookie(page, request, 'test@example.com')
   await expectCachePass(request, uri)

--- a/e2e/tests/9-behavior-tests/httpCache/categories.spec.ts
+++ b/e2e/tests/9-behavior-tests/httpCache/categories.spec.ts
@@ -36,7 +36,7 @@ const collectionXKeys =
   /* collection URI (for detecting addition of new categories) */
   '/api/camps/3c79b99ab424/categories'
 
-test.describe('cache test: /camps/{campId}/categories', () => {
+test.describe('cache test: /camps/{campId}/categories', { tag: '@mature' }, () => {
   test.describe.configure({ mode: 'serial' })
 
   test('caches /camps/{campId}/categories separately for each login', async () => {

--- a/e2e/tests/9-behavior-tests/httpCache/checklists.spec.ts
+++ b/e2e/tests/9-behavior-tests/httpCache/checklists.spec.ts
@@ -20,7 +20,7 @@ const collectionXKeys =
   /* collection URI (for detecting addition of new checklists) */
   '/api/camps/5d28f99890bc/checklists'
 
-test.describe('cache test: /camps/checklists', () => {
+test.describe('cache test: /camps/checklists', { tag: '@mature' }, () => {
   test.describe.configure({ mode: 'serial' })
 
   test('caches /camp/{campId}/checklists separately for each login', async () => {

--- a/e2e/tests/9-behavior-tests/httpCache/content-types.spec.ts
+++ b/e2e/tests/9-behavior-tests/httpCache/content-types.spec.ts
@@ -7,7 +7,7 @@ import { expectCacheHit, expectCacheMiss, apiGet, getAuthContext } from '@/utils
 const collectionXKeys =
   'a4211c11211c f17470519474 1a0f84e322c8 c462edd869f3 5e2028c55ee4 3ef17bd1df72 4f0c657fecef a4211c112939 44dcc7493c65 cfccaecd4bad 318e064ea0c9 /api/content_types'
 
-test.describe('cache test: /content-types', () => {
+test.describe('cache test: /content-types', { tag: '@mature' }, () => {
   test.describe.configure({ mode: 'serial' })
 
   test('caches collection separately for each login', async () => {

--- a/e2e/tests/9-behavior-tests/httpCache/days.spec.ts
+++ b/e2e/tests/9-behavior-tests/httpCache/days.spec.ts
@@ -24,7 +24,7 @@ const collectionXKeys =
   /* collection URI (for detecting addition of new days) */
   '/api/periods/76be24bce434/days'
 
-test.describe('cache test: /periods/{periodId}/days', () => {
+test.describe('cache test: /periods/{periodId}/days', { tag: '@mature' }, () => {
   test.describe.configure({ mode: 'serial' })
 
   test('caches /periods/{periodId}/days separately for each login', async () => {

--- a/e2e/tests/9-behavior-tests/httpCache/root.spec.ts
+++ b/e2e/tests/9-behavior-tests/httpCache/root.spec.ts
@@ -4,7 +4,7 @@ import { test } from '@playwright/test'
 const user1 = 'test@example.com'
 const user2 = 'castor@example.com'
 
-test('caches the root endpoint', async ({ browser }) => {
+test('caches the root endpoint', { tag: '@mature' }, async ({ browser }) => {
   const uri = '/api/index'
 
   // Create context for user 1

--- a/e2e/tests/9-behavior-tests/httpCache/scheduleEntries.spec.ts
+++ b/e2e/tests/9-behavior-tests/httpCache/scheduleEntries.spec.ts
@@ -35,159 +35,163 @@ const collectionXKeys =
   /* collection URI (for detecting addition of new schedule entries) */
   '/api/periods/7fa4564a5d5d/schedule_entries'
 
-test.describe('cache test: /periods/{periodId}/scheduleEntries', () => {
-  test.describe.configure({ mode: 'serial' })
+test.describe(
+  'cache test: /periods/{periodId}/scheduleEntries',
+  { tag: '@mature' },
+  () => {
+    test.describe.configure({ mode: 'serial' })
 
-  test('caches /periods/{periodId}/schedule_entries separately for each login', async () => {
-    const uri = `/api/periods/${skilagerPeriodId}/schedule_entries`
+    test('caches /periods/{periodId}/schedule_entries separately for each login', async () => {
+      const uri = `/api/periods/${skilagerPeriodId}/schedule_entries`
 
-    const bipiApi = await getAuthContext(bipiUser)
+      const bipiApi = await getAuthContext(bipiUser)
 
-    // first request is a cache miss
-    const res1 = await apiGet(bipiApi, uri)
-    const headers = res1.headers()
-    expect(headers['xkey']).toBe(collectionXKeys)
-    expect(headers['x-cache']).toBe('MISS')
-    expect(await res1.json()).toEqual(collectionResponse)
+      // first request is a cache miss
+      const res1 = await apiGet(bipiApi, uri)
+      const headers = res1.headers()
+      expect(headers['xkey']).toBe(collectionXKeys)
+      expect(headers['x-cache']).toBe('MISS')
+      expect(await res1.json()).toEqual(collectionResponse)
 
-    // second request is a cache hit
-    await expectCacheHit(bipiApi, uri)
+      // second request is a cache hit
+      await expectCacheHit(bipiApi, uri)
 
-    // request with a new user is a cache miss
-    const bruceApi = await getAuthContext(bruceWayneUser)
-    await expectCacheMiss(bruceApi, uri)
-  })
-
-  test('invalidates /periods/{periodId}/schedule_entries for all users on scheduleEntry patch', async () => {
-    const uri = `/api/periods/${grgrPeriodId}/schedule_entries`
-    const scheduleEntryId = '12f34c89ce11'
-
-    // bring data into defined state
-    const bipiApi = await getAuthContext(bipiUser)
-    await apiPatch(bipiApi, `/api/schedule_entries/${scheduleEntryId}`, {
-      start: '2026-05-10T16:00:00+00:00',
+      // request with a new user is a cache miss
+      const bruceApi = await getAuthContext(bruceWayneUser)
+      await expectCacheMiss(bruceApi, uri)
     })
 
-    // warm up cache
-    await apiGet(bipiApi, uri)
-    await expectCacheHit(bipiApi, uri)
+    test('invalidates /periods/{periodId}/schedule_entries for all users on scheduleEntry patch', async () => {
+      const uri = `/api/periods/${grgrPeriodId}/schedule_entries`
+      const scheduleEntryId = '12f34c89ce11'
 
-    const castorApi = await getAuthContext(castorUser)
-    await apiGet(castorApi, uri)
-    await expectCacheHit(castorApi, uri)
+      // bring data into defined state
+      const bipiApi = await getAuthContext(bipiUser)
+      await apiPatch(bipiApi, `/api/schedule_entries/${scheduleEntryId}`, {
+        start: '2026-05-10T16:00:00+00:00',
+      })
 
-    // touch scheduleEntry
-    await apiPatch(castorApi, `/api/schedule_entries/${scheduleEntryId}`, {
-      start: '2026-05-10T17:00:00+00:00',
+      // warm up cache
+      await apiGet(bipiApi, uri)
+      await expectCacheHit(bipiApi, uri)
+
+      const castorApi = await getAuthContext(castorUser)
+      await apiGet(castorApi, uri)
+      await expectCacheHit(castorApi, uri)
+
+      // touch scheduleEntry
+      await apiPatch(castorApi, `/api/schedule_entries/${scheduleEntryId}`, {
+        start: '2026-05-10T17:00:00+00:00',
+      })
+
+      // ensure cache was invalidated
+      await waitForCacheMiss(castorApi, uri)
+      await expectCacheHit(castorApi, uri)
+
+      await expectCacheMiss(bipiApi, uri)
     })
 
-    // ensure cache was invalidated
-    await waitForCacheMiss(castorApi, uri)
-    await expectCacheHit(castorApi, uri)
+    test('invalidates /periods/{periodId}/schedule_entries for new scheduleEntry', async () => {
+      const uri = `/api/periods/${grgrPeriodId}/schedule_entries`
 
-    await expectCacheMiss(bipiApi, uri)
-  })
+      const bipiApi = await getAuthContext(bipiUser)
 
-  test('invalidates /periods/{periodId}/schedule_entries for new scheduleEntry', async () => {
-    const uri = `/api/periods/${grgrPeriodId}/schedule_entries`
+      // warm up cache
+      await apiGet(bipiApi, uri)
+      await expectCacheHit(bipiApi, uri)
 
-    const bipiApi = await getAuthContext(bipiUser)
+      // add new scheduleEntry to period
+      const postRes = await apiPost(bipiApi, '/api/schedule_entries', {
+        start: '2026-05-10T10:00:00+00:00',
+        end: '2026-05-10T11:00:00+00:00',
+        period: `/api/periods/${grgrPeriodId}`,
+        activity: `/api/activities/ffd08c52288c`,
+      })
+      const body = await postRes.json()
+      const newScheduleEntryUri = body._links.self.href
 
-    // warm up cache
-    await apiGet(bipiApi, uri)
-    await expectCacheHit(bipiApi, uri)
+      // ensure cache was invalidated
+      await waitForCacheMiss(bipiApi, uri)
+      await expectCacheHit(bipiApi, uri)
 
-    // add new scheduleEntry to period
-    const postRes = await apiPost(bipiApi, '/api/schedule_entries', {
-      start: '2026-05-10T10:00:00+00:00',
-      end: '2026-05-10T11:00:00+00:00',
-      period: `/api/periods/${grgrPeriodId}`,
-      activity: `/api/activities/ffd08c52288c`,
-    })
-    const body = await postRes.json()
-    const newScheduleEntryUri = body._links.self.href
+      // delete newly created scheduleEntry
+      await apiDelete(bipiApi, newScheduleEntryUri)
 
-    // ensure cache was invalidated
-    await waitForCacheMiss(bipiApi, uri)
-    await expectCacheHit(bipiApi, uri)
-
-    // delete newly created scheduleEntry
-    await apiDelete(bipiApi, newScheduleEntryUri)
-
-    // ensure cache was invalidated
-    await waitForCacheMiss(bipiApi, uri)
-    await expectCacheHit(bipiApi, uri)
-  })
-
-  test('invalidates /periods/{periodId}/schedule_entries when moving a schedule entry to another period', async () => {
-    const uri1 = `/api/periods/${harryMainPeriodId}/schedule_entries`
-    const uri2 = `/api/periods/${harrySecondPeriodId}/schedule_entries`
-    const scheduleEntryId = '9a4173c9bb73'
-
-    const bipiApi = await getAuthContext(bipiUser)
-
-    // warm up cache
-    await apiGet(bipiApi, uri1)
-    await apiGet(bipiApi, uri2)
-    await expectCacheHit(bipiApi, uri1)
-    await expectCacheHit(bipiApi, uri2)
-
-    // move scheduleEntry to 2nd period
-    await apiPatch(bipiApi, `/api/schedule_entries/${scheduleEntryId}`, {
-      start: '2026-08-09T15:00:00+00:00',
-      end: '2026-08-09T17:00:00+00:00',
-      period: `/periods/${harrySecondPeriodId}`,
+      // ensure cache was invalidated
+      await waitForCacheMiss(bipiApi, uri)
+      await expectCacheHit(bipiApi, uri)
     })
 
-    // ensure cache was invalidated
-    await waitForCacheMiss(bipiApi, uri1)
-    await waitForCacheMiss(bipiApi, uri2)
-    await expectCacheHit(bipiApi, uri1)
-    await expectCacheHit(bipiApi, uri2)
+    test('invalidates /periods/{periodId}/schedule_entries when moving a schedule entry to another period', async () => {
+      const uri1 = `/api/periods/${harryMainPeriodId}/schedule_entries`
+      const uri2 = `/api/periods/${harrySecondPeriodId}/schedule_entries`
+      const scheduleEntryId = '9a4173c9bb73'
 
-    // move scheduleEntry back
-    await apiPatch(bipiApi, `/api/schedule_entries/${scheduleEntryId}`, {
-      start: '2026-07-20T15:00:00+00:00',
-      end: '2026-07-20T17:00:00+00:00',
-      period: `/periods/${harryMainPeriodId}`,
+      const bipiApi = await getAuthContext(bipiUser)
+
+      // warm up cache
+      await apiGet(bipiApi, uri1)
+      await apiGet(bipiApi, uri2)
+      await expectCacheHit(bipiApi, uri1)
+      await expectCacheHit(bipiApi, uri2)
+
+      // move scheduleEntry to 2nd period
+      await apiPatch(bipiApi, `/api/schedule_entries/${scheduleEntryId}`, {
+        start: '2026-08-09T15:00:00+00:00',
+        end: '2026-08-09T17:00:00+00:00',
+        period: `/periods/${harrySecondPeriodId}`,
+      })
+
+      // ensure cache was invalidated
+      await waitForCacheMiss(bipiApi, uri1)
+      await waitForCacheMiss(bipiApi, uri2)
+      await expectCacheHit(bipiApi, uri1)
+      await expectCacheHit(bipiApi, uri2)
+
+      // move scheduleEntry back
+      await apiPatch(bipiApi, `/api/schedule_entries/${scheduleEntryId}`, {
+        start: '2026-07-20T15:00:00+00:00',
+        end: '2026-07-20T17:00:00+00:00',
+        period: `/periods/${harryMainPeriodId}`,
+      })
+
+      // ensure cache was invalidated
+      await waitForCacheMiss(bipiApi, uri1)
+      await waitForCacheMiss(bipiApi, uri2)
+      await expectCacheHit(bipiApi, uri1)
+      await expectCacheHit(bipiApi, uri2)
     })
 
-    // ensure cache was invalidated
-    await waitForCacheMiss(bipiApi, uri1)
-    await waitForCacheMiss(bipiApi, uri2)
-    await expectCacheHit(bipiApi, uri1)
-    await expectCacheHit(bipiApi, uri2)
-  })
+    test('invalidates /periods/{periodId}/schedule_entries when changing the period dates', async () => {
+      const uri = `/api/periods/${grgrPeriodId}/schedule_entries`
 
-  test('invalidates /periods/{periodId}/schedule_entries when changing the period dates', async () => {
-    const uri = `/api/periods/${grgrPeriodId}/schedule_entries`
+      const bipiApi = await getAuthContext(bipiUser)
 
-    const bipiApi = await getAuthContext(bipiUser)
+      // warm up cache
+      await apiGet(bipiApi, uri)
+      await expectCacheHit(bipiApi, uri)
 
-    // warm up cache
-    await apiGet(bipiApi, uri)
-    await expectCacheHit(bipiApi, uri)
+      // move period start date
+      await apiPatch(bipiApi, `/api/periods/${grgrPeriodId}`, {
+        start: '2026-05-09',
+        end: '2026-05-12',
+        moveScheduleEntries: true,
+      })
 
-    // move period start date
-    await apiPatch(bipiApi, `/api/periods/${grgrPeriodId}`, {
-      start: '2026-05-09',
-      end: '2026-05-12',
-      moveScheduleEntries: true,
+      // ensure cache was invalidated
+      await waitForCacheMiss(bipiApi, uri)
+      await expectCacheHit(bipiApi, uri)
+
+      // move period start date
+      await apiPatch(bipiApi, `/api/periods/${grgrPeriodId}`, {
+        start: '2026-05-10',
+        end: '2026-05-13',
+        moveScheduleEntries: true,
+      })
+
+      // ensure cache was invalidated
+      await waitForCacheMiss(bipiApi, uri)
+      await expectCacheHit(bipiApi, uri)
     })
-
-    // ensure cache was invalidated
-    await waitForCacheMiss(bipiApi, uri)
-    await expectCacheHit(bipiApi, uri)
-
-    // move period start date
-    await apiPatch(bipiApi, `/api/periods/${grgrPeriodId}`, {
-      start: '2026-05-10',
-      end: '2026-05-13',
-      moveScheduleEntries: true,
-    })
-
-    // ensure cache was invalidated
-    await waitForCacheMiss(bipiApi, uri)
-    await expectCacheHit(bipiApi, uri)
-  })
-})
+  }
+)

--- a/e2e/tests/9-behavior-tests/nuxtPrint.spec.ts
+++ b/e2e/tests/9-behavior-tests/nuxtPrint.spec.ts
@@ -6,7 +6,7 @@ import { getPdfProperties } from '@/utils/getPdfProperties'
 import { loginAndSetCookie, mockDateNow } from '@/utils/helpers'
 import { CampItem, PeriodItem } from '@/shared-types/ecamp'
 
-test.describe('Nuxt print test', () => {
+test.describe('Nuxt print test', { tag: '@mature' }, () => {
   test.beforeEach(async ({ page, request }) => {
     await loginAndSetCookie(page, request, 'test@example.com')
     await mockDateNow(page)

--- a/e2e/tests/9-behavior-tests/zz-createCamp.spec.ts
+++ b/e2e/tests/9-behavior-tests/zz-createCamp.spec.ts
@@ -10,7 +10,7 @@ in2Days.setDate(in2Days.getDate() + 2)
 
 const campTitle = 'title'
 
-test.describe('create new camp', () => {
+test.describe('create new camp', { tag: '@mature' }, () => {
   test.beforeEach(async ({ page }) => {
     await mockDateNow(page)
   })

--- a/e2e/utils/helpers.ts
+++ b/e2e/utils/helpers.ts
@@ -144,6 +144,67 @@ export async function apiDelete(request: APIRequestContext, uri: string) {
   return await request.delete(`${API_ROOT_URL_CACHED}${uri}.jsonhal`)
 }
 
+export async function createCampViaUI(page: Page, campTitle: string): Promise<string> {
+  const tomorrow = new Date()
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  const in2Days = new Date()
+  in2Days.setDate(in2Days.getDate() + 2)
+
+  await page.goto('/camps')
+  await page.getByTestId('create-camp-button').click()
+
+  await page.locator('[data-testid="create-camp-title-input"] input').fill(campTitle)
+  await page
+    .locator('[data-testid="start-date-picker"] input')
+    .fill(tomorrow.toLocaleDateString('de-CH'))
+  await page
+    .locator('[data-testid="end-date-picker"] input')
+    .fill(in2Days.toLocaleDateString('de-CH'))
+
+  await page.getByTestId('create-camp-next-step').click()
+
+  await page.locator('div.v-input[data-testid="prototype-select"]').click()
+  await expect(page.locator('.v-overlay--active')).toBeVisible({ timeout: 10000 })
+  await page.locator('.v-overlay--active').getByText('Keine Vorlage').click()
+  await expect(
+    page.getByText('Achtung: Du hast "Keine Vorlage" ausgewählt.')
+  ).toBeVisible()
+  await expect(page.locator('.v-overlay')).not.toBeVisible({ timeout: 10000 })
+
+  await page.getByTestId('create-camp-button').click()
+  await page.waitForURL('**/admin/info', { timeout: 30000 })
+
+  return page.url().replace(/\/info$/, '')
+}
+
+export async function deleteCampViaUI(
+  page: Page,
+  campAdminBaseUrl: string,
+  campTitle: string
+): Promise<void> {
+  await page.goto(`${campAdminBaseUrl}/info`)
+
+  await page
+    .locator('.v-expansion-panel')
+    .filter({ hasText: 'Gefahrenzone' })
+    .locator('.v-expansion-panel-title')
+    .click()
+
+  await page
+    .locator('.v-expansion-panel-text')
+    .getByRole('button', { name: /Löschen/i })
+    .click()
+
+  await page.locator('[name="promptText"] input').fill(campTitle)
+
+  await page
+    .locator('.v-overlay--active')
+    .getByRole('button', { name: /Löschen/i })
+    .click()
+
+  await page.waitForURL(/\/camps$/, { timeout: 15000 })
+}
+
 export async function mockDateNow(page: Page, date: string = 'April 30 2026 13:00:00') {
   const fakeNow = new Date(date).valueOf()
 


### PR DESCRIPTION
This way we can add new e2e tests without fearing to break the other pr with instability. Once the e2e tests were successful for some time, we can mark them as \@mature.
- CI for PRs now only runs @mature tests (--grep \@mature) for faster feedback
- New workflow e2e-tests-all.yml runs ALL tests:
  - Nightly (cron: 0 2 * * *)
  - On workflow_dispatch
  - When PR has label 'run-all-e2e-tests'
- reusable-e2e-tests-run.yml accepts optional grep-filter input