### PR TITLE
frontend: add browser update notice for browsers which don't implement String::replaceAll

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,7 @@
         "@zxcvbn-ts/language-it": "3.0.2",
         "assert": "2.1.0",
         "axios": "1.16.1",
+        "browser-update": "3.3.63",
         "colorjs.io": "0.6.1",
         "comlink": "4.4.2",
         "dayjs": "1.11.21",
@@ -6331,6 +6332,12 @@
       "dependencies": {
         "base64-js": "^1.1.2"
       }
+    },
+    "node_modules/browser-update": {
+      "version": "3.3.63",
+      "resolved": "https://registry.npmjs.org/browser-update/-/browser-update-3.3.63.tgz",
+      "integrity": "sha512-cPzIE5mp6YSJOSI+KLMXM2p5vcBFux2Xq18jLJdn9ZeYCa5QdEPFrOMQ3j/oVWlCH1iUtJqGYqzQLz+VD+9bww==",
+      "license": "MIT"
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
     "@zxcvbn-ts/language-it": "3.0.2",
     "assert": "2.1.0",
     "axios": "1.16.1",
+    "browser-update": "3.3.63",
     "colorjs.io": "0.6.1",
     "comlink": "4.4.2",
     "dayjs": "1.11.21",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,3 +1,4 @@
+import browserUpdate from 'browser-update'
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from '@/router.js'
@@ -22,6 +23,17 @@ import '@/scss/global.scss'
 import '@/scss/tailwind.scss'
 import { initRefresh } from '@/plugins/auth.js'
 import { getEnv } from '@/environment.js'
+
+browserUpdate({
+  required: {
+    c: 90,
+    f: 90,
+    e: 90,
+    s: 14,
+    o: 80,
+  },
+  insecure: true,
+})
 
 const app = createApp(App)
 


### PR DESCRIPTION


fixes #7136
If we detect more errors we can increase the browser versions then.
I had to increase the minimum version to 90, with the new vue3/vite
chrome 80 crashes with a syntax error.
(And you don't even see the update notice).