### PR TITLE
.github: allow to checkout unsafe PRs

### DIFF
--- a/.github/workflows/reusable-build-and-push.yml
+++ b/.github/workflows/reusable-build-and-push.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set nightly tag if commit was on main
         id: add-nightly-tag
@@ -126,6 +127,7 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
           fetch-depth: 100
+          allow-unsafe-pr-checkout: true
 
       - run: |
           echo "inputs:"

--- a/.github/workflows/reusable-ecamp3-deployment.yml
+++ b/.github/workflows/reusable-ecamp3-deployment.yml
@@ -76,6 +76,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Dump secrets to /tmp/secrets.json
         run: |


### PR DESCRIPTION
Needed since https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target#opting-out-of-built-in-protections