### PR TITLE
frontend: improve experience for stale frontend state after deployments

### DIFF
--- a/e2e/tests/5-cross-browser-tests/staleDeployment.spec.ts
+++ b/e2e/tests/5-cross-browser-tests/staleDeployment.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test'
+import { bipiUser } from '@/utils/constants'
+import { loginAndSetCookie } from '@/utils/helpers'
+
+const CAMP_CREATE_CHUNK = /\/src\/views\/CampCreate\.vue/
+
+test('reloads the page when a route chunk is missing after a deploy', async ({
+  page,
+  request,
+  browserName,
+}) => {
+  //eslint-disable-next-line
+  if (browserName === 'webkit') {
+    // webkit crashes completely on the production build when an asset fails to load.
+    // I also didn't find a way to recover webkit after that.
+    //eslint-disable-next-line
+    test.skip()
+  }
+  await loginAndSetCookie(page, request, bipiUser)
+  await expect(page.getByTestId('create-camp-button')).toBeVisible()
+
+  await page.evaluate(() => {
+    ;(window as unknown as { __noReload: boolean }).__noReload = true
+  })
+
+  let chunkRequestCount = 0
+  await page.route(CAMP_CREATE_CHUNK, async (route) => {
+    chunkRequestCount += 1
+    if (chunkRequestCount === 1) {
+      await route.abort('failed')
+    } else {
+      await route.continue()
+    }
+  })
+
+  await page.getByTestId('create-camp-button').click()
+
+  await expect(page.locator('[data-testid="create-camp-title-input"] input')).toBeVisible(
+    {
+      timeout: 30000,
+    }
+  )
+  await expect(page).toHaveURL(/\/camps\/create$/)
+
+  const markerSurvived = await page.evaluate(
+    () => (window as unknown as { __noReload?: boolean }).__noReload === true
+  )
+  expect(markerSurvived).toBe(false)
+  expect(chunkRequestCount).toBeGreaterThanOrEqual(2)
+})

--- a/e2e/tests/5-cross-browser-tests/staleDeployment.spec.ts
+++ b/e2e/tests/5-cross-browser-tests/staleDeployment.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { bipiUser } from '@/utils/constants'
 import { loginAndSetCookie } from '@/utils/helpers'
 
