### PR TITLE
feat: replace external OAuth providers with navikt/mock-oauth2-server for local dev

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -49,22 +49,12 @@ JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=6521faf03b5be499f97cf0b40dc495f2
 ###< lexik/jwt-authentication-bundle ###
 
-###> league/oauth2-google ###
-OAUTH_GOOGLE_CLIENT_ID="889440431087-ueuhpadf2g7h5ucdke92mvfaf4l779m4.apps.googleusercontent.com"
-OAUTH_GOOGLE_CLIENT_SECRET="HNaD1FNO-a1qliacIrIfcGqO"
-###< league/oauth2-google ###
-
-OAUTH_PBSMIDATA_CLIENT_ID="2a955efdaaac73f665b29ec182cd9a114db01675ced710a464d33d10f58be600"
-OAUTH_PBSMIDATA_CLIENT_SECRET="00a23e48bcb776d453b255428ffe810643db7155a9f3d743d7edf52eac400580"
-OAUTH_PBSMIDATA_BASE_URL="https://pbs.puzzle.ch"
-
-OAUTH_CEVIDB_CLIENT_ID="raT1QFf6TOQzpn3yVH-My6YLrmsvOrfMhYypxzjPMWk"
-OAUTH_CEVIDB_CLIENT_SECRET="fTxMrzjBn3gPGg3eB0bNMmjRqg4ccs3_su7CaTXtljE"
-OAUTH_CEVIDB_BASE_URL="https://cevi.puzzle.ch"
-
-OAUTH_JUBLADB_CLIENT_ID="WrKABq7GwmC6h1F0W73OGX_fOTHWWXnKXfrPMHOdQWY"
-OAUTH_JUBLADB_CLIENT_SECRET="oQ164RDMIAocL6PhmCoeT1Ymcg-7WcOJZdxCnIph5gM"
-OAUTH_JUBLADB_BASE_URL="https://jubla.puzzle.ch"
+# Mock OAuth2 server (used in APP_ENV=dev via config/packages/dev/knpu_oauth2_client.yaml)
+# These defaults assume the API is running inside Docker (docker-compose.override.yml
+# sets these env vars to the correct Docker-internal addresses automatically).
+MOCK_OAUTH_INTERNAL_BASE_URL="http://mock-oauth2:8080"
+MOCK_OAUTH_EXTERNAL_BASE_URL="http://localhost:3000/mock-auth"
+MOCK_HITOBITO_INTERNAL_BASE_URL='http://reverse-proxy:3005'
 
 ###> sentry/sentry-symfony ###
 SENTRY_API_DSN=""

--- a/api/config/packages/knpu_oauth2_client.yaml
+++ b/api/config/packages/knpu_oauth2_client.yaml
@@ -70,3 +70,31 @@ knpu_oauth2_client:
             client_secret: '%env(OAUTH_JUBLADB_CLIENT_SECRET)%'
             redirect_route: connect_jubladb_check
             redirect_params: {}
+
+when@dev:
+    knpu_oauth2_client:
+        clients:
+            google:
+                provider_class: App\OAuth\MockGoogle
+                provider_options:
+                    baseUrl: '%env(MOCK_OAUTH_INTERNAL_BASE_URL)%/google'
+                    externalBaseUrl: '%env(MOCK_OAUTH_EXTERNAL_BASE_URL)%/google'
+            pbsmidata:
+                provider_class: App\OAuth\MockHitobito
+                provider_options:
+                    baseUrl: '%env(MOCK_HITOBITO_INTERNAL_BASE_URL)%/pbsmidata'
+                    externalBaseUrl: '%env(MOCK_OAUTH_EXTERNAL_BASE_URL)%/pbsmidata'
+                    # todo: check if really needed
+                    realBaseUrl: '%env(OAUTH_PBSMIDATA_BASE_URL)%'
+            cevidb:
+                provider_class: App\OAuth\MockHitobito
+                provider_options:
+                    baseUrl: '%env(MOCK_HITOBITO_INTERNAL_BASE_URL)%/cevidb'
+                    externalBaseUrl: '%env(MOCK_OAUTH_EXTERNAL_BASE_URL)%/cevidb'
+                    realBaseUrl: '%env(OAUTH_CEVIDB_BASE_URL)%'
+            jubladb:
+                provider_class: App\OAuth\MockHitobito
+                provider_options:
+                    baseUrl: '%env(MOCK_HITOBITO_INTERNAL_BASE_URL)%/jubladb'
+                    externalBaseUrl: '%env(MOCK_OAUTH_EXTERNAL_BASE_URL)%/jubladb'
+                    realBaseUrl: '%env(OAUTH_JUBLADB_BASE_URL)%'

