### PR TITLE
fix(#4964): reload schedule entries after category numbering style change

### DIFF
--- a/frontend/src/components/category/CategoryProperties.vue
+++ b/frontend/src/components/category/CategoryProperties.vue
@@ -11,6 +11,7 @@
       :items="numberingStyles"
       :disabled="disabled"
       vee-rules="required"
+      @saved="reloadScheduleEntries"
     />
   </api-form>
 </template>
@@ -34,6 +35,16 @@ export default {
         value: i,
         text: this.$t('entity.category.numberingStyles.' + i),
       }))
+    },
+  },
+  methods: {
+    reloadScheduleEntries() {
+      this.category
+        .camp()
+        .periods()
+        .items.forEach((period) => {
+          this.api.reload(period.scheduleEntries())
+        })
     },
   },
 }


### PR DESCRIPTION


This is a quick fix for now.
We once said that each component showing data should make sure it is not stale... but this seems difficult.
When a category's numberingStyle is changed, the backend recalculates the number field on all schedule entries in that category. The frontend was not reloading the schedule entries, so the old numbering remained visible until the page was refreshed.

After saving the numberingStyle, reload all schedule entries for each period in the camp so the updated numbers are immediately reflected.