### PR TITLE
Fix sourcemap warning in frontend build

### DIFF
--- a/frontend/src/pdf/vue-pdf-style-plugin.js
+++ b/frontend/src/pdf/vue-pdf-style-plugin.js
@@ -24,13 +24,8 @@ export const vuePdfStylePlugin = {
       code: `export default (component) => {
         component.pdfStyle = ${JSON.stringify(transformedRules)};
       }`,
-      // The following line fixes the warning "Sourcemap is likely to be incorrect: a plugin
-      // (vue-pdf-style-plugin) was used to transform files, but didn't generate a sourcemap
-      // for the transformation."
-      // But at the same time, vite in the frontend complains on HMR updates and refuses to update:
-      // "Multiple conflicting contents for sourcemap source".
-      // So for now, let's just live with the more harmless warning in the pdf module.
-      //map: null,
+      // The generated code has nothing in common with the CSS input, so there is nothing to map.
+      map: { mappings: '' },
     }
   },
 }


### PR DESCRIPTION
Fixes the countless errors like this in the logs of frontend image builds:
> [plugin vue-pdf-style-plugin] [SOURCEMAP_BROKEN] Sourcemap is likely to be incorrect: a plugin (vue-pdf-style-plugin) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help: https://rolldown.rs/guide/troubleshooting#warning-sourcemap-is-likely-to-be-incorrect
