### PR TITLE
e2e: mark client print test as not mature anymore

### DIFF
--- a/e2e/tests/5-cross-browser-tests/clientPrint.spec.ts
+++ b/e2e/tests/5-cross-browser-tests/clientPrint.spec.ts
@@ -6,7 +6,7 @@ import { loginAndSetCookie, mockDateNow } from '@/utils/helpers'
 
 import { readFileSync } from 'fs'
 
-test.describe('Client print test', { tag: '@mature' }, () => {
+test.describe('Client print test', () => {
   test.beforeEach(async ({ page }) => {
     await mockDateNow(page)
   })


### PR DESCRIPTION
It failed so often.