### PR TITLE
fix(#9974): replace deprecated next() callback in navigation guards

### DIFF
--- a/frontend/src/components/activity/ScheduleEntry.vue
+++ b/frontend/src/components/activity/ScheduleEntry.vue
@@ -350,8 +350,8 @@ export default {
       isPaperDisplaySize: () => this.isPaperDisplaySize,
     }
   },
-  async beforeRouteUpdate(to, from, next) {
-    return scheduleEntryRouteChange(this.activityId, to, from, next)
+  async beforeRouteUpdate(to, from) {
+    return scheduleEntryRouteChange(this.activityId, to, from)
   },
   props: {
     activityId: {

--- a/frontend/src/helpers/scheduleEntryRouteChange.js
+++ b/frontend/src/helpers/scheduleEntryRouteChange.js
@@ -6,10 +6,9 @@ import { apiStore } from '@/plugins/store'
  * @param activity
  * @param to
  * @param from
- * @param next
  * @return {Promise<*>}
  */
-export default async function scheduleEntryRouteChange(activity, to, from, next) {
+export default async function scheduleEntryRouteChange(activity, to, from) {
   if (
     to.params.scheduleEntryId !== from.params.scheduleEntryId ||
     to.params.activityId !== from.params.activityId
@@ -17,21 +16,17 @@ export default async function scheduleEntryRouteChange(activity, to, from, next)
     apiStore.get().activities({ id: to.params.activityId }).$reload()
     // activity reload doesn't need to be awaited, but for scheduleEntry we want to
     // ensure it exists and otherwise reroute
-    return await apiStore
+    return apiStore
       .get()
       .scheduleEntries({ id: to.params.scheduleEntryId })
       .$reload()
-      .then(() => next())
-      .catch(async () => {
-        return next({
-          name: 'camp/activity',
-          params: {
-            ...to.params,
-            scheduleEntryId: (await firstActivityScheduleEntry(to.params.activityId)).id,
-          },
-        })
-      })
-  } else {
-    return next()
+      .then(() => undefined)
+      .catch(async () => ({
+        name: 'camp/activity',
+        params: {
+          ...to.params,
+          scheduleEntryId: (await firstActivityScheduleEntry(to.params.activityId)).id,
+        },
+      }))
   }
 }

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -652,11 +652,11 @@ async function requireActivityScheduleEntry(to) {
           .get()
           .scheduleEntries({ id: to.params.scheduleEntryId })
           ._meta.load.then(
-            async (scheduleEntry) => {
+            (scheduleEntry) => {
               to.params.activityId = scheduleEntry.activity().id
               return to
             },
-            async () => ({
+            () => ({
               // scheduleEntry and activity are not found, fallback to camp program
               ...to,
               name: 'camp/program',

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -295,9 +295,7 @@ const router = createRouter({
         {
           path: 'program',
           name: 'camp/program',
-          async beforeEnter(to, from, next) {
-            return redirectToPeriod(to, from, next, 'camp/period/program')
-          },
+          beforeEnter: (to) => redirectToPeriod(to, 'camp/period/program'),
         },
         {
           path: 'overview/checklists',
@@ -313,9 +311,7 @@ const router = createRouter({
         {
           path: 'story',
           name: 'camp/story',
-          async beforeEnter(to, from, next) {
-            return redirectToPeriod(to, from, next, 'camp/period/story')
-          },
+          beforeEnter: (to) => redirectToPeriod(to, 'camp/period/story'),
         },
         {
           path: 'dashboard',
@@ -582,73 +578,54 @@ router.afterEach(() => {
 
 export default router
 
-function evaluateGuards(guards, to, from, next) {
-  const guardsLeft = guards.slice(0)
-  const nextGuard = guardsLeft.shift()
-
-  if (nextGuard === undefined) {
-    next()
-    return
-  }
-
-  nextGuard(to, from, (nextArg) => {
-    if (nextArg === undefined) {
-      evaluateGuards(guardsLeft, to, from, next)
-      return
-    }
-    next(nextArg)
-  })
-}
-
 function all(guards) {
-  return (to, from, next) => evaluateGuards(guards, to, from, next)
-}
-
-function requireAuth(to, from, next) {
-  if (isLoggedIn()) {
-    next()
-  } else {
-    next({ name: 'login', query: to.path === '/' ? {} : { redirect: to.fullPath } })
+  return async (to, from) => {
+    for (const guard of guards) {
+      const result = await guard(to, from)
+      if (result !== undefined) {
+        return result
+      }
+    }
   }
 }
 
-function requireAdmin(to, from, next) {
-  if (isAdmin()) {
-    next()
-  } else {
-    next({
+function requireAuth(to) {
+  if (!isLoggedIn()) {
+    return { name: 'login', query: to.path === '/' ? {} : { redirect: to.fullPath } }
+  }
+}
+
+function requireAdmin(to) {
+  if (!isAdmin()) {
+    return {
       name: 'PageNotFound',
       params: [to.fullPath, ''],
       replace: true,
-    })
+    }
   }
 }
 
-async function requireCamp(to, from, next) {
+async function requireCamp(to) {
   const camp = await campFromRoute(to)
   if (camp === undefined) {
-    next({
+    return {
+      name: 'PageNotFound',
+      params: [to.fullPath, ''],
+      replace: true,
+    }
+  }
+  return camp._meta.load.then(
+    () => undefined,
+    () => ({
       name: 'PageNotFound',
       params: [to.fullPath, ''],
       replace: true,
     })
-  } else {
-    await camp._meta.load
-      .then(() => {
-        next()
-      })
-      .catch(() => {
-        next({
-          name: 'PageNotFound',
-          params: [to.fullPath, ''],
-          replace: true,
-        })
-      })
-  }
+  )
 }
 
-async function requireActivityScheduleEntry(to, from, next) {
-  await apiStore
+async function requireActivityScheduleEntry(to) {
+  return apiStore
     .get()
     .activities({ id: to.params.activityId })
     .$reload()
@@ -662,112 +639,95 @@ async function requireActivityScheduleEntry(to, from, next) {
 
       if (scheduleEntry) {
         // activity and scheduleEntry exist
-        next()
-      } else {
-        // scheduleEntry is not found, use first activity scheduleEntry
-        to.params.scheduleEntryId = (await firstActivityScheduleEntry(activity)).id
-        next(to)
+        return undefined
       }
+      // scheduleEntry is not found, use first activity scheduleEntry
+      to.params.scheduleEntryId = (await firstActivityScheduleEntry(activity)).id
+      return to
     })
-    .catch(() => {
+    .catch(async () => {
       // activityId does not exist, check if scheduleEntryId exists
       if (to.params.scheduleEntryId) {
-        apiStore
+        return apiStore
           .get()
           .scheduleEntries({ id: to.params.scheduleEntryId })
-          ._meta.load.then(async (scheduleEntry) => {
-            to.params.activityId = scheduleEntry.activity().id
-            next(to)
-          })
-          .catch(async () => {
-            // scheduleEntry and activity are not found, fallback to camp program
-            next({
+          ._meta.load.then(
+            async (scheduleEntry) => {
+              to.params.activityId = scheduleEntry.activity().id
+              return to
+            },
+            async () => ({
+              // scheduleEntry and activity are not found, fallback to camp program
               ...to,
               name: 'camp/program',
             })
-          })
+          )
       }
     })
 }
 
-async function requirePeriod(to, from, next) {
+async function requirePeriod(to) {
   const period = await periodFromRoute(to)
   if (period === undefined) {
-    next({
+    return {
       name: 'PageNotFound',
       params: [to.fullPath, ''],
       replace: true,
-    })
-  } else {
-    await period._meta.load
-      .then(() => {
-        next()
-      })
-      .catch(() => {
-        next(campRoute(campFromRoute(to)))
-      })
+    }
   }
+  return period._meta.load.then(
+    () => undefined,
+    () => campRoute(campFromRoute(to))
+  )
 }
 
-async function requireCategory(to, from, next) {
+async function requireCategory(to) {
   const category = await categoryFromRoute(to)
   if (category === undefined) {
-    next({
+    return {
+      name: 'PageNotFound',
+      params: [to.fullPath, ''],
+      replace: true,
+    }
+  }
+  return category._meta.load.then(
+    () => undefined,
+    () => ({
       name: 'PageNotFound',
       params: [to.fullPath, ''],
       replace: true,
     })
-  } else {
-    await category._meta.load
-      .then(() => {
-        next()
-      })
-      .catch(() => {
-        next({
-          name: 'PageNotFound',
-          params: [to.fullPath, ''],
-          replace: true,
-        })
-      })
-  }
+  )
 }
 
-async function requireMaterialList(to, from, next) {
+async function requireMaterialList(to) {
   const materialList = await materialListFromRoute(to)
   if (materialList === undefined) {
-    next({
+    return {
       name: 'PageNotFound',
       params: [to.fullPath, ''],
       replace: true,
-    })
-  } else {
-    await materialList._meta.load
-      .then(() => {
-        next()
-      })
-      .catch(() => {
-        next(campRoute(campFromRoute(to)))
-      })
+    }
   }
+  return materialList._meta.load.then(
+    () => undefined,
+    () => campRoute(campFromRoute(to))
+  )
 }
 
-async function requireChecklist(to, from, next) {
+async function requireChecklist(to) {
   const checklist = await checklistFromRoute(to)
   if (checklist === undefined) {
-    next({
+    return {
       name: 'PageNotFound',
       params: [to.fullPath, ''],
       replace: true,
-    })
-  } else {
-    await checklist._meta.load
-      .then(() => {
-        next()
-      })
-      .catch(() => {
-        next(campRoute(campFromRoute(to)))
-      })
+    }
   }
+  return checklist._meta.load.then(
+    () => undefined,
+    () => campRoute(campFromRoute(to))
+  )
 }
 
 export function campFromRoute(route) {
@@ -1078,13 +1038,12 @@ export async function firstActivityScheduleEntry(activity) {
     )
 }
 
-async function redirectToPeriod(to, from, next, routeName) {
+async function redirectToPeriod(to, routeName) {
   const period = await firstFuturePeriod(to)
   if (period) {
     await period.camp()._meta.load
-    next(periodRoute(period, routeName, to.query))
-  } else {
-    const camp = await apiStore.get().camps({ id: to.params.campId })
-    next(campRoute(camp, 'camp/admin', to.query))
+    return periodRoute(period, routeName, to.query)
   }
+  const camp = await apiStore.get().camps({ id: to.params.campId })
+  return campRoute(camp, 'camp/admin', to.query)
 }

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -209,11 +209,9 @@ export default {
     HorizontalRule,
     AuthContainer,
   },
-  beforeRouteEnter(to, from, next) {
+  beforeRouteEnter(to) {
     if (isLoggedIn()) {
-      next(to.query.redirect || '/')
-    } else {
-      next()
+      return to.query.redirect || '/'
     }
   },
   data() {

--- a/frontend/src/views/auth/LoginCallback.vue
+++ b/frontend/src/views/auth/LoginCallback.vue
@@ -14,8 +14,8 @@
 <script>
 export default {
   name: 'LoginCallback',
-  beforeRouteEnter(to, from, next) {
-    next(decodeURI(to.query.redirect || '/'))
+  beforeRouteEnter(to) {
+    return decodeURI(to.query.redirect || '/')
   },
 }
 </script>

--- a/frontend/src/views/camp/activity/SideBarProgram.vue
+++ b/frontend/src/views/camp/activity/SideBarProgram.vue
@@ -43,8 +43,8 @@ import scheduleEntryRouteChange from '@/helpers/scheduleEntryRouteChange.js'
 export default {
   name: 'SideBarProgram',
   components: { DaySwitcher, SideBar, Picasso, ScheduleEntries },
-  async beforeRouteUpdate(to, from, next) {
-    return scheduleEntryRouteChange(this.activityId, to, from, next)
+  async beforeRouteUpdate(to, from) {
+    return scheduleEntryRouteChange(this.activityId, to, from)
   },
   props: {
     camp: { type: Object, required: true },


### PR DESCRIPTION
Vue Router 4 deprecates the `next()` callback pattern in navigation guards. This PR replaces all `next()` calls with the modern return-value pattern: return a route location to redirect, return undefined/nothing to allow.

## Changes

- **router.js**: Delete `evaluateGuards`, rewrite `all()` as an async for-loop guard chainer. Convert `requireAuth`, `requireAdmin`, `requireCamp`, `requirePeriod`, `requireCategory`, `requireMaterialList`, `requireChecklist`, `requireActivityScheduleEntry`, and `redirectToPeriod` to return values instead of calling `next()`. Convert inline `beforeEnter` on `camp/program` and `camp/story`.
- **scheduleEntryRouteChange.js**: Drop `next` param, return values directly.
- **Login.vue**: `beforeRouteEnter` returns redirect or undefined.
- **LoginCallback.vue**: `beforeRouteEnter` returns redirect.
- **SideBarProgram.vue** / **ScheduleEntry.vue**: `beforeRouteUpdate` drops `next`.

## Verification

- Zero `next(` calls remain in the guarded files
- `npm run lint:check` passes
- `npm run test:unit` passes
- `npm run build` passes
- Full-stack navigation test: 18 routes visited (login, login callback, camps, profile, program/story redirect, period/category/material-list/checklist guards, activity schedule entry navigation, admin) — all work, no `[Vue Router warn]: The next() callback in navigation guards is deprecated` in the console

Ref: ecamp/ecamp3#9974, bacluc-agent/agent-todo#153