### PR TITLE
fix(api): return 400 instead of 500 for invalid date/timezone strings

### DIFF
--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -42,3 +42,4 @@ api_platform:
         ApiPlatform\Metadata\Exception\InvalidArgumentException: 400
         ApiPlatform\ParameterValidator\Exception\ValidationExceptionInterface: 400
         Doctrine\ORM\OptimisticLockException: 409
+        \DateMalformedStringException: 400

--- a/api/tests/Api/ScheduleEntries/UpdateScheduleEntryTest.php
+++ b/api/tests/Api/ScheduleEntries/UpdateScheduleEntryTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Api\ScheduleEntries;
 
 use App\Entity\ScheduleEntry;
 use App\Tests\Api\ECampApiTestCase;
+use PHPUnit\Framework\Attributes\TestWith;
 
 /**
  * @internal
@@ -316,6 +317,26 @@ class UpdateScheduleEntryTest extends ECampApiTestCase {
                 ],
             ],
         ]);
+    }
+
+    public function testPatchScheduleEntryValidatesStartWithInvalidTimezone() {
+        $scheduleEntry = static::getFixture('scheduleEntry1');
+        static::createClientWithCredentials()->request('PATCH', '/schedule_entries/'.$scheduleEntry->getId(), ['json' => [
+            'start' => '2023-05-01T00:00:00+InvalidTimezone',
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    #[TestWith(['20206-01-01T00:00:00'])]
+    #[TestWith(['2026-31-12T00:00:00'])]
+    public function testPatchScheduleEntryValidatesStartWithInvalidDateTime($invalidDateTime) {
+        $scheduleEntry = static::getFixture('scheduleEntry1');
+        static::createClientWithCredentials()->request('PATCH', '/schedule_entries/'.$scheduleEntry->getId(), ['json' => [
+            'start' => $invalidDateTime,
+        ], 'headers' => ['Content-Type' => 'application/merge-patch+json']]);
+
+        $this->assertResponseStatusCodeSame(400);
     }
 
     public function testPatchScheduleEntryAllowsToEndAtMidnightOfLastDay() {


### PR DESCRIPTION
PHP 8.3+ throws DateMalformedStringException (extending ValueError -> Error) when parsing malformed date strings like an invalid timezone offset. Since it extends Error (not Exception), Symfony's exception handlers don't catch it automatically, resulting in a 500 response.

Map DateMalformedStringException to HTTP 400 in API Platform's exception_to_status config so clients receive a proper error response.

Closes #7030