### PR TITLE
fix(#7542): reload periods list when navigating back to camps view

### DIFF
--- a/frontend/src/views/Camps.vue
+++ b/frontend/src/views/Camps.vue
@@ -154,9 +154,12 @@ export default {
   methods: {
     async loadCamps() {
       await this.$auth.loadUser()
-      // Only reload camps if they were loaded before, to avoid console error
+      // Only reload if they were loaded before, to avoid console error
       if (this.camps._meta.self !== null) {
         this.api.reload(this.camps)
+      }
+      if (this.periods._meta.self !== null) {
+        this.api.reload(this.periods)
       }
 
       await Promise.all([this.camps._meta.load, this.periods._meta.load])


### PR DESCRIPTION
The camps view shows upcoming and past camps based on the periods collection. After creating a new camp, the periods collection was not being reloaded when the user navigated back to the camps list, so the newly created camp's periods were missing and the camp did not appear.

Reload both the camps and periods collections when they were previously loaded, following the same pattern already used for camps.

fixes: #7542
fixes: #10050