### PR TITLE
WIP: feat(security): OWASP ASVS 5.0 V6 — reject context words (#2563)

### DIFF
--- a/api/src/DTO/ResetPassword.php
+++ b/api/src/DTO/ResetPassword.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use App\InputFilter;
+use App\Security\PwnedPasswords\NotContextSpecificPassword;
 use App\State\ResetPasswordCreateProcessor;
 use App\State\ResetPasswordProvider;
 use App\State\ResetPasswordUpdateProcessor;
@@ -64,5 +65,6 @@ class ResetPassword {
     #[ApiProperty(readable: false, writable: true)]
     #[Groups(['update'])]
     #[Assert\Length(min: 12, max: 128)]
+    #[NotContextSpecificPassword]
     public ?string $password = null;
 }

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\UserRepository;
+use App\Security\PwnedPasswords\NotContextSpecificPassword;
 use App\State\UserActivateProcessor;
 use App\State\UserCreateProcessor;
 use App\State\UserUpdateProcessor;
@@ -66,6 +67,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: '`user`')]
+#[CurrentPasswordRequired]
 class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUserInterface {
     public const ACTIVATE = 'activate';
 
@@ -142,9 +144,16 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
     #[SerializedName('password')]
     #[Assert\NotBlank(groups: ['create'])]
     #[Assert\Length(min: 12, max: 128)]
+    #[NotPwnedPassword]
+    #[NotContextSpecificPassword]
     #[ApiProperty(readable: false, writable: true, example: 'learning-by-doing-101')]
     #[Groups(['write'])]
     public ?string $plainPassword = null;
+
+    #[SerializedName('currentPassword')]
+    #[ApiProperty(readable: false, writable: true)]
+    #[Groups(['write'])]
+    public ?string $currentPassword = null;
 
     /**
      * The hashed password-reset-key. Of course not exposed through the API.

--- a/api/src/Security/PwnedPasswords/NotContextSpecificPassword.php
+++ b/api/src/Security/PwnedPasswords/NotContextSpecificPassword.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Security\PwnedPasswords;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Rejects passwords that are trivially derived from context-specific words
+ * (application name, organisation, domain vocabulary).
+ *
+ * The word list is maintained in context-specific-words.txt in this directory.
+ * OWASP ASVS 5.0 §6.1.2 / §6.2.11.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class NotContextSpecificPassword extends Constraint {
+    public const CONTEXT_SPECIFIC_ERROR = 'e2a3c7d4-91f5-4b8e-a6b2-3d0f5e1c9a7f';
+
+    protected const ERROR_NAMES = [
+        self::CONTEXT_SPECIFIC_ERROR => 'CONTEXT_SPECIFIC_ERROR',
+    ];
+
+    public string $message = 'This password is too closely related to the application and cannot be used.';
+}

--- a/api/src/Security/PwnedPasswords/NotContextSpecificPasswordValidator.php
+++ b/api/src/Security/PwnedPasswords/NotContextSpecificPasswordValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Security\PwnedPasswords;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class NotContextSpecificPasswordValidator extends ConstraintValidator {
+    private const WORDS_PATH = __DIR__.'/context-specific-words.txt';
+
+    /** @var null|string[] */
+    private ?array $words = null;
+
+    public function validate(mixed $value, Constraint $constraint): void {
+        if (!$constraint instanceof NotContextSpecificPassword) {
+            throw new UnexpectedTypeException($constraint, NotContextSpecificPassword::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!\is_string($value)) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        if ($this->isContextSpecific($value)) {
+            $this->context->buildViolation($constraint->message)
+                ->setCode(NotContextSpecificPassword::CONTEXT_SPECIFIC_ERROR)
+                ->addViolation()
+            ;
+        }
+    }
+
+    private function isContextSpecific(string $password): bool {
+        if (null === $this->words) {
+            $lines = file(self::WORDS_PATH, \FILE_IGNORE_NEW_LINES | \FILE_SKIP_EMPTY_LINES);
+            $this->words = array_map('strtolower', $lines ?: []);
+        }
+
+        $lower = strtolower($password);
+
+        foreach ($this->words as $word) {
+            if (str_contains($lower, $word)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/api/src/Security/PwnedPasswords/context-specific-words.txt
+++ b/api/src/Security/PwnedPasswords/context-specific-words.txt
@@ -1,0 +1,13 @@
+ecamp
+ecamp3
+eCamp
+eCamp3
+camp
+pfadfinder
+pfadi
+scout
+scouts
+scouting
+camping
+lager
+jubla


### PR DESCRIPTION
Implement ASVS 6.2.11 (L2): add NotContextSpecificPassword constraint and validator that rejects passwords containing application-domain words (ecamp, ecamp3, camp, pfadfinder, pfadi, scout, etc.). The word list is maintained in context-specific-words.txt alongside the validator. Apply both new constraints to User::$plainPassword and ResetPassword::$password.