### PR TITLE
chore(api): remove abandoned composer/package-versions-deprecated

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -17,7 +17,6 @@
     "api-platform/state": "4.3.11",
     "api-platform/symfony": "4.3.11",
     "api-platform/validator": "4.3.13",
-    "composer/package-versions-deprecated": "1.11.99",
     "doctrine/common": "3.5.0",
     "doctrine/doctrine-bundle": "3.2.4",
     "doctrine/doctrine-migrations-bundle": "4.0.0",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "173ef6844f4723512752b01041fcf525",
+    "content-hash": "74df8f902ee48f663542b1c592b9eaa2",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -1447,80 +1447,6 @@
                 }
             ],
             "time": "2023-12-20T15:40:13+00:00"
-        },
-        {
-            "name": "composer/package-versions-deprecated",
-            "version": "1.11.99",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855",
-                "reference": "c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7 || ^8"
-            },
-            "replace": {
-                "ocramius/package-versions": "1.11.99"
-            },
-            "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "ext-zip": "^1.13",
-                "phpunit/phpunit": "^6.5 || ^7"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "support": {
-                "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/master"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "abandoned": true,
-            "time": "2020-08-25T05:50:16+00:00"
         },
         {
             "name": "composer/semver",

--- a/api/symfony.lock
+++ b/api/symfony.lock
@@ -25,9 +25,6 @@
     "clue/stream-filter": {
         "version": "v1.6.0"
     },
-    "composer/package-versions-deprecated": {
-        "version": "1.11.99.1"
-    },
     "composer/pcre": {
         "version": "1.0.0"
     },


### PR DESCRIPTION
composer/package-versions-deprecated is flagged abandoned by Composer ("No replacement was suggested"). It was a direct require in api/composer.json, but nothing actually needs it: no installed package declares it in `require` (the api-platform/doctrine references are only `conflict` entries) and no PHP code uses the PackageVersions\Versions class. Removing it drops the abandoned dependency.

composer remove also pulled in a few in-range patch updates (symfony/polyfill-deepclone, api-platform/jsonld, composer/pcre, guzzlehttp/psr7, webmozart/assert). Autoload regeneration, cache:clear, assets:install and the Util test suite all pass.