### PR TITLE
fix: use window.location.replace for OAuth redirect to fix back button

### DIFF
--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -176,7 +176,7 @@ async function redirectToOAuthLogin(provider) {
   return apiStore
     .href(apiStore.get(), provider, { callback: encodeURI(returnUrl) })
     .then((url) => {
-      window.location.href = url
+      window.location.replace(url)
     })
 }
 


### PR DESCRIPTION
window.location.href = url adds the OAuth provider URL to browser history, so after OAuth login the back button navigates to the provider.

Replace with window.location.replace(url) which replaces the current history entry instead of pushing a new one. After the OAuth callback the back button now navigates within eCamp rather than to the provider.

Fixes https://github.com/ecamp/ecamp3/issues/5086