### PR TITLE
.helm: pin maildev/maildev dependency

### DIFF
--- a/.helm/ecamp3/values.yaml.gotmpl
+++ b/.helm/ecamp3/values.yaml.gotmpl
@@ -152,8 +152,8 @@ mail:
   image:
     repository: "docker.io/maildev/maildev"
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose shared default is .Values.imageTag
-    tag: "latest"
+    # renovate: datasource=docker depName=docker.io/maildev/maildev
+    tag: "2.2.1"
   service:
     type: ClusterIP
     port: 1080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,14 @@ services:
     container_name: 'ecamp3-mail'
     environment:
       - MAILDEV_BASE_PATHNAME=/mail
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:1080/mail').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))",
+        ]
 
   docker-host:
     image: qoomon/docker-host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,7 +185,7 @@ services:
       - ./pgadmin-servers.json:/pgadmin4/servers.json
 
   mail:
-    image: maildev/maildev
+    image: maildev/maildev:2.2.1
     container_name: 'ecamp3-mail'
     environment:
       - MAILDEV_BASE_PATHNAME=/mail

--- a/e2e/tests/9-behavior-tests/mail.spec.ts
+++ b/e2e/tests/9-behavior-tests/mail.spec.ts
@@ -1,0 +1,6 @@
+import { test } from '@/utils/etest'
+import { expect } from '@playwright/test'
+
+test('mail service responds with 200', async ({ page }) => {
+  await expect(await page.request.get('/mail')).toBeOK()
+})


### PR DESCRIPTION
We used the latest tag, and they even pushed release candidates to this tag. They also return 404 now when the trailing slash is missing in the release candidate.