### PR TITLE
fix(sentry): ignore browser-injected __firefox__ reader mode errors

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -47,6 +47,7 @@ if (env && env.SENTRY_FRONTEND_DSN) {
     enableTracing: false,
     autoSessionTracking: false,
     logErrors: process.env.NODE_ENV !== 'production',
+    ignoreErrors: [/Can't find variable: __firefox__/, /window\.__firefox__/],
   })
 }
 


### PR DESCRIPTION
Brave on iOS (WebKit) injects reader mode detection that references window.__firefox__, a Firefox for iOS API. These ReferenceErrors and TypeErrors are not app errors, so filter them from Sentry.

fixes https://github.com/ecamp/ecamp3/issues/10187 fixes https://github.com/ecamp/ecamp3/issues/10188