### PR TITLE
fix(e2e): reenable downloads PDF/for picasso

### DIFF
--- a/e2e/tests/9-behavior-tests/nuxtPrint.spec.ts
+++ b/e2e/tests/9-behavior-tests/nuxtPrint.spec.ts
@@ -98,13 +98,15 @@ test.describe('Nuxt print test', { tag: '@mature' }, () => {
       expect(pdfProps.numPages).toBe(25)
     })
 
-    // eslint-disable-next-line playwright/no-skipped-test
-    test.skip('for picasso', async ({ page }) => {
+    test('for picasso', async ({ page }) => {
       await page.locator('a:has-text("Programm")').click()
       await page.locator('[data-testid="campprogram-menu"]').click()
 
       const downloadPromise = page.waitForEvent('download')
-      await page.locator('listitem:has-text("PDF herunterladen (Layout #1)")').click()
+      await page
+        .locator('.v-list-item')
+        .filter({ hasText: 'PDF herunterladen (Layout #1)' })
+        .click()
       const download = await downloadPromise
 
       const path = await download.path()


### PR DESCRIPTION
- Fix nuxtPrint picasso test: replace invalid `listitem` CSS selector   with `.v-list-item` class selector to correctly target Vuetify 3   list items in the campprogram menu dropdown

Issue: #10005

test run is here: https://github.com/BacLuc/ecamp3/actions/runs/27470377641