### PR TITLE
Fix loading state of material table

### DIFF
--- a/frontend/src/components/material/MaterialTable.vue
+++ b/frontend/src/components/material/MaterialTable.vue
@@ -18,10 +18,10 @@
     <!-- skeleton loader (slot #body overrides all others) -->
     <template
       v-if="materialItemCollection._meta.loading || camp.materialLists()._meta.loading"
-      #body="{ headers }"
+      #body
     >
       <tr v-for="row in 3" :key="row">
-        <td v-for="col in headers.length" :key="col">
+        <td v-for="col in tableHeaders.length" :key="col">
           <v-skeleton-loader height="25" class="pr-5 mt-1" type="text" />
         </td>
       </tr>
@@ -196,13 +196,13 @@
       </button>
     </template>
 
-    <template #[`body.append`]="{ headers }">
+    <template #[`body.append`]>
       <!-- add new item (desktop view) -->
       <MaterialCreateItem
         v-if="!layoutMode && isDefaultVariant && !disabled && isContributor"
         key="addItemRow"
         :camp="camp"
-        :columns="headers.length"
+        :columns="tableHeaders.length"
         :material-list="materialList"
         @item-adding="add"
       />


### PR DESCRIPTION
The styling was off

| before    | after |
| -------- | ------- |
| <img width="1211" height="861" alt="Bildschirmfoto 2026-06-10 um 20 59 33" src="https://github.com/user-attachments/assets/5fb0ed40-ef6a-45c8-8230-e6cdd0a0dc23" /> | <img width="1025" height="942" alt="Bildschirmfoto 2026-06-10 um 20 57 45" src="https://github.com/user-attachments/assets/fdd8d5ca-a15b-4fd6-91d5-7613d70c1033" /> |