### PR TITLE
Bulk invite collaborators

### DIFF
--- a/e2e/tests/9-behavior-tests/bulkInvite.spec.ts
+++ b/e2e/tests/9-behavior-tests/bulkInvite.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from '@playwright/test'
+import { bipiUser, grgrCampId } from '@/utils/constants'
+import { loginAndSetCookie } from '@/utils/helpers'
+
+const runId = Date.now()
+
+test.describe('bulk invite collaborators', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test.beforeEach(async ({ page, request }) => {
+    await loginAndSetCookie(page, request, bipiUser)
+    await expect(page.getByTestId('create-camp-button')).toBeVisible({ timeout: 60000 })
+    await page.goto(`/camps/${grgrCampId}/GRGR/admin/collaborators`)
+    await expect(
+      page.getByRole('button', { name: 'Mehrere Personen einladen' })
+    ).toBeVisible({ timeout: 20000 })
+  })
+
+  test('opens dialog and shows form fields', async ({ page }) => {
+    await page.getByRole('button', { name: 'Mehrere Personen einladen' }).click()
+    const overlay = page.locator('.v-overlay--active')
+    await expect(overlay).toBeVisible()
+
+    await expect(overlay.getByRole('textbox')).toBeVisible()
+    await expect(overlay.getByRole('combobox', { name: /Rolle/ })).toBeVisible()
+    const submitButton = overlay.getByRole('button', { name: 'Einladungen verschicken' })
+    await expect(submitButton).toBeVisible()
+    await expect(submitButton).toBeDisabled()
+  })
+
+  test('invites new people and shows success count', async ({ page }) => {
+    const email1 = `run${runId}-a@example.com`
+    const email2 = `run${runId}-b@example.com`
+
+    await page.getByRole('button', { name: 'Mehrere Personen einladen' }).click()
+    const overlay = page.locator('.v-overlay--active')
+    await expect(overlay).toBeVisible()
+
+    await overlay.getByRole('textbox').fill(`${email1}\n${email2}`)
+    await overlay.getByRole('button', { name: 'Einladungen verschicken' }).click()
+
+    await expect(overlay.locator('.v-alert')).toContainText('2')
+
+    await page.keyboard.press('Escape')
+    await expect(overlay).toBeHidden()
+
+    await expect(page.getByText(email1, { exact: true })).toBeVisible()
+    await expect(page.getByText(email2, { exact: true })).toBeVisible()
+  })
+
+  test('reports already-invited email in the result', async ({ page }) => {
+    const newEmail = `run${runId}-c@example.com`
+
+    await page.getByRole('button', { name: 'Mehrere Personen einladen' }).click()
+    const overlay = page.locator('.v-overlay--active')
+    await expect(overlay).toBeVisible()
+
+    await overlay.getByRole('textbox').fill(`x@z.com\n${newEmail}`)
+
+    await overlay.getByRole('button', { name: 'Einladungen verschicken' }).click()
+
+    await expect(overlay.getByRole('alert').filter({ hasText: 'x@z.com' })).toBeVisible()
+  })
+
+  test('shows failed email in the result when invite fails', async ({ page }) => {
+    const email1 = `run${runId}-d@example.com`
+    const email2 = `run2${runId}-d@example.com`
+
+    await page.getByRole('button', { name: 'Mehrere Personen einladen' }).click()
+    const overlay = page.locator('.v-overlay--active')
+    await expect(overlay).toBeVisible()
+
+    await overlay.getByRole('textbox').fill(`${email1};${email2}`)
+
+    await page.route('**/camp_collaborations', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({ status: 500, body: 'Internal Server Error' })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await overlay.getByRole('button', { name: 'Einladungen verschicken' }).click()
+
+    const failedAlert = overlay.getByRole('alert').filter({ hasText: email1 })
+    await expect(failedAlert).toContainText(email1)
+    await expect(failedAlert).toContainText(email2)
+
+    await expect(overlay.getByRole('textbox', { name: 'E-Mail-Adressen' })).toHaveValue(
+      `${email1};${email2}`
+    )
+  })
+
+  test('closes dialog and resets form on cancel', async ({ page }) => {
+    await page.getByRole('button', { name: 'Mehrere Personen einladen' }).click()
+    const overlay = page.locator('.v-overlay--active')
+    await expect(overlay).toBeVisible()
+
+    await overlay.getByRole('textbox').fill('test@example.com')
+
+    await page.keyboard.press('Escape')
+    await expect(overlay).toBeHidden()
+
+    await page.getByRole('button', { name: 'Mehrere Personen einladen' }).click()
+    await expect(page.locator('.v-overlay--active').getByRole('textbox')).toHaveValue('')
+  })
+})

