### PR TITLE
fix: add tabindex=-1 to picker icon buttons to skip them in tab order

### DIFF
--- a/frontend/src/components/form/base/BasePicker.vue
+++ b/frontend/src/components/form/base/BasePicker.vue
@@ -47,6 +47,7 @@ Displays a field as a picker (can be used with v-model)
                 :aria-label="
                   $t(buttonAriaLabelI18nKey, 0, { label: labelOrEntityFieldLabel })
                 "
+                tabindex="-1"
                 @click="(...args) => onMenuOpen(props, ...args)"
               >
                 {{ icon }}


### PR DESCRIPTION
The calendar/clock icon buttons in date and time pickers can only be activated with the mouse — they open a picker dialog that has no keyboard close mechanism. Keyboard users who accidentally Tab into these icons get stuck. Adding tabindex="-1" removes them from the tab order so keyboard users can navigate directly from field to field.

Fixes https://github.com/ecamp/ecamp3/issues/5488