### PR TITLE
fix Firefox stale deployment route interception

### DIFF
--- a/e2e/tests/5-cross-browser-tests/staleDeployment.spec.ts
+++ b/e2e/tests/5-cross-browser-tests/staleDeployment.spec.ts
@@ -31,7 +31,7 @@ test('reloads the page when a route chunk is missing after a deploy', async ({
     }
     chunkRequestCount += 1
     if (chunkRequestCount === 1) {
-      await route.abort('failed')
+      await route.fulfill({ status: 404, contentType: 'text/javascript', body: '' })
     } else {
       await route.continue()
     }


### PR DESCRIPTION
Return a realistic missing JavaScript response so Firefox rejects the lazy import and exercises router recovery consistently.

Is an AI guess i think.