--- a/frontend/src/components/collaborator/CollaboratorBulkCreate.vue
+++ b/frontend/src/components/collaborator/CollaboratorBulkCreate.vue
@@ -1,0 +1,179 @@
+<template>
+  <DetailPane
+    :model-value="showDialog"
+    :loading="loading"
+    :error="error"
+    icon="mdi-account-multiple-plus"
+    :title="$t('components.collaborator.collaboratorBulkCreate.title')"
+    :submit-action="bulkInvite"
+    :submit-label="$t('components.collaborator.collaboratorBulkCreate.invite')"
+    :submit-enabled="parsedEmails.length > 0"
+    submit-icon="mdi-email-fast"
+    submit-color="success"
+    :cancel-action="close"
+  >
+    <template #activator="{ props }">
+      <ButtonAdd
+        color="blue-grey-darken-2"
+        variant="text"
+        class="my-n2"
+        icon="mdi-account-multiple-plus"
+        v-bind="props"
+        @click="showDialog = true"
+      >
+        {{ $t('components.collaborator.collaboratorBulkCreate.inviteCta') }}
+      </ButtonAdd>
+    </template>
+
+    <e-form name="campCollaboration">
+      <v-textarea
+        v-model="emailsText"
+        :label="$t('components.collaborator.collaboratorBulkCreate.emailsLabel')"
+        :hint="$t('components.collaborator.collaboratorBulkCreate.emailsHint')"
+        :rows="5"
+        class="mb-2"
+      />
+
+      <CollaboratorRoleSelect v-model="role" />
+    </e-form>
+
+    <v-alert
+      v-if="result && result.createdCampCollaborations.length > 0"
+      type="success"
+      class="mt-2"
+      variant="tonal"
+    >
+      <div v-if="result.createdCampCollaborations.length > 0">
+        {{
+          $t('components.collaborator.collaboratorBulkCreate.successCount', {
+            count: result.createdCampCollaborations.length,
+          })
+        }}
+      </div>
+    </v-alert>
+
+    <v-alert
+      v-if="result && result.validationFailed.length > 0"
+      type="info"
+      class="mt-2"
+      variant="outlined"
+    >
+      <p>{{ $t('components.collaborator.collaboratorBulkCreate.validationFailed') }}</p>
+      <p>{{ result.validationFailed.join(', ') }}</p>
+    </v-alert>
+
+    <v-alert
+      v-if="result && result.failed.length > 0"
+      type="error"
+      class="mt-2"
+      variant="tonal"
+    >
+      {{
+        $t('components.collaborator.collaboratorBulkCreate.failedEmails', {
+          emails: result.failed.join(', '),
+        })
+      }}
+    </v-alert>
+  </DetailPane>
+</template>
+
+<script>
+import ButtonAdd from '@/components/buttons/ButtonAdd.vue'
+import DetailPane from '@/components/generic/DetailPane.vue'
+import CollaboratorRoleSelect from '@/components/collaborator/CollaboratorRoleSelect.vue'
+
+const DEFAULT_BULK_INVITE_ROLE = 'member'
+
+export default {
+  name: 'CollaboratorBulkCreate',
+  components: { ButtonAdd, DetailPane, CollaboratorRoleSelect },
+  props: {
+    camp: { type: Object, required: true },
+  },
+  data() {
+    return {
+      showDialog: false,
+      loading: false,
+      error: null,
+      emailsText: '',
+      role: DEFAULT_BULK_INVITE_ROLE,
+      result: null,
+    }
+  },
+  computed: {
+    parsedEmails() {
+      return this.emailsText
+        .split(/[\s,;]+/)
+        .map((e) => e.trim())
+        .filter((e) => e.length > 0)
+    },
+  },
+  methods: {
+    close() {
+      this.showDialog = false
+      this.reset()
+    },
+    reset() {
+      this.emailsText = ''
+      this.role = DEFAULT_BULK_INVITE_ROLE
+      this.result = null
+      this.error = null
+    },
+    async bulkInvite() {
+      this.loading = true
+      this.error = null
+      this.result = null
+
+      try {
+        const postUrl = await this.api.href(this.api.get(), 'campCollaborations')
+
+        const settled = await Promise.allSettled(
+          this.parsedEmails.map((email) =>
+            this.api.post(postUrl, {
+              camp: this.camp._meta.self,
+              inviteEmail: email,
+              role: this.role,
+            })
+          )
+        )
+
+        const createdCampCollaborations = []
+        const validationFailed = []
+        const failed = []
+
+        settled.forEach((r, i) => {
+          const email = this.parsedEmails[i]
+          if (r.status === 'fulfilled') {
+            createdCampCollaborations.push(email)
+          } else if (r.reason?.response?.status === 422) {
+            validationFailed.push(email)
+          } else {
+            failed.push(email)
+            if (!this.error) {
+              this.error = r.reason
+            }
+          }
+        })
+
+        this.result = {
+          createdCampCollaborations,
+          validationFailed,
+          failed,
+        }
+
+        if (failed.length === 0 && validationFailed.length === 0) {
+          this.emailsText = ''
+        }
+
+        if (createdCampCollaborations.length > 0) {
+          await this.api.reload(this.camp.campCollaborations())
+        }
+      } catch (err) {
+        this.error = err
+      } finally {
+        this.loading = false
+      }
+    },
+  },
+}
+</script>

