### PR TITLE
fix #8398: ensure MailMessageLogger is active and EntityManager is clean in API tests

### DIFF
--- a/api/tests/Api/ECampApiTestCase.php
+++ b/api/tests/Api/ECampApiTestCase.php
@@ -55,6 +55,12 @@ abstract class ECampApiTestCase extends ApiTestCase {
         self::bootKernel();
         parent::setUp();
 
+        // After populateDatabase() runs on the first test, the EntityManager's identity map
+        // may contain entities with stale inverse-side collection state (e.g. Camp::collaborations
+        // not reflecting all loaded CampCollaborations). Clearing the EM ensures subsequent
+        // requests load entities fresh from the database instead of using the stale cache.
+        static::getContainer()->get('doctrine')->getManager()->clear();
+
         // backup current timezone, in case it's change in one of the tests
         $this->currentTimezone = date_default_timezone_get();
     }
@@ -353,6 +359,15 @@ abstract class ECampApiTestCase extends ApiTestCase {
 
         $sortedResponseArray = ArrayDeepSort::sort($responseArray);
         $this->assertMatchesJsonSnapshot($sortedResponseArray);
+    }
+
+    /**
+     * Resets the mailer message log. Use this before a request when multiple requests
+     * are made in one test (with disableReboot()) and only emails from the last request
+     * should be counted.
+     */
+    protected function resetMailerEvents(): void {
+        static::getContainer()->get('mailer.message_logger_listener')->reset();
     }
 
     /**

--- a/api/tests/Api/UserActivation/ResendActivationTest.php
+++ b/api/tests/Api/UserActivation/ResendActivationTest.php
@@ -28,7 +28,7 @@ class ResendActivationTest extends ECampApiTestCase {
         $userId = $result->toArray()['id'];
         $user = $this->getEntityManager()->getRepository(User::class)->find($userId);
 
-        $client->enableProfiler();
+        $this->resetMailerEvents();
         $client->request(
             'POST',
             '/auth/resend_activation',
@@ -83,7 +83,7 @@ class ResendActivationTest extends ECampApiTestCase {
         $userId = $result->toArray()['id'];
         $user = $this->getEntityManager()->getRepository(User::class)->find($userId);
 
-        $client->enableProfiler();
+        $this->resetMailerEvents();
         $client->request(
             'POST',
             '/auth/resend_activation',
@@ -121,7 +121,7 @@ class ResendActivationTest extends ECampApiTestCase {
         $this->getEntityManager()->persist($user);
         $this->getEntityManager()->flush();
 
-        $client->enableProfiler();
+        $this->resetMailerEvents();
         $client->request(
             'POST',
             '/auth/resend_activation',
@@ -144,7 +144,6 @@ class ResendActivationTest extends ECampApiTestCase {
 
     public function testPostResendActivationReturns204ForUnknownEmailButSendsNoEmails() {
         $client = $this->createBasicClient();
-        $client->enableProfiler();
         $client->request(
             'POST',
             '/auth/resend_activation',


### PR DESCRIPTION


- Add EntityManager::clear() in ECampApiTestCase::setUp() to prevent stale inverse-side collection state after alice fixtures are loaded, fixing 403 errors in CampCollaboration and email tests run in isolation
- Add resetMailerEvents() helper that resets mailer.message_logger_listener directly; replace enableProfiler() abuse in ResendActivationTest (which was triggering a kernel boot just to reset the message log as a side effect)

fixes #8398