### PR TITLE
fix(#7426): Simplified Rename and Delete Buttons for Material Lists

### DIFF
--- a/frontend/src/views/camp/material/MaterialDetail.vue
+++ b/frontend/src/views/camp/material/MaterialDetail.vue
@@ -2,18 +2,33 @@
   <v-container fluid>
     <content-card :title="materialList.name" toolbar back>
       <template #title>
-        <v-toolbar-title v-if="!editMaterialListName" tag="h1" class="font-weight-bold ml-0">
+        <v-toolbar-title
+          v-if="!editMaterialListName"
+          tag="h1"
+          class="font-weight-bold ml-0"
+        >
           {{ materialList.name }}
 
-          <v-btn v-if="!editMaterialListName && !isOutsider" icon class="ml-1 visible-on-hover" width="24" height="24"
-            @click="makeMaterialListNameEditable()">
+          <v-btn
+            v-if="!editMaterialListName && !isOutsider"
+            icon
+            class="ml-1 visible-on-hover"
+            width="24"
+            height="24"
+            @click="makeMaterialListNameEditable()"
+          >
             <v-icon size="x-small">mdi-pencil</v-icon>
-
           </v-btn>
         </v-toolbar-title>
         <api-form v-if="editMaterialListName" :entity="materialList" class="flex-grow-1">
-          <api-text-field path="name" density="compact" autofocus :auto-save="false"
-            @finished="editMaterialListName = false" @keydown.esc="editMaterialListName = false" />
+          <api-text-field
+            path="name"
+            density="compact"
+            autofocus
+            :auto-save="false"
+            @finished="editMaterialListName = false"
+            @keydown.esc="editMaterialListName = false"
+          />
         </api-form>
       </template>
 
@@ -27,14 +42,28 @@
           <v-list class="py-0">
             <v-list-item :disabled="isDownloadingXlsx" @click.stop="downloadXlsx">
               <template #prepend>
-                <v-progress-circular v-if="isDownloadingXlsx" class="mr-2" indeterminate size="24" width="2" />
+                <v-progress-circular
+                  v-if="isDownloadingXlsx"
+                  class="mr-2"
+                  indeterminate
+                  size="24"
+                  width="2"
+                />
                 <v-icon v-else>mdi-microsoft-excel</v-icon>
               </template>
               {{ $t('global.button.download') }}
             </v-list-item>
-            <DialogEntityDelete :entity="materialList" :warning-text-entity="materialList.name"
+            <DialogEntityDelete
+              :entity="materialList"
+              :warning-text-entity="materialList.name"
               :error-handler="deleteErrorHandler"
-              :success-handler="() => $router.push({ path: `/camps/${camp.id}/${camp.shortTitle}/material/all` })">
+              :success-handler="
+                () =>
+                  $router.push({
+                    path: `/camps/${camp.id}/${camp.shortTitle}/material/all`,
+                  })
+              "
+            >
               <template #activator="{ props }">
                 <v-list-item v-bind="props">
                   <template #prepend>
@@ -49,14 +78,32 @@
           </v-list>
         </v-menu>
       </template>
-      <v-expansion-panels v-if="collection.length > 1" v-model="openPeriods" multiple flat variant="accordion">
-        <PeriodMaterialLists v-for="{ period, materialItems } in collection" :key="period._meta.self" :period="period"
-          :material-item-collection="materialItems" :material-list="materialList" :disabled="!isContributor" />
+      <v-expansion-panels
+        v-if="collection.length > 1"
+        v-model="openPeriods"
+        multiple
+        flat
+        variant="accordion"
+      >
+        <PeriodMaterialLists
+          v-for="{ period, materialItems } in collection"
+          :key="period._meta.self"
+          :period="period"
+          :material-item-collection="materialItems"
+          :material-list="materialList"
+          :disabled="!isContributor"
+        />
       </v-expansion-panels>
       <v-card-text v-else-if="collection.length === 1">
-        <MaterialTable v-for="{ period, materialItems } in collection" :key="period._meta.self" :camp="camp"
-          :material-item-collection="materialItems" :period="period" :material-list="materialList"
-          :disabled="!isContributor" />
+        <MaterialTable
+          v-for="{ period, materialItems } in collection"
+          :key="period._meta.self"
+          :camp="camp"
+          :material-item-collection="materialItems"
+          :period="period"
+          :material-list="materialList"
+          :disabled="!isContributor"
+        />
       </v-card-text>
     </content-card>
   </v-container>
@@ -83,15 +130,15 @@ export default {
     camp: { type: Object, required: true },
     materialList: { type: Object, required: true },
   },
+  setup(props) {
+    return useMaterialViewHelper(props.camp, true)
+  },
   data() {
     return {
       dragging: false,
       editMaterialListName: false,
       debouncedDisabled: true,
     }
-  },
-  setup(props) {
-    return useMaterialViewHelper(props.camp, true)
   },
   head() {
     return {
@@ -108,6 +155,6 @@ export default {
       }
       return null
     },
-  } 
+  },
 }
 </script>

