### PR TITLE
.ops/external-dns-gateway-api: use policy sync for dns entries

### DIFF
--- a/.ops/external-dns-gateway-api/values.yaml.gotmpl
+++ b/.ops/external-dns-gateway-api/values.yaml.gotmpl
@@ -1,5 +1,6 @@
 apiToken: {{ .Environment.Values | getOrNil "API_TOKEN" | required "API_TOKEN is required" }}
 external-dns:
+  policy: sync
   provider:
     name: {{ .Environment.Values | get "EXTERNAL_DNS_PROVIDER" "cloudflare" }}
   env:


### PR DESCRIPTION
This way not needed feature branch dns entries are deleted.