### PR TITLE
fix(#7088): disable category delete button while activities are loading

### DIFF
--- a/frontend/src/views/camp/category/Category.vue
+++ b/frontend/src/views/camp/category/Category.vue
@@ -41,6 +41,7 @@
               :warning-text-entity="category.name"
               :dialog-title="$t('views.camp.category.category.deleteCategory')"
               :success-handler="goToActivityAdmin"
+              :submit-enabled="!activitiesLoading"
             >
               <template #activator="{ props }">
                 <v-list-item v-bind="props">
@@ -52,6 +53,7 @@
                   </v-list-item-title>
                 </v-list-item>
               </template>
+              <v-skeleton-loader v-if="activitiesLoading" type="article" />
               <template v-if="findActivities(category).length > 0" #error>
                 <ErrorExistingActivitiesList
                   :camp="camp"
@@ -161,6 +163,9 @@ export default {
     }
   },
   computed: {
+    activitiesLoading() {
+      return this.camp.activities()._meta.loading
+    },
     contentNodes() {
       return this.category.contentNodes()
     },


### PR DESCRIPTION
The delete confirmation dialog showed the delete button as enabled before all activities had finished loading. If no activities were loaded yet, the error slot (which lists existing activities and disables the button) was not rendered, so the user could trigger the deletion prematurely.

Disable the submit button while activities are loading and show a progress bar inside the dialog to indicate that the check is still in progress.

fixes #7088