### PR TITLE
fix(frontend): re-add nickname field to the register form (#3763)

### DIFF
--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -26,6 +26,15 @@
           />
 
           <e-text-field
+            v-model="nickname"
+            append-inner-icon="mdi-account-outline"
+            autocomplete="nickname"
+            :density="$vuetify.display.xs ? 'comfortable' : undefined"
+            path="nickname"
+            type="text"
+          />
+
+          <e-text-field
             v-model="email"
             append-inner-icon="mdi-at"
             autocomplete="username"


### PR DESCRIPTION
The register form already bound a `nickname` model and forwarded it to the profile on registration, but the actual input field was lost during the Vue 3 migration, so users could never enter a nickname/scoutname while registering.

Re-add the optional nickname text field (no validation rules, so it stays non-required) between the surname and email fields, mirroring the field that existed in the legacy frontend.

Verified in the browser: the field renders with the translated "Nickname" label and without a required-marker.