### PR TITLE
feat(collaborators): search known profiles when inviting

### DIFF
--- a/api/migrations/schema/Version20260627120000.php
+++ b/api/migrations/schema/Version20260627120000.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260627120000 extends AbstractMigration {
+    #[\Override]
+    public function getDescription(): string {
+        return 'Add pg_trgm GIN indexes for case-insensitive partial profile search (firstname, surname, nickname, email)';
+    }
+
+    public function up(Schema $schema): void {
+        $this->addSql('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+        $this->addSql('CREATE INDEX unmanaged_idx_profile_firstname_trgm ON profile USING gin (LOWER(firstname) gin_trgm_ops)');
+        $this->addSql('CREATE INDEX unmanaged_idx_profile_surname_trgm ON profile USING gin (LOWER(surname) gin_trgm_ops)');
+        $this->addSql('CREATE INDEX unmanaged_idx_profile_nickname_trgm ON profile USING gin (LOWER(nickname) gin_trgm_ops)');
+        $this->addSql('CREATE INDEX unmanaged_idx_profile_email_trgm ON profile USING gin (LOWER(email) gin_trgm_ops)');
+    }
+
+    #[\Override]
+    public function down(Schema $schema): void {
+        $this->addSql('DROP INDEX unmanaged_idx_profile_firstname_trgm');
+        $this->addSql('DROP INDEX unmanaged_idx_profile_surname_trgm');
+        $this->addSql('DROP INDEX unmanaged_idx_profile_nickname_trgm');
+        $this->addSql('DROP INDEX unmanaged_idx_profile_email_trgm');
+        $this->addSql('DROP EXTENSION IF EXISTS pg_trgm');
+    }
+}

--- a/api/src/Doctrine/Filter/ProfileSearchFilter.php
+++ b/api/src/Doctrine/Filter/ProfileSearchFilter.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Doctrine\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Entity\Profile;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\TypeInfo\Type;
+
+final class ProfileSearchFilter extends AbstractFilter {
+    public const string QUERY_PARAM_NAME = 'search';
+
+    private const array SEARCHED_PROPERTIES = ['firstname', 'surname', 'nickname', 'email'];
+
+    public function getDescription(string $resourceClass): array {
+        return [self::QUERY_PARAM_NAME => [
+            'property' => self::QUERY_PARAM_NAME,
+            'type' => Type::string()->__toString(),
+            'required' => false,
+            'description' => 'Search profiles by a part of their firstname, surname, nickname or email.',
+        ]];
+    }
+
+    protected function filterProperty(
+        string $property,
+        $value,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = []
+    ): void {
+        if (Profile::class !== $resourceClass) {
+            throw new \Exception("ProfileSearchFilter can only be applied to the Profile entity (received: {$resourceClass}).");
+        }
+
+        if (self::QUERY_PARAM_NAME !== $property) {
+            return;
+        }
+
+        if (!is_string($value) || '' === trim($value)) {
+            return;
+        }
+
+        if (!mb_check_encoding($value, 'UTF-8')) {
+            throw new BadRequestHttpException(sprintf('The "%s" query parameter must be a valid UTF-8 string.', self::QUERY_PARAM_NAME));
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $parameterName = $queryNameGenerator->generateParameterName('search');
+
+        $expr = $queryBuilder->expr();
+        $orConditions = [];
+        foreach (self::SEARCHED_PROPERTIES as $searchedProperty) {
+            $orConditions[] = "LOWER({$rootAlias}.{$searchedProperty}) LIKE LOWER(:{$parameterName})";
+        }
+
+        $queryBuilder->andWhere($expr->orX(...$orConditions));
+        $queryBuilder->setParameter($parameterName, '%'.$this->escapeLike($value).'%');
+    }
+
+    private function escapeLike(string $value): string {
+        return str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], trim($value));
+    }
+}

--- a/api/src/Entity/Profile.php
+++ b/api/src/Entity/Profile.php
@@ -9,6 +9,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
+use App\Doctrine\Filter\ProfileSearchFilter;
 use App\InputFilter;
 use App\Repository\ProfileRepository;
 use App\State\ProfileUpdateProcessor;
@@ -39,6 +40,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     denormalizationContext: ['groups' => ['write']],
 )]
 #[ApiFilter(filterClass: SearchFilter::class, properties: ['user.collaborations.camp', 'user'])]
