### PR TITLE
fix: pre-warm e2e cache at container startup to prevent htmlpurifier race

### DIFF
--- a/api/docker/php/docker-entrypoint.sh
+++ b/api/docker/php/docker-entrypoint.sh
@@ -8,6 +8,10 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ] || [ 
     setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
   fi
 
+  if [ "$APP_ENV" = 'e2e' ]; then
+    php bin/console cache:warmup
+  fi
+
   if [ "$APP_ENV" != 'prod' ] && [ "$APP_ENV" != 'e2e' ]; then
     if [ ! -f config/jwt/private.pem ]; then
       jwt_passphrase=${JWT_PASSPHRASE:-$(grep ''^JWT_PASSPHRASE='' .env | cut -f 2 -d ''='')}


### PR DESCRIPTION


The CI e2e login test fails intermittently with a 500 when the frontend fetches /api/. Two error variants, same root cause:

- unlink(...): Is a directory (TOCTOU in Filesystem::remove)
- FilesystemIterator: Failed to open directory: No such file or directory

The API Docker image is built with APP_ENV=prod (cache warmed for prod), but CI runs with APP_ENV=e2e. var/cache/e2e is cold. On the first concurrent Playwright requests, Symfony rebuilds the e2e container cache during the request, running the htmlpurifier SerializerCacheWarmer which calls Filesystem::remove() on the htmlpurifier cache dir — racing with parallel PHP workers and throwing either error variant.

Pre-warm the e2e cache once in the entrypoint before frankenphp starts. cache:warmup is a no-op when fresh (fast restarts) and builds when cold. Scoped to APP_ENV=e2e only — prod and dev unaffected.