### PR TITLE
fix(program): avoid eager VOverlay mount causing Safari WeakMap error

### DIFF
--- a/frontend/src/components/dashboard/SelectFilter.vue
+++ b/frontend/src/components/dashboard/SelectFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-menu :close-on-content-click="!multiple" :multiple="null">
+  <v-menu :close-on-content-click="!multiple">
     <template #activator="{ props }">
       <v-chip
         :color="active ? 'primary' : 'surface'"

--- a/frontend/src/components/dialog/DialogForm.vue
+++ b/frontend/src/components/dialog/DialogForm.vue
@@ -3,7 +3,6 @@
     v-bind="$attrs"
     :fullscreen="$vuetify.display.xs"
     content-class="ec-dialog-form"
-    eager
     :max-width="maxWidth"
     :model-value
     @update:model-value="onInput"


### PR DESCRIPTION
Safari 17.1 throws "WeakMap keys must be objects or non-registered symbols" in Vue's reactivity system when many VOverlay instances are created simultaneously. This was triggered on the program/period view after creating a new activity: the schedule-entries reload caused all PicassoEntry components to mount, each eagerly mounting a VDialog (DialogActivityEdit) via DialogForm's hardcoded `eager` prop. With 50+ activities on screen, this created 50+ reactive Sets at once inside Vuetify's useStack(), hitting the Safari WeakMap limit.

Removing `eager` from DialogForm makes VOverlay mount lazily (only when the dialog is actually opened), eliminating the simultaneous burst. DetailPane.vue already passes `eager` explicitly via $attrs, so its behaviour is unchanged.

Also remove the stale `:multiple="null"` attribute on VMenu in SelectFilter — VMenu has no `multiple` prop, so this was always a no-op.

fixes https://github.com/ecamp/ecamp3/issues/10185