--- a/frontend/src/components/collaborator/CollaboratorForm.vue
+++ b/frontend/src/components/collaborator/CollaboratorForm.vue
@@ -11,65 +11,15 @@
         <slot name="statusChange" />
       </template>
     </e-text-field>
-    <e-select
+    <CollaboratorRoleSelect
       v-if="readonlyRole"
       v-model="localCollaboration.role"
-      path="role"
       readonly
       aria-readonly="true"
       aria-describedby="readonly"
-      :items="items"
       :hint="$t('components.collaborator.collaboratorForm.roleHint')"
-      persistent-hint
-      vee-rules="required"
-    >
-      <template #selection="{ item }">
-        <span>
-          {{ item.title }} &middot;
-          <span class="text-grey">
-            <template v-for="icon in item.raw.icons" :key="icon">
-              <v-icon size="x-small">{{ icon }}</v-icon>
-              &thinsp;
-            </template>
-          </span>
-        </span>
-      </template>
-    </e-select>
-    <e-select
-      v-else
-      v-model="localCollaboration.role"
-      path="role"
-      :items="items"
-      persistent-hint
-      item-title="role"
-      item-value="key"
-      vee-rules="required"
-    >
-      <template #item="{ item, props }">
-        <v-list-item lines="two" v-bind="props">
-          <v-list-item-subtitle>{{ item.raw.abilities }}</v-list-item-subtitle>
-          <template #append>
-            <span>
-              <template v-for="icon in item.raw.icons" :key="icon">
-                <v-icon size="small">{{ icon }}</v-icon>
-                &thinsp;
-              </template>
-            </span>
-          </template>
-        </v-list-item>
-      </template>
-      <template #selection="{ item }">
-        <span>
-          {{ item.title }} &middot;
-          <span class="text-grey">
-            <template v-for="icon in item.raw.icons" :key="icon">
-              <v-icon size="x-small">{{ icon }}</v-icon>
-              &thinsp;
-            </template>
-          </span>
-        </span>
-      </template>
-    </e-select>
+    />
+    <CollaboratorRoleSelect v-else v-model="localCollaboration.role" />
 
     <fieldset
       v-if="!!initialCollaboration"
@@ -105,10 +55,11 @@
 
 <script>
 import UserAvatar from '@/components/user/UserAvatar.vue'
