### PR TITLE
fix(checklist): make camp admin checklist UI read-only for guests (fixes #10046)

### DIFF
--- a/frontend/src/components/checklist/ChecklistDetail.vue
+++ b/frontend/src/components/checklist/ChecklistDetail.vue
@@ -10,7 +10,7 @@
       <v-toolbar-title v-if="!editChecklistName" tag="h1" class="font-weight-bold ml-0">
         {{ checklist.name }}
         <v-btn
-          v-if="!editChecklistName && !isOutsider"
+          v-if="!editChecklistName && !isReadOnly"
           icon
           class="ml-1 visible-on-hover"
           width="24"
@@ -116,6 +116,9 @@ export default {
     items() {
       return this.checklist.checklistItems().items.filter((item) => !item.parent)
     },
+    isReadOnly() {
+      return this.isGuest || this.isOutsider
+    },
   },
   async mounted() {
     await this.api
@@ -127,7 +130,7 @@ export default {
       .$loadItems()
 
     await nextTick()
-    this.debouncedDisabled = this.isOutsider
+    this.debouncedDisabled = this.isReadOnly
   },
   methods: {
     checklistRoute,


### PR DESCRIPTION
Fixes #10046

## Problem

In the camp admin, guests could still edit checklists: rename them, drag-drop items, and edit item content. The UI gated editability on `isOutsider` alone, but a guest has `isOutsider = false` (they have a role — just the wrong one). Only users with *no* role at all are outsiders.

## Fix

In `frontend/src/components/checklist/ChecklistDetail.vue`, gate editability on a new `isReadOnly` computed (`isGuest || isOutsider`) instead of `isOutsider`:

- Rename pencil button: `!isOutsider` → `!isReadOnly`
- `debouncedDisabled` (drives drag-drop and item editing via the `disabled` prop on `SortableChecklist`/`SortableChecklistItem`): `isOutsider` → `isReadOnly`

Using `isGuest || isOutsider` rather than `!isContributor` preserves editing in the global admin (`/admin/checklists`), where `camp` is null and all role flags are false.

## Verification

- `npm run lint:check` passes
- `npm run test:unit` passes (1268 tests, 0 failures)
- Verified `SortableChecklist.vue`/`SortableChecklistItem.vue` honor the `disabled` prop (read-only rendering, hidden add/edit controls); `ChecklistOverview.vue` already gates on `isContributor`

Tracked in bacluc-agent/agent-todo#152.