### PR TITLE
fix(#3573): show loading indicator during Excel material list download

### DIFF
--- a/frontend/src/components/material/useMaterialViewHelper.js
+++ b/frontend/src/components/material/useMaterialViewHelper.js
@@ -142,7 +142,16 @@ export function useMaterialViewHelper(camp, list) {
     }))
   })
 
-  const downloadXlsx = downloadMaterialList(camp, collection, computedList)
+  const isDownloadingXlsx = ref(false)
+  const _download = downloadMaterialList(camp, collection, computedList)
+  const downloadXlsx = async () => {
+    isDownloadingXlsx.value = true
+    try {
+      await _download()
+    } finally {
+      isDownloadingXlsx.value = false
+    }
+  }
   const openPeriods = loadPeriods(camp)
 
   onMounted(async () => {
@@ -162,6 +171,7 @@ export function useMaterialViewHelper(camp, list) {
   return {
     collection,
     downloadXlsx,
+    isDownloadingXlsx,
     downloadMaterialList,
     openPeriods,
   }

--- a/frontend/src/views/camp/material/MaterialDetail.vue
+++ b/frontend/src/views/camp/material/MaterialDetail.vue
@@ -19,9 +19,16 @@
                 </v-list-item>
               </template>
             </DialogMaterialListEdit>
-            <v-list-item @click="downloadXlsx">
+            <v-list-item :disabled="isDownloadingXlsx" @click="downloadXlsx">
               <template #prepend>
-                <v-icon>mdi-microsoft-excel</v-icon>
+                <v-progress-circular
+                  v-if="isDownloadingXlsx"
+                  class="mr-2"
+                  indeterminate
+                  size="24"
+                  width="2"
+                />
+                <v-icon v-else>mdi-microsoft-excel</v-icon>
               </template>
               {{ $t('global.button.download') }}
             </v-list-item>

--- a/frontend/src/views/camp/material/MaterialDetail.vue
+++ b/frontend/src/views/camp/material/MaterialDetail.vue
@@ -19,7 +19,7 @@
                 </v-list-item>
               </template>
             </DialogMaterialListEdit>
-            <v-list-item :disabled="isDownloadingXlsx" @click="downloadXlsx">
+            <v-list-item :disabled="isDownloadingXlsx" @click.stop="downloadXlsx">
               <template #prepend>
                 <v-progress-circular
                   v-if="isDownloadingXlsx"

--- a/frontend/src/views/camp/material/MaterialOverview.vue
+++ b/frontend/src/views/camp/material/MaterialOverview.vue
@@ -19,9 +19,16 @@
                 </v-list-item>
               </template>
             </DialogMaterialListCreate>
-            <v-list-item @click="downloadXlsx">
+            <v-list-item :disabled="isDownloadingXlsx" @click="downloadXlsx">
               <template #prepend>
-                <v-icon>mdi-microsoft-excel</v-icon>
+                <v-progress-circular
+                  v-if="isDownloadingXlsx"
+                  class="mr-2"
+                  indeterminate
+                  size="24"
+                  width="2"
+                />
+                <v-icon v-else>mdi-microsoft-excel</v-icon>
               </template>
               {{ $t('views.camp.material.materialOverview.download') }}
             </v-list-item>

--- a/frontend/src/views/camp/material/MaterialOverview.vue
+++ b/frontend/src/views/camp/material/MaterialOverview.vue
@@ -19,7 +19,7 @@
                 </v-list-item>
               </template>
             </DialogMaterialListCreate>
-            <v-list-item :disabled="isDownloadingXlsx" @click="downloadXlsx">
+            <v-list-item :disabled="isDownloadingXlsx" @click.stop="downloadXlsx">
               <template #prepend>
                 <v-progress-circular
                   v-if="isDownloadingXlsx"


### PR DESCRIPTION
The Excel generation can take noticeable time for large camps. Without any feedback, users may click the download button multiple times or think the app is unresponsive. Add a loading spinner and disable the menu item while the download is in progress.

Also use @click.stop that you see the loading spinner for the excel download.
(Pattern stolen from pdf download buttons.)

fixes #3573