### PR TITLE
e2e: reduce flaky test failures (#9643)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,12 +6,12 @@ export default defineConfig({
   testDir: './tests',
   timeout: 120000,
   expect: {
-    timeout: 8000,
+    timeout: 15000,
   },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: 0,
-  workers: undefined,
+  workers: process.env.CI ? undefined : 4,
   reporter: process.env.CI ? 'blob' : [['html', { open: 'never' }]],
   use: {
     baseURL: 'http://localhost:3000',


### PR DESCRIPTION
The Playwright e2e suite produced inconsistent failures, with different tests failing across runs (HTTP cache, dashboard filters, PDF downloads). Two root causes were identified and addressed in playwright.config.ts:

1. expect.timeout was 8s. The suite asserts against the full stack (frontend -> reverse-proxy -> API -> DB), and data-loading assertions (e.g. the dashboard filter chips re-rendering after page.reload() once the category/status endpoints have loaded) regularly need more than 8s on a loaded stack. Raised to 15s so these assertions stop racing the data load while still failing reasonably fast.

2. workers was undefined. In CI each project (chromium/firefox/webkit/ behavior-tests) runs as its own isolated job against its own backend, so the default is fine there. Locally, `npx playwright test` runs all projects at once against a single shared backend; on a many-core dev machine the default spawns many workers that all hammer that single stack (the heavy client-side PDF tests in particular saturate the API and starve other tests), which is the main source of the "different failures every run" flakiness. Cap local workers at 4 to keep the load on the shared stack bounded and deterministic regardless of machine size; CI behaviour is unchanged and a faster local run is still available via --workers.