### PR TITLE
Fix merge error and properly skip the whole test in firefox

### DIFF
--- a/e2e/tests/5-cross-browser-tests/clientPrint.spec.ts
+++ b/e2e/tests/5-cross-browser-tests/clientPrint.spec.ts
@@ -7,18 +7,18 @@ import { loginAndSetCookie } from '@/utils/helpers'
 import { readFileSync } from 'fs'
 
 test.describe('Client print test', { tag: '@mature' }, () => {
-  test.beforeEach(async ({ page, request }) => {
-    await loginAndSetCookie(page, request, 'test@example.com')
-  })
-
-  test('downloads PDF', async ({ page, browserName }) => {
-    // Client-side PDF rendering runs in a Web Worker (generatePdfMixin.js).
+  test.beforeEach(async ({ page, request, browserName }) => {
+    // Client-side PDF rendering runs in a Web Worker.
     // Playwright's Firefox driver throws "Assertion error" on the worker's
     // messages (https://github.com/microsoft/playwright/issues/14974), which
     // kills the test before the download regardless of how we capture it.
     // eslint-disable-next-line playwright/no-skipped-test
     test.skip(browserName === 'firefox', 'Playwright FF Web Worker bug')
 
+    await loginAndSetCookie(page, request, 'test@example.com')
+  })
+
+  test('downloads PDF', async ({ page }) => {
     await page.goto('/')
     await page.waitForURL('/camps')
 


### PR DESCRIPTION
The buggy firefox e2e test currently prevents deployments to dev