### PR TITLE
Add explicit minimal permissions blocks to e2e workflow files

### DIFF
--- a/.github/workflows/e2e-tests-all.yml
+++ b/.github/workflows/e2e-tests-all.yml
@@ -1,5 +1,8 @@
 name: 'Tests: All End-to-End (including non-mature)'
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/reusable-e2e-tests-build.yml
+++ b/.github/workflows/reusable-e2e-tests-build.yml
@@ -1,5 +1,9 @@
 name: '[reusable only] e2e tests build'
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   workflow_call:
 

--- a/.github/workflows/reusable-e2e-tests-run.yml
+++ b/.github/workflows/reusable-e2e-tests-run.yml
@@ -1,5 +1,9 @@
 name: '[reusable only] e2e tests run'
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary
This PR adds explicit minimal `permissions:` blocks to the three e2e test workflow files as security hardening.

## Changes
- `.github/workflows/e2e-tests-all.yml`: Added `permissions: contents: read`
- `.github/workflows/reusable-e2e-tests-build.yml`: Added `permissions: contents: read, actions: write`
- `.github/workflows/reusable-e2e-tests-run.yml`: Added `permissions: contents: read, actions: write`

## Why
Without explicit permissions blocks, workflows inherit the repository's default token permissions. A compromised token or injected action could exploit these overly broad permissions.

This resolves the [zizmor](https://github.com/woodruffw/zizmor) overly-broad-permissions finding.

## Related
- Closes ecamp/ecamp3#9971
- Related to bacluc-agent/agent-todo#154