### PR TITLE
Improve deploy feature branch

### DIFF
--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    if: contains(github.event.pull_request.labels.*.name, 'deploy!')
+    if: contains(github.event.pull_request.labels.*.name, 'deploy!') && github.event.pull_request.state == 'open'
     name: Build and push docker images
     uses: ./.github/workflows/reusable-build-and-push.yml
     with:

--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    if: contains(github.event.pull_request.labels.*.name, 'deploy!') && github.event.pull_request.state == 'open'
+    if: (github.event_name == 'workflow_dispatch') || (contains(github.event.pull_request.labels.*.name, 'deploy!') && github.event.pull_request.state == 'open')
     name: Build and push docker images
     uses: ./.github/workflows/reusable-build-and-push.yml
     with:


### PR DESCRIPTION
fix(cd): skip feature branch deploy when PR is closed

Adding a label to an already-closed PR triggered pull_request_target/labeled
and deployed anyway. Guard with github.event.pull_request.state == 'open'.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

fix(cd): allow workflow_dispatch to bypass PR state check

After adding the PR state guard, workflow_dispatch no longer triggered
build-and-push because github.event.pull_request.state is empty for
manual dispatches. Short-circuit the check for workflow_dispatch events.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>