--- a/api/src/OAuth/MockGoogle.php
+++ b/api/src/OAuth/MockGoogle.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OAuth;
+
+use League\OAuth2\Client\Provider\Google;
+use League\OAuth2\Client\Token\AccessToken;
+
+/**
+ * Google OAuth2 provider configured to use navikt/mock-oauth2-server for local development.
+ *
+ * Extends the real Google provider so the production code path (GoogleUser, assertMatchingDomain,
+ * scope handling) is exercised unchanged. Only the three hard-coded Google URLs are replaced with
+ * configurable ones pointing at the mock server.
+ */
+class MockGoogle extends Google {
+    /** Internal Docker network URL (API → mock-oauth2 container), includes issuer path. */
+    protected string $baseUrl;
+
+    /** External URL reachable by the browser (proxied through nginx at /mock-auth). */
+    protected string $externalBaseUrl;
+
+    public function getBaseAuthorizationUrl(): string {
+        return $this->externalBaseUrl.'/authorize';
+    }
+
+    public function getBaseAccessTokenUrl(array $params): string {
+        return $this->baseUrl.'/token';
+    }
+
+    public function getResourceOwnerDetailsUrl(AccessToken $token): string {
+        return $this->baseUrl.'/userinfo';
+    }
+}

--- a/api/src/OAuth/MockHitobito.php
+++ b/api/src/OAuth/MockHitobito.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OAuth;
+
+/**
+ * Hitobito OAuth2 provider configured to use navikt/mock-oauth2-server for local development.
+ *
+ * Extends the real Hitobito provider unchanged so the full production code path
+ * (HitobitoUser parsing, X-Scope header, /oauth/profile endpoint) is exercised.
+ *
+ * The only override is getBaseAuthorizationUrl(), which must use the browser-visible
+ * externalBaseUrl so the user is redirected to the nginx-proxied mock server URL.
+ * All internal API calls (token exchange, userinfo) go through a dedicated nginx
+ * server block (port 3005) that translates Hitobito-style paths to the mock server's
+ * OIDC paths:
+ *
+ *   /{issuer}/oauth/token   →  /{issuer}/token
+ *   /{issuer}/oauth/profile →  /{issuer}/userinfo
+ *
+ * The X-Scope header added by the parent's fetchResourceOwnerDetails() is silently
+ * ignored by navikt/mock-oauth2-server, so no override is needed.
+ *
+ * See reverse-proxy-nginx.conf (port 3005 server block).
+ */
+class MockHitobito extends Hitobito {
+    /** External URL reachable by the browser (proxied through nginx at /mock-auth). */
+    protected string $externalBaseUrl;
+
+    /** baseUrl is inherited from Hitobito and points to the nginx hitobito adapter (port 3005). */
+    public function getBaseAuthorizationUrl(): string {
+        // The browser-visible authorize URL uses the Hitobito /oauth/authorize path;
+        // nginx at port 3000 translates /mock-auth/{issuer}/oauth/authorize → /{issuer}/authorize.
+        return $this->externalBaseUrl.'/oauth/authorize';
+    }
+
+    #[\Override]
+    protected function getDefaultScopes(): array {
+        // navikt/mock-oauth2-server requires openid in the scope (OIDC mandate).
+        return ['openid', 'name'];
+    }
+}

--- a/dev-setup/mock-oauth/mock-oauth2-config.json
+++ b/dev-setup/mock-oauth/mock-oauth2-config.json
@@ -1,0 +1,4 @@
+{
+  "interactiveLogin": true,
+  "loginPagePath": "/app/login.html"
+}

