### PR TITLE
test(e2e): make stale-deployment chunk-abort abort only the JS route chunk

### DIFF
--- a/e2e/tests/5-cross-browser-tests/staleDeployment.spec.ts
+++ b/e2e/tests/5-cross-browser-tests/staleDeployment.spec.ts
@@ -25,6 +25,10 @@ test('reloads the page when a route chunk is missing after a deploy', async ({
 
   let chunkRequestCount = 0
   await page.route(CAMP_CREATE_CHUNK, async (route) => {
+    if (!route.request().url().endsWith('.js')) {
+      await route.continue()
+      return
+    }
     chunkRequestCount += 1
     if (chunkRequestCount === 1) {
       await route.abort('failed')


### PR DESCRIPTION
Vite emits both a JS module request and a CSS stylesheet preload for the CampCreate route chunk, and both match the test's /.*CampCreate.*/ regex. The test aborted whichever request the browser happened to fetch first (chunkRequestCount === 1), and JS-vs-CSS request ordering across browsers isn't guaranteed, so the test nondeterministically simulated a missing CSS chunk instead of a missing JS route chunk. This left intermittent CI flakes where the post-reload assertion gave mixed results.

Abort only the first .js request and always let the CSS through, so the test deterministically models "a route chunk missing after a deploy" (the JS dynamic import), which is what its assertions (reload to /camps/create, marker wiped, chunk re-fetched) actually assume.

Verified deterministic: 32/32 isolated firefox runs and 6/6 full 5-cross-browser-tests firefox suite runs (CI-faithful config: vite preview production build + prod API image at APP_ENV=e2e) pass where runs were previously intermittent.