### PR TITLE
CampCreateStep2: fix pasting camp url for firefox, without e2e test for now

### DIFF
--- a/frontend/src/components/campCreate/CampCreateStep2.vue
+++ b/frontend/src/components/campCreate/CampCreateStep2.vue
@@ -26,12 +26,13 @@
           :vee-rules="{ required: true }"
           class="flex-grow-1"
           path="campPrototypeUrl"
-          @input="setClipboardEntityUrl"
+          @update:model-value="setClipboardEntityUrl"
         />
         <ClipboardInfoDialog
           v-if="showClipboardPrompt"
           ref="clipboardInfoDialog"
           translation-context-i18n-key="components.campCreate.campCreateStep2.clipboardInfoDialog"
+          @clipboard-text="setClipboardEntityUrl"
           @closed="attemptLoadingEntityFromClipboard"
         >
           <template #activator="{ props }">


### PR DESCRIPTION
Styling is also atrocious, but at least it works again.
Extracted from #10514