### PR TITLE
fix(picasso): reload schedule entries and days after changing period dates

### DIFF
--- a/frontend/src/components/campAdmin/DialogPeriodDateEdit.vue
+++ b/frontend/src/components/campAdmin/DialogPeriodDateEdit.vue
@@ -119,6 +119,14 @@ export default {
     },
   },
   methods: {
+    onSuccess(response) {
+      // dates of schedule entries and days are calculated from the period start by the API
+      // and days are added or removed, so the cached collections are outdated now
+      this.api.reload(this.period.scheduleEntries())
+      this.api.reload(this.period.days())
+      this.api.reload(this.period.dayResponsibles())
+      return DialogBase.methods.onSuccess.call(this, response)
+    },
     updateStartAndNotify(start) {
       this.entityData.start = start
       this.startChanged()

--- a/frontend/src/components/campAdmin/__tests__/DialogPeriodDateEdit.spec.js
+++ b/frontend/src/components/campAdmin/__tests__/DialogPeriodDateEdit.spec.js
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import flushPromises from 'flush-promises'
+import dayjs from '@/common/helpers/dayjs.js'
+import DialogPeriodDateEdit from '@/components/campAdmin/DialogPeriodDateEdit.vue'
+
+function createPeriod() {
+  const scheduleEntries = { _meta: { self: '/schedule_entries?period=/periods/1' } }
+  const days = { _meta: { self: '/days?period=/periods/1' } }
+  const dayResponsibles = { _meta: { self: '/day_responsibles?day.period=/periods/1' } }
+  return {
+    _meta: { self: '/periods/1' },
+    description: 'Hauptlager',
+    start: '2024-07-01',
+    end: '2024-07-07',
+    scheduleEntries: () => scheduleEntries,
+    days: () => days,
+    dayResponsibles: () => dayResponsibles,
+  }
+}
+
+async function mountDialog({
+  mode = 'move',
+  patch = vi.fn().mockResolvedValue({}),
+} = {}) {
+  const period = createPeriod()
+  const api = {
+    get: () => ({
+      _meta: {
+        load: Promise.resolve({
+          start: period.start,
+          end: period.end,
+          moveScheduleEntries: false,
+        }),
+      },
+    }),
+    patch,
+    reload: vi.fn().mockResolvedValue({}),
+  }
+  const wrapper = shallowMount(DialogPeriodDateEdit, {
+    props: { period, mode },
+    global: {
+      mocks: { $t: (key) => key, $date: dayjs, api },
+      stubs: {
+        DialogForm: {
+          props: ['submitAction'],
+          template: '<button data-testid="submit" @click="submitAction" />',
+        },
+        EForm: true,
+        EDatePicker: true,
+        ETextField: true,
+      },
+    },
+  })
+  wrapper.vm.open()
+  await flushPromises()
+  return { wrapper, period, api }
+}
+
+async function submit(wrapper) {
+  await wrapper.find('[data-testid="submit"]').trigger('click')
+  await flushPromises()
+}
+
+describe('DialogPeriodDateEdit', () => {
+  // The dates of schedule entries and days are derived from the period start on the server,
+  // so the cached collections are stale after the period dates changed (#5283).
+  it.each([['move'], ['changeStart'], ['changeEnd']])(
+    'reloads the schedule entries, days and day responsibles of the period after saving in mode %s',
+    async (mode) => {
+      const { wrapper, period, api } = await mountDialog({ mode })
+
+      await submit(wrapper)
+
+      expect(api.patch).toHaveBeenCalledOnce()
+      expect(api.reload).toHaveBeenCalledWith(period.scheduleEntries())
+      expect(api.reload).toHaveBeenCalledWith(period.days())
+      expect(api.reload).toHaveBeenCalledWith(period.dayResponsibles())
+    }
+  )
+
+  it('closes the dialog after saving', async () => {
+    const { wrapper } = await mountDialog()
+
+    await submit(wrapper)
+
+    expect(wrapper.vm.showDialog).toBe(false)
+    expect(wrapper.emitted('success')).toHaveLength(1)
+  })
+
+  it('does not reload anything when saving fails', async () => {
+    const { wrapper, api } = await mountDialog({
+      patch: vi.fn().mockRejectedValue(new Error('nope')),
+    })
+
+    await submit(wrapper)
+
+    expect(api.reload).not.toHaveBeenCalled()
+    expect(wrapper.vm.showDialog).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #5283

## Problem

After moving a period (or changing its start/end) in the camp admin, the Picasso of that period is empty when navigating back: no schedule entries and no day responsibles, while the displayed dates are correct. A hard refresh (F5) shows everything again.

## Cause

The API does not store absolute dates for schedule entries and days. It stores offsets (`startOffset`, `dayOffset`) and calculates `start`/`end` from the period start (`ScheduleEntry::getStart()`, `Day::getStart()`). When a period is moved, its schedule entries and days get new dates without being written themselves; when the start or end changes, days are also added or removed (`PeriodPersistProcessor`).

`DialogPeriodDateEdit` only PATCHed the period. The cached collections `period.scheduleEntries()`, `period.days()` and `period.dayResponsibles()` kept their old data, and `CampProgram` loads them via `_meta.load`, which returns the cache without a request. The Picasso then rendered the new date range with entries on the old dates. Day responsibles disappeared too, because `DayResponsibles.vue` finds the day by comparing `day.start` with the calendar date.

## Fix

`DialogPeriodDateEdit` reloads the three collections after a successful update, in all modes (move, changeStart, changeEnd), since every mode changes the days. It then calls `DialogBase`'s `onSuccess`, so the `success` event, `successHandler` and closing the dialog keep working. (The only other `onSuccess` override, in `DialogActivityCreate`, re-implements closing instead; calling the base here is deliberate.)

I did not re-add a forced reload in `CampProgram.mounted()`: that would refetch on every navigation to the program. Reloading what the mutation invalidated follows the existing pattern (`DialogActivityEdit`, `CategoryProperties`).

## Tests

- New `frontend/src/components/campAdmin/__tests__/DialogPeriodDateEdit.spec.js`
  - reloads schedule entries, days and day responsibles after saving, for each mode (failed before the fix: `api.reload` was never called)
  - still closes the dialog and emits `success`
  - does not reload anything when saving fails
- Frontend unit tests: all green (1273 passed), `npm run lint` clean

## Manual verification

Dev data, camp "Sola 2023", period "Hauptlager":

1. Picasso shows 61 schedule entries on 13.–20.07.2036
2. Admin → move period to start 13.08.2036
3. Navigate back to the Picasso via the menu (no page reload): 61 schedule entries on 13.–20.08.2036
4. Network: `PATCH /api/periods/fe47dfd2b541` is followed by `GET …/schedule_entries`, `GET …/days` and `GET /api/day_responsibles?day.period=…`

Day responsibles were verified at the network level (collections refetched), not by counting them in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFW7MN47y7xfBBZvqAigaN