-const CAMP_CREATE_CHUNK = /\/src\/views\/CampCreate\.vue/
+const CAMP_CREATE_CHUNK = /.*CampCreate.*/
 
 test('reloads the page when a route chunk is missing after a deploy', async ({
   page,
@@ -47,4 +47,53 @@ test('reloads the page when a route chunk is missing after a deploy', async ({
   )
   expect(markerSurvived).toBe(false)
   expect(chunkRequestCount).toBeGreaterThanOrEqual(2)
+})
+
+const FEATURE_CHUNK_PATH = '/src/components/activity/ContentNode.vue'
+
+test('shows the update popup instead of reloading when an in-page feature chunk is missing', async ({
+  page,
+  request,
+  browserName,
+}) => {
+  //eslint-disable-next-line
+  if (browserName === 'webkit') {
+    // webkit just silently fails when a chunk cannot be loaded without a route change.
+    //eslint-disable-next-line
+    test.skip()
+  }
+  await loginAndSetCookie(page, request, bipiUser)
+  await expect(page.getByTestId('create-camp-button')).toBeVisible()
+  const urlBefore = page.url()
+
+  await page.evaluate(() => {
+    ;(window as unknown as { __noReload: boolean }).__noReload = true
+  })
+
+  await page.route(FEATURE_CHUNK_PATH, (route) =>
+    route.fulfill({ status: 404, contentType: 'text/plain', body: 'gone' })
+  )
+
+  await page.evaluate((path) => {
+    void import(/* @vite-ignore */ path)
+  }, FEATURE_CHUNK_PATH)
+
+  const dialog = page.getByTestId('new-version-dialog')
+  await expect(dialog).toBeVisible({ timeout: 30000 })
+  await expect(page.getByTestId('new-version-update')).toBeVisible()
+  await expect(page.getByTestId('new-version-continue')).toBeVisible()
+
+  const markerSurvived = await page.evaluate(
+    () => (window as unknown as { __noReload?: boolean }).__noReload === true
+  )
+  expect(markerSurvived).toBe(true)
+  expect(page.url()).toBe(urlBefore)
+
+  await page.getByTestId('new-version-continue').click()
+  await expect(dialog).toBeHidden()
+  expect(page.url()).toBe(urlBefore)
+  const stillNoReload = await page.evaluate(
+    () => (window as unknown as { __noReload?: boolean }).__noReload === true
+  )
+  expect(stillNoReload).toBe(true)
 })

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -18,6 +18,8 @@
       </p>
     </v-footer>
     <v-snackbar-queue v-model="snackbarMessages"></v-snackbar-queue>
+
+    <NewVersionAvailableDialog />
   </v-app>
 </template>
 
@@ -26,9 +28,11 @@ import VueI18n from '@/plugins/i18n'
 import { headEnvironment } from '@/plugins/index.js'
 import { mapGetters } from 'vuex'
 import { useHead } from '@unhead/vue'
+import NewVersionAvailableDialog from '@/components/NewVersionAvailableDialog.vue'
 
 export default {
   name: 'App',
+  components: { NewVersionAvailableDialog },
   setup() {
     useHead({
       title: null,

--- a/frontend/src/components/NewVersionAvailableDialog.vue
+++ b/frontend/src/components/NewVersionAvailableDialog.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-dialog
+    :model-value="show"
+    persistent
+    max-width="480"
+    data-testid="new-version-dialog"
+    @update:model-value="onModelValue"
+  >
+    <v-card>
+      <v-card-title class="text-wrap">
+        {{ $t('global.newVersion.title') }}
+      </v-card-title>
+      <v-card-text>
+        {{ $t('global.newVersion.description') }}
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          variant="text"
+          data-testid="new-version-continue"
+          @click="continueWithoutUpdating"
+        >
+          {{ $t('global.newVersion.updateLater') }}
+        </v-btn>
+        <v-btn
+          color="primary"
+          variant="elevated"
+          data-testid="new-version-update"
+          @click="update"
+        >
+          {{ $t('global.newVersion.update') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import {
+  dismissNewVersion,
+  updateToNewVersion,
+  useNewVersionAvailable,
+} from '@/helpers/newVersionAvailable.js'
+
+export default {
+  name: 'NewVersionAvailableDialog',
+  setup() {
+    return { newVersionAvailable: useNewVersionAvailable() }
+  },
+  computed: {
+    show() {
+      return this.newVersionAvailable
+    },
+  },
+  methods: {
+    continueWithoutUpdating() {
+      dismissNewVersion()
+    },
+    update() {
+      updateToNewVersion()
+    },
+    onModelValue(value) {
+      if (!value) {
+        dismissNewVersion()
+      }
+    },
+  },
+}
+</script>

--- a/frontend/src/helpers/__tests__/chunkLoadError.spec.js
+++ b/frontend/src/helpers/__tests__/chunkLoadError.spec.js
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearChunkReloadGuard,
+  isChunkLoadError,
+  reloadOnChunkLoadError,
+} from '@/helpers/chunkLoadError.js'
+
+describe('isChunkLoadError', () => {
+  it.each([
+    'Failed to fetch dynamically imported module: https://e.camp/assets/Foo-abc123.js',
+    'error loading dynamically imported module: https://e.camp/assets/Foo.js',
+    'Importing a module script failed.',
+  ])('detects chunk load error "%s"', (message) => {
+    expect(isChunkLoadError(new Error(message))).toBe(true)
+  })
+
+  it.each([
+    new Error('Something else went wrong'),
+    new TypeError('Cannot read properties of undefined'),
+    null,
+    undefined,
+    {},
+  ])('ignores unrelated error %s', (error) => {
+    expect(isChunkLoadError(error)).toBe(false)
+  })
+})
+
+describe('reloadOnChunkLoadError', () => {
+  const assign = vi.fn()
+  let store = {}
+
+  beforeEach(() => {
+    assign.mockReset()
+    store = {}
+    vi.stubGlobal('window', {
+      location: {
+        assign,
+        pathname: '/current',
+        search: '',
+        hash: '',
+      },
+      sessionStorage: {
+        getItem: (key) => (key in store ? store[key] : null),
+        setItem: (key, value) => {
+          store[key] = String(value)
+        },
+        removeItem: (key) => {
+          delete store[key]
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const chunkError = new Error('Failed to fetch dynamically imported module: x.js')
+
+  it('reloads to the target path on a chunk load error', () => {
+    const reloaded = reloadOnChunkLoadError(chunkError, { fullPath: '/camp/123' })
+
+    expect(reloaded).toBe(true)
+    expect(assign).toHaveBeenCalledWith('/camp/123')
+  })
+
+  it('does not reload for unrelated errors', () => {
+    const reloaded = reloadOnChunkLoadError(new Error('boom'), { fullPath: '/camp/123' })
+
+    expect(reloaded).toBe(false)
+    expect(assign).not.toHaveBeenCalled()
+  })
+
+  it('reloads only once per target path to avoid an infinite loop', () => {
+    expect(reloadOnChunkLoadError(chunkError, { fullPath: '/camp/123' })).toBe(true)
+    expect(reloadOnChunkLoadError(chunkError, { fullPath: '/camp/123' })).toBe(false)
+    expect(assign).toHaveBeenCalledTimes(1)
+  })
+
+  it('reloads again for a different target path', () => {
+    expect(reloadOnChunkLoadError(chunkError, { fullPath: '/camp/123' })).toBe(true)
+    expect(reloadOnChunkLoadError(chunkError, { fullPath: '/camp/456' })).toBe(true)
+    expect(assign).toHaveBeenCalledTimes(2)
+  })
+
+  it('reloads again after the guard is cleared by a successful navigation', () => {
+    expect(reloadOnChunkLoadError(chunkError, { fullPath: '/camp/123' })).toBe(true)
+    clearChunkReloadGuard()
+    expect(reloadOnChunkLoadError(chunkError, { fullPath: '/camp/123' })).toBe(true)
+    expect(assign).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to the current location when no target route is given', () => {
+    reloadOnChunkLoadError(chunkError, undefined)
+
+    expect(assign).toHaveBeenCalledWith('/current')
+  })
+})

--- a/frontend/src/helpers/__tests__/newVersionAvailable.spec.js
+++ b/frontend/src/helpers/__tests__/newVersionAvailable.spec.js
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  dismissNewVersion,
+  notifyNewVersionAvailable,
+  updateToNewVersion,
+  useNewVersionAvailable,
+} from '@/helpers/newVersionAvailable.js'
+
+describe('newVersionAvailable', () => {
+  beforeEach(() => {
+    dismissNewVersion()
+  })
+
+  afterEach(() => {
+    dismissNewVersion()
+    vi.unstubAllGlobals()
+  })
+
+  it('is not available by default', () => {
+    expect(useNewVersionAvailable().value).toBe(false)
+  })
+
+  it('becomes available after notifying', () => {
+    notifyNewVersionAvailable()
+    expect(useNewVersionAvailable().value).toBe(true)
+  })
+
+  it('shares the same reactive state across calls', () => {
+    const a = useNewVersionAvailable()
+    const b = useNewVersionAvailable()
+    notifyNewVersionAvailable()
+    expect(a.value).toBe(true)
+    expect(b.value).toBe(true)
+  })
+
+  it('is dismissable so the user can continue working', () => {
+    notifyNewVersionAvailable()
+    dismissNewVersion()
+    expect(useNewVersionAvailable().value).toBe(false)
+  })
+
+  it('reloads the page to update', () => {
+    const reload = vi.fn()
+    vi.stubGlobal('window', { location: { reload } })
+    updateToNewVersion()
+    expect(reload).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/helpers/chunkLoadError.js
+++ b/frontend/src/helpers/chunkLoadError.js
@@ -1,0 +1,41 @@
+const RELOAD_PATH_KEY = 'ecamp3:chunkReloadPath'
+
+export function isChunkLoadError(error) {
+  const message = error?.message ?? ''
+  const chromiumMessage = /Failed to fetch dynamically imported module/i
+  if (chromiumMessage.test(message)) {
+    return true
+  }
+  const firefoxMessage = /error loading dynamically imported module/i
+  if (firefoxMessage.test(message)) {
+    return true
+  }
+  const safariMessage = /Importing a module script failed/i
+  // noinspection RedundantIfStatementJS
+  if (safariMessage.test(message)) {
+    return true
+  }
+  return false
+}
+
+export function reloadOnChunkLoadError(error, to) {
+  if (!isChunkLoadError(error)) {
+    return false
+  }
+
+  const targetPath =
+    to?.fullPath ??
+    window.location.pathname + window.location.search + window.location.hash
+
+  if (window.sessionStorage.getItem(RELOAD_PATH_KEY) === targetPath) {
+    return false
+  }
+
+  window.sessionStorage.setItem(RELOAD_PATH_KEY, targetPath)
+  window.location.assign(targetPath)
+  return true
+}
+
+export function clearChunkReloadGuard() {
+  window.sessionStorage.removeItem(RELOAD_PATH_KEY)
+}

--- a/frontend/src/helpers/newVersionAvailable.js
+++ b/frontend/src/helpers/newVersionAvailable.js
@@ -1,4 +1,5 @@
 import { ref } from 'vue'
+import * as Sentry from '@sentry/browser'
 
 const newVersionAvailable = ref(false)
 
@@ -7,6 +8,7 @@ export function useNewVersionAvailable() {
 }
 
 export function notifyNewVersionAvailable() {
+  Sentry.captureMessage('In route chunk loading failed after deployment.')
   newVersionAvailable.value = true
 }
 

--- a/frontend/src/helpers/newVersionAvailable.js
+++ b/frontend/src/helpers/newVersionAvailable.js
@@ -1,0 +1,19 @@
+import { ref } from 'vue'
+
+const newVersionAvailable = ref(false)
+
+export function useNewVersionAvailable() {
+  return newVersionAvailable
+}
+
+export function notifyNewVersionAvailable() {
+  newVersionAvailable.value = true
+}
+
+export function updateToNewVersion() {
+  window.location.reload()
+}
+
+export function dismissNewVersion() {
+  newVersionAvailable.value = false
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -626,6 +626,12 @@
       "help": "Hilfe",
       "news": "News"
     },
+    "newVersion": {
+      "title": "Eine neue Version ist verfügbar",
+      "description": "Diese Funktion ist nicht verfügbar, bis du auf die neueste Version aktualisierst.",
+      "update": "Jetzt aktualisieren",
+      "updateLater": "Später aktualisieren"
+    },
     "serverError": {
       "409": "Uuuups... Diese Aktion hat zu einem Fehler auf dem Server geführt.",
       "short": "Serverfehler"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -626,6 +626,12 @@
       "help": "Help",
       "news": "News"
     },
+    "newVersion": {
+      "title": "A new version is available",
+      "description": "This feature is not available until you update to the latest version.",
+      "update": "Update now",
+      "updateLater": "Update later"
+    },
     "serverError": {
       "409": "Uuuups... This action caused an server-side error.",
       "short": "Server error"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -620,6 +620,12 @@
       "help": "Aide",
       "news": "Actualités"
     },
+    "newVersion": {
+      "title": "Une nouvelle version est disponible",
+      "description": "Cette fonctionnalité n’est pas disponible tant que vous n’avez pas installé la dernière version.",
+      "update": "Mettre à jour maintenant",
+      "updateLater": "Mettre à jour plus tard"
+    },
     "serverError": {
       "409": "Oooops... Cette action a provoqué une erreur côté serveur.",
       "short": "erreur de serveur"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -505,6 +505,12 @@
       "help": "Aiuto",
       "news": "Notizie"
     },
+    "newVersion": {
+      "title": "È disponibile una nuova versione",
+      "description": "Questa funzione non è disponibile finché non si esegue l’aggiornamento all’ultima versione.",
+      "update": "Aggiorna ora",
+      "updateLater": "Aggiorna più tardi"
+    },
     "serverError": {
       "409": "Oooops... Questa azione ha causato un errore sul lato server.",
       "short": "Errore del server"

--- a/frontend/src/locales/rm.json
+++ b/frontend/src/locales/rm.json
@@ -431,6 +431,12 @@
       "help": "Agid",
       "news": "Noviteds"
     },
+    "newVersion": {
+      "title": "Ina nova versiun è disponibla",
+      "description": "Questa funcziun na è betg disponibla fin che ti actualiseschas a l’ultima versiun.",
+      "update": "Actualisar ussa",
+      "updateLater": "Actualisar plus tard"
+    },
     "serverError": {
       "409": "Uuuups... Questa acziun ha chaschunà ina errur sin il server."
     },

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -23,6 +23,8 @@ import '@/scss/global.scss'
 import '@/scss/tailwind.scss'
 import { initRefresh } from '@/plugins/auth.js'
 import { getEnv } from '@/environment.js'
+import { isChunkLoadError } from '@/helpers/chunkLoadError.js'
+import { notifyNewVersionAvailable } from '@/helpers/newVersionAvailable.js'
 
 browserUpdate({
   required: {
@@ -49,6 +51,26 @@ if (env && env.SENTRY_FRONTEND_DSN) {
     logErrors: process.env.NODE_ENV !== 'production',
   })
 }
+
+const previousErrorHandler = app.config.errorHandler
+app.config.errorHandler = (error, instance, info) => {
+  if (isChunkLoadError(error)) {
+    notifyNewVersionAvailable()
+    return
+  }
+  if (previousErrorHandler) {
+    previousErrorHandler(error, instance, info)
+  } else {
+    // Keep Vue's default behaviour of surfacing unexpected errors.
+    console.error(error)
+  }
+}
+
+window.addEventListener('unhandledrejection', (event) => {
+  if (isChunkLoadError(event.reason)) {
+    notifyNewVersionAvailable()
+  }
+})
 
 app.use(auth)
 app.use(head)

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -4,6 +4,10 @@ import { isAdmin, isLoggedIn } from '@/plugins/auth'
 import { apiStore } from '@/plugins/store'
 import { campShortTitle } from '@/common/helpers/campShortTitle'
 import { getEnv } from '@/environment.js'
+import {
+  clearChunkReloadGuard,
+  reloadOnChunkLoadError,
+} from '@/helpers/chunkLoadError.js'
 
 const NavigationAuth = () => import('./views/auth/NavigationAuth.vue')
 const NavigationDefault = () => import('./views/NavigationDefault.vue')
@@ -549,6 +553,13 @@ const router = createRouter({
       },
     },
   ],
+})
+router.onError((error, to) => {
+  reloadOnChunkLoadError(error, to)
+})
+
+router.afterEach(() => {
+  clearChunkReloadGuard()
 })
 
 export default router

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -8,6 +8,7 @@ import {
   clearChunkReloadGuard,
   reloadOnChunkLoadError,
 } from '@/helpers/chunkLoadError.js'
+import * as Sentry from '@sentry/browser'
 
 const NavigationAuth = () => import('./views/auth/NavigationAuth.vue')
 const NavigationDefault = () => import('./views/NavigationDefault.vue')
@@ -555,6 +556,7 @@ const router = createRouter({
   ],
 })
 router.onError((error, to) => {
+  Sentry.captureMessage('Chunk load failed after deployment')
   reloadOnChunkLoadError(error, to)
 })
 


### PR DESCRIPTION
fix(frontend): recover from stale deployments via chunk-load reload

After a deployment, clients that still hold an outdated index.html
reference hashed JS/CSS chunks that no longer exist on the server. The
first time such a client lazily loads a route chunk via a dynamic
import(), the request fails and the user is left on a broken page
(issue #339).

Add a vue-router onError handler that detects dynamic-import / chunk
load failures (covering the differing Chromium, Firefox and Safari
error messages) and triggers a single full page reload of the target
route. This fetches the freshly deployed index.html and chunk
references, so the navigation succeeds on the second attempt. Because
the reload only happens when a navigation fails, users that are
actively editing are never interrupted.

A sessionStorage guard remembers the path we reloaded for to avoid an
infinite reload loop if the chunk genuinely keeps failing (e.g. a real
404 or an offline client); the guard is reset after the next
successful navigation so future deployments can be recovered from
again.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---

test(e2e): cover stale-deployment chunk-load reload recovery

Add a behavior e2e test for issue #339 that simulates a stale
deployment: it aborts the first request for a lazily loaded route
chunk (CampCreate.vue), as if the file had been removed by a deploy,
then lets later requests through.

The test asserts that the frontend recovers by reloading to the target
route - the create-camp form becomes visible, the URL is /camps/create,
a document marker set before the navigation is wiped (proving a full
reload happened rather than a silent in-app retry), and the chunk was
fetched again after the reload.

Verified the test fails when the router.onError recovery handler is
disabled, so it genuinely guards against the regression.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---

feat(frontend): show update popup when an in-page feature chunk is stale

Counterpart to the route-level chunk-load recovery. When a chunk fails to
load while the user is already on a page - e.g. an asynchronously loaded
component pulled in by an interaction - reloading (as the router does for
failed navigations) would discard the user's unsaved work.

Instead, surface a non-destructive popup informing the user that a new
version is available and that this feature stays blocked until they
update, letting them choose between updating now (reload) and continuing
to work (issue #339).

Chunk-load errors that happen outside a route navigation are caught via
app.config.errorHandler (chained with any previous handler, e.g. Sentry's)
and a window 'unhandledrejection' listener, both of which flag a reactive
"new version available" state rendered by NewVersionAvailableDialog. The
route-level recovery in router.onError is unchanged and still reloads for
failed navigations.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---

test(e2e): cover stale-deployment blocked-feature update popup

Add a behavior e2e test for the in-page side of issue #339. While on a
settled route it simulates an interaction that lazily imports a feature
chunk a deployment has removed (the dev server preloads a page's
components during navigation, so there is no real post-navigation lazy
load to block).

The test asserts the frontend shows the "new version available" popup
with update/continue actions, does NOT reload (a document marker
survives and the URL is unchanged), and that choosing "continue"
dismisses the popup so the user can keep working.

Verified the test fails when the unhandledrejection popup handler is
disabled, so it genuinely guards against the regression.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---

frontend: add sentry notification if a deployment lead to failing chunks

Signed-off-by: BacLuc <lucius.bachmann@clubpage.ch>

[e5bd3209827eeec4c338a5bc5da851cf55dd9171.webm](https://github.com/user-attachments/assets/c5b0ec72-8d5f-4d3d-a876-e49f14c8cbab)


[6605bda7646e1ddb23b6e0402ce10b08ac32e159.webm](https://github.com/user-attachments/assets/dd078a0d-1000-44bf-9b6e-5e7c1e89fc1c)