--- a/frontend/src/views/camp/material/MaterialDetail.vue
+++ b/frontend/src/views/camp/material/MaterialDetail.vue
@@ -1,6 +1,22 @@
 <template>
   <v-container fluid>
-    <content-card :title="materialList.name" toolbar>
+    <content-card :title="materialList.name" toolbar back>
+      <template #title>
+        <v-toolbar-title v-if="!editMaterialListName" tag="h1" class="font-weight-bold ml-0">
+          {{ materialList.name }}
+
+          <v-btn v-if="!editMaterialListName && !isOutsider" icon class="ml-1 visible-on-hover" width="24" height="24"
+            @click="makeMaterialListNameEditable()">
+            <v-icon size="x-small">mdi-pencil</v-icon>
+
+          </v-btn>
+        </v-toolbar-title>
+        <api-form v-if="editMaterialListName" :entity="materialList" class="flex-grow-1">
+          <api-text-field path="name" density="compact" autofocus :auto-save="false"
+            @finished="editMaterialListName = false" @keydown.esc="editMaterialListName = false" />
+        </api-form>
+      </template>
+
       <template #title-actions>
         <v-menu offset-y>
           <template #activator="{ props }">
@@ -9,58 +25,38 @@
             </v-btn>
           </template>
           <v-list class="py-0">
-            <DialogMaterialListEdit v-if="isContributor" :material-list="materialList">
-              <template #activator="{ props }">
-                <v-list-item v-bind="props">
-                  <template #prepend>
-                    <v-icon>mdi-pencil</v-icon>
-                  </template>
-                  {{ $t('global.button.edit') }}
-                </v-list-item>
-              </template>
-            </DialogMaterialListEdit>
             <v-list-item :disabled="isDownloadingXlsx" @click.stop="downloadXlsx">
               <template #prepend>
-                <v-progress-circular
-                  v-if="isDownloadingXlsx"
-                  class="mr-2"
-                  indeterminate
-                  size="24"
-                  width="2"
-                />
+                <v-progress-circular v-if="isDownloadingXlsx" class="mr-2" indeterminate size="24" width="2" />
                 <v-icon v-else>mdi-microsoft-excel</v-icon>
               </template>
               {{ $t('global.button.download') }}
             </v-list-item>
+            <DialogEntityDelete :entity="materialList" :warning-text-entity="materialList.name"
+              :error-handler="deleteErrorHandler"
+              :success-handler="() => $router.push({ path: `/camps/${camp.id}/${camp.shortTitle}/material/all` })">
+              <template #activator="{ props }">
+                <v-list-item v-bind="props">
+                  <template #prepend>
+                    <v-icon>mdi-delete</v-icon>
+                  </template>
+                  <v-list-item-title>
+                    {{ $t('global.button.delete') }}
+                  </v-list-item-title>
+                </v-list-item>
+              </template>
+            </DialogEntityDelete>
           </v-list>
         </v-menu>
       </template>
