### PR TITLE
fix(e2e): improve stability of create-category test

### DIFF
--- a/e2e/tests/9-behavior-tests/category/create-category.ts
+++ b/e2e/tests/9-behavior-tests/category/create-category.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { expect } from '@playwright/test'
 import { bipiUser } from '@/utils/constants'
 import {
   loginAndSetCookie,
@@ -6,6 +6,7 @@ import {
   createCampViaUI,
   deleteCampViaUI,
 } from '@/utils/helpers'
+import { test } from '@/utils/etest'
 
 const campTitle = 'CatTestCamp'
 
@@ -24,6 +25,7 @@ test.describe('category on new camp', () => {
   })
 
   test.afterAll(async ({ browser }) => {
+    if (!campAdminBaseUrl) return
     const context = await browser.newContext()
     const page = await context.newPage()
     await loginAndSetCookie(page, null, bipiUser)
@@ -31,22 +33,31 @@ test.describe('category on new camp', () => {
     await context.close()
   })
 
-  test('creates a new category on the camp', async ({ page, request }) => {
+  test('creates a new category on the camp', async ({ page, request, runId }) => {
+    const categoryName = `Test Category ${runId}`
     await mockDateNow(page)
     await loginAndSetCookie(page, request, bipiUser)
 
     await page.goto(`${campAdminBaseUrl}/activity`)
 
-    await page.getByRole('button', { name: /Block-Kategorie erstellen/i }).click()
+    const createButton = page.getByRole('button', { name: /Block-Kategorie erstellen/i })
+    await expect(createButton).toBeVisible({ timeout: 15000 })
+    await createButton.click()
 
     const dialog = page.locator('.v-overlay--active')
     await expect(dialog).toBeVisible({ timeout: 10000 })
 
     await dialog.locator('[name="short"] input').fill('TC')
-    await dialog.locator('[name="name"] input').fill('Test Category')
+    await dialog.locator('[name="name"] input').fill(categoryName)
 
     await dialog.getByRole('button', { name: /Erstellen/i }).click()
 
-    await expect(page.getByText('Test Category')).toBeVisible({ timeout: 10000 })
+    await expect(dialog).toBeHidden({ timeout: 10000 })
+    await expect(page.getByText(categoryName, { exact: true }).first()).toBeVisible({
+      timeout: 10000,
+    })
+
+    await page.goto(`${campAdminBaseUrl}/activity`)
+    await expect(page.getByText(categoryName)).toBeVisible()
   })
 })

--- a/e2e/utils/etest.ts
+++ b/e2e/utils/etest.ts
@@ -1,0 +1,10 @@
+import { Fixtures, test as base } from '@playwright/test'
+import { runIdFixture } from '@/utils/fixtures/runId'
+
+const fixtureObject = {
+  ...runIdFixture,
+}
+
+const fixtures: Fixtures<{ fixtureObject: never }> = fixtureObject
+
+export const test = base.extend<typeof fixtureObject>(fixtures)

--- a/e2e/utils/fixtures/runId.ts
+++ b/e2e/utils/fixtures/runId.ts
@@ -1,0 +1,18 @@
+function createRandomId(length = 5) {
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+  const bytes = new Uint8Array(length)
+
+  crypto.getRandomValues(bytes)
+
+  return Array.from(bytes, (byte) => chars[byte % chars.length]).join('')
+}
+
+export const runIdFixture = {
+  createRandomId: async ({}, use: (a: () => string) => Promise<void>) => {
+    await use(createRandomId)
+  },
+  runId: async ({}, use: (a: string) => Promise<void>) => {
+    const runId = createRandomId()
+    await use(runId)
+  },
+}

--- a/e2e/utils/helpers.ts
+++ b/e2e/utils/helpers.ts
@@ -151,7 +151,9 @@ export async function createCampViaUI(page: Page, campTitle: string): Promise<st
   in2Days.setDate(in2Days.getDate() + 2)
 
   await page.goto('/camps')
-  await page.getByTestId('create-camp-button').click()
+  const createCampButton = page.getByTestId('create-camp-button')
+  await expect(createCampButton).toBeVisible({ timeout: 10_000 })
+  await createCampButton.click()
 
   await page.locator('[data-testid="create-camp-title-input"] input').fill(campTitle)
   await page
@@ -163,7 +165,9 @@ export async function createCampViaUI(page: Page, campTitle: string): Promise<st
 
   await page.getByTestId('create-camp-next-step').click()
 
-  await page.locator('div.v-input[data-testid="prototype-select"]').click()
+  const prototypeSelect = page.locator('div.v-input[data-testid="prototype-select"]')
+  await expect(prototypeSelect).toBeVisible({ timeout: 10_000 })
+  await prototypeSelect.click()
   await expect(page.locator('.v-overlay--active')).toBeVisible({ timeout: 10000 })
   await page.locator('.v-overlay--active').getByText('Keine Vorlage').click()
   await expect(


### PR DESCRIPTION
- Guard afterAll against undefined campAdminBaseUrl when beforeAll fails
- Wait for create button to be visible before clicking (page may not be fully loaded)
- Wait for dialog to close before asserting new category appears
- Use exact text match for category name assertion to avoid false positives