### PR TITLE
chore(vite): exclude generated dirs from vite dev-server watch

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -50,6 +50,9 @@ export default defineConfig(({ mode }) => ({
   server: {
     port: 3000,
     allowedHosts: ['frontend', 'localhost:3000'],
+    watch: {
+      ignored: ['**/data/**', '**/dist/**'],
+    },
   },
   plugins,
   worker: {

--- a/pdf/vite.config.js
+++ b/pdf/vite.config.js
@@ -26,6 +26,9 @@ export default defineConfig({
     },
     preserveSymlinks: true,
   },
+  watch: {
+    ignored: ['**/data/**', '**/dist/**'],
+  },
   build: {
     lib: {
       // Could also be a dictionary or array of multiple entry points


### PR DESCRIPTION
The vitest coverage report (./data/coverage) and the production build (./dist) are generated output. Vite watched them by default, so regenerating coverage (~75 MB of HTML) triggered a reload storm that could wedge the dev server. Exclude both from server.watch.