+import CollaboratorRoleSelect from '@/components/collaborator/CollaboratorRoleSelect.vue'
 
 export default {
   name: 'SettingsCollaboratorForm',
-  components: { UserAvatar },
+  components: { UserAvatar, CollaboratorRoleSelect },
   props: {
     collaboration: { type: Object, required: true },
     status: { type: [String, Boolean], required: false, default: false },
@@ -116,28 +67,6 @@ export default {
     initialCollaboration: { type: Object, required: false, default: null },
   },
   computed: {
-    items() {
-      return [
-        {
-          value: 'manager',
-          text: this.$t('entity.camp.collaborators.manager'),
-          abilities: this.$t('global.collaborationAbilities.manager'),
-          icons: ['mdi-eye-outline', 'mdi-pencil-outline', 'mdi-cog-outline'],
-        },
-        {
-          value: 'member',
-          text: this.$t('entity.camp.collaborators.member'),
-          abilities: this.$t('global.collaborationAbilities.member'),
-          icons: ['mdi-eye-outline', 'mdi-pencil-outline'],
-        },
-        {
-          value: 'guest',
-          text: this.$t('entity.camp.collaborators.guest'),
-          abilities: this.$t('global.collaborationAbilities.guest'),
-          icons: ['mdi-eye-outline'],
-        },
-      ]
-    },
     localCollaboration() {
       return this.collaboration
     },

--- a/frontend/src/components/collaborator/CollaboratorRoleSelect.vue
+++ b/frontend/src/components/collaborator/CollaboratorRoleSelect.vue
@@ -1,0 +1,77 @@
+<template>
+  <e-select
+    v-model="localRole"
+    path="role"
+    :items="items"
+    persistent-hint
+    vee-rules="required"
+    v-bind="$attrs"
+  >
+    <template #item="{ item, props }">
+      <v-list-item lines="two" v-bind="props">
+        <v-list-item-subtitle>{{ item.raw.abilities }}</v-list-item-subtitle>
+        <template #append>
+          <span>
+            <template v-for="icon in item.raw.icons" :key="icon">
+              <v-icon size="small">{{ icon }}</v-icon>
+              &thinsp;
+            </template>
+          </span>
+        </template>
+      </v-list-item>
+    </template>
+    <template #selection="{ item }">
+      <span>
+        {{ item.title }} &middot;
+        <span class="text-grey">
+          <template v-for="icon in item.raw.icons" :key="icon">
+            <v-icon size="x-small">{{ icon }}</v-icon>
+            &thinsp;
+          </template>
+        </span>
+      </span>
+    </template>
+  </e-select>
+</template>
+
+<script>
+export default {
+  name: 'CollaboratorRoleSelect',
+  props: {
+    modelValue: { type: String, required: false, default: 'member' },
+  },
+  emits: ['update:modelValue'],
+  computed: {
+    localRole: {
+      get() {
+        return this.modelValue
+      },
+      set(value) {
+        this.$emit('update:modelValue', value)
+      },
+    },
+    items() {
+      return [
+        {
+          value: 'manager',
+          text: this.$t('entity.camp.collaborators.manager'),
+          abilities: this.$t('global.collaborationAbilities.manager'),
+          icons: ['mdi-eye-outline', 'mdi-pencil-outline', 'mdi-cog-outline'],
+        },
+        {
+          value: 'member',
+          text: this.$t('entity.camp.collaborators.member'),
+          abilities: this.$t('global.collaborationAbilities.member'),
+          icons: ['mdi-eye-outline', 'mdi-pencil-outline'],
+        },
+        {
+          value: 'guest',
+          text: this.$t('entity.camp.collaborators.guest'),
+          abilities: this.$t('global.collaborationAbilities.guest'),
+          icons: ['mdi-eye-outline'],
+        },
+      ]
+    },
+  },
+}
+</script>

--- a/frontend/src/components/form/base/ETextarea.vue
+++ b/frontend/src/components/form/base/ETextarea.vue
@@ -2,7 +2,7 @@
   <ValidationField
     v-slot="{ handleChange, errors: veeErrors }"
     :label="validationLabel"
-    :name="veeId ?? path"
+    :name="veeId ?? path ?? validationLabel"
     :vee-rules="veeRules"
   >
     <v-tiptap-editor

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -262,6 +262,16 @@
       }
     },
     "collaborator": {
+      "collaboratorBulkCreate": {
+        "validationFailed": "Bereits im Team oder ungültige E-Mail-Adresse:",
+        "emailsHint": "Eine E-Mail-Adresse pro Zeile oder durch Kommas getrennt eingeben",
+        "emailsLabel": "E-Mail-Adressen",
+        "failedEmails": "Einladung fehlgeschlagen: {emails}",
+        "invite": "Einladungen verschicken",
+        "inviteCta": "Mehrere Personen einladen",
+        "successCount": "{count} Einladung(en) verschickt",
+        "title": "Mehrere Personen einladen"
+      },
       "collaboratorCreate": {
         "emailLabel": "E-Mail-Adresse",
         "invite": "Einladung verschicken",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -262,6 +262,16 @@
       }
     },
     "collaborator": {
+      "collaboratorBulkCreate": {
+        "validationFailed": "Already in camp or invalid email:",
+        "emailsHint": "Enter one email address per line, or separate with commas",
+        "emailsLabel": "Email addresses",
+        "failedEmails": "Failed to invite: {emails}",
+        "invite": "Send invitations",
+        "inviteCta": "Invite multiple people",
+        "successCount": "{count} invitation(s) sent",
+        "title": "Invite multiple people"
+      },
       "collaboratorCreate": {
         "emailLabel": "Email address",
         "invite": "Send invitation",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -262,6 +262,16 @@
       }
     },
     "collaborator": {
+      "collaboratorBulkCreate": {
+        "validationFailed": "Déjà dans le camp ou e-mail invalide:",
+        "emailsHint": "Entrer une adresse e-mail par ligne ou séparées par des virgules",
+        "emailsLabel": "Adresses e-mail",
+        "failedEmails": "Échec de l'invitation: {emails}",
+        "invite": "Envoyer les invitations",
+        "inviteCta": "Inviter plusieurs personnes",
+        "successCount": "{count} invitation(s) envoyée(s)",
+        "title": "Inviter plusieurs personnes"
+      },
       "collaboratorCreate": {
         "invite": "Envoyer l'invitation",
         "inviteCta": "Inviter",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -203,6 +203,16 @@
       }
     },
     "collaborator": {
+      "collaboratorBulkCreate": {
+        "validationFailed": "Già nel campo o email non valida:",
+        "emailsHint": "Inserisci un indirizzo e-mail per riga o separati da virgole",
+        "emailsLabel": "Indirizzi e-mail",
+        "failedEmails": "Invito fallito: {emails}",
+        "invite": "Inviare gli inviti",
+        "inviteCta": "Invitare più persone",
+        "successCount": "{count} invito/i inviato/i",
+        "title": "Invitare più persone"
+      },
       "collaboratorCreate": {
         "invite": "Inviare l'invito",
         "inviteCta": "Invitare",

--- a/frontend/src/locales/rm.json
+++ b/frontend/src/locales/rm.json
@@ -141,6 +141,16 @@
       }
     },
     "collaborator": {
+      "collaboratorBulkCreate": {
+        "validationFailed": "Gia en il camp u email invalida:",
+        "emailsHint": "Endatescha in'adressa e-mail per lingia u separadas cun virglas",
+        "emailsLabel": "Adressas e-mail",
+        "failedEmails": "Invitaziun fallida: {emails}",
+        "invite": "Trametter las invitaziuns",
+        "inviteCta": "Envidar pliras persunas",
+        "successCount": "{count} invitaziun(s) tramessa(s)",
+        "title": "Envidar pliras persunas"
+      },
       "collaboratorCreate": {
         "invite": "Trametter l'invitaziun",
         "inviteCta": "Envidar en il team",

--- a/frontend/src/views/camp/admin/Collaborators.vue
+++ b/frontend/src/views/camp/admin/Collaborators.vue
@@ -7,6 +7,7 @@ Displays collaborators of a single camp.
       <ContentGroup :title="$t('views.camp.admin.collaborators.members')">
         <template #title-actions>
           <CollaboratorCreate v-if="isManager" :camp="camp" />
+          <CollaboratorBulkCreate v-if="isManager" :camp="camp" />
         </template>
         <CollaboratorList :collaborators="established" :is-manager="isManager" />
       </ContentGroup>
@@ -28,6 +29,7 @@ Displays collaborators of a single camp.
   </content-card>
 </template>
 <script>
+import CollaboratorBulkCreate from '@/components/collaborator/CollaboratorBulkCreate.vue'
 import CollaboratorCreate from '@/components/collaborator/CollaboratorCreate.vue'
 import ContentCard from '@/components/layout/ContentCard.vue'
 import ContentGroup from '@/components/layout/ContentGroup.vue'
@@ -39,6 +41,7 @@ export default {
   components: {
     CollaboratorList,
     CollaboratorCreate,
+    CollaboratorBulkCreate,
     ContentGroup,
     ContentCard,
   },


### PR DESCRIPTION
feat: add bulk camp invitation endpoint and frontend component

Adds POST /camp_collaborations/bulk_invite to invite multiple people
to a camp at once by providing a list of email addresses.

- BulkInvite DTO entity with camp, inviteEmails, role fields
- BulkInviteProcessor handles creating CampCollaborations for each email,
skipping emails that are already collaborators
- CollaboratorBulkCreate.vue frontend component with textarea for emails
- Translations for de, en, fr, it, rm locales

Fixes https://github.com/ecamp/ecamp3/issues/8045