### PR TITLE
api: run kernel without DEBUG in e2e profile

### DIFF
--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -36,6 +36,10 @@ services:
     App\Validator\MaterialItemUpdateGroupSequence:
         public: true
 
+    App\EventListener\DebugExceptionHeadersSubscriber:
+        arguments:
+            $env: '%kernel.environment%'
+
     # Since the input filter classes are resolved at runtime instead
     # of with constructor dependency injection, we create a service
     # locator that will serve all the required classes

--- a/api/src/EventListener/DebugExceptionHeadersSubscriber.php
+++ b/api/src/EventListener/DebugExceptionHeadersSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final readonly class DebugExceptionHeadersSubscriber implements EventSubscriberInterface {
+    public function __construct(private string $env) {}
+
+    public static function getSubscribedEvents(): array {
+        return [KernelEvents::EXCEPTION => ['onException', -256]];
+    }
+
+    public function onException(ExceptionEvent $event): void {
+        if ('e2e' !== $this->env) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        if (null === $response) {
+            return;
+        }
+
+        $throwable = $event->getThrowable();
+        $response->headers->set('X-Debug-Exception', rawurlencode(substr($throwable->getMessage(), 0, 2000)));
+        $response->headers->set('X-Debug-Exception-File', rawurlencode($throwable->getFile()).':'.$throwable->getLine());
+    }
+}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,6 +13,7 @@ services:
       - ./.cache/composer:/tmp/composer/cache:delegated
     environment:
       APP_ENV: dev
+      APP_DEBUG: 1
       DATABASE_URL: "postgresql://ecamp3:ecamp3@database:5432/ecamp3?serverVersion=18\
         &charset=utf8"
       # See https://docs.docker.com/docker-for-mac/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
         protocol: tcp
     environment:
       APP_ENV: ${APP_ENV:-prod}
+      APP_DEBUG: ${APP_DEBUG:-0}
       DATA_MIGRATIONS_DIR: ${DATA_MIGRATIONS_DIR:-dev-data}
       DATABASE_URL: "postgresql://ecamp3:ecamp3@database:5432/ecamp3dev?serverVersion\
         =15&charset=utf8"


### PR DESCRIPTION
fix(e2e): run api container with APP_DEBUG=0 to stop htmlpurifier warmer race

The e2e API container ran with debug=true: api/config/bootstrap.php defaults APP_DEBUG to ('prod' !== APP_ENV), and APP_ENV=e2e left debug on. With debug true the kernel re-validates/rebuilds the container on requests, re-running the exercise/htmlpurifier-bundle SerializerCacheWarmer (Filesystem::remove+mkdir on var/cache/e2e/htmlpurifier). Concurrent first requests then raced that dir (FilesystemIterator TOCTOU at symfony/filesystem Filesystem.php:184), surfacing as a 500 on GET /api/ that intermittently broke loginAndSetCookie.

The prior cache:warmup entrypoint fix pre-warms but is insufficient while debug keeps re-validating. Run e2e prod-like with APP_DEBUG=0 so the warmed, non-debug container (App_KernelE2eContainer) stays authoritative and the warmer never runs concurrently.

- docker-compose.yml: expose APP_DEBUG (default 0, prod-like)
- docker-compose.override.yml: keep local dev debug true (APP_DEBUG: 1)
- .env.ci: pin APP_DEBUG=0 for e2e

---

ix(e2e): re-inject X-Debug-Exception headers under APP_DEBUG=0

APP_DEBUG=0 (needed to stop the htmlpurifier warmer race) disables Symfony's verbose error output, which surfaced via the X-Debug-Exception / X-Debug-Exception-File response headers - the very headers that diagnosed the warm race. Re-add them, scoped to e2e, via a tiny kernel.exception subscriber that runs after the default renderer and copies the same header values Symfony would have set when kernel.debug is true. Gated by %kernel.environment% (== e2e) so it auto-enables only in e2e and stays off in prod/dev/test - no env-var delivery pipeline or env-processor defaulting. prod/dev unaffected.

- api/src/EventListener/DebugExceptionHeadersSubscriber.php (new)
- api/config/services.yaml: wire $env from %kernel.environment%