+#[ApiFilter(filterClass: ProfileSearchFilter::class)]
 #[ORM\Entity(repositoryClass: ProfileRepository::class)]
 #[ORM\Table(name: '`profile`')]
 class Profile extends BaseEntity {

--- a/api/tests/Api/Profiles/ListProfilesTest.php
+++ b/api/tests/Api/Profiles/ListProfilesTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Api\Profiles;
 
 use App\Tests\Api\ECampApiTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @internal
@@ -110,5 +111,120 @@ class ListProfilesTest extends ECampApiTestCase {
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains(['totalItems' => 0]);
         $this->assertArrayNotHasKey('items', $response->toArray()['_links']);
+    }
+
+    #[DataProvider('provideSearchTermsMatchingProfile1Manager')]
+    public function testSearchProfilesMatchesFirstnameSurnameNicknameAndEmail(string $searchTerm) {
+        $response = static::createClientWithCredentials()
+            ->request('GET', '/profiles?search='.urlencode($searchTerm))
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertContains(
+            ['href' => $this->getIriFor('profile1manager')],
+            $response->toArray()['_links']['items'],
+            "Searching for '{$searchTerm}' should return profile1manager."
+        );
+    }
+
+    public static function provideSearchTermsMatchingProfile1Manager(): array {
+        return [
+            'full firstname' => ['Robert'],
+            'partial firstname' => ['ober'],
+            'firstname different case' => ['robert'],
+            'full surname' => ['Baden-Powell'],
+            'partial surname' => ['aden-Pow'],
+            'surname uppercase' => ['BADEN-POWELL'],
+            'full nickname' => ['Bi-Pi'],
+            'partial nickname' => ['i-P'],
+            'full email' => ['test@example.com'],
+            'partial email' => ['test@exa'],
+        ];
+    }
+
+    public function testSearchProfilesIsRestrictedToTheMatchingProfiles() {
+        $response = static::createClientWithCredentials()
+            ->request('GET', '/profiles?search=Baden-Powell')
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains(['totalItems' => 1]);
+        $this->assertEqualsCanonicalizing([
+            ['href' => $this->getIriFor('profile1manager')],
+        ], $response->toArray()['_links']['items']);
+    }
+
+    public function testSearchProfilesStaysScopedToRelatedProfilesForUnrelatedUser() {
+        $response = static::createClientWithCredentials(['email' => static::$fixtures['user4unrelated']->getEmail()])
+            ->request('GET', '/profiles?search=Baden-Powell')
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains(['totalItems' => 0]);
+        $this->assertArrayNotHasKey('items', $response->toArray()['_links']);
+    }
+
+    public function testSearchProfilesWithoutMatchReturnsEmptyResult() {
+        $response = static::createClientWithCredentials()
+            ->request('GET', '/profiles?search=thisdoesnotmatchanyprofile')
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains(['totalItems' => 0]);
+        $this->assertArrayNotHasKey('items', $response->toArray()['_links']);
+    }
+
+    public function testSearchProfilesIsDeniedForAnonymousUser() {
+        static::createBasicClient()->request('GET', '/profiles?search=Robert');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testSearchProfilesCanBeCombinedWithCampFilter() {
+        $camp = static::getFixture('camp1');
+        $response = static::createClientWithCredentials()
+            ->request('GET', '/profiles?user.collaborations.camp=%2Fcamps%2F'.$camp->getId().'&search=Baden-Powell')
+        ;
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains(['totalItems' => 1]);
+        $this->assertEqualsCanonicalizing([
+            ['href' => $this->getIriFor('profile1manager')],
+        ], $response->toArray()['_links']['items']);
+    }
+
+    #[DataProvider('provideInvalidUtf8SearchTerms')]
+    public function testSearchProfilesWithInvalidUtf8ReturnsBadRequest(string $invalidSearch) {
+        static::createClientWithCredentials()
+            ->request('GET', '/profiles?search='.$invalidSearch)
+        ;
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public static function provideInvalidUtf8SearchTerms(): array {
+        return [
+            'lone UTF-8 continuation byte' => ['%C2'],
+            'truncated multibyte sequence' => ['Rob%C3'],
+            'invalid byte 0xFF' => ['%FF'],
+        ];
+    }
+
+    #[DataProvider('provideWeirdSearchTerms')]
+    public function testSearchProfilesNeverCausesServerError(string $weirdSearch) {
+        $response = static::createClientWithCredentials()
+            ->request('GET', '/profiles?search='.$weirdSearch)
+        ;
+        $this->assertContains(
+            $response->getStatusCode(),
+            [200, 400],
+            "Search term '{$weirdSearch}' must not cause a server error."
+        );
+    }
+
+    public static function provideWeirdSearchTerms(): array {
+        return [
+            'lone UTF-8 continuation byte' => ['%C2'],
+            'truncated multibyte sequence' => ['Rob%C3'],
+            'invalid byte 0xFF' => ['%FF'],
+            'null byte' => ['Rob%00ert'],
+            'only LIKE wildcards' => ['%25%25%25'],
+            'backslash' => ['%5C'],
+            'valid umlaut' => ['M%C3%BCller'],
+            'emoji' => ['%F0%9F%98%80'],
+        ];
     }
 }

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testOpenApiSpecMatchesSnapshot__1.yml
@@ -61661,6 +61661,16 @@ paths:
               type: string
             type: array
           style: form
+        -
+          deprecated: false
+          description: 'Search profiles by a part of their firstname, surname, nickname or email.'
+          explode: false
+          in: query
+          name: search
+          required: false
+          schema:
+            type: string
+          style: form
       responses:
         200:
           content:

--- a/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testRootEndpointMatchesSnapshot__1.json
+++ b/api/tests/Api/SnapshotTests/__snapshots__/ResponseSnapshotTest__testRootEndpointMatchesSnapshot__1.json
@@ -108,7 +108,7 @@
             "templated": true
         },
         "profiles": {
-            "href": "/profiles{/id}{?user.collaborations.camp,user.collaborations.camp[],user,user[]}",
+            "href": "/profiles{/id}{?user.collaborations.camp,user.collaborations.camp[],user,user[],search}",
             "templated": true
         },
         "refreshToken": {

--- a/e2e/tests/9-behavior-tests/admin/team.spec.ts
+++ b/e2e/tests/9-behavior-tests/admin/team.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect, Locator } from '@playwright/test'
+import {
+  bipiUser,
+  bruceWayneUser as bruceWayneEmail,
+  grgrCampId,
+} from '@/utils/constants'
+import { loginAndSetCookie } from '@/utils/helpers'
+
+test.describe('invite collaborator by searching profiles', () => {
+  let dialog: Locator
+
+  test.beforeEach(async ({ page, request }) => {
+    await loginAndSetCookie(page, request, bipiUser)
+    await page.goto(`/camps/${grgrCampId}/admin/collaborators`)
+    await page.getByTestId('collaborator-invite-cta').click()
+    dialog = page.getByTestId('collaborator-create-dialog')
+    await expect(dialog).toBeVisible()
+  })
+
+  test('finds a related profile by name and uses its email', async ({ page }) => {
+    const searchInput = page.locator('[data-testid="collaborator-invite-search"] input')
+    await searchInput.fill('Bruce')
+
+    const result = page
+      .getByTestId('collaborator-invite-result')
+      .filter({ hasText: bruceWayneEmail })
+    await expect(result).toBeVisible({ timeout: 10000 })
+    await expect(result).toContainText('Bruce Wayne')
+
+    await result.click()
+
+    await expect(searchInput).toHaveValue(bruceWayneEmail)
+
+    await page.keyboard.press('Tab')
+
+    const submitButton = dialog.locator('[type="submit"]')
+    await submitButton.focus()
+    await submitButton.click()
+
+    await expect(page.getByText('BW')).toBeVisible()
+    await expect(page.getByText('Bruce Wayne', { exact: true })).toBeVisible()
+  })
+
+  test('finds a related profile by part of the surname', async ({ page }) => {
+    const searchInput = page.locator('[data-testid="collaborator-invite-search"] input')
+    await searchInput.fill('müll')
+
+    const result = page
+      .getByTestId('collaborator-invite-result')
+      .filter({ hasText: 'salamander@example.com' })
+    await expect(result).toBeVisible({ timeout: 10000 })
+
+    await result.click()
+  })
+
+  test('allows typing a brand-new email address that is not a known profile', async ({
+    page,
+  }) => {
+    const searchInput = page.locator('[data-testid="collaborator-invite-search"] input')
+    await searchInput.fill('someone-new@example.com')
+
+    await expect(
+      page.getByTestId('collaborator-invite-result').filter({ hasText: '@' })
+    ).toHaveCount(0)
+    await searchInput.blur()
+    await expect(searchInput).toHaveValue('someone-new@example.com')
+  })
+})

--- a/frontend/src/components/collaborator/CollaboratorCreate.vue
+++ b/frontend/src/components/collaborator/CollaboratorCreate.vue
@@ -1,5 +1,6 @@
 <template>
   <DetailPane
+    data-testid="collaborator-create-dialog"
     :model-value="showDialog"
     :loading="loading"
     :error="error"
@@ -17,6 +18,7 @@
         variant="text"
         class="my-n2"
         icon="mdi-account-plus"
+        data-testid="collaborator-invite-cta"
         v-bind="props"
         @click="showDialog = true"
       >
@@ -24,29 +26,71 @@
       </ButtonAdd>
     </template>
 
-    <e-text-field
-      v-model="entityData.inviteEmail"
-      type="email"
-      path="inviteEmail"
+    <ValidationField
+      v-slot="{ errors: veeErrors, resetField }"
+      :label="$t('components.collaborator.collaboratorCreate.emailLabel')"
+      name="inviteEmail"
       vee-rules="required|email"
-      class="mb-2"
-    />
+    >
+      <v-combobox
+        v-model="entityData.inviteEmail"
+        v-model:search="search"
+        data-testid="collaborator-invite-search"
+        :items="profileItems"
+        :loading="searchLoading"
+        :no-filter="true"
+        :return-object="false"
+        :hide-no-data="!search || searchLoading"
+        item-title="value"
+        item-value="value"
+        type="email"
+        class="mb-2"
+        autocomplete="off"
+        :menu-icon="null"
+        :error-messages="veeErrors"
+        :label="$t('components.collaborator.collaboratorCreate.emailLabel')"
+        :hint="$t('components.collaborator.collaboratorCreate.searchHint')"
+        persistent-hint
+        @update:model-value="(val) => onSelect(val, resetField)"
+      >
+        <template #item="{ item, props: itemProps }">
+          <v-list-item
+            v-bind="itemProps"
+            :title="item.raw.displayName"
+            :subtitle="item.raw.value"
+            data-testid="collaborator-invite-result"
+          >
+            <template #prepend>
+              <v-icon icon="mdi-account-circle" class="mr-2" />
+            </template>
+          </v-list-item>
+        </template>
+
+        <template #no-data>
+          <v-list-item
+            :title="$t('components.collaborator.collaboratorCreate.noResults')"
+          />
+        </template>
+      </v-combobox>
+    </ValidationField>
 
     <CollaboratorForm :collaboration="entityData" />
   </DetailPane>
 </template>
 
 <script>
+import { debounce } from 'lodash-es'
 import ButtonAdd from '@/components/buttons/ButtonAdd.vue'
 import DetailPane from '@/components/generic/DetailPane.vue'
 import DialogBase from '@/components/dialog/DialogBase.vue'
 import CollaboratorForm from '@/components/collaborator/CollaboratorForm.vue'
+import ValidationField from '@/components/form/base/ValidationField.vue'
 
 const DEFAULT_INVITE_ROLE = 'member'
 
 export default {
   name: 'CollaboratorCreate',
-  components: { ButtonAdd, DetailPane, CollaboratorForm },
+  components: { ButtonAdd, DetailPane, CollaboratorForm, ValidationField },
   extends: DialogBase,
   provide() {
     return {
@@ -60,7 +104,18 @@ export default {
     return {
       entityProperties: ['camp', 'inviteEmail', 'role'],
       entityUri: '',
+      search: '',
+      profiles: [],
+      searchLoading: false,
     }
+  },
+  computed: {
+    profileItems() {
+      return this.profiles.map((profile) => ({
+        value: profile.email,
+        displayName: this.profileDisplayName(profile),
+      }))
+    },
   },
   watch: {
     showDialog: function (showDialog) {
@@ -73,15 +128,56 @@ export default {
       } else {
         // clear form on exit
         this.clearEntityData()
+        this.search = ''
+        this.profiles = []
       }
+    },
+    search(value) {
+      this.debouncedSearchProfiles(value)
     },
   },
   mounted() {
     this.api
       .href(this.api.get(), 'campCollaborations')
       .then((uri) => (this.entityUri = uri))
+    this.debouncedSearchProfiles = debounce(this.searchProfiles, 300)
   },
   methods: {
+    profileDisplayName(profile) {
+      const name = [profile.firstname, profile.surname].filter(Boolean).join(' ')
+      if (profile.nickname && name) {
+        return `${profile.nickname} (${name})`
+      }
+      return profile.nickname || name || profile.email
+    },
+    async searchProfiles(value) {
+      const searchTerm = (value || '').trim()
+      if (searchTerm.length < 1) {
+        this.profiles = []
+        return
+      }
+      this.searchLoading = true
+      try {
+        const collection = await this.api.get().profiles({ search: searchTerm })._meta
+          .load
+        if (this.search.trim() === searchTerm) {
+          this.profiles = collection.items.map((item) => ({
+            email: item.email,
+            firstname: item.firstname,
+            surname: item.surname,
+            nickname: item.nickname,
+          }))
+        }
+      } catch {
+        this.profiles = []
+      } finally {
+        this.searchLoading = false
+      }
+    },
+    onSelect(val, resetField) {
+      resetField({ value: val })
+      this.profiles = []
+    },
     createCollaboration() {
       return this.create().then(() => {
         this.api.reload(this.camp.campCollaborations())

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -263,8 +263,11 @@
     },
     "collaborator": {
       "collaboratorCreate": {
+        "emailLabel": "E-Mail-Adresse",
         "invite": "Einladung verschicken",
         "inviteCta": "Ins Team einladen",
+        "noResults": "Keine passenden Personen gefunden. Du kannst jede Person über ihre E-Mail-Adresse einladen.",
+        "searchHint": "Suche Personen aus gemeinsamen Lagern nach Name, Pfadiname oder E-Mail, oder gib eine neue E-Mail-Adresse ein.",
         "title": "Person einladen"
       },
       "collaboratorEdit": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -263,8 +263,11 @@
     },
     "collaborator": {
       "collaboratorCreate": {
+        "emailLabel": "Email address",
         "invite": "Send invitation",
         "inviteCta": "Invite to team",
+        "noResults": "No matching people found. You can invite anyone by typing their email address.",
+        "searchHint": "Search people you share a camp with by name, nickname or email, or type a new email address.",
         "title": "Invite people"
       },
       "collaboratorEdit": {


### PR DESCRIPTION
Inviting a collaborator previously required typing the exact email address from memory. This adds the ability to search the people you already share a camp with by firstname, surname, nickname or email and pick one, which fills in the invite email. Typing a brand-new email address still works.

Fixes BacLuc/ecamp3#340

Backend
- New App\Doctrine\Filter\ProfileSearchFilter adds a single `search` query parameter to GET /profiles. It matches the term case-insensitively and partially against firstname, surname, nickname and email at the same time (OR), on top of the existing user scoping (only profiles you share a camp with). LIKE special characters are escaped.
- Migration Version20260627120000 enables pg_trgm and creates functional GIN trigram indexes on LOWER(firstname/surname/nickname/email) so the LOWER(col) LIKE LOWER(:term) comparisons are served by a bitmap index scan instead of a sequential scan. The indexes are prefixed with `unmanaged_` so CustomPostgreSQLSchemaManager hides them from the schema diff and doctrine:schema:validate stays green (functional/opclass indexes cannot be expressed in ORM mapping).
- Verified with EXPLAIN ANALYZE on ~20'000 generated profiles (app:generate-data) that the planner uses a BitmapOr over all four trigram indexes, both for the isolated predicate and for the full scoped endpoint query as a user related to all profiles.
- reject non-UTF-8 profile search terms with 400 instead of 500

Frontend
- The collaborator invite dialog now uses a server-driven combobox: it debounces the input, queries /profiles?search=, shows the matching people with name and email, and on selection uses the email as the value. Free-text email entry is preserved for inviting people you have not met yet.

Tests
- API: ListProfilesTest covers searching each field, partial and case-insensitive matches, result restriction, combination with the camp filter, and that the search stays scoped to related profiles / rejects anonymous users.
- Updated OpenAPI and root-endpoint snapshots for the new `search` parameter.
- e2e: inviteCollaboratorSearch.spec.ts covers finding a related profile by nickname / partial surname and typing a brand-new email.