### PR TITLE
fix(print): use vue-i18n v11 via overrides (fixes #10594)

### DIFF
--- a/print/package-lock.json
+++ b/print/package-lock.json
@@ -2285,19 +2285,17 @@
       }
     },
     "node_modules/@intlify/vue-i18n-extensions": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-extensions/-/vue-i18n-extensions-8.0.0.tgz",
-      "integrity": "sha512-w0+70CvTmuqbskWfzeYhn0IXxllr6mU+IeM2MU0M+j9OW64jkrvqY+pYFWrUnIIC9bEdij3NICruicwd5EgUuQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-extensions/-/vue-i18n-extensions-9.0.0.tgz",
+      "integrity": "sha512-Du+4FQiLiwP7OxvHYuglCTkRRIuA5oaYhVpL+ptaEy/wwGxz6EB0Bk99gV6BP2FfVwsDCnP1Pc72a1EU8cGX1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.6",
-        "@intlify/shared": "^10.0.0",
-        "@vue/compiler-dom": "^3.2.45",
-        "vue-i18n": "^10.0.0"
+        "@vue/compiler-dom": "^3.2.45"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 22"
       },
       "peerDependencies": {
         "@intlify/shared": "^9.0.0 || ^10.0.0 || ^11.0.0",
@@ -2318,75 +2316,6 @@
         "vue-i18n": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/core-base": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.8.tgz",
-      "integrity": "sha512-FoHslNWSoHjdUBLy35bpm9PV/0LVI/DSv9L6Km6J2ad8r/mm0VaGg06C40FqlE8u2ADcGUM60lyoU7Myo4WNZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/message-compiler": "10.0.8",
-        "@intlify/shared": "10.0.8"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/message-compiler": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.8.tgz",
-      "integrity": "sha512-DV+sYXIkHVd5yVb2mL7br/NEUwzUoLBsMkV3H0InefWgmYa34NLZUvMCGi5oWX+Hqr2Y2qUxnVrnOWF4aBlgWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/shared": "10.0.8",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/shared": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.8.tgz",
-      "integrity": "sha512-BcmHpb5bQyeVNrptC3UhzpBZB/YHHDoEREOUERrmF2BRxsyOEuRrq+Z96C/D4+2KJb8kuHiouzAei7BXlG0YYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@intlify/vue-i18n-extensions/node_modules/vue-i18n": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.8.tgz",
-      "integrity": "sha512-mIjy4utxMz9lMMo6G9vYePv7gUFt4ztOMhY9/4czDJxZ26xPeJ49MAGa9wBAE3XuXbYCrtVPmPxNjej7JJJkZQ==",
-      "deprecated": "v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/core-base": "10.0.8",
-        "@intlify/shared": "10.0.8",
-        "@vue/devtools-api": "^6.5.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
       }
     },
     "node_modules/@ioredis/commands": {

--- a/print/package.json
+++ b/print/package.json
@@ -66,6 +66,7 @@
     "vue": "3.5.42"
   },
   "overrides": {
+    "@intlify/vue-i18n-extensions": "9.0.0",
     "uri-js": "npm:uri-js-replace"
   }
 }


### PR DESCRIPTION
Closes #10594

Root cause: `@nuxtjs/i18n@10.6.0` → `@intlify/unplugin-vue-i18n@11.2.5` → `@intlify/vue-i18n-extensions@8.0.0` hard-depends on `vue-i18n@^10.0.0`, pulling deprecated `vue-i18n@10.0.8` (plus `@intlify/core-base`, `message-compiler`, `shared` 10.0.8) nested under `print/node_modules`.

Fix: override `@intlify/vue-i18n-extensions` to `9.0.0`, which removed the hard `vue-i18n` dependency (now optional peer `^9 || ^10 || ^11`), so npm resolves the hoisted `vue-i18n@11.4.10` everywhere. `frontend/` is untouched.

Why 9.0.0: `8.0.0` → `vue-i18n@^10.0.0` hard dep forces 10.0.8; `9.0.0` makes it an optional peer `^9||^10||^11` → dedupes to existing 11.4.10.

Verification:
- `npm ls vue-i18n` shows only `vue-i18n@11.4.10`
- `grep -c '10.0.8' print/package-lock.json` → 0
- `npm run lint:check` in `print/` passes; `test` and `build` pass (build needs `NODE_OPTIONS=--openssl-legacy-provider`)
- Lockfile regenerated with npm 11 (node 24.20.0); diff +6/-76

Supersedes #10730 which is identical content on branch `issue-150-remove-deprecated-vue-i18n`; this PR is the canonical `issue-150` branch per spec.
