### PR TITLE
api: create htmlpurifier cache directory in image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -51,6 +51,8 @@ RUN set -eux; \
 ###< doctrine/doctrine-bundle ###
 ###< recipes ###
 
+RUN mkdir -p /app/var/cache/e2e/htmlpurifier
+
 COPY --link docker/php/conf.d/10-api-platform.ini $PHP_INI_DIR/app.conf.d/
 ENV LOG_LEVEL=info
 COPY --link docker/caddy/Caddyfile /etc/frankenphp/Caddyfile


### PR DESCRIPTION
We had the following errors in the e2e tests:
Uncaught Exception: Failed to remove file \"/app/var/cache/e2e/htmlpurifier\"