### PR TITLE
Improve token refresh experience

### DIFF
--- a/.helm/ecamp3/env.example.yaml
+++ b/.helm/ecamp3/env.example.yaml
@@ -4,6 +4,7 @@
   "API_DATA_MIGRATIONS_DIR": "dev-data",
   "API_NUM_THREADS": null,
   "API_SENTRY_DSN": null,
+  "AUTH_REFRESH_TOKEN_TTL": null,
   "AUTOSCALING_ENABLED": false,
   "BACKUP_ENCRYPTION_KEY": null,
   "BACKUP_S3_ACCESS_KEY": null,

--- a/.helm/ecamp3/templates/api_configmap.yaml
+++ b/.helm/ecamp3/templates/api_configmap.yaml
@@ -10,6 +10,9 @@ data:
   {{- if and (.Values.api.authenticationTokenTtl) (ne (.Values.api.authenticationTokenTtl | toString) "<no value>") }}
   AUTHENTICATION_TOKEN_TTL: {{ .Values.api.authenticationTokenTtl | quote }}
   {{- end }}
+  {{- if and (.Values.auth.refreshTokenTtl) (ne (.Values.auth.refreshTokenTtl | toString) "<no value>") }}
+  REFRESH_TOKEN_TTL: {{ .Values.auth.refreshTokenTtl | quote }}
+  {{- end }}
   COOKIE_PREFIX: {{ include "api.cookiePrefix" . | quote }}
   APP_ENV: {{ .Values.api.appEnv | quote }}
   APP_DEBUG: {{ .Values.api.appDebug | quote }}

