### PR TITLE
Fixes toolbars & listitems

### DIFF
--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -7,7 +7,7 @@ Displays a single scheduleEntry
     :key="activityId"
     class="ec-schedule-entry"
     toolbar
-    back
+    :back="backRoute"
     :loaded="!scheduleEntry._meta.loading && !activity.camp()._meta.loading"
     :max-width="isPaperDisplaySize ? '944px' : ''"
   >
@@ -296,6 +296,7 @@ import ActivityResponsibles from '@/components/activity/ActivityResponsibles.vue
 import { dateHelperUTCFormatted } from '@/mixins/dateHelperUTCFormatted.js'
 import { campRoleMixin } from '@/mixins/campRoleMixin'
 import router, {
+  campRoute,
   firstActivityScheduleEntry,
   periodRoute,
   scheduleEntryRoute,
@@ -379,6 +380,14 @@ export default {
     }
   },
   computed: {
+    backRoute() {
+      return (
+        window.history.state?.activityBack ||
+        (this.scheduleEntry?.period
+          ? periodRoute(this.scheduleEntry.period())
+          : campRoute(this.camp, 'program'))
+      )
+    },
     activity() {
       return this.api.get().activities({ id: this.activityId })
     },

--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -84,6 +84,7 @@ Displays a single scheduleEntry
           autofocus
           :auto-save="false"
           @finished="editActivityTitle = false"
+          @keydown.esc="editActivityTitle = false"
         />
       </api-form>
     </template>

--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -13,7 +13,7 @@ Displays a single scheduleEntry
   >
     <template #title>
       <h1 class="font-weight-bold text-h6 d-flex gap-1 sm:gap-2 items-center truncate">
-        <span class="tabular-nums">
+        <span v-if="scheduleEntry.number !== ''" class="tabular-nums">
           {{ scheduleEntry.number }}
         </span>
         <v-menu
@@ -69,14 +69,14 @@ Displays a single scheduleEntry
       <v-btn
         v-if="isContributor && !editActivityTitle"
         icon
-        class="ml-1 visible-on-hover"
+        class="d-none d-sm-block ml-1 visible-on-hover"
         width="24"
         height="24"
         @click="makeTitleEditable()"
       >
         <v-icon size="x-small">mdi-pencil</v-icon>
       </v-btn>
-      <api-form v-if="editActivityTitle" :entity="activity" class="mx-2 flex-grow-1">
+      <api-form v-if="editActivityTitle" :entity="activity" class="mx-2 flex-grow-10">
         <api-text-field
           path="title"
           :disabled="layoutMode"
@@ -168,7 +168,11 @@ Displays a single scheduleEntry
       <template v-else>
         <!-- Header -->
         <v-row dense class="activity-header">
-          <v-col cols="12" sm="6" class="px-0 pt-0 d-flex flex-wrap gap-x-4">
+          <v-col
+            cols="12"
+            sm="6"
+            class="px-0 pt-0 d-flex flex-wrap gap-x-4 align-content-start gap-y-1"
+          >
             <table>
               <thead>
                 <tr>
@@ -556,15 +560,6 @@ export default {
   margin-bottom: 0;
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   padding: 1.5rem 16px;
-}
-
-:deep(.ec-content-card__toolbar:not(:hover) button.visible-on-hover:not(:focus)) {
-  opacity: 0;
-}
-
-:deep(.ec-content-card__toolbar button.visible-on-hover) {
-  opacity: 1;
-  transition: opacity 0.2s linear;
 }
 
 .e-category-chip-save-icon {

--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -109,9 +109,7 @@ Displays a single scheduleEntry
       <!-- hamburger menu -->
       <v-menu v-if="!layoutMode" offset-y>
         <template #activator="{ props }">
-          <v-btn icon v-bind="props">
-            <v-icon>mdi-dots-vertical</v-icon>
-          </v-btn>
+          <v-btn icon="mdi-dots-vertical" v-bind="props" />
         </template>
 
         <v-list>
@@ -120,26 +118,29 @@ Displays a single scheduleEntry
 
           <v-divider v-if="!isOutsider" />
 
+          <v-list-item
+            v-if="isContributor"
+            :title="$t('global.button.rename')"
+            prepend-icon="mdi-pencil"
+            @click="makeTitleEditable()"
+          />
+
           <!-- layout/content switch (switch to layout mode) -->
           <v-list-item
             v-if="!isOutsider"
+            :title="$t('components.activity.scheduleEntry.changeLayout')"
+            prepend-icon="mdi-puzzle-edit-outline"
             :disabled="!isContributor"
             @click="layoutMode = true"
-          >
-            <v-list-item-title>
-              <v-icon start>mdi-puzzle-edit-outline</v-icon>
-              {{ $t('components.activity.scheduleEntry.changeLayout') }}
-            </v-list-item-title>
-          </v-list-item>
+          />
 
           <v-divider />
 
-          <v-list-item @click="copyUrlToClipboard">
-            <v-list-item-title>
-              <v-icon start>mdi-content-copy</v-icon>
-              {{ $t('components.activity.scheduleEntry.copyScheduleEntry') }}
-            </v-list-item-title>
-          </v-list-item>
+          <v-list-item
+            :title="$t('components.activity.scheduleEntry.copyScheduleEntry')"
+            prepend-icon="mdi-content-copy"
+            @click="copyUrlToClipboard"
+          />
           <ClipboardInfoDialog
             ref="copyInfoDialog"
             translation-context-i18n-key="components.activity.scheduleEntry.clipboardInfoDialog"
@@ -150,12 +151,12 @@ Displays a single scheduleEntry
           <!-- remove activity -->
           <DialogEntityDelete v-if="!isOutsider" :entity="activity" @submit="onDelete">
             <template #activator="{ props }">
-              <v-list-item :disabled="!isContributor" v-bind="props">
-                <v-list-item-title>
-                  <v-icon start>mdi-delete</v-icon>
-                  {{ $t('global.button.delete') }}
-                </v-list-item-title>
-              </v-list-item>
+              <v-list-item
+                :title="$t('global.button.delete')"
+                prepend-icon="mdi-delete"
+                :disabled="!isContributor"
+                v-bind="props"
+              />
             </template>
             {{ $t('components.activity.scheduleEntry.deleteWarning') }}
           </DialogEntityDelete>

--- a/frontend/src/components/activity/content/layout/ContentNodeCard.vue
+++ b/frontend/src/components/activity/content/layout/ContentNodeCard.vue
@@ -11,7 +11,7 @@
       <api-form
         v-if="editInstanceName"
         :entity="contentNode"
-        style="flex: 1"
+        class="flex-grow-1 ml-2"
         @click.stop
         @keyup.prevent
       >
@@ -27,32 +27,33 @@
 
       <v-toolbar-title
         v-if="!editInstanceName"
-        style="flex-basis: auto"
+        class="basis-auto"
         tag="h2"
         :class="{ 'user-select-none': layoutMode }"
       >
         {{ instanceOrContentTypeName }}
+
+        <v-btn
+          v-if="!editInstanceName && !disabled"
+          icon
+          class="ml-1"
+          :class="{ 'visible-on-hover': !layoutMode }"
+          width="24"
+          height="24"
+          @click="toggleEditInstanceName"
+        >
+          <v-icon size="x-small">mdi-pencil</v-icon>
+        </v-btn>
       </v-toolbar-title>
 
-      <v-btn
-        v-if="!editInstanceName && !disabled"
-        icon
-        class="ml-1"
-        :class="{ 'visible-on-hover': !layoutMode }"
-        width="24"
-        height="24"
-        @click="toggleEditInstanceName"
-      >
-        <v-icon size="small">mdi-pencil</v-icon>
-      </v-btn>
-
-      <v-spacer v-if="!editInstanceName" />
-      <IconWithTooltip
-        v-if="!editInstanceName && !layoutMode"
-        :tooltip-i18n-key="`contentNode.${camelCase(contentNode.contentTypeName)}.info`"
-        width="36"
-        height="36"
-      />
+      <template #append>
+        <IconWithTooltip
+          v-if="!editInstanceName && !layoutMode"
+          :tooltip-i18n-key="`contentNode.${camelCase(contentNode.contentTypeName)}.info`"
+          width="36"
+          height="36"
+        />
+      </template>
 
       <DialogEntityDelete
         v-if="layoutMode && !disabled"

--- a/frontend/src/components/activity/content/layout/ContentNodeCard.vue
+++ b/frontend/src/components/activity/content/layout/ContentNodeCard.vue
@@ -21,6 +21,7 @@
           :auto-save="false"
           path="instanceName"
           @finished="editInstanceName = false"
+          @keydown.esc="editInstanceName = false"
         />
       </api-form>
 

--- a/frontend/src/components/activity/content/storyboard/StoryboardRowDefault.vue
+++ b/frontend/src/components/activity/content/storyboard/StoryboardRowDefault.vue
@@ -102,9 +102,5 @@ export default {
     width: 15%;
     padding-bottom: 0.5rem;
   }
-
-  .e-storyboard-row__controls {
-    align-content: space-between;
-  }
 }
 </style>

--- a/frontend/src/components/activity/content/storyboard/StoryboardRowDefault.vue
+++ b/frontend/src/components/activity/content/storyboard/StoryboardRowDefault.vue
@@ -52,7 +52,7 @@
             :disabled="isLastSection"
             v-bind="props"
           >
-            <v-icon icon="mdi-delete-outline" size="24" />
+            <v-icon icon="mdi-delete-outline" />
           </v-btn>
         </template>
       </dialog-remove-section>

--- a/frontend/src/components/buttons/ButtonBack.vue
+++ b/frontend/src/components/buttons/ButtonBack.vue
@@ -3,7 +3,7 @@
     v-bind="$attrs"
     :icon="!visibleLabel"
     :aria-label="$t('global.button.back')"
-    @click="$router.go(-1)"
+    @click="goBack"
   >
     <v-icon :start="visibleLabel" icon="mdi-arrow-left" />
     <template v-if="visibleLabel">
@@ -16,9 +16,23 @@
 export default {
   name: 'ButtonBack',
   props: {
+    to: {
+      type: [String, Object],
+      default: null,
+    },
     visibleLabel: {
       type: Boolean,
       default: false,
+    },
+  },
+  methods: {
+    goBack() {
+      if (this.to) {
+        this.$router.push(this.to)
+        return
+      }
+
+      this.$router.back()
     },
   },
 }

--- a/frontend/src/components/buttons/ButtonDelete.vue
+++ b/frontend/src/components/buttons/ButtonDelete.vue
@@ -30,7 +30,7 @@ export default {
   props: {
     icon: { type: String, default: 'mdi-delete' },
     text: { type: Boolean, default: true },
-    color: { type: String, default: 'blue-grey' },
+    color: { type: String, default: null },
     iconOnly: { type: Boolean, default: false },
     btnIcon: { type: Boolean, default: true },
   },

--- a/frontend/src/components/campAdmin/ErrorExistingActivitiesList.vue
+++ b/frontend/src/components/campAdmin/ErrorExistingActivitiesList.vue
@@ -11,17 +11,7 @@
             v-for="scheduleEntry in activity.scheduleEntries().items"
             :key="scheduleEntry._meta.self"
           >
-            <router-link
-              :to="{
-                name: 'camp/activity',
-                params: {
-                  campId: camp.id,
-                  activityId: activity.id,
-                  scheduleEntryId: scheduleEntry.id,
-                },
-              }"
-              class="e-title-link"
-            >
+            <router-link :to="scheduleEntryRoute(scheduleEntry)" class="e-title-link">
               <strong>{{ scheduleEntry.number }}</strong>
               {{ rangeShort(scheduleEntry.start, scheduleEntry.end, translate) }}
             </router-link>
@@ -34,6 +24,7 @@
 
 <script>
 import { rangeShort } from '@/common/helpers/dateHelperUTCFormatted.js'
+import { scheduleEntryRoute } from '@/router.js'
 export default {
   name: 'ErrorExistingActivitiesList',
   props: {
@@ -42,6 +33,7 @@ export default {
   },
   methods: {
     rangeShort,
+    scheduleEntryRoute,
     translate(...args) {
       return this.$t(...args)
     },

--- a/frontend/src/components/checklist/ChecklistDetail.vue
+++ b/frontend/src/components/checklist/ChecklistDetail.vue
@@ -4,7 +4,7 @@
     :key="checklist._meta.self"
     class="ec-checklist"
     toolbar
-    back
+    :back="checklistRoute(camp)"
   >
     <template #title>
       <v-toolbar-title v-if="!editChecklistName" tag="h1" class="font-weight-bold">
@@ -129,6 +129,7 @@ export default {
     this.debouncedDisabled = this.isOutsider
   },
   methods: {
+    checklistRoute,
     makeChecklistNameEditable() {
       this.editChecklistName = true
     },

--- a/frontend/src/components/checklist/ChecklistDetail.vue
+++ b/frontend/src/components/checklist/ChecklistDetail.vue
@@ -27,6 +27,7 @@
           autofocus
           :auto-save="false"
           @finished="editChecklistName = false"
+          @keydown.esc="editChecklistName = false"
         />
       </api-form>
     </template>

--- a/frontend/src/components/checklist/ChecklistDetail.vue
+++ b/frontend/src/components/checklist/ChecklistDetail.vue
@@ -7,20 +7,20 @@
     :back="checklistRoute(camp)"
   >
     <template #title>
-      <v-toolbar-title v-if="!editChecklistName" tag="h1" class="font-weight-bold">
+      <v-toolbar-title v-if="!editChecklistName" tag="h1" class="font-weight-bold ml-0">
         {{ checklist.name }}
+        <v-btn
+          v-if="!editChecklistName && !isOutsider"
+          icon
+          class="ml-1 visible-on-hover"
+          width="24"
+          height="24"
+          @click="makeChecklistNameEditable()"
+        >
+          <v-icon size="x-small">mdi-pencil</v-icon>
+        </v-btn>
       </v-toolbar-title>
-      <v-btn
-        v-if="!editChecklistName && !isOutsider"
-        icon
-        class="ml-1 visible-on-hover"
-        width="24"
-        height="24"
-        @click="makeChecklistNameEditable()"
-      >
-        <v-icon size="small">mdi-pencil</v-icon>
-      </v-btn>
-      <api-form v-if="editChecklistName" :entity="checklist" class="mx-2 flex-grow-1">
+      <api-form v-if="editChecklistName" :entity="checklist" class="flex-grow-1">
         <api-text-field
           path="name"
           density="compact"

--- a/frontend/src/components/checklist/ChecklistItemCreate.vue
+++ b/frontend/src/components/checklist/ChecklistItemCreate.vue
@@ -16,6 +16,7 @@
         <ButtonAdd
           color="secondary"
           text
+          variant="text"
           class="my-n2"
           icon="mdi-playlist-plus"
           v-bind="props"

--- a/frontend/src/components/checklist/SortableChecklist.vue
+++ b/frontend/src/components/checklist/SortableChecklist.vue
@@ -43,7 +43,7 @@
           v-bind="props"
         >
           <template #prepend>
-            <v-avatar class="mr-2" size="32">
+            <v-avatar size="32" color="transparent">
               <v-icon color="currentColor">mdi-plus</v-icon>
             </v-avatar>
           </template>

--- a/frontend/src/components/checklist/SortableChecklistItem.vue
+++ b/frontend/src/components/checklist/SortableChecklistItem.vue
@@ -2,9 +2,7 @@
   <div class="e-sortable-checklist-item" @dragstart="startDragging">
     <v-list-item v-if="disabled" class="px-2 rounded min-h-0 py-1">
       <template #prepend>
-        <v-avatar color="rgba(0,0,0,0.12)" class="mr-2" size="32">{{
-          itemPosition + 1
-        }}</v-avatar>
+        <v-avatar color="rgba(0,0,0,0.12)" size="32">{{ itemPosition + 1 }}</v-avatar>
       </template>
       <v-list-item-title :class="{ 'font-weight-bold': item?.parent == null }">{{
         item.text
@@ -17,12 +15,10 @@
           v-bind="props"
         >
           <template #prepend>
-            <v-btn variant="plain" icon class="my-n1 ml-n1 pointer-events-none">
-              <v-icon>mdi-drag</v-icon>
+            <v-btn variant="plain" icon size="32" class="my-n1 pointer-events-none">
+              <v-icon size="24">mdi-drag</v-icon>
             </v-btn>
-            <v-avatar color="rgba(0,0,0,0.12)" class="mr-2" size="32">{{
-              itemPosition + 1
-            }}</v-avatar>
+            <v-avatar color="rgba(0,0,0,0.12)" size="32">{{ itemPosition + 1 }}</v-avatar>
           </template>
           <v-list-item-title :class="{ 'font-weight-bold': item?.parent == null }">{{
             item.text
@@ -86,6 +82,10 @@ export default {
 .e-sortable-checklist-item--drag-preview {
   background: white;
   border-radius: 4px;
+}
+
+.drag-and-drop-handle {
+  --v-list-prepend-gap: 8px;
 }
 .e-sortable-checklist-item--drag-preview:deep(.e-sortable-checklist-item__add) {
   display: none;

--- a/frontend/src/components/collaborator/CollaboratorListItem.vue
+++ b/frontend/src/components/collaborator/CollaboratorListItem.vue
@@ -16,7 +16,7 @@
             }}<span>
               &middot;
               <template v-for="icon in roles[collaborator.role].icons" :key="icon"
-                ><v-icon class="vertical-baseline" size="x-small">{{ icon }}</v-icon
+                ><v-icon class="vertical-baseline" :size="null">{{ icon }}</v-icon
                 >&thinsp;</template
               ></span
             >

--- a/frontend/src/components/comments/CommentCard.vue
+++ b/frontend/src/components/comments/CommentCard.vue
@@ -40,13 +40,15 @@
         <PromptEntityDelete v-if="isOwnComment" :entity="comment._meta.self">
           <template #activator="{ props }">
             <v-btn
-              icon="mdi-delete"
+              icon
               variant="text"
               size="x-small"
               class="ec-comment-card__delete visible-on-hover flex-0-0"
               :aria-label="$t('global.button.delete')"
               v-bind="props"
-            />
+            >
+              <v-icon size="small">mdi-delete</v-icon>
+            </v-btn>
           </template>
           {{ $t('components.comments.commentCard.deleteWarning') }}
         </PromptEntityDelete>

--- a/frontend/src/components/form/api/ApiWrapperAppend.vue
+++ b/frontend/src/components/form/api/ApiWrapperAppend.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-flex" style="margin-top: -5px">
+  <div class="d-flex">
     <!-- Success icon after saving -->
     <div class="checkIconContainer">
       <v-icon color="green" class="checkIcon" :class="checkIconAddon">
@@ -12,9 +12,10 @@
       <v-tooltip class="ml-auto" location="bottom">
         <template #activator="{ props }">
           <v-btn
-            fab
             dark
-            size="x-small"
+            size="small"
+            width="28"
+            min-width="28"
             variant="flat"
             color="error"
             type="submit"
@@ -31,9 +32,11 @@
       <v-tooltip class="ml-auto" location="bottom">
         <template #activator="{ props }">
           <v-btn
-            fab
             dark
-            size="x-small"
+            size="small"
+            width="28"
+            min-width="28"
+            class="mr-n1"
             variant="flat"
             color="grey"
             :aria-label="$t('global.button.cancel')"
@@ -51,13 +54,14 @@
       <v-tooltip v-if="wrapper.dirty" class="ml-auto" location="bottom">
         <template #activator="{ props }">
           <v-btn
-            fab
             dark
-            size="x-small"
+            size="small"
+            width="28"
+            min-width="28"
             variant="flat"
             color="success"
             type="submit"
-            class="mr-1"
+            class="mr-1 min-w-0"
             :aria-label="$t('global.button.save')"
             v-bind="props"
             @click="wrapper.on.save"
@@ -70,9 +74,11 @@
       <v-tooltip class="ml-auto" location="bottom">
         <template #activator="{ props }">
           <v-btn
-            fab
             dark
-            size="x-small"
+            width="28"
+            min-width="28"
+            class="mr-n1"
+            size="small"
             variant="flat"
             color="grey"
             :aria-label="$t('global.button.cancel')"
@@ -123,8 +129,8 @@ export default {
 }
 .v-icon.checkIcon {
   position: relative;
-  top: -11px;
-  right: 13px;
+  top: -14px;
+  right: 16px;
   transition: opacity 0.2s ease-out;
   opacity: 0;
 }

--- a/frontend/src/components/generic/LockButton.vue
+++ b/frontend/src/components/generic/LockButton.vue
@@ -2,14 +2,16 @@
   <v-tooltip :disabled="tooltip == ''" location="bottom">
     <template #activator="{ props }">
       <v-btn
-        :icon="modelValue ? 'mdi-lock-open-variant' : 'mdi-lock'"
+        icon
         :aria-label="tooltip"
         :aria-disabled="disabledForGuest"
         size="small"
         :class="{ 'e-shake-lock': shake }"
         v-bind="props"
         @click="onClick"
-      />
+      >
+        <v-icon :icon="modelValue ? 'mdi-lock-open-variant' : 'mdi-lock'" size="small" />
+      </v-btn>
     </template>
     <span>{{ tooltip }}</span>
   </v-tooltip>

--- a/frontend/src/components/layout/ContentCard.vue
+++ b/frontend/src/components/layout/ContentCard.vue
@@ -17,7 +17,11 @@ Displays the content wrapped inside a card.
       </v-toolbar-items>
 
       <slot name="title">
-        <v-toolbar-title tag="h1" class="font-weight-bold flex-none">
+        <v-toolbar-title
+          tag="h1"
+          class="font-weight-bold flex-none"
+          :class="{ 'ml-0': showBackButton }"
+        >
           {{ title }}
         </v-toolbar-title>
       </slot>
@@ -79,6 +83,15 @@ export default {
     top: 0;
     z-index: 5;
   }
+}
+
+:deep(.ec-content-card__toolbar:not(:hover) button.visible-on-hover:not(:focus)) {
+  opacity: 0;
+}
+
+:deep(.ec-content-card__toolbar button.visible-on-hover) {
+  opacity: 1;
+  transition: opacity 0.2s linear;
 }
 
 .ec-content-card__toolbar--border {

--- a/frontend/src/components/layout/ContentCard.vue
+++ b/frontend/src/components/layout/ContentCard.vue
@@ -13,9 +13,7 @@ Displays the content wrapped inside a card.
       density="compact"
     >
       <v-toolbar-items>
-        <button-back
-          v-if="back || (!$vuetify.display.mdAndUp && !!$route.query.isDetail)"
-        />
+        <button-back v-if="showBackButton" :to="backTarget" />
       </v-toolbar-items>
 
       <slot name="title">
@@ -52,8 +50,21 @@ export default {
     title: { type: String, required: false, default: '' },
     toolbar: { type: Boolean, required: false, default: false },
     noBorder: { type: Boolean, required: false, default: false },
-    back: { type: Boolean, required: false, default: false },
+    back: { type: [Boolean, String, Object], default: false },
     maxWidth: { type: String, default: '' },
+  },
+  computed: {
+    backTarget() {
+      const target = this.back || this.$route?.meta?.back
+      return typeof target === 'object' || typeof target === 'string' ? target : null
+    },
+    showBackButton() {
+      return (
+        !!this.back ||
+        !!this.$route?.meta?.back ||
+        (!!this.$route?.meta?.backMobile && !this.$vuetify.display.mdAndUp)
+      )
+    },
   },
 }
 </script>

--- a/frontend/src/components/material/MaterialLists.vue
+++ b/frontend/src/components/material/MaterialLists.vue
@@ -1,10 +1,6 @@
 <template>
   <v-list>
-    <v-list-item
-      :to="materialListRoute(camp, '/all', { isDetail: true })"
-      lines="two"
-      exact-path
-    >
+    <v-list-item :to="materialListRoute(camp, '/all')" lines="two" exact-path>
       <v-list-item-title>
         {{ $t('components.material.materialLists.overview') }}
       </v-list-item-title>
@@ -14,7 +10,7 @@
     </v-list-item>
     <v-list-item
       v-if="unassignedCount > 0"
-      :to="materialListRoute(camp, '/unassigned', { isDetail: true })"
+      :to="materialListRoute(camp, '/unassigned')"
       lines="two"
       exact-path
     >
@@ -41,7 +37,7 @@
       v-for="materialList in materailListsSorted"
       :key="materialList._meta.self"
       lines="two"
-      :to="materialListRoute(camp, materialList, { isDetail: true })"
+      :to="materialListRoute(camp, materialList)"
       exact-path
     >
       <v-list-item-title>{{ materialList.name }}</v-list-item-title>

--- a/frontend/src/components/navigation/UserMeta.vue
+++ b/frontend/src/components/navigation/UserMeta.vue
@@ -63,12 +63,7 @@
       </v-btn>
     </template>
     <v-list class="user-nav py-0" tag="ul" light>
-      <v-list-item
-        tag="li"
-        block
-        :to="{ name: 'profile', query: { isDetail: true } }"
-        @click="open = false"
-      >
+      <v-list-item tag="li" block :to="{ name: 'profile' }" @click="open = false">
         <v-icon start icon="mdi-account" />
         <span>{{ $t('components.navigation.userMeta.profile') }}</span>
       </v-list-item>

--- a/frontend/src/components/program/PeriodSwitcher.vue
+++ b/frontend/src/components/program/PeriodSwitcher.vue
@@ -1,16 +1,16 @@
 <template>
-  <v-toolbar-items v-if="period.camp().periods().items.length > 1">
+  <v-toolbar-items v-if="hasMultiplePeriods" class="overflow-hidden">
     <v-menu offset-y>
       <template #activator="{ props, isActive }">
         <v-btn
           variant="text"
           size="large"
-          class="justify-start px-4 my-1 rounded-pill ec-period-switcher__button"
+          class="justify-start px-4 my-1 rounded-pill ec-period-switcher__button d-block"
           height="auto"
           block
           v-bind="props"
         >
-          <h1 class="text-subtitle-1">
+          <h1 class="text-subtitle-1 text-truncate">
             {{ period.description }}
           </h1>
           <v-icon v-if="isActive" end>mdi-menu-up</v-icon>
@@ -35,8 +35,8 @@
       </v-list>
     </v-menu>
   </v-toolbar-items>
-  <v-toolbar-title v-else>
-    <h1 class="text-subtitle-1 text-center">
+  <v-toolbar-title v-else class="basis-auto ml-2">
+    <h1 class="text-subtitle-1 text-center text-truncate">
       {{ period.description }}
     </h1>
   </v-toolbar-title>
@@ -59,6 +59,9 @@ export default {
   computed: {
     allPeriods() {
       return sortBy(this.period.camp().periods().items, (p) => p.start)
+    },
+    hasMultiplePeriods() {
+      return this.period.camp().periods().items.length > 1
     },
   },
   methods: {

--- a/frontend/src/components/story/StoryDay.vue
+++ b/frontend/src/components/story/StoryDay.vue
@@ -22,17 +22,7 @@
                   dense
                 />
               </span>
-              <router-link
-                :to="{
-                  name: 'camp/activity',
-                  params: {
-                    campId: day.period().camp().id,
-                    activityId: scheduleEntry.activity().id,
-                    scheduleEntryId: scheduleEntry.id,
-                  },
-                }"
-                class="e-title-link"
-              >
+              <router-link :to="scheduleEntryRoute(scheduleEntry)" class="e-title-link">
                 <span>{{ scheduleEntry.activity().title }}</span>
                 <template v-if="chapter.instanceName">
                   - {{ chapter.instanceName }}
@@ -65,6 +55,7 @@
 import ApiForm from '@/components/form/api/ApiForm.vue'
 import { dateHelperUTCFormatted } from '@/mixins/dateHelperUTCFormatted.js'
 import CategoryChip from '@/components/generic/CategoryChip.vue'
+import { scheduleEntryRoute } from '@/router.js'
 
 export default {
   name: 'StoryDay',
@@ -107,6 +98,9 @@ export default {
       // See StoryPeriod.vue: v-expansion-panels.v-model
       return this.day.start.substr(0, 10)
     },
+  },
+  methods: {
+    scheduleEntryRoute,
   },
 }
 </script>

--- a/frontend/src/components/story/StoryPeriod.vue
+++ b/frontend/src/components/story/StoryPeriod.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-skeleton-loader v-if="loading" class="mt-2 mt-sm-3" type="list-item-three-line" />
+  <v-skeleton-loader v-if="loading" class="ma-4" type="list-item-three-line" />
   <v-expansion-panels v-else v-model="expandedDays" flat multiple variant="accordion">
     <story-day
       v-for="day in sortedDays"

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -171,6 +171,7 @@ const router = createRouter({
     {
       path: '/profile',
       name: 'profile',
+      meta: { backMobile: true },
       components: {
         navigation: NavigationDefault,
         default: () => import('./views/Profile.vue'),
@@ -212,6 +213,7 @@ const router = createRouter({
     {
       path: '/camps/create',
       name: 'camps/create',
+      meta: { back: { name: 'camps' } },
       components: {
         navigation: NavigationDefault,
         default: () => import('./views/CampCreate.vue'),
@@ -320,6 +322,7 @@ const router = createRouter({
     {
       name: 'camp/material/all',
       path: '/camps/:campId/:campShortTitle?/material/all',
+      meta: { backMobile: true },
       components: {
         navigation: NavigationCamp,
         default: () => import('./views/camp/material/MaterialOverview.vue'),
@@ -337,6 +340,7 @@ const router = createRouter({
     {
       name: 'camp/material/unassigned',
       path: '/camps/:campId/:campShortTitle?/material/unassigned',
+      meta: { backMobile: true },
       components: {
         navigation: NavigationCamp,
         default: () => import('./views/camp/material/MaterialUnassigned.vue'),
@@ -354,6 +358,7 @@ const router = createRouter({
     {
       name: 'camp/overview/checklists/checklist',
       path: '/camps/:campId/:campShortTitle?/overview/checklists/:checklistId/:checklistName?',
+      meta: { backMobile: true },
       components: {
         navigation: NavigationCamp,
         default: () => import('./views/camp/checklistOverview/ChecklistOverview.vue'),
@@ -388,6 +393,7 @@ const router = createRouter({
     {
       name: 'camp/material/detail',
       path: '/camps/:campId/:campShortTitle?/material/:materialId/:materialName?',
+      meta: { backMobile: true },
       components: {
         navigation: NavigationCamp,
         default: () => import('./views/camp/material/MaterialDetail.vue'),
@@ -560,7 +566,19 @@ router.onError((error, to) => {
   reloadOnChunkLoadError(error, to)
 })
 
-router.afterEach(() => {
+router.afterEach((to, from, failure) => {
+  if (!failure && to.name === 'camp/activity') {
+    const currentState = window.history.state || {}
+    let back = currentState.activityBack
+
+    if (from.matched.length && from.name !== 'camp/activity') {
+      back = from.params.campId === to.params.campId ? from.fullPath : null
+    }
+
+    if (back !== currentState.activityBack) {
+      window.history.replaceState({ ...currentState, activityBack: back }, '')
+    }
+  }
   clearChunkReloadGuard()
 })
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -566,19 +566,7 @@ router.onError((error, to) => {
   reloadOnChunkLoadError(error, to)
 })
 
-router.afterEach((to, from, failure) => {
-  if (!failure && to.name === 'camp/activity') {
-    const currentState = window.history.state || {}
-    let back = currentState.activityBack
-
-    if (from.matched.length && from.name !== 'camp/activity') {
-      back = from.params.campId === to.params.campId ? from.fullPath : null
-    }
-
-    if (back !== currentState.activityBack) {
-      window.history.replaceState({ ...currentState, activityBack: back }, '')
-    }
-  }
+router.afterEach(() => {
   clearChunkReloadGuard()
 })
 
@@ -929,6 +917,21 @@ export function scheduleEntryRoute(scheduleEntry, query = {}) {
       activityName: slugify(activity.title),
     },
     query,
+    state: activityBackState(camp.id),
+  }
+}
+
+function activityBackState(campId) {
+  const from = router.currentRoute.value
+  if (!from.matched.length) return {}
+
+  return {
+    activityBack:
+      from.name === 'camp/activity'
+        ? window.history.state?.activityBack
+        : from.params.campId === campId
+          ? from.fullPath
+          : null,
   }
 }
 
@@ -950,6 +953,7 @@ export async function firstActivityScheduleEntryRoute(activity, query = {}) {
       activityName: slugify(activity.title),
     },
     query,
+    state: activityBackState(camp.id),
   }
 }
 

--- a/frontend/src/scss/global.scss
+++ b/frontend/src/scss/global.scss
@@ -88,7 +88,7 @@ body {
   height: 100%;
 }
 
-.v-btn .v-icon {
+.v-app-bar .v-btn .v-icon {
   --v-icon-size-multiplier: 0.75;
 }
 

--- a/frontend/src/scss/tailwind.scss
+++ b/frontend/src/scss/tailwind.scss
@@ -10,6 +10,10 @@
   flex: none;
 }
 
+.flex-grow-10 {
+  flex-grow: 10;
+}
+
 .whitespace-normal {
   white-space: normal;
 }
@@ -40,6 +44,10 @@
 
 .gap-x-1 {
   column-gap: 4px;
+}
+
+.gap-y-1 {
+  row-gap: 4px;
 }
 
 .gap-2 {

--- a/frontend/src/test/router.spec.js
+++ b/frontend/src/test/router.spec.js
@@ -1,11 +1,33 @@
 import { describe, it, expect, vi } from 'vitest'
-import { activityFromRoute, campFromRoute, materialListRoute } from '../router'
+import router, {
+  activityFromRoute,
+  campFromRoute,
+  materialListRoute,
+  scheduleEntryRoute,
+} from '../router'
+
+vi.mock('@/plugins/auth', () => ({
+  isAdmin: () => false,
+  isLoggedIn: () => true,
+}))
 
 vi.mock('@/plugins/store', () => ({
   apiStore: {
     get: () => ({
-      activities: ({ id }) => `activity ${id}`,
-      camps: ({ id }) => `camp ${id}`,
+      activities: ({ id }) => {
+        if (!id.startsWith('activity-')) return `activity ${id}`
+
+        const activity = {
+          scheduleEntries: () => ({
+            items: [{ id: id.replace('activity-', 'entry-') }],
+          }),
+        }
+        activity.$reload = () => Promise.resolve(activity)
+        return activity
+      },
+      camps: ({ id }) =>
+        id === 'camp-1' ? { _meta: { load: Promise.resolve() } } : `camp ${id}`,
+      periods: ({ id }) => ({ id, _meta: { load: Promise.resolve() } }),
     }),
   },
 }))
@@ -122,4 +144,46 @@ describe('activityFromRoute', () => {
   it('leaves it to the API to reject a malformed activity id', () => {
     expect(() => activityFromRoute({ params: { activityId: 'nope' } })).not.toThrow()
   })
+})
+
+describe('activity back route', () => {
+  it('keeps the original program route when switching activities', async () => {
+    const activityRoute = (number) => {
+      const activity = {
+        id: `activity-${number}`,
+        title: `Activity ${number}`,
+        _meta: { loading: false },
+        camp: () => ({ id: 'camp-1', shortTitle: 'camp' }),
+      }
+      return scheduleEntryRoute({
+        id: `entry-${number}`,
+        _meta: { loading: false },
+        activity: () => activity,
+      })
+    }
+
+    await router.replace({
+      name: 'camp/period/program',
+      params: { campId: 'camp-1', campShortTitle: 'camp', periodId: 'period-1' },
+    })
+    const origin = router.currentRoute.value.fullPath
+
+    await router.push(activityRoute(1))
+    const firstActivity = router.currentRoute.value.fullPath
+    await router.push(activityRoute(2))
+
+    expect(window.history.state.activityBack).toBe(origin)
+
+    const navigatedBack = new Promise((resolve) => {
+      const removeHook = router.afterEach(() => {
+        removeHook()
+        resolve()
+      })
+    })
+    window.history.back()
+    await navigatedBack
+
+    expect(router.currentRoute.value.fullPath).toBe(firstActivity)
+    expect(window.history.state.activityBack).toBe(origin)
+  }, 15_000)
 })

--- a/frontend/src/types/router.d.ts
+++ b/frontend/src/types/router.d.ts
@@ -1,0 +1,17 @@
+import 'vue-router'
+import type { RouteLocationRaw } from 'vue-router'
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    /**
+     * Target route (name/path/object) or boolean for the back button.
+     * When set, shows a back button in ContentCard.
+     */
+    back?: RouteLocationRaw | boolean
+
+    /**
+     * When true, shows the back button only on mobile devices (e.g. for master-detail views).
+     */
+    backMobile?: boolean
+  }
+}

--- a/frontend/src/views/camp/CampProgram.vue
+++ b/frontend/src/views/camp/CampProgram.vue
@@ -46,9 +46,12 @@ Show all activity schedule entries of a single period.
       />
       <v-menu offset-y>
         <template #activator="{ props }">
-          <v-btn icon size="small" v-bind="props" data-testid="campprogram-menu">
-            <v-icon size="large">mdi-dots-horizontal</v-icon>
-          </v-btn>
+          <v-btn
+            icon="mdi-dots-vertical"
+            size="small"
+            v-bind="props"
+            data-testid="campprogram-menu"
+          />
         </template>
         <v-list class="py-0">
           <LockUnlockListItem

--- a/frontend/src/views/camp/admin/AdminMaterialLists.vue
+++ b/frontend/src/views/camp/admin/AdminMaterialLists.vue
@@ -7,7 +7,12 @@ Show all material lists for a camp on mobile
     <template v-if="isContributor" #title-actions>
       <DialogMaterialListCreate :camp="camp">
         <template #activator="{ props }">
-          <ButtonAdd v-bind="props" class="mr-2" height="32"
+          <ButtonAdd
+            variant="text"
+            color="secondary"
+            v-bind="props"
+            class="mr-2"
+            height="32"
             >{{ $t('global.button.create') }}
           </ButtonAdd>
         </template>

--- a/frontend/src/views/camp/category/Category.vue
+++ b/frontend/src/views/camp/category/Category.vue
@@ -8,7 +8,7 @@
       :max-width="isPaperDisplaySize ? '944px' : ''"
     >
       <template #title>
-        <v-toolbar-title class="font-weight-bold">
+        <v-toolbar-title class="font-weight-bold ml-0">
           <CategoryChip :category="category" dense large />
           {{ category.name }}
         </v-toolbar-title>

--- a/frontend/src/views/camp/category/Category.vue
+++ b/frontend/src/views/camp/category/Category.vue
@@ -4,7 +4,7 @@
       v-if="category"
       class="ec-category"
       toolbar
-      back
+      :back="adminRoute(camp, 'activity')"
       :max-width="isPaperDisplaySize ? '944px' : ''"
     >
       <template #title>
@@ -109,7 +109,7 @@ import ErrorExistingActivitiesList from '@/components/campAdmin/ErrorExistingAct
 import CategoryProperties from '@/components/category/CategoryProperties.vue'
 import CategoryTemplate from '@/components/category/CategoryTemplate.vue'
 import TogglePaperSize from '@/components/activity/TogglePaperSize.vue'
-import router, { categoryRoute } from '@/router.js'
+import router, { adminRoute, categoryRoute } from '@/router.js'
 import ClipboardInfoDialog from '@/components/generic/ClipboardInfoDialog.vue'
 import { useToast } from 'vue-toastification'
 
@@ -200,6 +200,7 @@ export default {
     this.loading = false
   },
   methods: {
+    adminRoute,
     findActivities(category) {
       return this.camp
         .activities()

--- a/frontend/src/views/camp/checklistOverview/ChecklistLists.vue
+++ b/frontend/src/views/camp/checklistOverview/ChecklistLists.vue
@@ -5,7 +5,7 @@
       <v-list-item
         v-for="checklist in checklists.items"
         :key="checklist._meta.self"
-        :to="checklistOverviewRoute(camp, checklist, { isDetail: true })"
+        :to="checklistOverviewRoute(camp, checklist)"
         exact-path
       >
         <v-list-item-title>{{ checklist.name }}</v-list-item-title>

--- a/frontend/src/views/camp/material/MaterialListsMobile.vue
+++ b/frontend/src/views/camp/material/MaterialListsMobile.vue
@@ -7,7 +7,7 @@ Show all material lists for a camp on mobile
     <template v-if="!isGuest" #title-actions>
       <DialogMaterialListCreate :camp="camp">
         <template #activator="{ props }">
-          <ButtonAdd class="mr-n2" height="32" v-bind="props"
+          <ButtonAdd class="mr-2" height="32" v-bind="props"
             >{{ $t('global.button.create') }}
           </ButtonAdd>
         </template>

--- a/frontend/src/views/camp/navigation/mobile/NavSidebar.vue
+++ b/frontend/src/views/camp/navigation/mobile/NavSidebar.vue
@@ -21,7 +21,7 @@
             user.profile().nickname &&
             user.profile().firstname + ' ' + user.profile().surname
           "
-          :to="{ name: 'profile', query: { isDetail: true } }"
+          :to="{ name: 'profile' }"
         >
           <template #pre>
             <UserAvatar
@@ -34,7 +34,7 @@
         <SidebarListItem
           :title="$t('views.camp.navigation.mobile.navSidebar.itemCamps', 2)"
           icon="mdi-format-list-bulleted-triangle"
-          :to="{ name: 'camps', query: { isDetail: true } }"
+          :to="{ name: 'camps' }"
         />
       </v-list>
 


### PR DESCRIPTION
## Back Navigation & Routing
Replaced `?isDetail=true` query params with declarative `meta.back`/`meta.backMobile`, added typed `RouteMeta` definitions.

Now the back button goes back to the initial overview view instead of another activity (when switching via sidebar).

## Card & Title UI
Cleaned up `ContentCard` toolbar alignment, integrated inline edit buttons inside titles, added `Escape` key to cancel edits in title edit fields, and fixed text truncation in `PeriodSwitcher`.
| before | after |
|--------|------|
| <img width="392" height="844" alt="Bildschirmfoto 2026-09-01 um 11 22 51" src="https://github.com/user-attachments/assets/7f67f305-eeb3-49ae-be9d-12462d97d071" /> | <img width="391" height="844" alt="Bildschirmfoto 2026-09-01 um 11 23 06" src="https://github.com/user-attachments/assets/d5e9133c-5138-45a1-838e-a7eb5112e8f3" /> |
| <img width="954" height="501" alt="Bildschirmfoto 2026-09-01 um 11 32 00" src="https://github.com/user-attachments/assets/4dbb9516-6843-4891-aa10-78dfd96f43ee" /> | <img width="953" height="481" alt="Bildschirmfoto 2026-09-01 um 11 32 35" src="https://github.com/user-attachments/assets/74d77364-e0d7-4844-985f-25f2591602d5" /> |

## Icons & Button Polish
Standardized `ApiWrapperAppend` button sizes, scoped the app-bar icon multiplier to prevent sizing glitches, and modernized action buttons/menus across views.

| before | after |
|--------|------|
| <img width="392" height="844" alt="Bildschirmfoto 2026-09-01 um 11 25 58" src="https://github.com/user-attachments/assets/61074f8a-dbac-418b-9042-1a1433212fe4" /> | <img width="392" height="844" alt="Bildschirmfoto 2026-09-01 um 11 25 06" src="https://github.com/user-attachments/assets/04d1dfc0-104d-4a75-afbc-1d610baffaae" /> |





