### PR TITLE
feat(frontend): add /form-test route to drive form components from the URL

### DIFF
--- a/e2e/tests/9-behavior-tests/components/form/base/formComponentTest.spec.ts
+++ b/e2e/tests/9-behavior-tests/components/form/base/formComponentTest.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test'
+
+function formTestUrl(
+  component: string,
+  options: { props?: unknown; value?: unknown } = {}
+) {
+  const params = new URLSearchParams()
+  if (options.props !== undefined) params.set('props', JSON.stringify(options.props))
+  if (options.value !== undefined) params.set('value', JSON.stringify(options.value))
+  const query = params.toString()
+  return `/form-test/${component}${query ? `?${query}` : ''}`
+}
+
+test('lists the available form components', async ({ page }) => {
+  await page.goto('/form-test')
+  const list = page.getByTestId('form-test-unknown')
+  await expect(list).toContainText('ETextField')
+  await expect(list).toContainText('ECheckbox')
+})
+
+test('ETextField reflects typed input in its v-model', async ({ page }) => {
+  await page.goto(formTestUrl('ETextField', { props: { label: 'Name' } }))
+
+  const subject = page.getByTestId('form-test-subject')
+  await expect(subject.locator('label').first()).toHaveText('Name')
+  await expect(page.getByTestId('form-test-model')).toHaveText('null')
+
+  await subject.locator('input').fill('Hello world')
+
+  await expect(page.getByTestId('form-test-model')).toHaveText('"Hello world"')
+})
+
+test('ECheckbox toggles its boolean v-model', async ({ page }) => {
+  await page.goto(formTestUrl('ECheckbox', { props: { label: 'Agree' }, value: false }))
+
+  await expect(page.getByTestId('form-test-model')).toHaveText('false')
+
+  await page.getByTestId('form-test-subject').locator('input[type="checkbox"]').click()
+
+  await expect(page.getByTestId('form-test-model')).toHaveText('true')
+})

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -32,6 +32,16 @@ const router = createRouter({
             },
             beforeEnter: requireAuth,
           },
+          // Render a single form component selected via the URL, so form
+          // components can be driven and asserted on with Playwright.
+          // No auth required: the base components work without API/store.
+          {
+            path: '/form-test/:component?',
+            name: 'formTest',
+            components: {
+              default: () => import('./views/dev/FormComponentTest.vue'),
+            },
+          },
         ]
       : []),
 

--- a/frontend/src/views/dev/FormComponentTest.vue
+++ b/frontend/src/views/dev/FormComponentTest.vue
@@ -1,0 +1,113 @@
+<template>
+  <v-container fluid class="form-component-test pa-6">
+    <v-card class="pa-6">
+      <h1 class="text-h6 mb-4" data-testid="form-test-component-name">
+        {{ componentName || 'Form component test' }}
+      </h1>
+
+      <template v-if="resolvedComponent">
+        <e-form>
+          <div data-testid="form-test-subject">
+            <component
+              :is="resolvedComponent"
+              ref="subject"
+              v-model="model"
+              v-bind="componentProps"
+            />
+          </div>
+        </e-form>
+
+        <v-divider class="my-4" />
+
+        <div class="text-caption text-medium-emphasis">v-model value</div>
+        <pre data-testid="form-test-model" class="form-test-model">{{ modelJson }}</pre>
+      </template>
+
+      <div v-else data-testid="form-test-unknown">
+        <p v-if="componentName" class="text-error">
+          Unknown form component "{{ componentName }}".
+        </p>
+        <p class="mb-2">Available components:</p>
+        <ul>
+          <li v-for="name in availableComponents" :key="name">
+            <router-link :to="{ name: 'formTest', params: { component: name } }">
+              {{ name }}
+            </router-link>
+          </li>
+        </ul>
+      </div>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import EForm from '@/components/form/base/EForm.vue'
+
+const modules = import.meta.glob('../../components/form/base/E*.vue', {
+  eager: true,
+})
+const registry = {}
+for (const path in modules) {
+  const name = path.split('/').pop().replace('.vue', '')
+  registry[name] = modules[path].default
+}
+
+function parseJsonQuery(value, fallback) {
+  if (value === undefined || value === null) return fallback
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+export default {
+  name: 'FormComponentTest',
+  components: { EForm },
+  data() {
+    return {
+      model: parseJsonQuery(this.$route.query.value, null),
+    }
+  },
+  computed: {
+    componentName() {
+      return this.$route.params.component ?? ''
+    },
+    resolvedComponent() {
+      const name = this.componentName
+      if (!name) return null
+      if (registry[name]) return registry[name]
+      throw new Error(`Component ${name} not found`)
+    },
+    availableComponents() {
+      return Object.keys(registry).sort()
+    },
+    componentProps() {
+      return parseJsonQuery(this.$route.query.props, { name: 'test' })
+    },
+    modelJson() {
+      try {
+        return JSON.stringify(this.model)
+      } catch {
+        return String(this.model)
+      }
+    },
+  },
+  watch: {
+    '$route.fullPath'() {
+      this.model = parseJsonQuery(this.$route.query.value, null)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.form-test-model {
+  margin: 0;
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+</style>


### PR DESCRIPTION


Add a dev-only route that renders a single ecamp form component selected via the URL, so the form components can be driven and asserted on with Playwright (or by hand) in isolation - without needing a camp, login or API data.

  /form-test/:component        e.g. /form-test/ETextField
    ?props=<json>              props passed to the component
    ?value=<json>             initial v-model value

The view auto-discovers all form base components (E*.vue) via import.meta.glob, renders the chosen one wrapped in EForm, and exposes the live v-model value in [data-testid="form-test-model"] (the component itself is under [data-testid="form-test-subject"]). Visiting /form-test without a component lists the available ones. The route is gated behind FEATURE_DEVELOPER like /controls but needs no auth, since the base components work standalone.

Includes an example Playwright spec (e2e) showing how to assert on a component's v-model after interacting with it (ETextField, ECheckbox).