### PR TITLE
fix(dashboard): avoid unhandled rejection when activity progressLabel…

### DIFF
--- a/common/helpers/filterMatchScheduleEntry.js
+++ b/common/helpers/filterMatchScheduleEntry.js
@@ -41,10 +41,10 @@ const filterMatchScheduleEntry = (scheduleEntry, filter) => {
     (filter.progressLabel === null ||
       filter.progressLabel === undefined ||
       filter.progressLabel.length === 0 ||
-      scheduleEntry.activity()._meta?.loading ||
-      filter.progressLabel.includes(
-        scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
-      ))
+      (!scheduleEntry.activity()._meta?.loading &&
+        filter.progressLabel.includes(
+          scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
+        )))
   )
 }
 

--- a/common/helpers/filterMatchScheduleEntry.js
+++ b/common/helpers/filterMatchScheduleEntry.js
@@ -41,6 +41,7 @@ const filterMatchScheduleEntry = (scheduleEntry, filter) => {
     (filter.progressLabel === null ||
       filter.progressLabel === undefined ||
       filter.progressLabel.length === 0 ||
+      scheduleEntry.activity()._meta?.loading ||
       filter.progressLabel.includes(
         scheduleEntry.activity().progressLabel?.()._meta.self ?? 'none'
       ))

--- a/frontend/src/components/dashboard/ActivityRow.vue
+++ b/frontend/src/components/dashboard/ActivityRow.vue
@@ -124,7 +124,9 @@ export default {
       return this.scheduleEntry.activity().title
     },
     progressLabel() {
-      return this.scheduleEntry.activity().progressLabel?.().title
+      const activity = this.scheduleEntry.activity()
+      if (activity._meta?.loading) return undefined
+      return activity.progressLabel?.().title
     },
     location() {
       return this.scheduleEntry.activity().location


### PR DESCRIPTION
… is null

hal-json-vuex's loading proxy returns a truthy callable function for any property access, even when the actual API value is null. This caused progressLabel?.() to always fire on loading resources, creating a promise that rejected once the activity loaded with a null progressLabel.

Guard with _meta?.loading before calling progressLabel() as a relation in ActivityRow and filterMatchScheduleEntry.

fixes https://github.com/ecamp/ecamp3/issues/10193