### PR TITLE
reusable-build-and-push.yml: ignore errors on caching

### DIFF
--- a/.github/workflows/reusable-build-and-push.yml
+++ b/.github/workflows/reusable-build-and-push.yml
@@ -257,7 +257,7 @@ jobs:
           build-args: |
             ${{ steps.transform-build-args.outputs.result }}
           cache-from: type=gha,scope=${{ matrix.build-config.image }}
-          cache-to: type=gha,scope=${{ matrix.build-config.image }},mode=max
+          cache-to: type=gha,scope=${{ matrix.build-config.image }},mode=max,ignore-error=true
 
       - name: Retag and push images
         if: steps.check-image.outputs.result == 'true'


### PR DESCRIPTION
We currently have problems with this:
Issue: https://github.com/ecamp/ecamp3/issues/10240

Tested here:
- #10241 