### PR TITLE
Fix lock file maintenance configuration

### DIFF
--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -37,6 +37,7 @@
         "@vue/server-renderer": "3.5.41",
         "@vue/shared": "3.5.41",
         "@vue/test-utils": "2.4.11",
+        "esbuild": "0.28.1",
         "eslint": "10.8.1",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-local-rules": "3.0.2",

--- a/print/package.json
+++ b/print/package.json
@@ -47,6 +47,7 @@
     "@vue/server-renderer": "3.5.41",
     "@vue/shared": "3.5.41",
     "@vue/test-utils": "2.4.11",
+    "esbuild": "0.28.1",
     "eslint": "10.8.1",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-local-rules": "3.0.2",

--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,10 @@
       "automerge": true
     },
     {
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "rebaseWhen": "behind-base"
+    },
+    {
       "groupName": "api-platform packages",
       "groupSlug": "api-platform",
       "matchDatasources": ["packagist"],


### PR DESCRIPTION
The build system of nuxt and vite often have a conflict about the esbuild version. Also force lock-file-maintenance to always rebase when behind that we don't accidentally revert things.