--- a/dev-setup/mock-oauth/mock-oauth2-login.html
+++ b/dev-setup/mock-oauth/mock-oauth2-login.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Mock OAuth2 Sign-in</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        max-width: 480px;
+        margin: 60px auto;
+        padding: 0 16px;
+      }
+      h2 {
+        margin-bottom: 4px;
+      }
+      p.subtitle {
+        color: #666;
+        font-size: 0.9em;
+        margin-top: 0;
+        margin-bottom: 24px;
+      }
+      .user-btn {
+        display: block;
+        width: 100%;
+        margin-bottom: 10px;
+        padding: 10px 16px;
+        font-size: 1em;
+        text-align: left;
+        cursor: pointer;
+        background: #f5f5f5;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+      }
+      .user-btn:hover {
+        background: #e8e8e8;
+      }
+      .user-email {
+        font-weight: bold;
+      }
+      .user-name {
+        color: #555;
+        font-size: 0.9em;
+      }
+      hr {
+        margin: 24px 0;
+      }
+      .custom-row {
+        display: flex;
+        gap: 8px;
+      }
+      .custom-row input {
+        flex: 1;
+        padding: 8px;
+        font-size: 1em;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+      }
+      .custom-row button {
+        padding: 8px 16px;
+        font-size: 1em;
+        cursor: pointer;
+        border-radius: 4px;
+        border: 1px solid #aaa;
+      }
+      textarea[name='claims'] {
+        min-width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Mock OAuth2 Sign-in</h2>
+    <p class="subtitle">Local development only – not present in production.</p>
+
+    <!-- ── Pre-configured test users ─────────────────────────────────────── -->
+    <!--
+    Claims are universal: include both OIDC fields (given_name/family_name for
+    GoogleUser) and Hitobito fields (first_name/last_name/id for HitobitoUser).
+    The username becomes the token sub when sub is not in the claims JSON.
+  -->
+
+    <form method="post">
+      <input type="hidden" name="username" value="test@example.com" />
+      <input
+        type="hidden"
+        name="claims"
+        value='{"email":"test@example.com","name":"Test User","given_name":"Test","family_name":"User","id":1001,"first_name":"Test","last_name":"User","nickname":"test"}'
+      />
+      <button type="submit" class="user-btn">
+        <span class="user-email">test@example.com</span><br />
+        <span class="user-name">Test User</span>
+      </button>
+    </form>
+
+    <form method="post">
+      <input type="hidden" name="username" value="test2@example.com" />
+      <input
+        type="hidden"
+        name="claims"
+        value='{"email":"test2@example.com","name":"Test User 2","given_name":"Test","family_name":"User2","id":1002,"first_name":"Test","last_name":"User2","nickname":"test2"}'
+      />
+      <button type="submit" class="user-btn">
+        <span class="user-email">test2@example.com</span><br />
+        <span class="user-name">Test User 2</span>
+      </button>
+    </form>
+
+    <form method="post">
+      <input type="hidden" name="username" value="admin@example.com" />
+      <input
+        type="hidden"
+        name="claims"
+        value='{"email":"admin@example.com","name":"Admin User","given_name":"Admin","family_name":"User","id":1003,"first_name":"Admin","last_name":"User","nickname":"admin"}'
+      />
+      <button type="submit" class="user-btn">
+        <span class="user-email">admin@example.com</span><br />
+        <span class="user-name">Admin User</span>
+      </button>
+    </form>
+
+    <hr />
+    <form method="post">
+      <div class="custom-row">
+        <input type="hidden" name="username" placeholder="Enter email (or leave empty)" />
+        <!--suppress HtmlFormInputWithoutLabel -->
+        <textarea name="claims" rows="10">
+        {
+          "email":"my@email.com",
+          "given_name":"Custom",
+          "family_name":"User",
+          "first_name":"Custom",
+          "last_name":"User",
+          "nickname": "nickname",
+          "id":9999
+        }
+      </textarea
+        >
+      </div>
+      <div class="custom-row">
+        <button type="submit">Sign in</button>
+      </div>
+    </form>
+  </body>
+</html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     depends_on:
       - database
       - docker-host
+      - mock-oauth2
     volumes:
       - ./api/config/jwt:/app/config/jwt:rw,delegated
     ports:
@@ -220,6 +221,15 @@ services:
     network_mode: host
     working_dir: /e2e
 
+  mock-oauth2:
+    image: ghcr.io/navikt/mock-oauth2-server:4.0.0
+    volumes:
+      - ./dev-setup/mock-oauth/mock-oauth2-config.json:/app/config.json:ro
+      - ./dev-setup/mock-oauth/mock-oauth2-login.html:/app/login.html:ro
+    environment:
+      JSON_CONFIG_PATH: /app/config.json
+      SERVER_PORT: 8080
+
   reverse-proxy:
     image: nginx:1.31
     container_name: 'ecamp3-reverse-proxy'
@@ -229,6 +239,7 @@ services:
       - frontend
       - api
       - frontend-old
+      - mock-oauth2
     ports:
       - target: 3000
         published: 3000

--- a/e2e/tests/9-behavior-tests/oauth-login.spec.ts
+++ b/e2e/tests/9-behavior-tests/oauth-login.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test'
+import {
+  loginWithOAuth,
+  withOAuthSession,
+  getProfileEmail,
+  type OAuthProvider,
+} from '@/utils/oauthHelpers'
+
+test.describe('OAuth login', () => {
+  const providers: OAuthProvider[] = ['Google', 'MiData', 'CeviDB', 'JublaDB']
+
+  for (const provider of providers) {
+    test(`${provider}: shows camp list after login`, async ({ page }) => {
+      await loginWithOAuth(page, provider, 'test@example.com')
+      await expect(page).toHaveURL('/camps')
+    })
+  }
+})
+
+test.describe('OAuth login – account re-use', () => {
+  test('Google: second login returns the same account', async ({ browser }) => {
+    const email1 = await withOAuthSession(
+      browser,
+      'Google',
+      'admin@example.com',
+      getProfileEmail
+    )
+    const email2 = await withOAuthSession(
+      browser,
+      'Google',
+      'admin@example.com',
+      getProfileEmail
+    )
+    expect(email2).toBe(email1)
+  })
+})
+
+test.describe('OAuth login – cross-provider account linking', () => {
+  test('Google and MiData with the same email link to the same account', async ({
+    browser,
+  }) => {
+    const email1 = await withOAuthSession(
+      browser,
+      'Google',
+      'test2@example.com',
+      getProfileEmail
+    )
+    const email2 = await withOAuthSession(
+      browser,
+      'MiData',
+      'test2@example.com',
+      getProfileEmail
+    )
+    expect(email2).toBe(email1)
+  })
+
+  test('CeviDB and JublaDB with the same email link to the same account', async ({
+    browser,
+  }) => {
+    const email1 = await withOAuthSession(
+      browser,
+      'CeviDB',
+      'test2@example.com',
+      getProfileEmail
+    )
+    const email2 = await withOAuthSession(
+      browser,
+      'JublaDB',
+      'test2@example.com',
+      getProfileEmail
+    )
+    expect(email2).toBe(email1)
+  })
+})
+
+test.describe('OAuth login – separate users', () => {
+  test('two different usernames produce two different accounts', async ({ browser }) => {
+    const email1 = await withOAuthSession(
+      browser,
+      'Google',
+      'test@example.com',
+      getProfileEmail
+    )
+    const email2 = await withOAuthSession(
+      browser,
+      'Google',
+      'test2@example.com',
+      getProfileEmail
+    )
+    expect(email1).not.toBe(email2)
+  })
+})

--- a/e2e/utils/oauthHelpers.ts
+++ b/e2e/utils/oauthHelpers.ts
@@ -1,0 +1,40 @@
+import { type Page, type Browser } from '@playwright/test'
+
+export type OAuthProvider = 'Google' | 'MiData' | 'CeviDB' | 'JublaDB'
+
+export async function loginWithOAuth(
+  page: Page,
+  provider: OAuthProvider,
+  username: string = 'test@example.com'
+): Promise<void> {
+  await page.goto('/login')
+  await page.getByRole('button', { name: provider }).click()
+  await page.waitForURL(/\/mock-auth\//, { timeout: 10_000 })
+  await page.getByRole('button', { name: new RegExp(escapeRegExp(username)) }).click()
+  await page.waitForURL('/camps', { timeout: 30_000 })
+}
+
+export async function withOAuthSession<T>(
+  browser: Browser,
+  provider: OAuthProvider,
+  username: string,
+  fn: (page: Page) => Promise<T>
+): Promise<T> {
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+  try {
+    await loginWithOAuth(page, provider, username)
+    return await fn(page)
+  } finally {
+    await ctx.close()
+  }
+}
+
+export async function getProfileEmail(page: Page): Promise<string> {
+  await page.goto('/profile')
+  return page.getByRole('textbox', { name: /email/i }).inputValue()
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/reverse-proxy-nginx.conf
+++ b/reverse-proxy-nginx.conf
@@ -45,6 +45,10 @@ http {
       server mail:1080;
   }
 
+  upstream mock-oauth2 {
+      server mock-oauth2:8080;
+  }
+
   upstream pgadmin {
       server pg-admin:80;
   }
@@ -96,7 +100,53 @@ http {
       proxy_pass http://pg-admin/;
       proxy_redirect off;
     }
+
+    # Hitobito-style authorize path: /mock-auth/{issuer}/oauth/authorize
+    # Translates to the mock server's OIDC endpoint: /{issuer}/authorize
+    # (Hitobito uses /oauth/authorize; the OIDC mock server uses /authorize)
+    location ~ ^/mock-auth/([^/]+)/oauth/authorize {
+      rewrite ^/mock-auth/([^/]+)/oauth/authorize(.*)$ /$1/authorize$2 break;
+      proxy_pass http://mock-oauth2;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Mock OAuth2 server – local development and CI (always present in docker-compose.yml).
+    # Routes /mock-auth/{issuer}/... to the navikt/mock-oauth2-server container.
+    location /mock-auth/ {
+      proxy_pass http://mock-oauth2/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
   }
+  # Internal Hitobito OAuth2 adapter (API container → this → mock-oauth2).
+  # Translates Hitobito-style paths to the mock server's OIDC paths so that
+  # the real Hitobito provider class can be used without modification:
+  #
+  #   /{issuer}/oauth/token   →  /{issuer}/token    (token exchange)
+  #   /{issuer}/oauth/profile →  /{issuer}/userinfo (resource owner details)
+  #
+  # The API's MOCK_HITOBITO_INTERNAL_BASE_URL points here (http://reverse-proxy:3005).
+  # Not exposed to the host; only reachable within the Docker network.
+  server {
+    listen 3005;
+    server_name localhost;
+
+    location ~ ^/([^/]+)/oauth/token {
+      rewrite ^/([^/]+)/oauth/token(.*)$ /$1/token$2 break;
+      proxy_pass http://mock-oauth2;
+    }
+
+    location ~ ^/([^/]+)/oauth/profile {
+      rewrite ^/([^/]+)/oauth/profile(.*)$ /$1/userinfo$2 break;
+      proxy_pass http://mock-oauth2;
+    }
+  }
+
   server {
     listen 3004;
     server_name localhost;


### PR DESCRIPTION
In APP_ENV=dev (local Docker development), all four OAuth providers (Google, PBS MiData, CeviDB, JublaDB) are now backed by navikt/mock-oauth2-server instead of reaching out to real external services.

This lets developers and e2e tests exercise the full OAuth login flow— including the browser redirect, user-selection screen and callback— without real credentials or network access to external identity providers.

## What is NOT changed

- Helm charts (.helm/) are untouched: deployed environments (feature branches, staging, production) still use the real external OAuth providers.
- Existing knpu_oauth2_client.yaml (prod config) is untouched.
- GoogleAuthenticator and HitobitoAuthenticator are untouched and still used except for url and claim list overrides.