--- a/.helm/ecamp3/templates/frontend_configmap.yaml
+++ b/.helm/ecamp3/templates/frontend_configmap.yaml
@@ -10,6 +10,9 @@ data:
     window.environment = {
       API_ROOT_URL: '{{ include "api.url" . }}',
       COOKIE_PREFIX: '{{ include "api.cookiePrefix" . }}',
+    {{- if and (.Values.auth.refreshTokenTtl) (ne (.Values.auth.refreshTokenTtl | toString) "<no value>") }}
+      REFRESH_TOKEN_TTL: '{{ .Values.auth.refreshTokenTtl }}',
+    {{- end }}
       PRINT_URL: '{{ include "print.url" . }}',
     {{- if .Values.frontend.sentryDsn }}
       SENTRY_FRONTEND_DSN: '{{ .Values.frontend.sentryDsn }}',

--- a/.helm/ecamp3/values.yaml.gotmpl
+++ b/.helm/ecamp3/values.yaml.gotmpl
@@ -24,6 +24,10 @@ featureToggle:
   developer: {{ .Environment.Values | getOrNil "FEATURE_DEVELOPER" | default false }}
   checklist: {{ .Environment.Values | getOrNil "FEATURE_CHECKLIST" | default false }}
 
+# Authentication token lifetimes (in seconds), shared by api and frontend
+auth:
+  refreshTokenTtl: {{ .Environment.Values | getOrNil "AUTH_REFRESH_TOKEN_TTL" | default 2592000 }}
+
 api:
   authenticationTokenTtl: {{ .Environment.Values | getOrNil "API_AUTHENTICATION_TOKEN_TTL" }}
   dataMigrationsDir: {{ .Environment.Values | getOrNil "API_DATA_MIGRATIONS_DIR" | default "prod-data" }}

--- a/api/.env
+++ b/api/.env
@@ -81,6 +81,8 @@ MAIL_FROM_NAME="eCamp v3"
 RECAPTCHA_SECRET="disabled"
 ###< google/recaptcha ###
 
-# Tokens are valid for 12 hours..
+# Access tokens are valid for 12 hours..
 AUTHENTICATION_TOKEN_TTL=43200
+# Refresh tokens are valid for 30 days..
+REFRESH_TOKEN_TTL=2592000
 TRANSLATE_ERRORS_TO_LOCALES="en,de,fr,it,rm"

--- a/api/config/packages/gesdinet_jwt_refresh_token.yaml
+++ b/api/config/packages/gesdinet_jwt_refresh_token.yaml
@@ -1,4 +1,5 @@
 gesdinet_jwt_refresh_token:
+    ttl: '%env(int:REFRESH_TOKEN_TTL)%'
     cookie:
         enabled: true
         same_site: strict

--- a/e2e/tests/9-behavior-tests/auth.e2e.spec.ts
+++ b/e2e/tests/9-behavior-tests/auth.e2e.spec.ts
@@ -1,0 +1,98 @@
+import { type BrowserContext, expect, type Page, test } from '@playwright/test'
+import { loginAndSetCookie } from '@/utils/helpers'
+
+const COOKIE_PREFIX = 'localhost_'
+const S_COOKIE = `${COOKIE_PREFIX}jwt_s`
+
+test.describe('auth token handling', () => {
+  test('expired jwt is refreshed and the protected page loads', async ({
+    page,
+    context,
+  }) => {
+    await loginAndSetCookie(page, context, 'test@example.com')
+    const campRows = page.locator('.v-list-item[role="link"]')
+    await expect.poll(async () => campRows.count()).toBeGreaterThan(3)
+
+    await context.clearCookies({ name: S_COOKIE })
+
+    await page.goto('/camps')
+    await expect(page).toHaveURL(/\/camps/, { timeout: 15000 })
+    await expect.poll(async () => campRows.count()).toBeGreaterThan(3)
+  })
+
+  test('redirects to login when the refresh fails', async ({ page }) => {
+    await page.route(/\/token\/refresh$/, (route) =>
+      route.fulfill({ status: 401, body: '' })
+    )
+
+    await page.goto('/camps')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('skips refresh and redirects to login when refresh token is known expired', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('refreshTokenExpiresAt', '1')
+    })
+
+    await page.goto('/camps')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('mid-session 401 triggers transparent refresh and page stays loaded', async ({
+    page,
+    context,
+  }) => {
+    await loginAndSetCookie(page, context, 'test@example.com')
+
+    // Make the first camps request fail with 401; no anchor so query params are ignored
+    let failed = false
+    await page.route(/\/api\/camps/, async (route) => {
+      if (!failed) {
+        failed = true
+        await route.fulfill({ status: 401, body: '' })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await page.reload()
+    await expect(page).toHaveURL(/\/camps/, { timeout: 15000 })
+  })
+
+  test('token refreshed in one tab keeps another tab authenticated', async ({
+    browser,
+  }) => {
+    const context: BrowserContext = await browser.newContext()
+
+    try {
+      const tabA: Page = await context.newPage()
+      const tabB: Page = await context.newPage()
+
+      await loginAndSetCookie(tabA, context, 'test@example.com')
+      await tabB.goto('/camps')
+      await expect(tabB).toHaveURL(/\/camps/)
+
+      // Make the first camps request in tab A return 401, triggering a real token refresh
+      let failed = false
+      await context.route(/\/api\/camps/, async (route) => {
+        if (!failed) {
+          failed = true
+          await route.fulfill({ status: 401, body: '' })
+        } else {
+          await route.continue()
+        }
+      })
+
+      await tabA.goto('/camps')
+      await expect(tabA).toHaveURL(/\/camps/, { timeout: 15000 })
+
+      // After the token rotated in tab A, tab B must still work
+      await tabB.reload()
+      await expect(tabB).toHaveURL(/\/camps/, { timeout: 15000 })
+    } finally {
+      await context.close()
+    }
+  })
+})

--- a/e2e/tests/9-behavior-tests/reLoginDialog.e2e.spec.ts
+++ b/e2e/tests/9-behavior-tests/reLoginDialog.e2e.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test'
+import { loginAndSetCookie, makeExpiredJwt } from '@/utils/helpers'
+
+const COOKIE_PREFIX = 'localhost_'
+const S_COOKIE = `${COOKIE_PREFIX}jwt_s`
+const HP_COOKIE = `${COOKIE_PREFIX}jwt_hp`
+
+test.describe('re-login dialog', () => {
+  test.beforeEach(async ({ page, context }) => {
+    await loginAndSetCookie(page, context, 'test@example.com')
+
+    let apiCampIntercepted = false
+    await page.route(/\/api\/camps/, (route) => {
+      if (!apiCampIntercepted) {
+        apiCampIntercepted = true
+        return route.fulfill({ status: 401, body: '' })
+      }
+      route.continue()
+    })
+
+    let refreshIntercepted = false
+    await page.route(/\/token\/refresh$/, (route) => {
+      if (!refreshIntercepted) {
+        refreshIntercepted = true
+        return route.fulfill({ status: 401, body: '' })
+      }
+      route.continue()
+    })
+
+    await context.clearCookies({ name: S_COOKIE })
+    await page.reload()
+    await expect(page.getByText('Sitzung abgelaufen')).toBeVisible({ timeout: 15000 })
+
+    // clear the HP cookie at the end, else we get thrown to the login page.
+    await context.clearCookies({ name: HP_COOKIE })
+    await context.addCookies([
+      { name: HP_COOKIE, value: makeExpiredJwt(), url: 'http://localhost:3000' },
+    ])
+  })
+
+  test('dialog appears when session expires mid-session', async ({ page }) => {
+    await expect(page.getByText('Sitzung abgelaufen')).toBeVisible()
+    await expect(page).toHaveURL(/\/camps/)
+  })
+
+  test('re-login in new tab closes dialog and stays on page', async ({
+    page,
+    context,
+  }) => {
+    const newTabPromise = context.waitForEvent('page')
+    await page.getByRole('button', { name: /Anmeld/i }).click()
+    const loginTab = await newTabPromise
+
+    const loginButton = loginTab.getByRole('button', { name: 'Login' })
+    await expect(loginButton).toBeVisible({ timeout: 10_000 })
+
+    await loginButton.click()
+    await expect(loginTab).toHaveURL((url) => url.pathname !== '/login')
+    const campRows = loginTab.locator('.v-list-item[role="link"]')
+    await expect.poll(async () => campRows.count()).toBeGreaterThan(3)
+
+    await expect(page.getByText('Sitzung abgelaufen')).toBeHidden({ timeout: 5000 })
+    await expect(page).toHaveURL(/\/camps/)
+  })
+
+  test('logout button in dialog navigates to login page', async ({ page }) => {
+    await page.getByRole('button', { name: 'Ausloggen' }).click()
+
+    await expect(page).toHaveURL(/\/login/)
+  })
+})
+
+test('dialog is not shown when the refresh token silently renews the session', async ({
+  page,
+  context,
+}) => {
+  await loginAndSetCookie(page, context, 'test@example.com')
+  await context.clearCookies({ name: HP_COOKIE })
+  await context.addCookies([
+    { name: HP_COOKIE, value: makeExpiredJwt(), url: 'http://localhost:3000' },
+  ])
+
+  await page.goto('/camps')
+
+  await expect(page.getByText('Sitzung abgelaufen')).toBeHidden()
+  await expect(page).toHaveURL(/\/camps/, { timeout: 15000 })
+})

--- a/e2e/utils/helpers.ts
+++ b/e2e/utils/helpers.ts
@@ -47,6 +47,24 @@ export async function getAuthContext(user: string): Promise<APIRequestContext> {
 
 export { getPdfProperties } from './getPdfProperties'
 
+export function makeExpiredJwt(): string {
+  const b64url = (obj: object) =>
+    Buffer.from(JSON.stringify(obj))
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '')
+  const header = b64url({ typ: 'JWT', alg: 'RS256' })
+  const payload = b64url({
+    iat: 0,
+    exp: 0,
+    roles: ['ROLE_USER'],
+    username: 'x',
+    user: '/users/x',
+  })
+  return `${header}.${payload}`
+}
+
 export async function expectCacheHeader(
   request: APIRequestContext,
   uri: string,

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -18,6 +18,7 @@
       </p>
     </v-footer>
     <v-snackbar-queue v-model="snackbarMessages"></v-snackbar-queue>
+    <ReLoginDialog />
   </v-app>
 </template>
 
@@ -26,9 +27,11 @@ import VueI18n from '@/plugins/i18n'
 import { headEnvironment } from '@/plugins/index.js'
 import { mapGetters } from 'vuex'
 import { useHead } from '@unhead/vue'
+import ReLoginDialog from '@/components/auth/ReLoginDialog.vue'
 
 export default {
   name: 'App',
+  components: { ReLoginDialog },
   setup() {
     useHead({
       title: null,

--- a/frontend/src/components/auth/ReLoginDialog.vue
+++ b/frontend/src/components/auth/ReLoginDialog.vue
@@ -1,0 +1,70 @@
+<template>
+  <v-dialog v-model="isAuthRequired" persistent max-width="500">
+    <v-card style="overflow: hidden">
+      <v-card-title>{{ $t('global.reLoginDialog.title') }}</v-card-title>
+      <v-card-text>
+        <p class="mb-0">{{ $t('global.reLoginDialog.description') }}</p>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn variant="outlined" @click="openLoginTab">
+          {{ $t('global.reLoginDialog.loginAgain') }}
+        </v-btn>
+        <v-spacer />
+        <v-btn variant="text" @click="logOut">{{ $t('global.button.logout') }}</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import { resolveReAuth, rejectReAuth, getJWTExpirationTimestamp } from '@/plugins/auth.js'
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'ReLoginDialog',
+  data() {
+    return {
+      pollInterval: null,
+    }
+  },
+  computed: {
+    ...mapGetters(['isAuthRequired']),
+  },
+  watch: {
+    isAuthRequired(val) {
+      if (!val) {
+        this.stopPolling()
+      }
+    },
+  },
+  beforeUnmount() {
+    this.stopPolling()
+  },
+  methods: {
+    openLoginTab() {
+      window.open(this.$router.resolve({ name: 'login' }).href, '_blank')
+      this.startPolling()
+    },
+    startPolling() {
+      if (this.pollInterval) return
+      this.pollInterval = setInterval(() => {
+        if (Date.now() < getJWTExpirationTimestamp()) {
+          this.stopPolling()
+          resolveReAuth()
+        }
+      }, 1000)
+    },
+    stopPolling() {
+      if (this.pollInterval) {
+        clearInterval(this.pollInterval)
+        this.pollInterval = null
+      }
+    },
+    async logOut() {
+      this.stopPolling()
+      rejectReAuth()
+      await this.$auth.logout()
+    },
+  },
+}
+</script>

--- a/frontend/src/environment.js
+++ b/frontend/src/environment.js
@@ -8,6 +8,7 @@ export function getEnv() {
   return {
     API_ROOT_URL: env.VITE_API_ROOT_URL ?? '/api',
     COOKIE_PREFIX: env.VITE_COOKIE_PREFIX ?? 'localhost_',
+    REFRESH_TOKEN_TTL: Number(env.VITE_REFRESH_TOKEN_TTL ?? 2592000),
     PRINT_URL: env.VITE_PRINT_URL ?? '/print',
     SENTRY_FRONTEND_DSN: env.VITE_SENTRY_FRONTEND_DSN,
     SENTRY_ENVIRONMENT: env.VITE_SENTRY_ENVIRONMENT ?? 'local',

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -641,6 +641,11 @@
     },
     "warning": {
       "delete": "Möchtest du das wirklich löschen? | Möchtest du \"{entity}\" wirklich löschen?"
+    },
+    "reLoginDialog": {
+      "title": "Sitzung abgelaufen",
+      "description": "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an, um fortzufahren.",
+      "loginAgain": "Erneut anmelden"
     }
   },
   "views": {
@@ -868,6 +873,9 @@
     "pageNotFound": {
       "backToHome": "Zurück zur Startseite",
       "detail": "Hoppla. Du bist vom Weg abgekommen…{br}Dieser Link funktioniert leider nicht."
+    },
+    "pageLoading": {
+      "loading": "Einen Moment bitte…"
     },
     "profile": {
       "changeEmail": "Ändern",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -641,6 +641,11 @@
     },
     "warning": {
       "delete": "Do you really want to delete this? | Do you really want to delete \"{entity}\"?"
+    },
+    "reLoginDialog": {
+      "title": "Session expired",
+      "description": "Your session has expired. Please log in again to continue.",
+      "loginAgain": "Log in again"
     }
   },
   "views": {
@@ -868,6 +873,9 @@
     "pageNotFound": {
       "backToHome": "Back to home",
       "detail": "Oops. You've lost your way…{br}Unfortunately, this link does not work."
+    },
+    "pageLoading": {
+      "loading": "Loading…"
     },
     "profile": {
       "changeEmail": "Change",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -635,6 +635,11 @@
     },
     "warning": {
       "delete": "Veux-tu vraiment le supprimer ? | Veux-tu vraiment supprimer \"{entity}\" ?"
+    },
+    "reLoginDialog": {
+      "title": "Session expirée",
+      "description": "Ta session a expiré. Merci de te reconnecter pour continuer.",
+      "loginAgain": "Se reconnecter"
     }
   },
   "views": {
@@ -862,6 +867,9 @@
     "pageNotFound": {
       "backToHome": "Retour à l'accueil",
       "detail": "Hop là ! Tu t'es égaré...{br}Ce lien ne fonctionne malheureusement pas."
+    },
+    "pageLoading": {
+      "loading": "Chargement…"
     },
     "profile": {
       "changeEmail": "Changement",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -517,6 +517,11 @@
     },
     "warning": {
       "delete": "Volete davvero cancellarlo? | Volete davvero cancellarlo \"{entity}\"?"
+    },
+    "reLoginDialog": {
+      "title": "Sessione scaduta",
+      "description": "La tua sessione è scaduta. Effettua di nuovo il login per continuare.",
+      "loginAgain": "Accedi di nuovo"
     }
   },
   "views": {
@@ -719,6 +724,9 @@
     "pageNotFound": {
       "backToHome": "Torna a casa",
       "detail": "Ops. Hai perso la strada…{br}Purtroppo questo link non funziona."
+    },
+    "pageLoading": {
+      "loading": "Caricamento…"
     },
     "profile": {
       "changeEmail": "Cambiamento",

--- a/frontend/src/locales/rm.json
+++ b/frontend/src/locales/rm.json
@@ -440,6 +440,11 @@
     },
     "warning": {
       "delete": "Vuls ti propi stizzar quai? | Vuls ti propi stizzar \"{entity}\"?"
+    },
+    "reLoginDialog": {
+      "title": "Sessiun scadida",
+      "description": "Tia sessiun è scadida. Torna t'annunzia per cuntinuar.",
+      "loginAgain": "S'annunziar puspè"
     }
   },
   "views": {
@@ -635,6 +640,9 @@
     "pageNotFound": {
       "backToHome": "Enavos a la pagina da partenza",
       "detail": "Hopla. Ti has pers la via…{br}Questa colliaziun na funcziuna deplorablamain betg."
+    },
+    "pageLoading": {
+      "loading": "Chargiar…"
     },
     "profile": {
       "changeEmail": "Midar",

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { apiStore, store } from '@/plugins/store'
 import { hasLoggedOutFromLocalStorage } from '@/plugins/store/auth.js'
 import router from '@/router'
@@ -6,14 +5,57 @@ import Cookies from 'js-cookie'
 import { getEnv } from '@/environment.js'
 import { isNavigationFailure, NavigationFailureType } from 'vue-router'
 
-axios.interceptors.response.use(null, (error) => {
-  if (error.status === 401) {
-    logout().then(() => {})
-  }
-  return Promise.reject(error)
-})
+const REFRESH_PATH = '/token/refresh'
 
 let scheduledRefresh = null
+let refreshTokenPromise = null
+
+function isRefreshRequest(config) {
+  return !!config?.url && config.url.includes(REFRESH_PATH)
+}
+
+export function setupAxiosAuthInterceptor(axiosInstance) {
+  axiosInstance.interceptors.response.use(null, async (error) => {
+    const request = error.config
+    const status = error.response?.status ?? error.status
+
+    if (
+      status !== 401 ||
+      !request ||
+      request._authRetried ||
+      isRefreshRequest(request) ||
+      hasLoggedOutFromLocalStorage()
+    ) {
+      return Promise.reject(error)
+    }
+
+    request._authRetried = true
+
+    try {
+      await refreshAuthTokenSingleton()
+    } catch {
+      await logout()
+      return Promise.reject(error)
+    }
+
+    rescheduleRefresh()
+    return axiosInstance(request)
+  })
+}
+
+function refreshAuthTokenSingleton() {
+  async function refresh() {
+    const url = await apiStore.href(apiStore.get(), 'refreshToken')
+    return apiStore.post(url)
+  }
+
+  if (!refreshTokenPromise) {
+    refreshTokenPromise = refresh().finally(() => {
+      refreshTokenPromise = null
+    })
+  }
+  return refreshTokenPromise
+}
 
 export async function initRefresh() {
   // Cookies.get was not reliable to detect if the cookie was present.
@@ -27,7 +69,7 @@ export async function initRefresh() {
   let refreshedSuccessfully = false
   if (!isLoggedIn()) {
     try {
-      await refresh()
+      await refreshAuthTokenSingleton()
     } catch {
       /* empty */
     }
@@ -57,13 +99,8 @@ function rescheduleRefresh() {
 }
 
 async function refreshAndSchedule() {
-  await refresh()
+  await refreshAuthTokenSingleton()
   rescheduleRefresh()
-}
-
-async function refresh() {
-  const url = await apiStore.href(apiStore.get(), 'refreshToken')
-  return apiStore.post(url)
 }
 
 function getJWTPayloadFromCookie() {

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -1,5 +1,8 @@
 import { apiStore, store } from '@/plugins/store'
-import { hasLoggedOutFromLocalStorage } from '@/plugins/store/auth.js'
+import {
+  hasLoggedOutFromLocalStorage,
+  getRefreshTokenExpiresAt,
+} from '@/plugins/store/auth.js'
 import router from '@/router'
 import Cookies from 'js-cookie'
 import { getEnv } from '@/environment.js'
@@ -9,6 +12,41 @@ const REFRESH_PATH = '/token/refresh'
 
 let scheduledRefresh = null
 let refreshTokenPromise = null
+let reAuthPromise = null
+let reAuthResolve = null
+let reAuthReject = null
+
+function waitForReAuth() {
+  if (!reAuthPromise) {
+    reAuthPromise = new Promise((resolve, reject) => {
+      reAuthResolve = resolve
+      reAuthReject = reject
+    })
+  }
+  return reAuthPromise
+}
+
+export function resolveReAuth() {
+  reAuthResolve?.()
+  reAuthPromise = null
+  reAuthResolve = null
+  reAuthReject = null
+  store.commit('setAuthRequired', false)
+}
+
+export function rejectReAuth() {
+  reAuthReject?.(new Error('Re-authentication cancelled'))
+  reAuthPromise = null
+  reAuthResolve = null
+  reAuthReject = null
+  store.commit('setAuthRequired', false)
+}
+
+export function isRefreshLikelyPossible() {
+  const refreshTokenExpiry = getRefreshTokenExpiresAt()
+  if (refreshTokenExpiry === 0) return false
+  return Date.now() < refreshTokenExpiry
+}
 
 function isRefreshRequest(config) {
   return !!config?.url && config.url.includes(REFRESH_PATH)
@@ -34,8 +72,13 @@ export function setupAxiosAuthInterceptor(axiosInstance) {
     try {
       await refreshAuthTokenSingleton()
     } catch {
-      await logout()
-      return Promise.reject(error)
+      store.commit('setAuthRequired', true)
+      try {
+        await waitForReAuth()
+      } catch {
+        return Promise.reject(error)
+      }
+      return axiosInstance(request)
     }
 
     rescheduleRefresh()
@@ -58,34 +101,41 @@ function refreshAuthTokenSingleton() {
 }
 
 export async function initRefresh() {
-  // Cookies.get was not reliable to detect if the cookie was present.
-  if (hasLoggedOutFromLocalStorage()) {
-    return
-  }
-  let originalTarget = `${window.location.pathname}`
-  if (window.location.search) {
-    originalTarget += `?${window.location.search}`
-  }
-  let refreshedSuccessfully = false
-  if (!isLoggedIn()) {
-    try {
-      await refreshAuthTokenSingleton()
-    } catch {
-      /* empty */
-    }
-    if (!isLoggedIn()) {
+  try {
+    // Cookies.get was not reliable to detect if the cookie was present.
+    if (hasLoggedOutFromLocalStorage()) {
       return
     }
-    refreshedSuccessfully = true
-  }
-  rescheduleRefresh()
-  if (refreshedSuccessfully) {
-    await router.replace(originalTarget).catch((e) => {
-      // Silently ignore if we are already at that target
-      if (!isNavigationFailure(e, NavigationFailureType.duplicated)) {
-        return Promise.reject(e)
+    let originalTarget = `${window.location.pathname}`
+    if (window.location.search) {
+      originalTarget += `?${window.location.search}`
+    }
+    let refreshedSuccessfully = false
+    if (!isLoggedIn()) {
+      if (getRefreshTokenExpiresAt() === 0) {
+        return
       }
-    })
+      try {
+        await refreshAuthTokenSingleton()
+      } catch {
+        /* empty */
+      }
+      if (!isLoggedIn()) {
+        return
+      }
+      refreshedSuccessfully = true
+    }
+    rescheduleRefresh()
+    if (refreshedSuccessfully) {
+      await router.replace(originalTarget).catch((e) => {
+        // Silently ignore if we are already at that target
+        if (!isNavigationFailure(e, NavigationFailureType.duplicated)) {
+          return Promise.reject(e)
+        }
+      })
+    }
+  } finally {
+    store.commit('setAuthInitializing', false)
   }
 }
 
@@ -93,6 +143,7 @@ function rescheduleRefresh() {
   if (scheduledRefresh != null) {
     clearTimeout(scheduledRefresh)
   }
+  store.commit('setRefreshTokenExpiresAt', Date.now() + getEnv().REFRESH_TOKEN_TTL * 1000)
   const timeout = (getJWTExpirationTimestamp() - Date.now()) / 2
   const realTimeout = Math.max(Math.min(timeout, 30 * 60 * 1000), 2 * 60 * 1000)
   scheduledRefresh = setTimeout(refreshAndSchedule, realTimeout)
@@ -125,7 +176,7 @@ function parseJWTPayload(payload) {
   return JSON.parse(jsonPayload)
 }
 
-function getJWTExpirationTimestamp() {
+export function getJWTExpirationTimestamp() {
   return (parseJWTPayload(getJWTPayloadFromCookie()).exp ?? 0) * 1000
 }
 

--- a/frontend/src/plugins/store/auth.js
+++ b/frontend/src/plugins/store/auth.js
@@ -6,9 +6,16 @@ import { apiStore } from '@/plugins/store/index'
  * to refresh the access token.
  */
 const HAS_LOGGED_OUT = 'hasLoggedOut'
+const REFRESH_TOKEN_EXPIRES_AT_KEY = 'refreshTokenExpiresAt'
 
 export const state = {
   user: null,
+  authInitializing: true,
+  authRequired: false,
+  refreshTokenExpiresAt: parseInt(
+    window.localStorage.getItem(REFRESH_TOKEN_EXPIRES_AT_KEY) ?? '0',
+    10
+  ),
 }
 
 export const mutations = {
@@ -19,7 +26,22 @@ export const mutations = {
 
   logout(state) {
     state.user = null
+    state.refreshTokenExpiresAt = 0
     window.localStorage.setItem(HAS_LOGGED_OUT, 'true')
+    window.localStorage.removeItem(REFRESH_TOKEN_EXPIRES_AT_KEY)
+  },
+
+  setAuthInitializing(state, initializing) {
+    state.authInitializing = initializing
+  },
+
+  setAuthRequired(state, required) {
+    state.authRequired = required
+  },
+
+  setRefreshTokenExpiresAt(state, timestamp) {
+    state.refreshTokenExpiresAt = timestamp
+    window.localStorage.setItem(REFRESH_TOKEN_EXPIRES_AT_KEY, timestamp.toString())
   },
 }
 export const getters = {
@@ -30,10 +52,21 @@ export const getters = {
   getLoggedInUser: (authState) => {
     return authState.user ? apiStore.get(authState.user._meta.self) : authState.user
   },
+  isAuthInitializing: (authState) => {
+    return authState.authInitializing
+  },
+  isAuthRequired: (authState) => {
+    return authState.authRequired
+  },
 }
 
 export function hasLoggedOutFromLocalStorage() {
   return window.localStorage.getItem(HAS_LOGGED_OUT) === 'true'
+}
+
+export function getRefreshTokenExpiresAt() {
+  const stored = window.localStorage.getItem(REFRESH_TOKEN_EXPIRES_AT_KEY)
+  return stored ? parseInt(stored, 10) : 0
 }
 
 export default {

--- a/frontend/src/plugins/store/index.js
+++ b/frontend/src/plugins/store/index.js
@@ -6,6 +6,7 @@ import auth from './auth'
 import preferences from './preferences'
 import snackbarMessagesStore from './snackbarMessagesStore'
 import { getEnv } from '@/environment.js'
+import { setupAxiosAuthInterceptor } from '@/plugins/auth.js'
 
 export default {
   install: (app, _) => {
@@ -21,7 +22,7 @@ export default {
 
     app.use(store)
 
-    const axiosInstance = axios.create({
+    axiosInstance = axios.create({
       withCredentials: true,
       baseURL: getEnv().API_ROOT_URL,
       headers: { common: { Accept: 'application/hal+json' } },
@@ -32,6 +33,7 @@ export default {
       }
       return config
     })
+    setupAxiosAuthInterceptor(axiosInstance)
 
     // create and inject API
     apiStore = new HalJsonVuex(store, axiosInstance, {
@@ -44,3 +46,4 @@ export default {
 
 export let apiStore
 export let store
+export let axiosInstance

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { slugify } from '@/plugins/slugify.js'
-import { isAdmin, isLoggedIn } from '@/plugins/auth'
+import { isAdmin, isLoggedIn, isRefreshLikelyPossible } from '@/plugins/auth'
+import { hasLoggedOutFromLocalStorage } from '@/plugins/store/auth.js'
 import { apiStore } from '@/plugins/store'
 import { campShortTitle } from '@/common/helpers/campShortTitle'
 import { getEnv } from '@/environment.js'
@@ -541,6 +542,13 @@ const router = createRouter({
       redirect: { name: 'camps' },
     },
     {
+      path: '/loading',
+      name: 'loading',
+      components: {
+        default: () => import('./views/PageLoading.vue'),
+      },
+    },
+    {
       path: '/**',
       name: 'PageNotFound',
       components: {
@@ -578,9 +586,13 @@ function all(guards) {
 function requireAuth(to, from, next) {
   if (isLoggedIn()) {
     next()
-  } else {
-    next({ name: 'login', query: to.path === '/' ? {} : { redirect: to.fullPath } })
+    return
   }
+  if (!hasLoggedOutFromLocalStorage() && isRefreshLikelyPossible()) {
+    next({ name: 'loading', query: to.path === '/' ? {} : { redirect: to.fullPath } })
+    return
+  }
+  next({ name: 'login', query: to.path === '/' ? {} : { redirect: to.fullPath } })
 }
 
 function requireAdmin(to, from, next) {

--- a/frontend/src/views/PageLoading.vue
+++ b/frontend/src/views/PageLoading.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="sky">
+    <div class="hill">
+      <TentNight class="tent" />
+      <div class="relative">
+        <p class="text-white text-center px-3 d-flex justify-center mb-n8 relative">
+          {{ $t('views.pageLoading.loading') }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import TentNight from '@/assets/tents/TentNight.vue'
+import { isLoggedIn } from '@/plugins/auth.js'
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'PageLoading',
+  components: { TentNight },
+  computed: {
+    ...mapGetters(['isAuthInitializing']),
+  },
+  watch: {
+    isAuthInitializing(initializing) {
+      if (!initializing) this.navigateAfterAuth()
+    },
+  },
+  mounted() {
+    if (!this.$store.state.auth.authInitializing) {
+      this.navigateAfterAuth()
+    }
+  },
+  methods: {
+    navigateAfterAuth() {
+      if (this.$route.name !== 'loading') return
+      const redirect = this.$route.query.redirect
+      if (isLoggedIn()) {
+        this.$router.replace(redirect || { name: 'home' }).catch(() => {})
+      } else {
+        this.$router
+          .replace({ name: 'login', query: redirect ? { redirect } : {} })
+          .catch(() => {})
+      }
+    },
+  },
+}
+</script>
+
+<style scoped lang="scss">
+.sky {
+  height: 100%;
+  background-image:
+    radial-gradient(circle at bottom, #607d8b, #0c3c4c, #0e1c22),
+    url('../assets/tents/stars.svg');
+  background-blend-mode: screen;
+  background-size: contain, 1470px;
+  background-repeat: no-repeat, repeat-x;
+  background-position:
+    bottom,
+    center top;
+  animation: 350s linear infinite sky-translate;
+}
+
+@keyframes sky-translate {
+  0% {
+    background-position:
+      bottom,
+      calc(50% + 120px) top;
+  }
+  100% {
+    background-position:
+      top,
+      calc(50% + 120px - 1780px) top;
+  }
+}
+
+.hill {
+  height: 100%;
+  background-image: radial-gradient(
+    150vmax 70% at bottom,
+    #0f252e,
+    #0d171d 70.1%,
+    transparent 50%
+  );
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background-position: bottom center;
+  overflow: hidden;
+  position: relative;
+}
+
+.tent {
+  height: 300px;
+  max-height: 80vw;
+  width: auto;
+  margin: 0 auto;
+  z-index: 2;
+}
+</style>


### PR DESCRIPTION
refresh_token: retry requests to the api after refreshing the auth token

Issue: #8950

---

frontend: if the token refresh doesn't work, allow the user to login in another tab

This also supports oauth and keeps the state the user was in.
Also do not route to the login page as long as we don't know if
we need to authenticate or not.
