### PR TITLE
fix(frontend): avoid resolving null user relation on loading collaborations

### DIFF
--- a/frontend/src/mixins/__tests__/campRoleMixin.spec.js
+++ b/frontend/src/mixins/__tests__/campRoleMixin.spec.js
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { campRoleMixin } from '@/mixins/campRoleMixin'
+
+const currentUserLink = '/users/me'
+
+function mockThis(campCollaborations) {
+  return {
+    $store: { getters: { getLoggedInUser: { _meta: { self: currentUserLink } } } },
+    _campCollaborations: campCollaborations,
+  }
+}
+
+function loadedCollaboration(role, userSelf) {
+  return {
+    _meta: { loading: false },
+    role,
+    user: () => ({ _meta: { self: userSelf } }),
+  }
+}
+
+function invitedCollaboration(role) {
+  return { _meta: { loading: false }, role, user: null }
+}
+
+function loadingCollaboration() {
+  return {
+    _meta: { loading: true },
+    get user() {
+      return () => {
+        throw new Error('user() must not be called on a loading collaboration')
+      }
+    },
+  }
+}
+
+describe('campRoleMixin._campRole', () => {
+  it('returns the current user role and ignores invited collaborators', () => {
+    const collaborations = [
+      invitedCollaboration('member'),
+      loadedCollaboration('member', '/users/other'),
+      loadedCollaboration('manager', currentUserLink),
+    ]
+
+    expect(campRoleMixin.computed._campRole.call(mockThis(collaborations))).toBe(
+      'manager'
+    )
+  })
+
+  it('does not resolve user() on still-loading collaborations', () => {
+    const collaborations = [
+      loadingCollaboration(),
+      loadedCollaboration('manager', currentUserLink),
+    ]
+
+    expect(() =>
+      campRoleMixin.computed._campRole.call(mockThis(collaborations))
+    ).not.toThrow()
+    expect(campRoleMixin.computed._campRole.call(mockThis(collaborations))).toBe(
+      'manager'
+    )
+  })
+
+  it('returns null while collaborations are still loading and no match found yet', () => {
+    const collaborations = [
+      loadingCollaboration(),
+      loadedCollaboration('member', '/users/other'),
+    ]
+
+    expect(campRoleMixin.computed._campRole.call(mockThis(collaborations))).toBeNull()
+  })
+
+  it('returns undefined when the user is not a collaborator and all are loaded', () => {
+    const collaborations = [
+      invitedCollaboration('member'),
+      loadedCollaboration('member', '/users/other'),
+    ]
+
+    expect(
+      campRoleMixin.computed._campRole.call(mockThis(collaborations))
+    ).toBeUndefined()
+  })
+})

--- a/frontend/src/mixins/campRoleMixin.js
+++ b/frontend/src/mixins/campRoleMixin.js
@@ -28,11 +28,15 @@ export const campRoleMixin = {
     },
     _campRole() {
       const currentUserLink = this.$store.getters.getLoggedInUser?._meta.self
-      const result = this._campCollaborations
+      const campCollaborations = this._campCollaborations
+      const result = campCollaborations
+        .filter((coll) => !coll._meta.loading)
         .filter((coll) => typeof coll.user === 'function')
         .find((coll) => coll.user()._meta.self === currentUserLink)
 
-      if (result?._meta.loading) return null
+      if (!result && campCollaborations.some((coll) => coll._meta.loading)) {
+        return null
+      }
       return result?.role
     },
     _campCollaborations() {


### PR DESCRIPTION


The _campRole computed in campRoleMixin called coll.user() on camp collaborations to find the one belonging to the current user. The `typeof coll.user === 'function'` guard was meant to skip invited collaborators (whose `user` relation is null), and it works for loaded resources: hal-json-vuex exposes a null relation as a plain null property.

However, on a still-loading hal-json-vuex proxy every relation access returns a function, so the guard passed for loading collaborations too. Calling coll.user() then resolved to null once the collaboration finished loading, rejecting the load promise with "Property 'user' ... was used like a relation, but no relation with this name was returned by the API (actual return value: null)" and surfacing as an unhandled rejection in Sentry.

Skip still-loading collaborations before resolving .user(), and report no role yet (null) while collaborations are loading. Add unit tests for the mixin.

fixes https://github.com/ecamp/ecamp3/issues/10085