-      <v-expansion-panels
-        v-if="collection.length > 1"
-        v-model="openPeriods"
-        multiple
-        flat
-        variant="accordion"
-      >
-        <PeriodMaterialLists
-          v-for="{ period, materialItems } in collection"
-          :key="period._meta.self"
-          :period="period"
-          :material-item-collection="materialItems"
-          :material-list="materialList"
-          :disabled="!isContributor"
-        />
+      <v-expansion-panels v-if="collection.length > 1" v-model="openPeriods" multiple flat variant="accordion">
+        <PeriodMaterialLists v-for="{ period, materialItems } in collection" :key="period._meta.self" :period="period"
+          :material-item-collection="materialItems" :material-list="materialList" :disabled="!isContributor" />
       </v-expansion-panels>
       <v-card-text v-else-if="collection.length === 1">
-        <MaterialTable
-          v-for="{ period, materialItems } in collection"
-          :key="period._meta.self"
-          :camp="camp"
-          :material-item-collection="materialItems"
-          :period="period"
-          :material-list="materialList"
-          :disabled="!isContributor"
-        />
+        <MaterialTable v-for="{ period, materialItems } in collection" :key="period._meta.self" :camp="camp"
+          :material-item-collection="materialItems" :period="period" :material-list="materialList"
+          :disabled="!isContributor" />
       </v-card-text>
     </content-card>
   </v-container>
@@ -70,7 +66,7 @@
 import ContentCard from '@/components/layout/ContentCard.vue'
 import PeriodMaterialLists from '@/components/material/PeriodMaterialLists.vue'
 import MaterialTable from '@/components/material/MaterialTable.vue'
-import DialogMaterialListEdit from '@/components/campAdmin/DialogMaterialListEdit.vue'
+import DialogEntityDelete from '@/components/dialog/DialogEntityDelete.vue'
 import { campRoleMixin } from '@/mixins/campRoleMixin.js'
 import { useMaterialViewHelper } from '@/components/material/useMaterialViewHelper.js'
 
@@ -78,7 +74,7 @@ export default {
   name: 'MaterialDetail',
   components: {
     ContentCard,
-    DialogMaterialListEdit,
+    DialogEntityDelete,
     MaterialTable,
     PeriodMaterialLists,
   },
@@ -86,6 +82,13 @@ export default {
   props: {
     camp: { type: Object, required: true },
     materialList: { type: Object, required: true },
+  },
+  data() {
+    return {
+      dragging: false,
+      editMaterialListName: false,
+      debouncedDisabled: true,
+    }
   },
   setup(props) {
     return useMaterialViewHelper(props.camp, true)
@@ -95,5 +98,16 @@ export default {
       title: () => this.materialList.name,
     }
   },
+  methods: {
+    makeMaterialListNameEditable() {
+      this.editMaterialListName = true
+    },
+    deleteErrorHandler(e) {
+      if (e?.response?.status === 422 /* Validation Error */) {
+        return this.$t('components.campAdmin.dialogMaterialListEdit.deleteError')
+      }
+      return null
+    },
+  } 
 }
 </script>


### PR DESCRIPTION

Looking to fix Issue https://github.com/ecamp/ecamp3/issues/7426, @manuelmeister  and me decided to split the edit menu for a material list into a rename button located next to the name of the list and a delete button which now replaces aforementioned edit button.

🗑️ -From now on, empty lists can be deleted with the **new delete button in the 3-dot menu**, no need to enter an edit dialog before.

↪️ -Successfully deleting a list won't glitch the delete prompt like before, instead **the user will be redirected into the overview page of the material lists**.

📝 -The **Edit button has been removed from the 3-dot menu** and both its functions have been repurposed into that new delete button as well as **a rename button which is displayed as a pen icon next to the title** of the current list. Pressing it will replace the title with a field containing the name of the list. The user can change the name and either cancel this operation or confirm the change, which will update the name of the list, taking instant effect on the side register as well.

‼️It's worth noting that the error notice which prevents a non-empty list from being deleted is colored orange rather than red, if that's reason for concern.

Showcase 👀

https://github.com/user-attachments/assets/4857f6f1-f5dd-4aad-8fb4-cab75d7d4a83

