### PR TITLE
Reload target period on schedule entry move, create and delete

### DIFF
--- a/frontend/src/components/activity/dialog/DialogActivityEdit.vue
+++ b/frontend/src/components/activity/dialog/DialogActivityEdit.vue
@@ -159,6 +159,17 @@ export default {
       this.close()
       this.api.reload(this.activity)
       this.api.reload(this.scheduleEntry.period().scheduleEntries())
+      const originalPeriodUri = this.scheduleEntry.period()._meta.self
+      const reloadedPeriods = new Set([originalPeriodUri])
+      this.entityData.scheduleEntries
+        .filter((entry) => typeof entry.period === 'function')
+        .forEach((entry) => {
+          const targetPeriodUri = entry.period()._meta.self
+          if (!reloadedPeriods.has(targetPeriodUri)) {
+            reloadedPeriods.add(targetPeriodUri)
+            this.api.reload(this.api.get(targetPeriodUri).scheduleEntries())
+          }
+        })
       this.$emit('activityUpdated', data)
     },
   },

--- a/frontend/src/components/program/DialogActivityCreate.vue
+++ b/frontend/src/components/program/DialogActivityCreate.vue
@@ -253,6 +253,21 @@ export default {
       return this.create(payloadData)
     },
     onSuccess(activity) {
+      const scheduleEntries = activity.scheduleEntries().items
+      if (scheduleEntries.length > 0) {
+        const firstPeriodIri = scheduleEntries[0].period()._meta.self
+        this.api.reload(this.api.get(firstPeriodIri).scheduleEntries())
+        const reloadedPeriods = new Set([firstPeriodIri])
+        scheduleEntries
+          .filter((entry) => typeof entry.period === 'function')
+          .forEach((entry) => {
+            const targetPeriodUri = entry.period()._meta.self
+            if (!reloadedPeriods.has(targetPeriodUri)) {
+              reloadedPeriods.add(targetPeriodUri)
+              this.api.reload(this.api.get(targetPeriodUri).scheduleEntries())
+            }
+          })
+      }
       this.close()
       this.$emit('activityCreated', activity)
     },

--- a/frontend/src/components/program/DialogActivityCreate.vue
+++ b/frontend/src/components/program/DialogActivityCreate.vue
@@ -252,6 +252,7 @@ export default {
 
       return this.create(payloadData)
     },
+    // noinspection JSUnusedGlobalSymbols
     onSuccess(activity) {
       const scheduleEntries = activity.scheduleEntries().items
       if (scheduleEntries.length > 0) {


### PR DESCRIPTION
fix(https://github.com/ecamp/ecamp3/issues/5059): reload target period's schedule entries after schedule entry move
When a schedule entry's start time was changed to a date belonging to a
different period, only the original period's schedule entries were
reloaded. The target period retained stale data and didn't show the
moved entry until page reload.

After a successful update, reload schedule entries for all periods that
any of the edited schedule entries were moved to.

fixes #5059