### PR TITLE
fix: reload personalInvitations after accepting/rejecting invitation

### DIFF
--- a/frontend/src/views/camp/Invitation.vue
+++ b/frontend/src/views/camp/Invitation.vue
@@ -185,6 +185,7 @@ export default {
         .then((postUrl) => this.api.patch(postUrl, {}))
         .then(
           (_) => {
+            this.api.get().personalInvitations().$reload()
             this.$router.push(this.campLink).catch(ignoreNavigationFailure)
           },
           () => {
@@ -204,6 +205,7 @@ export default {
         .then((postUrl) => this.api.patch(postUrl, {}))
         .then(
           (_) => {
+            this.api.get().personalInvitations().$reload()
             this.$router
               .push({ name: 'invitationRejected' })
               .catch(ignoreNavigationFailure)


### PR DESCRIPTION
When a user accepts or rejects an invitation via the invitation link page (Invitation.vue), the personalInvitations collection was not reloaded. This left the notification bubble and list showing the stale invitation, and interacting with it again would cause an error.

Add personalInvitations().$reload() in both success branches, matching the existing pattern in PersonalInvitations.vue.

Fixes https://github.com/ecamp/ecamp3/issues/7097