### PR TITLE
feat: adapt myActivities filter label based on active filters (#4952)

### DIFF
--- a/frontend/src/components/program/ScheduleEntryFilters.vue
+++ b/frontend/src/components/program/ScheduleEntryFilters.vue
@@ -8,7 +8,7 @@
       <BooleanFilter
         v-if="loadingEndpoints !== true && loadingEndpoints.campCollaborations !== true"
         v-model="showOnlyMyActivities"
-        :label="$t('components.program.scheduleEntryFilters.onlyMyActivities')"
+        :label="myActivitiesLabel"
         :result-count="myActivitiesCount"
       />
       <v-skeleton-loader
@@ -338,6 +338,11 @@ export default {
           progressLabel: [],
         })
       },
+    },
+    myActivitiesLabel() {
+      return this.filterSet && !this.showOnlyMyActivities
+        ? this.$t('components.program.scheduleEntryFilters.allMyActivities')
+        : this.$t('components.program.scheduleEntryFilters.onlyMyActivities')
     },
     myActivitiesCount() {
       return this.filterFn({

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -527,6 +527,7 @@
         "clearFilters": "Filter entfernen",
         "day": "Datum",
         "dayLabel": "Tag {dayNumber} ({date})",
+        "allMyActivities": "Alle meine Aktivitäten",
         "onlyMyActivities": "Nur meine Aktivitäten",
         "period": "Lagerabschnitt",
         "progressLabel": "Status",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -527,6 +527,7 @@
         "clearFilters": "Clear filters",
         "day": "Date",
         "dayLabel": "Day {dayNumber} ({date})",
+        "allMyActivities": "All my activities",
         "onlyMyActivities": "Only my activities",
         "period": "Period",
         "progressLabel": "State",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -521,6 +521,7 @@
         "clearFilters": "Effacer les filtres",
         "day": "Date",
         "dayLabel": "Jour {dayNumber} ({date})",
+        "allMyActivities": "Toutes mes activités",
         "onlyMyActivities": "Seulement mes activités",
         "period": "Période",
         "progressLabel": "Statut",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -407,6 +407,7 @@
       "scheduleEntryFilters": {
         "category": "Categoria",
         "clearFilters": "Cancella i filtri",
+        "allMyActivities": "Tutte le mie attività",
         "onlyMyActivities": "Solo le mie attività",
         "period": "Periodo",
         "progressLabel": "Stati",

--- a/frontend/src/locales/rm.json
+++ b/frontend/src/locales/rm.json
@@ -340,6 +340,7 @@
       "scheduleEntryFilters": {
         "category": "Categoria",
         "clearFilters": "Allontanar il filter",
+        "allMyActivities": "Tut mias activitads",
         "onlyMyActivities": "Mo mias activitads",
         "period": "Part dal champ",
         "progressLabel": "Status",


### PR DESCRIPTION
When no other filters are active, the button label stays 'Only my activities'. When other filters are already applied, the label changes to 'All my activities' to signal that clicking the button will reset all other filters and show all of the user's activities.

Added allMyActivities locale key in all 5 languages (de, en, fr, it, rm).

Fixes https://github.com/ecamp/ecamp3/issues/4952