### PR TITLE
fix(e2e): reenable skipped e2e tests

### DIFF
--- a/e2e/tests/9-behavior-tests/httpCache/categories.spec.ts
+++ b/e2e/tests/9-behavior-tests/httpCache/categories.spec.ts
@@ -120,8 +120,7 @@ test.describe('cache test: /camps/{campId}/categories', { tag: '@mature' }, () =
     await expectCacheHit(bipiApi, uri)
   })
 
-  // eslint-disable-next-line playwright/no-skipped-test
-  test.skip('invalidates cached data when user leaves a camp', async ({ browser }) => {
+  test('invalidates cached data when user leaves a camp', async ({ browser }) => {
     const castorContext = await browser.newContext()
     const bipiContext = await browser.newContext()
     const castorPage = await castorContext.newPage()
@@ -139,7 +138,7 @@ test.describe('cache test: /camps/{campId}/categories', { tag: '@mature' }, () =
 
     // deactivate Castor
     await bipiPage.goto(`/camps/${grgrCampId}/GRGR/admin/collaborators`)
-    await bipiPage.locator('.v-list-item__title', { hasText: 'Castor' }).click()
+    await bipiPage.locator('.v-list-item-title', { hasText: 'Castor' }).click()
     await bipiPage.getByRole('button', { name: 'Deaktivieren' }).first().click()
     await Promise.all([
       bipiPage.waitForResponse(
@@ -161,7 +160,7 @@ test.describe('cache test: /camps/{campId}/categories', { tag: '@mature' }, () =
     await apiDelete(bipiApi, '/mail/email/all')
 
     // invite Castor
-    await bipiPage.locator('.v-list-item__title', { hasText: 'Castor' }).click()
+    await bipiPage.locator('.v-list-item-title', { hasText: 'Castor' }).click()
     await Promise.all([
       bipiPage.waitForResponse(
         (res) =>

--- a/e2e/tests/9-behavior-tests/nuxtPrint.spec.ts
+++ b/e2e/tests/9-behavior-tests/nuxtPrint.spec.ts
@@ -98,13 +98,15 @@ test.describe('Nuxt print test', { tag: '@mature' }, () => {
       expect(pdfProps.numPages).toBe(25)
     })
 
-    // eslint-disable-next-line playwright/no-skipped-test
-    test.skip('for picasso', async ({ page }) => {
+    test('for picasso', async ({ page }) => {
       await page.locator('a:has-text("Programm")').click()
       await page.locator('[data-testid="campprogram-menu"]').click()
 
       const downloadPromise = page.waitForEvent('download')
-      await page.locator('listitem:has-text("PDF herunterladen (Layout #1)")').click()
+      await page
+        .locator('.v-list-item')
+        .filter({ hasText: 'PDF herunterladen (Layout #1)' })
+        .click()
       const download = await downloadPromise
 
       const path = await download.path()


### PR DESCRIPTION
- Fix nuxtPrint picasso test: replace invalid `listitem` CSS selector with `.v-list-item` class selector to correctly target Vuetify 3 list items in the campprogram menu dropdown
- Fix categories cache test: update `.v-list-item__title` (Vuetify 2) to `.v-list-item-title` (Vuetify 3) for collaborator list items

Closes #10005