### PR TITLE
fix(frontend): set cache-control headers to avoid stale index.html

### DIFF
--- a/.docker-hub/frontend/nginx.conf
+++ b/.docker-hub/frontend/nginx.conf
@@ -17,11 +17,25 @@ http {
   server {
     listen       3000;
     server_name  localhost;
+    root   /app;
+
+    location /assets/ {
+      try_files $uri =404;
+      add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
     location / {
-      root   /app;
       index  index.html;
       try_files $uri $uri/ /index.html;
     }
+
+    location = /index.html {
+      add_header Cache-Control "no-cache";
+    }
+    location = /environment.js {
+      add_header Cache-Control "no-cache";
+    }
+
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
       root   /usr/share/nginx/html;


### PR DESCRIPTION
The nginx serving the built frontend did not emit any Cache-Control headers, so browsers applied heuristic caching. A stale cached index.html keeps referencing content-hashed assets that no longer exist after a deployment, producing console errors and broken functionality (issue #7633).

Serve the content-hashed files under /assets/ as immutable so they can be cached indefinitely, and force revalidation of the entry point (index.html, including SPA-route fallbacks) and the runtime config environment.js via Cache-Control: no-cache. Revalidation stays cheap thanks to the existing ETag (304). Also return a real 404 for missing assets instead of silently falling back to index.html.

Fixes #7633