### PR TITLE
.agents: ignore .completion-check-command

### DIFF
--- a/.agents/.gitignore
+++ b/.agents/.gitignore
@@ -1,0 +1,1 @@
+.completion-check-command


### PR DESCRIPTION
This can be used to have a per user command that the (for now only) opencode agent should run when the model notified the harness that the task is completed.