### PR TITLE
docker-compose*.yml: remove warning when variables are not set

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,7 +21,7 @@ services:
       XDEBUG_MODE: ${XDEBUG_MODE:-off}
       # default port for Xdebug 3 is 9003
       # idekey=VSCODE if you are debugging with VSCode
-      XDEBUG_CONFIG: ${XDEBUG_CONFIG}
+      XDEBUG_CONFIG: ${XDEBUG_CONFIG:-}
       # This should correspond to the server declared in PHPStorm `Preferences | Languages & Frameworks | PHP | Servers`
       # Then PHPStorm will use the corresponding path mappings
       PHP_IDE_CONFIG: serverName=localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - NODE_ENV=development
       - NPM_CONFIG_UPDATE_NOTIFIER=false
       - NPM_CONFIG_CACHE=/home/node/.npm
-      - CI=${CI}
+      - CI=${CI:-}
     working_dir: /app
     command: ./docker-setup.sh
     stop_signal: SIGKILL
@@ -42,7 +42,7 @@ services:
       - NODE_ENV=development
       - NPM_CONFIG_UPDATE_NOTIFIER=false
       - NPM_CONFIG_CACHE=/home/node/.npm
-      - CI=${CI}
+      - CI=${CI:-}
     working_dir: /app
     command: ./docker-setup.sh
     stop_signal: SIGKILL
@@ -123,7 +123,7 @@ services:
       - NODE_ENV=development
       - NPM_CONFIG_UPDATE_NOTIFIER=false
       - NPM_CONFIG_CACHE=/home/node/.npm
-      - CI=${CI}
+      - CI=${CI:-}
 
   print:
     image: node:24.16.0
@@ -141,7 +141,7 @@ services:
       - NITRO_PORT=3003
       - NPM_CONFIG_UPDATE_NOTIFIER=false
       - NPM_CONFIG_CACHE=/home/node/.npm
-      - CI=${CI}
+      - CI=${CI:-}
     env_file:
       - ./print/print.env
     working_dir: /app
@@ -265,7 +265,7 @@ services:
     environment:
       - NPM_CONFIG_UPDATE_NOTIFIER=false
       - NPM_CONFIG_CACHE=/home/node/.npm
-      - CI=${CI}
+      - CI=${CI:-}
 
 volumes:
   db-data-postgres: null


### PR DESCRIPTION
Saves precious tokens and doesn't distract contributors and agents.